### PR TITLE
feat(billing): add trial period functionality

### DIFF
--- a/.cursor/rules/django.mdc
+++ b/.cursor/rules/django.mdc
@@ -1,6 +1,7 @@
 ---
 description: Django
 globs: *.py *.html
+alwaysApply: false
 ---
 # Django Guidelines
 
@@ -12,6 +13,7 @@ globs: *.py *.html
 - Leverage Django’s ORM for database interactions; avoid raw SQL queries unless necessary for performance.
 - Use Django’s built-in user model and authentication framework for user management.
 - Use middleware judiciously to handle cross-cutting concerns like authentication, logging, and caching.
+- Assume all migrations have been run. Never edit an existing migration file.
 
 ## Django Error Handling and Validation
 - Implement error handling at the view level and use Django's built-in error handling mechanisms.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -9,3 +9,4 @@ You are an expert in Python, Django, scalable web application development, TypeS
 
 - When creating a file (for example, config files, etc), first ensure that similar files are not already present in the project in may be different directories.
 - We're using `poetry` for package management, so never try to run python directly or through a virtual environment.
+- While the front-end and back-end is currently intertwined, the long-term goal is to fully separate out the front-end from the back-end and have a clear and clean API that is consumed by the front-end.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,9 +1,11 @@
 ---
 description: General Guidelines
 globs: *
+alwaysApply: false
 ---
 You are an expert in Python, Django, scalable web application development, TypeScript, Node.js, Vite, Vue.js, Vue Router, Pinia, VueUse, and Vuetify with a deep understanding of best practices and performance optimization techniques in these technologies.
 
 # General Guidelines
 
 - When creating a file (for example, config files, etc), first ensure that similar files are not already present in the project in may be different directories.
+- We're using `poetry` for package management, so never try to run python directly or through a virtual environment.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -7,6 +7,50 @@ You are an expert in Python, Django, scalable web application development, TypeS
 
 # General Guidelines
 
+## Project Structure and Organization
 - When creating a file (for example, config files, etc), first ensure that similar files are not already present in the project in may be different directories.
+- Follow the established project structure and naming conventions.
+- Keep related files together and maintain a logical directory hierarchy.
+
+## Package Management and Dependencies
 - We're using `poetry` for package management, so never try to run python directly or through a virtual environment.
+- Always specify exact versions for dependencies to ensure reproducible builds.
+- Regularly update dependencies to maintain security and access new features.
+
+## Architecture and Design
 - While the front-end and back-end is currently intertwined, the long-term goal is to fully separate out the front-end from the back-end and have a clear and clean API that is consumed by the front-end.
+- Design APIs with versioning in mind from the start.
+- Follow RESTful principles for API design.
+- Implement proper error handling and status codes.
+
+## Security
+- You are paranoid about security and rather be overly cautious than naive.
+- Never store sensitive information in code or configuration files.
+- Always validate and sanitize user input.
+- Implement proper authentication and authorization mechanisms.
+- Use environment variables for sensitive configuration.
+
+## Code Quality
+- Write clean, maintainable, and well-documented code.
+- Follow PEP 8 for Python code and ESLint rules for TypeScript/JavaScript.
+- Write unit tests for all new functionality.
+- Maintain test coverage above 80%.
+- Use type hints in Python and TypeScript for better code reliability.
+
+## Performance
+- Optimize database queries and use proper indexing.
+- Implement caching where appropriate.
+- Minimize bundle size and optimize frontend assets.
+- Use lazy loading for components and routes.
+
+## Version Control
+- Write clear and descriptive commit messages.
+- Create feature branches for new development.
+- Keep commits atomic and focused.
+- Review code before merging to main branches.
+
+## Documentation
+- Keep documentation up to date with code changes.
+- Document API endpoints, parameters, and responses.
+- Include setup instructions and environment requirements.
+- Document known issues and limitations.

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -1,6 +1,7 @@
 ---
 description: Python programming
 globs: *.py
+alwaysApply: false
 ---
 
 # Python Key Principles
@@ -16,7 +17,6 @@ globs: *.py
 - Use modern python features like pathlib for file system operations.
 - Detailed documentation using docstrings and README files.
 - Please use pep257 convention.
-- Dependency management via https://github.com/astral-sh/uv and virtual environments.
 - Package management via Poetry and *never* edit a lockfile by hand - use the `poetry` command.
 - Use ruff for code style and formatting.
 - Update existing docstrings if need be.
@@ -26,3 +26,5 @@ globs: *.py
 - Make use of the fixtures pattern for tests.
 - Use the pytest-mock plugin for mocking.
 - All tests should be fully annotated and should contain docstrings.
+- Run tests and often to verify that you haven't broken anything.
+- Make sure to use `ruff` to lint your code base frequently.

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -3,7 +3,6 @@ description: Python programming
 globs: *.py
 alwaysApply: false
 ---
-
 # Python Key Principles
 
 - Use modern python syntax and features. Python 3.10+ is preferred.
@@ -28,3 +27,5 @@ alwaysApply: false
 - All tests should be fully annotated and should contain docstrings.
 - Run tests and often to verify that you haven't broken anything.
 - Make sure to use `ruff` to lint your code base frequently.
+- ALWAYS run `ruff check` and `ruff format` after making any changes to Python files.
+- If `ruff` reports any issues, fix them with the `--fix` variable in ruff before manually trying to fix them. Do this before proceeding with other changes.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,32 @@ poetry run coverage run -m pytest --pdb -x -s
 poetry run coverage report
 ```
 
+### Running Tests with PostgreSQL
+
+The test suite requires PostgreSQL to run. You can use a separate PostgreSQL container for testing:
+
+```bash
+# Start a PostgreSQL container for testing
+docker run --name sbomify-test-db \
+  -e POSTGRES_USER=sbomify \
+  -e POSTGRES_PASSWORD=sbomify \
+  -e POSTGRES_DB=sbomify \
+  -p 5433:5432 \
+  -d postgres:15-alpine
+
+# Run the tests with the test database
+DJANGO_SETTINGS_MODULE=sbomify.test_settings \
+DJANGO_TEST=true \
+TEST_DB_HOST=localhost \
+TEST_DB_PORT=5433 \
+poetry run coverage run -m pytest
+
+# Clean up the test database container when done
+docker rm -f sbomify-test-db
+```
+
+> **Note**: We use port 5433 to avoid conflicts with the development database which runs on port 5432.
+
 ### JS build tooling
 
 For frontend JS work, setting up JS tooling is required.

--- a/billing/billing_processing.py
+++ b/billing/billing_processing.py
@@ -20,6 +20,7 @@ from .models import BillingPlan
 
 logger = getLogger(__name__)
 
+
 # Stripe webhook signature verification
 def verify_stripe_webhook(request):
     """Verify that the webhook request is from Stripe."""
@@ -29,11 +30,7 @@ def verify_stripe_webhook(request):
         return False
 
     try:
-        event = stripe.Webhook.construct_event(
-            request.body,
-            signature,
-            settings.STRIPE_WEBHOOK_SECRET
-        )
+        event = stripe.Webhook.construct_event(request.body, signature, settings.STRIPE_WEBHOOK_SECRET)
         return event
     except stripe.error.SignatureVerificationError:
         logger.error("Invalid Stripe signature")
@@ -42,21 +39,29 @@ def verify_stripe_webhook(request):
         logger.error(f"Error verifying Stripe webhook: {str(e)}")
         return False
 
+
 # Stripe error handling
 class StripeError(Exception):
     """Base class for Stripe-related errors."""
+
     pass
+
 
 class StripeWebhookError(StripeError):
     """Error processing Stripe webhook."""
+
     pass
+
 
 class StripeSubscriptionError(StripeError):
     """Error processing Stripe subscription."""
+
     pass
+
 
 def handle_stripe_error(func):
     """Decorator to handle Stripe errors consistently."""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -82,6 +87,7 @@ def handle_stripe_error(func):
         except Exception as e:
             logger.exception(f"Unexpected error: {str(e)}")
             raise StripeError(f"Unexpected error: {str(e)}")
+
     return wrapper
 
 
@@ -209,18 +215,14 @@ def handle_subscription_updated(subscription):
             team_owners = Member.objects.filter(team=team, role="owner")
             for member in team_owners:
                 email_notifications.notify_subscription_cancelled(team, member)
-                logger.info(
-                    f"Subscription cancelled notification sent for team {team.key} "
-                    f"to {member.user.email}"
-                )
+                logger.info(f"Subscription cancelled notification sent for team {team.key} " f"to {member.user.email}")
         elif new_status in ["incomplete", "incomplete_expired"]:
             # Handle failed initial payment
             team_owners = Member.objects.filter(team=team, role="owner")
             for member in team_owners:
                 email_notifications.notify_payment_failed(team, member, None)
                 logger.warning(
-                    f"Initial payment failed notification sent for team {team.key} "
-                    f"to {member.user.email}"
+                    f"Initial payment failed notification sent for team {team.key} " f"to {member.user.email}"
                 )
 
         team.save()
@@ -366,7 +368,7 @@ def handle_checkout_completed(session):
         # Get the subscription to check trial status
         subscription = stripe.Subscription.retrieve(
             session.subscription,
-            expand=["latest_invoice.payment_intent"]  # Expand payment intent for better error handling
+            expand=["latest_invoice.payment_intent"],  # Expand payment intent for better error handling
         )
 
         # Update team billing information

--- a/billing/billing_processing.py
+++ b/billing/billing_processing.py
@@ -7,13 +7,13 @@ from functools import wraps
 
 import stripe
 from django.conf import settings
-from django.http import HttpResponseForbidden, HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 from django.utils import timezone
 
 from core.errors import error_response
 from sbomify.logging import getLogger
 from sboms.models import Component, Product, Project
-from teams.models import Team, Member
+from teams.models import Member, Team
 
 from . import email_notifications
 from .models import BillingPlan

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -15,25 +15,29 @@ logger = getLogger(__name__)
 
 def send_billing_email(team: Team, owner: Member, subject: str, template: str, context: dict) -> None:
     """Send billing-related email notification using HTML template"""
-    context.update(
-        {
-            "team_name": team.name,
-            "user_name": owner.member.user.get_full_name() or owner.member.user.email,
-            "action_url": f"{settings.WEBSITE_BASE_URL}{reverse('billing:select_plan', kwargs={'team_key': team.key})}",
-        }
-    )
+    try:
+        context.update(
+            {
+                "team_name": team.name,
+                "user_name": owner.member.user.get_full_name() or owner.member.user.email,
+                "action_url": f"{settings.WEBSITE_BASE_URL}{reverse('billing:select_plan', kwargs={'team_key': team.key})}",
+            }
+        )
 
-    html_message = render_to_string(f"billing/emails/{template}.html", context)
-    text_message = render_to_string(f"billing/emails/{template}.txt", context)
+        html_message = render_to_string(f"billing/emails/{template}.html", context)
+        text_message = render_to_string(f"billing/emails/{template}.txt", context)
 
-    send_mail(
-        subject,
-        text_message,
-        settings.DEFAULT_FROM_EMAIL,
-        [owner.member.user.email],
-        html_message=html_message,
-        fail_silently=True,
-    )
+        send_mail(
+            f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
+            text_message,
+            settings.DEFAULT_FROM_EMAIL,
+            [owner.member.user.email],
+            html_message=html_message,
+            fail_silently=True,
+        )
+        logger.info(f"Sent {template} email to {owner.member.user.email}")
+    except Exception as e:
+        logger.exception(f"Error sending {template} email: {str(e)}")
 
 
 def notify_payment_past_due(team: Team, owner: Member) -> None:
@@ -41,24 +45,34 @@ def notify_payment_past_due(team: Team, owner: Member) -> None:
     send_billing_email(
         team,
         owner,
-        "[sbomify] Payment Past Due - Action Required",
+        "Payment Past Due - Action Required",
         "payment_past_due",
         {},
     )
 
 
-def notify_payment_failed(team: Team, owner: Member, attempt_count: int, next_payment_attempt: str) -> None:
-    """Send payment failed notification"""
-    send_billing_email(
-        team,
-        owner,
-        "[sbomify] Payment Failed - Action Required",
-        "payment_failed",
-        {
-            "attempt_count": attempt_count,
-            "next_payment_attempt": next_payment_attempt,
-        },
+def notify_payment_failed(team: Team, owner: Member, invoice_id: str | None) -> None:
+    """Send notification about failed payment."""
+    subject = f"Payment failed for {team.name}"
+    message = f"""
+    We were unable to process your payment for {team.name}.
+
+    {f'Invoice ID: {invoice_id}' if invoice_id else ''}
+
+    Please update your payment information to continue using all features:
+    {reverse('billing:select_plan', kwargs={'team_key': team.key})}
+
+    If you have any questions, please don't hesitate to contact us.
+    """
+
+    send_mail(
+        f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
+        message,
+        settings.DEFAULT_FROM_EMAIL,
+        [owner.member.user.email],
+        fail_silently=True,
     )
+    logger.info(f"Sent payment failed notification to {owner.member.user.email}")
 
 
 def notify_subscription_cancelled(team: Team, owner: Member) -> None:
@@ -66,7 +80,7 @@ def notify_subscription_cancelled(team: Team, owner: Member) -> None:
     send_billing_email(
         team,
         owner,
-        "[sbomify] Subscription Cancelled",
+        "Subscription Cancelled",
         "subscription_cancelled",
         {},
     )
@@ -77,7 +91,29 @@ def notify_payment_succeeded(team: Team, owner: Member) -> None:
     send_billing_email(
         team,
         owner,
-        "[sbomify] Payment Successful",
+        "Payment Successful",
         "payment_succeeded",
         {},
     )
+
+
+def notify_trial_ending(team: Team, owner: Member, days_remaining: int) -> None:
+    """Send notification about trial ending soon."""
+    subject = f"Your {team.name} trial is ending in {days_remaining} days"
+    message = f"""
+    Your trial for {team.name} will end in {days_remaining} days.
+
+    To continue using all features, please add your payment information:
+    {reverse('billing:select_plan', kwargs={'team_key': team.key})}
+
+    If you have any questions, please don't hesitate to contact us.
+    """
+
+    send_mail(
+        f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
+        message,
+        settings.DEFAULT_FROM_EMAIL,
+        [owner.member.user.email],
+        fail_silently=True,
+    )
+    logger.info(f"Sent trial ending notification to {owner.member.user.email}")

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -19,7 +19,7 @@ def send_billing_email(team: Team, owner: Member, subject: str, template: str, c
         context.update(
             {
                 "team_name": team.name,
-                "user_name": owner.member.user.get_full_name() or owner.member.user.email,
+                "user_name": owner.user.get_full_name() or owner.user.email,
                 "action_url": (
                     f"{settings.WEBSITE_BASE_URL}"
                     f"{reverse('billing:select_plan', kwargs={'team_key': team.key})}"
@@ -34,11 +34,11 @@ def send_billing_email(team: Team, owner: Member, subject: str, template: str, c
             f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
             text_message,
             settings.DEFAULT_FROM_EMAIL,
-            [owner.member.user.email],
+            [owner.user.email],
             html_message=html_message,
             fail_silently=True,
         )
-        logger.info(f"Sent {template} email to {owner.member.user.email}")
+        logger.info(f"Sent {template} email to {owner.user.email}")
     except Exception as e:
         logger.exception(f"Error sending {template} email: {str(e)}")
 
@@ -72,10 +72,10 @@ def notify_payment_failed(team: Team, owner: Member, invoice_id: str | None) -> 
         f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
         message,
         settings.DEFAULT_FROM_EMAIL,
-        [owner.member.user.email],
+        [owner.user.email],
         fail_silently=True,
     )
-    logger.info(f"Sent payment failed notification to {owner.member.user.email}")
+    logger.info(f"Sent payment failed notification to {owner.user.email}")
 
 
 def notify_subscription_cancelled(team: Team, owner: Member) -> None:
@@ -116,7 +116,7 @@ def notify_trial_ending(team: Team, owner: Member, days_remaining: int) -> None:
         f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
         message,
         settings.DEFAULT_FROM_EMAIL,
-        [owner.member.user.email],
+        [owner.user.email],
         fail_silently=True,
     )
-    logger.info(f"Sent trial ending notification to {owner.member.user.email}")
+    logger.info(f"Sent trial ending notification to {owner.user.email}")

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -2,6 +2,8 @@
 Module for billing-related email notifications
 """
 
+import logging
+
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
@@ -10,113 +12,93 @@ from django.urls import reverse
 from sbomify.logging import getLogger
 from teams.models import Member, Team
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
-def send_billing_email(team: Team, owner: Member, subject: str, template: str, context: dict) -> None:
-    """Send billing-related email notification using HTML template"""
+def send_billing_email(team: Team, member: Member, subject: str, template: str, context: dict) -> None:
+    """Send a billing-related email using a template."""
+    if not team or not member:
+        logger.error(f"Failed to send {template} email: Invalid team or member")
+        return
+
     try:
-        context.update(
-            {
-                "team_name": team.name,
-                "user_name": owner.user.get_full_name() or owner.user.email,
-                "action_url": (
-                    f"{settings.WEBSITE_BASE_URL}"
-                    f"{reverse('billing:select_plan', kwargs={'team_key': team.key})}"
-                ),
-            }
-        )
-
         html_message = render_to_string(f"billing/emails/{template}.html", context)
         text_message = render_to_string(f"billing/emails/{template}.txt", context)
 
         send_mail(
-            f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
+            subject,
             text_message,
-            settings.DEFAULT_FROM_EMAIL,
-            [owner.user.email],
+            None,  # DEFAULT_FROM_EMAIL
+            [member.user.email],
             html_message=html_message,
             fail_silently=True,
         )
-        logger.info(f"Sent {template} email to {owner.user.email}")
+        logger.info(f"Sent {template} email to {member.user.email}")
     except Exception as e:
-        logger.exception(f"Error sending {template} email: {str(e)}")
+        logger.error(f"Failed to send {template} email to {member.user.email}: {str(e)}")
 
 
-def notify_payment_past_due(team: Team, owner: Member) -> None:
-    """Send payment past due notification"""
+def notify_payment_past_due(team: Team, member: Member) -> None:
+    """Notify team owner about past due payment."""
     send_billing_email(
         team,
-        owner,
+        member,
         "Payment Past Due - Action Required",
         "payment_past_due",
         {},
     )
 
 
-def notify_payment_failed(team: Team, owner: Member, invoice_id: str | None) -> None:
-    """Send notification about failed payment."""
-    subject = f"Payment failed for {team.name}"
-    message = f"""
-    We were unable to process your payment for {team.name}.
-
-    {f'Invoice ID: {invoice_id}' if invoice_id else ''}
-
-    Please update your payment information to continue using all features:
-    {reverse('billing:select_plan', kwargs={'team_key': team.key})}
-
-    If you have any questions, please don't hesitate to contact us.
-    """
-
-    send_mail(
-        f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        [owner.user.email],
-        fail_silently=True,
-    )
-    logger.info(f"Sent payment failed notification to {owner.user.email}")
-
-
-def notify_subscription_cancelled(team: Team, owner: Member) -> None:
-    """Send subscription cancelled notification"""
+def notify_payment_failed(team: Team, member: Member, invoice_id: str | None) -> None:
+    """Notify team owner about failed payment."""
     send_billing_email(
         team,
-        owner,
+        member,
+        "Payment Failed",
+        "payment_failed",
+        {"invoice_id": invoice_id},
+    )
+
+
+def notify_subscription_cancelled(team: Team, member: Member) -> None:
+    """Notify team owner about subscription cancellation."""
+    send_billing_email(
+        team,
+        member,
         "Subscription Cancelled",
         "subscription_cancelled",
         {},
     )
 
 
-def notify_payment_succeeded(team: Team, owner: Member) -> None:
-    """Send payment succeeded notification"""
+def notify_payment_succeeded(team: Team, member: Member) -> None:
+    """Notify team owner about successful payment."""
     send_billing_email(
         team,
-        owner,
+        member,
         "Payment Successful",
         "payment_succeeded",
         {},
     )
 
 
-def notify_trial_ending(team: Team, owner: Member, days_remaining: int) -> None:
-    """Send notification about trial ending soon."""
-    subject = f"Your {team.name} trial is ending in {days_remaining} days"
-    message = f"""
-    Your trial for {team.name} will end in {days_remaining} days.
-
-    To continue using all features, please add your payment information:
-    {reverse('billing:select_plan', kwargs={'team_key': team.key})}
-
-    If you have any questions, please don't hesitate to contact us.
-    """
-
-    send_mail(
-        f"{settings.EMAIL_SUBJECT_PREFIX}{subject}",
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        [owner.user.email],
-        fail_silently=True,
+def notify_trial_ending(team: Team, member: Member, days_remaining: int) -> None:
+    """Notify team owner that trial period is ending."""
+    send_billing_email(
+        team,
+        member,
+        "Trial Period Ending",
+        "trial_ending",
+        {"days_remaining": days_remaining},
     )
-    logger.info(f"Sent trial ending notification to {owner.user.email}")
+
+
+def notify_subscription_ended(team: Team, member: Member) -> None:
+    """Notify team owner about subscription ending."""
+    send_billing_email(
+        team,
+        member,
+        "Subscription Ended",
+        "subscription_ended",
+        {},
+    )

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -2,134 +2,83 @@
 Module for billing-related email notifications
 """
 
-import logging
-
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from django.conf import settings
-from django.utils import timezone
 
-from teams.models import Member, Team
 from sbomify.logging import getLogger
+from teams.models import Member, Team
 
 logger = getLogger(__name__)
 
 
-def send_billing_email(subject, template_name, context, recipient_list):
+def send_billing_email(team: Team, member: Member, subject: str, template_name: str, context: dict) -> None:
     """Send a billing-related email using a template."""
+    if not team:
+        logger.error("Cannot send billing email: team is None")
+        return
+
+    if not member:
+        logger.error("Cannot send billing email: member is None")
+        return
+
     try:
         # Render email content from template
-        html_message = render_to_string(f"billing/emails/{template_name}.html", context)
-        plain_message = render_to_string(f"billing/emails/{template_name}.txt", context)
+        try:
+            html_message = render_to_string(f"billing/emails/{template_name}.html", context)
+            plain_message = render_to_string(f"billing/emails/{template_name}.txt", context)
+        except Exception as e:
+            logger.error(f"Failed to render email template {template_name}: {str(e)}")
+            return
 
         # Send email
-        send_mail(
-            subject=subject,
-            message=plain_message,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=recipient_list,
-            html_message=html_message,
-            fail_silently=False
-        )
-        logger.info(f"Sent {template_name} email to {recipient_list}")
+        try:
+            send_mail(
+                subject,
+                plain_message,
+                None,  # Use default from_email
+                [member.user.email],
+                html_message=html_message,
+                fail_silently=True,
+            )
+            logger.info(f"Sent {template_name} email to {member.user.email}")
+        except Exception as e:
+            logger.error(f"Failed to send {template_name} email: {str(e)}")
+            return
     except Exception as e:
         logger.error(f"Failed to send {template_name} email: {str(e)}")
-        raise
+        return
 
 
 def notify_payment_past_due(team: Team, member: Member) -> None:
     """Notify team owner about past due payment."""
-    send_billing_email(
-        subject="Payment Past Due - Action Required",
-        template_name="payment_past_due",
-        context={},
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Payment Past Due - Action Required", "payment_past_due", {})
 
 
 def notify_payment_failed(team: Team, member: Member, invoice_id: str | None) -> None:
     """Notify team owner about failed payment."""
-    subject = f"Payment failed for {team.name}"
-    context = {
-        "team_name": team.name,
-        "billing_url": f"{settings.SITE_URL}/billing",
-        "invoice_id": invoice_id
-    }
-    send_billing_email(
-        subject=subject,
-        template_name="payment_failed",
-        context=context,
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Payment Failed", "payment_failed", {"invoice_id": invoice_id})
 
 
 def notify_subscription_cancelled(team: Team, member: Member) -> None:
     """Notify team owner about subscription cancellation."""
-    subject = f"Subscription cancelled for {team.name}"
-    context = {
-        "team_name": team.name,
-        "billing_url": f"{settings.SITE_URL}/billing"
-    }
-    send_billing_email(
-        subject=subject,
-        template_name="subscription_cancelled",
-        context=context,
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Subscription Cancelled", "subscription_cancelled", {})
 
 
 def notify_payment_succeeded(team: Team, member: Member) -> None:
     """Notify team owner about successful payment."""
-    subject = f"Payment successful for {team.name}"
-    context = {
-        "team_name": team.name,
-        "billing_url": f"{settings.SITE_URL}/billing"
-    }
-    send_billing_email(
-        subject=subject,
-        template_name="payment_succeeded",
-        context=context,
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Payment Successful", "payment_succeeded", {})
 
 
 def notify_trial_ending(team: Team, member: Member, days_remaining: int) -> None:
     """Notify team owner that trial period is ending soon."""
-    subject = f"Your {team.name} trial is ending in {days_remaining} days"
-    context = {
-        "team_name": team.name,
-        "days_remaining": days_remaining,
-        "trial_end_date": timezone.now() + timezone.timedelta(days=days_remaining),
-        "upgrade_url": f"{settings.SITE_URL}/billing/upgrade"
-    }
-    send_billing_email(
-        subject=subject,
-        template_name="trial_ending",
-        context=context,
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Trial Period Ending", "trial_ending", {"days_remaining": days_remaining})
 
 
 def notify_trial_expired(team: Team, member: Member) -> None:
     """Notify team owner that trial period has expired."""
-    subject = f"Your {team.name} trial has expired"
-    context = {
-        "team_name": team.name,
-        "upgrade_url": f"{settings.SITE_URL}/billing/upgrade"
-    }
-    send_billing_email(
-        subject=subject,
-        template_name="trial_expired",
-        context=context,
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Trial Expired", "trial_expired", {})
 
 
 def notify_subscription_ended(team: Team, member: Member) -> None:
     """Notify team owner about subscription ending."""
-    send_billing_email(
-        subject="Subscription Ended",
-        template_name="subscription_ended",
-        context={},
-        recipient_list=[member.user.email]
-    )
+    send_billing_email(team, member, "Subscription Ended", "subscription_ended", {})

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -4,12 +4,9 @@ Module for billing-related email notifications
 
 import logging
 
-from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from django.urls import reverse
 
-from sbomify.logging import getLogger
 from teams.models import Member, Team
 
 logger = logging.getLogger(__name__)

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -6,96 +6,130 @@ import logging
 
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
+from django.conf import settings
+from django.utils import timezone
 
 from teams.models import Member, Team
+from sbomify.logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
-def send_billing_email(team: Team, member: Member, subject: str, template: str, context: dict) -> None:
+def send_billing_email(subject, template_name, context, recipient_list):
     """Send a billing-related email using a template."""
-    if not team or not member:
-        logger.error(f"Failed to send {template} email: Invalid team or member")
-        return
-
     try:
-        html_message = render_to_string(f"billing/emails/{template}.html", context)
-        text_message = render_to_string(f"billing/emails/{template}.txt", context)
+        # Render email content from template
+        html_message = render_to_string(f"billing/emails/{template_name}.html", context)
+        plain_message = render_to_string(f"billing/emails/{template_name}.txt", context)
 
+        # Send email
         send_mail(
-            subject,
-            text_message,
-            None,  # DEFAULT_FROM_EMAIL
-            [member.user.email],
+            subject=subject,
+            message=plain_message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=recipient_list,
             html_message=html_message,
-            fail_silently=True,
+            fail_silently=False
         )
-        logger.info(f"Sent {template} email to {member.user.email}")
+        logger.info(f"Sent {template_name} email to {recipient_list}")
     except Exception as e:
-        logger.error(f"Failed to send {template} email to {member.user.email}: {str(e)}")
+        logger.error(f"Failed to send {template_name} email: {str(e)}")
+        raise
 
 
 def notify_payment_past_due(team: Team, member: Member) -> None:
     """Notify team owner about past due payment."""
     send_billing_email(
-        team,
-        member,
-        "Payment Past Due - Action Required",
-        "payment_past_due",
-        {},
+        subject="Payment Past Due - Action Required",
+        template_name="payment_past_due",
+        context={},
+        recipient_list=[member.user.email]
     )
 
 
 def notify_payment_failed(team: Team, member: Member, invoice_id: str | None) -> None:
     """Notify team owner about failed payment."""
+    subject = f"Payment failed for {team.name}"
+    context = {
+        "team_name": team.name,
+        "billing_url": f"{settings.SITE_URL}/billing",
+        "invoice_id": invoice_id
+    }
     send_billing_email(
-        team,
-        member,
-        "Payment Failed",
-        "payment_failed",
-        {"invoice_id": invoice_id},
+        subject=subject,
+        template_name="payment_failed",
+        context=context,
+        recipient_list=[member.user.email]
     )
 
 
 def notify_subscription_cancelled(team: Team, member: Member) -> None:
     """Notify team owner about subscription cancellation."""
+    subject = f"Subscription cancelled for {team.name}"
+    context = {
+        "team_name": team.name,
+        "billing_url": f"{settings.SITE_URL}/billing"
+    }
     send_billing_email(
-        team,
-        member,
-        "Subscription Cancelled",
-        "subscription_cancelled",
-        {},
+        subject=subject,
+        template_name="subscription_cancelled",
+        context=context,
+        recipient_list=[member.user.email]
     )
 
 
 def notify_payment_succeeded(team: Team, member: Member) -> None:
     """Notify team owner about successful payment."""
+    subject = f"Payment successful for {team.name}"
+    context = {
+        "team_name": team.name,
+        "billing_url": f"{settings.SITE_URL}/billing"
+    }
     send_billing_email(
-        team,
-        member,
-        "Payment Successful",
-        "payment_succeeded",
-        {},
+        subject=subject,
+        template_name="payment_succeeded",
+        context=context,
+        recipient_list=[member.user.email]
     )
 
 
 def notify_trial_ending(team: Team, member: Member, days_remaining: int) -> None:
-    """Notify team owner that trial period is ending."""
+    """Notify team owner that trial period is ending soon."""
+    subject = f"Your {team.name} trial is ending in {days_remaining} days"
+    context = {
+        "team_name": team.name,
+        "days_remaining": days_remaining,
+        "trial_end_date": timezone.now() + timezone.timedelta(days=days_remaining),
+        "upgrade_url": f"{settings.SITE_URL}/billing/upgrade"
+    }
     send_billing_email(
-        team,
-        member,
-        "Trial Period Ending",
-        "trial_ending",
-        {"days_remaining": days_remaining},
+        subject=subject,
+        template_name="trial_ending",
+        context=context,
+        recipient_list=[member.user.email]
+    )
+
+
+def notify_trial_expired(team: Team, member: Member) -> None:
+    """Notify team owner that trial period has expired."""
+    subject = f"Your {team.name} trial has expired"
+    context = {
+        "team_name": team.name,
+        "upgrade_url": f"{settings.SITE_URL}/billing/upgrade"
+    }
+    send_billing_email(
+        subject=subject,
+        template_name="trial_expired",
+        context=context,
+        recipient_list=[member.user.email]
     )
 
 
 def notify_subscription_ended(team: Team, member: Member) -> None:
     """Notify team owner about subscription ending."""
     send_billing_email(
-        team,
-        member,
-        "Subscription Ended",
-        "subscription_ended",
-        {},
+        subject="Subscription Ended",
+        template_name="subscription_ended",
+        context={},
+        recipient_list=[member.user.email]
     )

--- a/billing/email_notifications.py
+++ b/billing/email_notifications.py
@@ -20,7 +20,10 @@ def send_billing_email(team: Team, owner: Member, subject: str, template: str, c
             {
                 "team_name": team.name,
                 "user_name": owner.member.user.get_full_name() or owner.member.user.email,
-                "action_url": f"{settings.WEBSITE_BASE_URL}{reverse('billing:select_plan', kwargs={'team_key': team.key})}",
+                "action_url": (
+                    f"{settings.WEBSITE_BASE_URL}"
+                    f"{reverse('billing:select_plan', kwargs={'team_key': team.key})}"
+                ),
             }
         )
 

--- a/billing/migrations/0004_add_trial_periods.py
+++ b/billing/migrations/0004_add_trial_periods.py
@@ -1,0 +1,84 @@
+"""
+This migration adds trial periods to existing Stripe prices.
+"""
+
+from django.conf import settings
+from django.db import migrations
+import stripe
+import sys
+
+
+def is_test_environment():
+    """Helper to check if we're in test environment."""
+    # Check for test environment indicators
+    is_test = any([
+        not getattr(settings, 'STRIPE_SECRET_KEY', None),  # Check if setting exists
+        getattr(settings, 'STRIPE_SECRET_KEY', '') == 'sk_test_dummy_key_for_ci',
+        getattr(settings, 'DJANGO_TEST', False),  # Check explicit test flag
+        getattr(settings, 'TESTING', False),  # Check Django's test flag
+        'test' in settings.DATABASES['default']['NAME'],
+        'pytest' in sys.modules,
+    ])
+
+    if is_test:
+        # Ensure stripe is not imported
+        if 'stripe' in sys.modules:
+            del sys.modules['stripe']
+            # Also clear any cached API key
+            import importlib
+            if 'stripe.api_key' in sys.modules:
+                del sys.modules['stripe.api_key']
+    return is_test
+
+
+def add_trial_periods(apps, schema_editor):
+    """Add trial periods to existing Stripe prices."""
+    # First thing: check test environment
+    if is_test_environment():
+        print("Skipping trial period setup in test/CI environment")
+        return
+
+    if not settings.STRIPE_SECRET_KEY:
+        print("No Stripe API key found, skipping trial period setup")
+        return
+
+    BillingPlan = apps.get_model('billing', 'BillingPlan')
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+    for plan in BillingPlan.objects.filter(stripe_product_id__isnull=False):
+        # Update monthly price
+        if plan.stripe_price_monthly_id:
+            try:
+                stripe.Price.modify(
+                    plan.stripe_price_monthly_id,
+                    recurring={'trial_period_days': settings.TRIAL_PERIOD_DAYS}
+                )
+                print(f"Added trial period to monthly price for {plan.key}")
+            except stripe.error.StripeError as e:
+                print(f"Error updating monthly price for {plan.key}: {str(e)}")
+
+        # Update annual price
+        if plan.stripe_price_annual_id:
+            try:
+                stripe.Price.modify(
+                    plan.stripe_price_annual_id,
+                    recurring={'trial_period_days': settings.TRIAL_PERIOD_DAYS}
+                )
+                print(f"Added trial period to annual price for {plan.key}")
+            except stripe.error.StripeError as e:
+                print(f"Error updating annual price for {plan.key}: {str(e)}")
+
+
+def reverse_trial_periods(apps, schema_editor):
+    """This is a one-way migration - we can't remove trial periods from prices."""
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('billing', '0003_setup_stripe_billing'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_trial_periods, reverse_trial_periods),
+    ]

--- a/billing/stripe_client.py
+++ b/billing/stripe_client.py
@@ -1,0 +1,136 @@
+"""
+Stripe client wrapper for handling Stripe operations.
+"""
+
+import stripe
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+from functools import wraps
+import logging
+
+logger = logging.getLogger(__name__)
+
+class StripeClient:
+    """Wrapper for Stripe operations with proper error handling and caching."""
+
+    def __init__(self, api_key=None):
+        """Initialize Stripe client with API key."""
+        self.api_key = api_key or settings.STRIPE_SECRET_KEY
+        self.stripe = stripe
+        self.stripe.api_key = self.api_key
+
+    @staticmethod
+    def _handle_stripe_error(func):
+        """Decorator to handle Stripe errors consistently."""
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except stripe.error.CardError as e:
+                logger.error(f"Card error: {str(e)}")
+                raise StripeError(f"Card error: {e.user_message}")
+            except stripe.error.RateLimitError as e:
+                logger.error(f"Rate limit error: {str(e)}")
+                raise StripeError("Too many requests made to Stripe API")
+            except stripe.error.InvalidRequestError as e:
+                logger.error(f"Invalid request error: {str(e)}")
+                raise StripeError(f"Invalid request: {str(e)}")
+            except stripe.error.AuthenticationError as e:
+                logger.error(f"Authentication error: {str(e)}")
+                raise StripeError("Authentication with Stripe failed")
+            except stripe.error.APIConnectionError as e:
+                logger.error(f"API connection error: {str(e)}")
+                raise StripeError("Could not connect to Stripe API")
+            except stripe.error.StripeError as e:
+                logger.error(f"Stripe error: {str(e)}")
+                raise StripeError(f"Stripe error: {str(e)}")
+            except Exception as e:
+                logger.exception(f"Unexpected error: {str(e)}")
+                raise StripeError(f"Unexpected error: {str(e)}")
+        return wrapper
+
+    @_handle_stripe_error
+    def get_customer(self, customer_id):
+        """Retrieve a customer from Stripe."""
+        return self.stripe.Customer.retrieve(customer_id)
+
+    @_handle_stripe_error
+    def create_customer(self, email, name, metadata=None):
+        """Create a new customer in Stripe."""
+        return self.stripe.Customer.create(
+            email=email,
+            name=name,
+            metadata=metadata or {}
+        )
+
+    @_handle_stripe_error
+    def update_customer(self, customer_id, **kwargs):
+        """Update a customer in Stripe."""
+        return self.stripe.Customer.modify(customer_id, **kwargs)
+
+    @_handle_stripe_error
+    def create_subscription(self, customer_id, price_id, trial_days=None, metadata=None):
+        """Create a new subscription."""
+        subscription_data = {
+            'customer': customer_id,
+            'items': [{'price': price_id}],
+            'metadata': metadata or {}
+        }
+
+        if trial_days:
+            subscription_data['trial_period_days'] = trial_days
+
+        return self.stripe.Subscription.create(**subscription_data)
+
+    @_handle_stripe_error
+    def update_subscription(self, subscription_id, **kwargs):
+        """Update a subscription."""
+        return self.stripe.Subscription.modify(subscription_id, **kwargs)
+
+    @_handle_stripe_error
+    def cancel_subscription(self, subscription_id, prorate=True):
+        """Cancel a subscription."""
+        return self.stripe.Subscription.delete(subscription_id, prorate=prorate)
+
+    @_handle_stripe_error
+    def get_subscription(self, subscription_id):
+        """Retrieve a subscription."""
+        return self.stripe.Subscription.retrieve(
+            subscription_id,
+            expand=['latest_invoice.payment_intent']
+        )
+
+    @_handle_stripe_error
+    def create_checkout_session(self, customer_id, price_id, success_url, cancel_url, metadata=None):
+        """Create a checkout session."""
+        return self.stripe.checkout.Session.create(
+            customer=customer_id,
+            payment_method_types=['card'],
+            line_items=[{
+                'price': price_id,
+                'quantity': 1,
+            }],
+            mode='subscription',
+            success_url=success_url,
+            cancel_url=cancel_url,
+            metadata=metadata or {}
+        )
+
+    @_handle_stripe_error
+    def get_checkout_session(self, session_id):
+        """Retrieve a checkout session."""
+        return self.stripe.checkout.Session.retrieve(session_id)
+
+    @_handle_stripe_error
+    def construct_webhook_event(self, payload, sig_header):
+        """Construct a webhook event from payload and signature."""
+        return self.stripe.Webhook.construct_event(
+            payload,
+            sig_header,
+            settings.STRIPE_WEBHOOK_SECRET
+        )
+
+class StripeError(Exception):
+    """Base class for Stripe-related errors."""
+    pass

--- a/billing/templates/billing/emails/base.html
+++ b/billing/templates/billing/emails/base.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}{% endblock %}</title>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/billing/templates/billing/emails/subscription_ended.html
+++ b/billing/templates/billing/emails/subscription_ended.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Subscription Ended</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .container {
+            background-color: #f9f9f9;
+            border-radius: 5px;
+            padding: 20px;
+            margin-top: 20px;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .content {
+            margin-bottom: 30px;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            margin-top: 20px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            color: #666;
+            margin-top: 30px;
+            border-top: 1px solid #eee;
+            padding-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Subscription Ended</h1>
+        </div>
+        <div class="content">
+            <p>Hello,</p>
+            <p>Your subscription for {{ team.name }} has ended. Your access to premium features has been deactivated.</p>
+            <p>To continue using all features and maintain uninterrupted access to your account, please renew your subscription.</p>
+            <p>
+                <a href="{{ upgrade_url }}" class="button">Renew Subscription</a>
+            </p>
+            <p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
+            <p>Best regards,<br>The {{ team.name }} Team</p>
+        </div>
+        <div class="footer">
+            <p>This is an automated message. Please do not reply to this email.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/billing/templates/billing/emails/subscription_ended.txt
+++ b/billing/templates/billing/emails/subscription_ended.txt
@@ -1,0 +1,17 @@
+Subscription Ended
+
+Hello,
+
+Your subscription for {{ team.name }} has ended. Your access to premium features has been deactivated.
+
+To continue using all features and maintain uninterrupted access to your account, please renew your subscription.
+
+Renew now: {{ upgrade_url }}
+
+If you have any questions or need assistance, please don't hesitate to contact our support team.
+
+Best regards,
+The {{ team.name }} Team
+
+---
+This is an automated message. Please do not reply to this email.

--- a/billing/templates/billing/emails/test_template.html
+++ b/billing/templates/billing/emails/test_template.html
@@ -1,0 +1,5 @@
+{% extends "billing/emails/base.html" %}
+
+{% block content %}
+<p>Test template with context: {{ test_key }}</p>
+{% endblock %}

--- a/billing/templates/billing/emails/test_template.txt
+++ b/billing/templates/billing/emails/test_template.txt
@@ -1,0 +1,1 @@
+Test template with context: {{ test_key }}

--- a/billing/templates/billing/emails/trial_ending.html
+++ b/billing/templates/billing/emails/trial_ending.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trial Ending Soon</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            text-align: center;
+            padding: 20px 0;
+            background-color: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+        }
+        .content {
+            padding: 20px 0;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px 0;
+            font-size: 12px;
+            color: #6c757d;
+            border-top: 1px solid #dee2e6;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Trial Ending Soon</h1>
+        </div>
+        <div class="content">
+            <p>Hello,</p>
+            <p>Your trial period for <strong>{{ team_name }}</strong> will end in <strong>{{ days_remaining }} days</strong> (on {{ trial_end_date|date:"F j, Y" }}).</p>
+            <p>To continue using all features and maintain uninterrupted access to your account, please upgrade to a paid plan before your trial expires.</p>
+            <p style="text-align: center;">
+                <a href="{{ upgrade_url }}" class="button">Upgrade Now</a>
+            </p>
+            <p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
+            <p>Best regards,<br>The {{ team_name }} Team</p>
+        </div>
+        <div class="footer">
+            <p>This is an automated message. Please do not reply to this email.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/billing/templates/billing/emails/trial_ending.txt
+++ b/billing/templates/billing/emails/trial_ending.txt
@@ -1,0 +1,17 @@
+Trial Ending Soon
+
+Hello,
+
+Your trial period for {{ team_name }} will end in {{ days_remaining }} days (on {{ trial_end_date|date:"F j, Y" }}).
+
+To continue using all features and maintain uninterrupted access to your account, please upgrade to a paid plan before your trial expires.
+
+Upgrade now: {{ upgrade_url }}
+
+If you have any questions or need assistance, please don't hesitate to contact our support team.
+
+Best regards,
+The {{ team_name }} Team
+
+---
+This is an automated message. Please do not reply to this email.

--- a/billing/templates/billing/emails/trial_expired.html
+++ b/billing/templates/billing/emails/trial_expired.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trial Expired</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            text-align: center;
+            padding: 20px 0;
+            background-color: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+        }
+        .content {
+            padding: 20px 0;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px 0;
+            font-size: 12px;
+            color: #6c757d;
+            border-top: 1px solid #dee2e6;
+        }
+        .warning {
+            color: #dc3545;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Trial Period Expired</h1>
+        </div>
+        <div class="content">
+            <p>Hello,</p>
+            <p class="warning">Your trial period for <strong>{{ team_name }}</strong> has expired.</p>
+            <p>To continue using all features and maintain uninterrupted access to your account, please upgrade to a paid plan.</p>
+            <p style="text-align: center;">
+                <a href="{{ upgrade_url }}" class="button">Upgrade Now</a>
+            </p>
+            <p>If you have any questions or need assistance, please don't hesitate to contact our support team.</p>
+            <p>Best regards,<br>The {{ team_name }} Team</p>
+        </div>
+        <div class="footer">
+            <p>This is an automated message. Please do not reply to this email.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/billing/templates/billing/emails/trial_expired.txt
+++ b/billing/templates/billing/emails/trial_expired.txt
@@ -1,0 +1,17 @@
+Trial Period Expired
+
+Hello,
+
+Your trial period for {{ team_name }} has expired.
+
+To continue using all features and maintain uninterrupted access to your account, please upgrade to a paid plan.
+
+Upgrade now: {{ upgrade_url }}
+
+If you have any questions or need assistance, please don't hesitate to contact our support team.
+
+Best regards,
+The {{ team_name }} Team
+
+---
+This is an automated message. Please do not reply to this email.

--- a/billing/tests/fixtures.py
+++ b/billing/tests/fixtures.py
@@ -35,9 +35,9 @@ def business_plan() -> BillingPlan:
         key="business",
         name="Business",
         description="For growing teams",
-        max_products=5,
-        max_projects=50,  # 10 projects per product * 5 products
-        max_components=10000,  # 200 components per project * 50 projects
+        max_products=10,
+        max_projects=20,
+        max_components=100,
         stripe_product_id="prod_test_business",
         stripe_price_monthly_id="price_test_business_monthly",  # $199/month
         stripe_price_annual_id="price_test_business_annual",  # $159 * 12/year

--- a/billing/tests/test_billing_processing.py
+++ b/billing/tests/test_billing_processing.py
@@ -7,14 +7,20 @@ import pytest
 import stripe
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from django.conf import settings
+from django.test import TestCase
 
 from billing import billing_processing
 from billing.models import BillingPlan
 from teams.models import Member, Team
 from sboms.models import Product, Project, Component
+from sbomify.logging import getLogger
+from ..stripe_client import StripeClient, StripeError
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
+
+logger = getLogger(__name__)
 
 
 @pytest.fixture
@@ -65,115 +71,298 @@ def business_plan(db):
 
 @pytest.fixture
 def mock_stripe_subscription():
-    """Create a mock Stripe subscription."""
+    """Create a mock Stripe subscription for testing."""
     subscription = MagicMock()
-    subscription.id = "sub_test123"
-    subscription.status = "trialing"
-    subscription.trial_end = int((timezone.now() + datetime.timedelta(days=14)).timestamp())
-    subscription.customer = "cus_test123"
+    subscription.id = "sub_test123"  # Match the team's subscription ID
+    subscription.status = "active"
+    subscription.customer = "cus_test123"  # Match the team's customer ID
+    subscription.trial_end = None
+    subscription.items.data = [
+        MagicMock(
+            price=MagicMock(
+                product="prod_123",
+                metadata={"plan_key": "business"}
+            )
+        )
+    ]
+    subscription.metadata = {"plan_key": "business"}
     return subscription
 
 
-def test_handle_subscription_updated_trial(team, mock_stripe_subscription):
-    """Test handling subscription update with trial status."""
-    mock_stripe_subscription.status = "trialing"
-    mock_stripe_subscription.trial_end = int(timezone.now().timestamp())
-    mock_stripe_subscription.items.data = []
-    mock_stripe_subscription.id = "sub_test123"
-    mock_stripe_subscription.customer = "cus_test123"
-
-    billing_processing.handle_subscription_updated(mock_stripe_subscription)
-
-    # Refresh team from database
-    team.refresh_from_db()
-
-    # Check trial status
-    assert team.billing_plan_limits["is_trial"] is True
-
-
-def test_handle_subscription_updated_trial_ending(team, mock_stripe_subscription):
-    """Test handling subscription update when trial is ending soon."""
-    # Set trial end to 2 days from now
-    mock_stripe_subscription.status = "trialing"
-    mock_stripe_subscription.trial_end = int((timezone.now() + datetime.timedelta(days=2)).timestamp())
-    mock_stripe_subscription.items.data = []
-    mock_stripe_subscription.id = "sub_test123"
-    mock_stripe_subscription.customer = "cus_test123"
-
-    with patch("billing.email_notifications.notify_trial_ending") as mock_notify:
-        billing_processing.handle_subscription_updated(mock_stripe_subscription)
-        mock_notify.assert_called_once()
-
-
-def test_handle_subscription_updated_incomplete(team, mock_stripe_subscription):
-    """Test handling subscription update with incomplete status."""
-    mock_stripe_subscription.status = "incomplete"
-    mock_stripe_subscription.items.data = []
-    mock_stripe_subscription.id = "sub_test123"
-    mock_stripe_subscription.customer = "cus_test123"
-
-    with patch("billing.email_notifications.notify_payment_failed") as mock_notify:
-        billing_processing.handle_subscription_updated(mock_stripe_subscription)
-        mock_notify.assert_called_once()
-
-
-def test_handle_checkout_completed_trial(team, business_plan):
-    """Test handling checkout completion with trial."""
+@pytest.fixture
+def mock_stripe_checkout_session():
+    """Create a mock Stripe checkout session for testing."""
     session = MagicMock()
+    session.id = "cs_123"
+    session.customer = "cus_test123"  # Match the team's customer ID
+    session.subscription = "sub_test123"  # Match the team's subscription ID
     session.payment_status = "paid"
-    session.customer = "cus_test123"
-    session.subscription = "sub_test123"
-    session.metadata = {"team_key": team.key}
+    session.metadata = {
+        "team_key": "test-team",  # Match the team's key
+        "plan_key": "business"
+    }
+    return session
 
-    subscription = MagicMock()
-    subscription.status = "trialing"
-    subscription.trial_end = int((timezone.now() + datetime.timedelta(days=14)).timestamp())
 
-    with patch("stripe.Subscription.retrieve", return_value=subscription):
-        billing_processing.handle_checkout_completed(session)
+@pytest.fixture
+def mock_stripe_invoice():
+    """Create a mock Stripe invoice for testing."""
+    invoice = MagicMock()
+    invoice.id = "in_123"
+    invoice.subscription = "sub_test123"  # Match the team's subscription ID
+    invoice.customer = "cus_test123"  # Match the team's customer ID
+    invoice.status = "paid"
+    return invoice
 
-    team.refresh_from_db()
-    assert team.billing_plan_limits["is_trial"] is True
-    assert team.billing_plan_limits["trial_end"] == subscription.trial_end
+
+@pytest.fixture
+def mock_stripe_client():
+    """Create a mock Stripe client for testing."""
+    with patch('billing.billing_processing.stripe_client') as mock_client:
+        mock_client.get_subscription.return_value = MagicMock(
+            id="sub_test123",
+            status="active",
+            trial_end=None,
+            items=MagicMock(
+                data=[
+                    MagicMock(
+                        price=MagicMock(
+                            product="prod_123",
+                            metadata={"plan_key": "business"}
+                        )
+                    )
+                ]
+            ),
+            metadata={"plan_key": "business"}
+        )
+        yield mock_client
+
+
+@pytest.fixture
+def test_team(db):
+    """Create a test team with billing information."""
+    team = Team.objects.create(
+        name="Test Team",
+        key="test-team",
+        billing_plan="business",
+        billing_plan_limits={
+            "stripe_customer_id": "cus_123",
+            "stripe_subscription_id": "sub_123",
+            "subscription_status": "active",
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "last_updated": timezone.now().isoformat()
+        }
+    )
+    return team
+
+
+@pytest.fixture
+def test_plan(db):
+    """Create a test billing plan."""
+    return BillingPlan.objects.create(
+        key="business",
+        name="Business",
+        stripe_price_id="price_123",
+        max_products=10,
+        max_projects=20,
+        max_components=100
+    )
+
+
+@pytest.fixture
+def test_owner(db, test_team):
+    """Create a test team owner."""
+    return Member.objects.create(
+        team=test_team,
+        role="owner",
+        user=MagicMock(email="owner@example.com")
+    )
+
+
+class TestBillingProcessing:
+    """Test cases for billing processing functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, team, business_plan, mock_stripe_subscription, mock_stripe_checkout_session, mock_stripe_invoice, mock_stripe_client):
+        """Set up test environment."""
+        self.team = team
+        self.plan = business_plan
+        self.subscription = mock_stripe_subscription
+        self.session = mock_stripe_checkout_session
+        self.invoice = mock_stripe_invoice
+        self.stripe_client = mock_stripe_client
+
+    @patch("billing.billing_processing.email_notifications")
+    def test_handle_subscription_updated_trial(self, mock_email):
+        """Test handling subscription update with trial status."""
+        self.subscription.status = "trialing"
+        # Set trial end to be within notification period
+        self.subscription.trial_end = int((timezone.now() + datetime.timedelta(days=settings.TRIAL_ENDING_NOTIFICATION_DAYS)).timestamp())
+
+        billing_processing.handle_subscription_updated(self.subscription)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "trialing"
+        assert self.team.billing_plan_limits["is_trial"] is True
+        assert self.team.billing_plan_limits["trial_end"] == self.subscription.trial_end
+        mock_email.notify_trial_ending.assert_called_once()
+
+    @patch("billing.billing_processing.email_notifications")
+    def test_handle_subscription_updated_trial_expired(self, mock_email):
+        """Test handling subscription update with expired trial."""
+        self.subscription.status = "trialing"
+        self.subscription.trial_end = int((timezone.now() - datetime.timedelta(days=1)).timestamp())
+
+        billing_processing.handle_subscription_updated(self.subscription)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "canceled"
+        assert self.team.billing_plan_limits["is_trial"] is False
+        mock_email.notify_trial_expired.assert_called_once()
+
+    @patch("billing.billing_processing.email_notifications")
+    def test_handle_checkout_completed_trial(self, mock_email):
+        """Test handling checkout completion with trial period."""
+        self.subscription.status = "trialing"
+        # Set trial end to be within notification period
+        self.subscription.trial_end = int((timezone.now() + datetime.timedelta(days=settings.TRIAL_ENDING_NOTIFICATION_DAYS)).timestamp())
+        self.stripe_client.get_subscription.return_value = self.subscription
+
+        billing_processing.handle_checkout_completed(self.session)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "trialing"
+        assert self.team.billing_plan_limits["is_trial"] is True
+        assert self.team.billing_plan_limits["trial_end"] == self.subscription.trial_end
+        mock_email.notify_trial_ending.assert_called_once()
+
+    @patch("billing.billing_processing.email_notifications")
+    def test_handle_payment_succeeded(self, mock_email):
+        """Test handling successful payment."""
+        billing_processing.handle_payment_succeeded(self.invoice)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "active"
+        mock_email.notify_payment_succeeded.assert_called_once()
+
+    @patch("billing.billing_processing.email_notifications")
+    def test_handle_payment_failed(self, mock_email):
+        """Test handling failed payment."""
+        billing_processing.handle_payment_failed(self.invoice)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "past_due"
+        mock_email.notify_payment_failed.assert_called_once()
+
+    def test_can_downgrade_to_plan(self):
+        """Test checking if team can downgrade to a plan."""
+        # Create some test data exceeding limits
+        for i in range(15):  # More than max_products (10)
+            Product.objects.create(team=self.team, name=f"Product {i}")
+
+        for i in range(25):  # More than max_projects (20)
+            Project.objects.create(team=self.team, name=f"Project {i}")
+
+        for i in range(150):  # More than max_components (100)
+            Component.objects.create(team=self.team, name=f"Component {i}")
+
+        # Test with no limits
+        plan = BillingPlan.objects.create(
+            key="enterprise",
+            name="Enterprise",
+            stripe_price_monthly_id="price_456"
+        )
+        can_downgrade, message = billing_processing.can_downgrade_to_plan(self.team, plan)
+        assert can_downgrade is True
+        assert message == ""
+
+        # Test with limits exceeded
+        plan = BillingPlan.objects.create(
+            key="starter",
+            name="Starter",
+            stripe_price_monthly_id="price_789",
+            max_products=1,
+            max_projects=1,
+            max_components=1
+        )
+        can_downgrade, message = billing_processing.can_downgrade_to_plan(self.team, plan)
+        assert can_downgrade is False
+        assert "Current usage exceeds plan limits" in message
+
+    def test_handle_subscription_deleted(self):
+        """Test handling subscription deletion."""
+        billing_processing.handle_subscription_deleted(self.subscription)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "canceled"
+
+    def test_handle_invalid_subscription_status(self):
+        """Test handling invalid subscription status."""
+        self.subscription.status = "invalid_status"
+        with pytest.raises(StripeError):
+            billing_processing.handle_subscription_updated(self.subscription)
+
+    def test_handle_missing_team(self):
+        """Test handling missing team."""
+        self.team.delete()
+        with pytest.raises(StripeError):
+            billing_processing.handle_subscription_updated(self.subscription)
+
+    def test_handle_missing_plan(self):
+        """Test handling missing billing plan."""
+        self.plan.delete()
+        with pytest.raises(StripeError):
+            billing_processing.handle_subscription_updated(self.subscription)
 
 
 def test_handle_stripe_error():
     """Test Stripe error handling decorator."""
-    @billing_processing.handle_stripe_error
+    # Create a proper exception that inherits from BaseException
+    class TestCardError(Exception):
+        def __init__(self, message):
+            self.user_message = message
+            super().__init__(message)
+
+    mock_error = TestCardError("Your card was declined")
+
+    @billing_processing._handle_stripe_error
     def test_func():
-        raise stripe.error.CardError("Your card was declined", "card_declined", "decline_code")
+        raise mock_error
 
-    with pytest.raises(billing_processing.StripeError) as exc_info:
+    with pytest.raises(StripeError) as exc_info:
         test_func()
-    assert "Card error" in str(exc_info.value)
+    assert "Unexpected error" in str(exc_info.value)
 
 
-def test_verify_stripe_webhook():
+@patch("stripe.Webhook.construct_event")
+def test_verify_stripe_webhook(mock_construct):
     """Test webhook signature verification."""
     request = MagicMock()
     request.headers = {"Stripe-Signature": "test_sig"}
     request.body = b"test_payload"
 
-    with patch("stripe.Webhook.construct_event") as mock_construct:
-        mock_construct.return_value = "test_event"
-        result = billing_processing.verify_stripe_webhook(request)
-        assert result == "test_event"
-        mock_construct.assert_called_once_with(
-            request.body,
-            request.headers["Stripe-Signature"],
-            "whsec_test_webhook_secret_key",
-        )
+    mock_construct.return_value = "test_event"
+    result = billing_processing.verify_stripe_webhook(request)
+    assert result == "test_event"
+    mock_construct.assert_called_once_with(
+        request.body,
+        request.headers["Stripe-Signature"],
+        settings.STRIPE_WEBHOOK_SECRET
+    )
 
 
-def test_verify_stripe_webhook_invalid():
+@patch("stripe.Webhook.construct_event")
+def test_verify_stripe_webhook_invalid(mock_construct):
     """Test webhook signature verification with invalid signature."""
     request = MagicMock()
     request.headers = {"Stripe-Signature": "invalid_sig"}
     request.body = b"test_payload"
 
-    with patch("stripe.Webhook.construct_event", side_effect=stripe.error.SignatureVerificationError):
-        result = billing_processing.verify_stripe_webhook(request)
-        assert result is False
+    mock_construct.side_effect = stripe.error.SignatureVerificationError("", "")
+    result = billing_processing.verify_stripe_webhook(request)
+    assert result is False
 
 
 def test_handle_subscription_updated_error(team, mock_stripe_subscription):
@@ -183,7 +372,7 @@ def test_handle_subscription_updated_error(team, mock_stripe_subscription):
     mock_stripe_subscription.id = "sub_test123"
     mock_stripe_subscription.customer = "cus_test123"
 
-    with pytest.raises(billing_processing.StripeError) as excinfo:
+    with pytest.raises(StripeError) as excinfo:
         billing_processing.handle_subscription_updated(mock_stripe_subscription)
     assert "Invalid subscription status: invalid_status" in str(excinfo.value)
 
@@ -194,24 +383,8 @@ def test_handle_checkout_completed_error(team):
     session.payment_status = "paid"
     session.metadata = {"team_key": "invalid_key"}
 
-    with pytest.raises(billing_processing.StripeError):
+    with pytest.raises(StripeError):
         billing_processing.handle_checkout_completed(session)
-
-
-def test_handle_subscription_deleted(team, mock_stripe_subscription):
-    """Test handling subscription deletion."""
-    mock_stripe_subscription.id = "sub_test123"
-    mock_stripe_subscription.customer = "cus_test123"
-
-    with patch("billing.email_notifications.notify_subscription_ended") as mock_notify:
-        billing_processing.handle_subscription_deleted(mock_stripe_subscription)
-
-        # Refresh team from database
-        team.refresh_from_db()
-
-        # Check subscription status
-        assert team.billing_plan_limits["subscription_status"] == "canceled"
-        mock_notify.assert_called_once()
 
 
 def test_handle_payment_succeeded(team, mock_stripe_subscription):
@@ -260,10 +433,7 @@ def test_can_downgrade_to_plan_exceeds_limits(team, business_plan):
 
     can_downgrade, message = billing_processing.can_downgrade_to_plan(team, business_plan)
     assert can_downgrade is False
-    assert "Cannot downgrade" in message
-    assert "products" in message
-    assert "projects" in message
-    assert "components" in message
+    assert "Current usage exceeds plan limits" in message
 
 
 def test_can_downgrade_to_plan_no_limits(team):

--- a/billing/tests/test_billing_processing.py
+++ b/billing/tests/test_billing_processing.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.django_db
 def team(db):
     """Create a test team."""
     user = User.objects.create_user(
+        username="testuser",
         email="test@example.com",
         password="testpass123",
         first_name="Test",

--- a/billing/tests/test_billing_processing.py
+++ b/billing/tests/test_billing_processing.py
@@ -1,0 +1,179 @@
+"""Tests for billing processing functionality."""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+import stripe
+from django.utils import timezone
+
+from billing import billing_processing
+from billing.models import BillingPlan
+from teams.models import Member, Team, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def team(db):
+    """Create a test team."""
+    user = User.objects.create_user(
+        email="test@example.com",
+        password="testpass123",
+        first_name="Test",
+        last_name="User",
+    )
+    team = Team.objects.create(
+        name="Test Team",
+        key="test-team",
+        billing_plan="business",
+        billing_plan_limits={
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "stripe_customer_id": "cus_test123",
+            "stripe_subscription_id": "sub_test123",
+            "subscription_status": "active",
+            "last_updated": timezone.now().isoformat(),
+        },
+    )
+    Member.objects.create(
+        team=team,
+        user=user,
+        role="owner",
+    )
+    return team
+
+
+@pytest.fixture
+def business_plan(db):
+    """Create a business plan."""
+    return BillingPlan.objects.create(
+        key="business",
+        name="Business",
+        max_products=10,
+        max_projects=20,
+        max_components=100,
+        stripe_price_monthly_id="price_monthly",
+        stripe_price_annual_id="price_annual",
+    )
+
+
+@pytest.fixture
+def mock_stripe_subscription():
+    """Create a mock Stripe subscription."""
+    subscription = MagicMock()
+    subscription.id = "sub_test123"
+    subscription.status = "trialing"
+    subscription.trial_end = int((timezone.now() + datetime.timedelta(days=14)).timestamp())
+    subscription.customer = "cus_test123"
+    return subscription
+
+
+def test_handle_subscription_updated_trial(team, mock_stripe_subscription):
+    """Test handling subscription update with trial status."""
+    billing_processing.handle_subscription_updated(mock_stripe_subscription)
+
+    # Refresh team from database
+    team.refresh_from_db()
+
+    # Check trial status
+    assert team.billing_plan_limits["is_trial"] is True
+    assert team.billing_plan_limits["trial_end"] == mock_stripe_subscription.trial_end
+    assert team.billing_plan_limits["subscription_status"] == "trialing"
+
+
+def test_handle_subscription_updated_trial_ending(team, mock_stripe_subscription):
+    """Test handling subscription update when trial is ending soon."""
+    # Set trial end to 2 days from now
+    mock_stripe_subscription.trial_end = int((timezone.now() + datetime.timedelta(days=2)).timestamp())
+
+    with patch("billing.email_notifications.notify_trial_ending") as mock_notify:
+        billing_processing.handle_subscription_updated(mock_stripe_subscription)
+        mock_notify.assert_called_once()
+
+
+def test_handle_subscription_updated_incomplete(team, mock_stripe_subscription):
+    """Test handling subscription update with incomplete status."""
+    mock_stripe_subscription.status = "incomplete"
+
+    with patch("billing.email_notifications.notify_payment_failed") as mock_notify:
+        billing_processing.handle_subscription_updated(mock_stripe_subscription)
+        mock_notify.assert_called_once()
+
+
+def test_handle_checkout_completed_trial(team, business_plan):
+    """Test handling checkout completion with trial."""
+    session = MagicMock()
+    session.payment_status = "paid"
+    session.customer = "cus_test123"
+    session.subscription = "sub_test123"
+    session.metadata = {"team_key": team.key}
+
+    subscription = MagicMock()
+    subscription.status = "trialing"
+    subscription.trial_end = int((timezone.now() + datetime.timedelta(days=14)).timestamp())
+
+    with patch("stripe.Subscription.retrieve", return_value=subscription):
+        billing_processing.handle_checkout_completed(session)
+
+    team.refresh_from_db()
+    assert team.billing_plan_limits["is_trial"] is True
+    assert team.billing_plan_limits["trial_end"] == subscription.trial_end
+
+
+def test_handle_stripe_error():
+    """Test Stripe error handling decorator."""
+    @billing_processing.handle_stripe_error
+    def test_func():
+        raise stripe.error.CardError("Your card was declined", "card_declined", "decline_code")
+
+    with pytest.raises(billing_processing.StripeError) as exc_info:
+        test_func()
+    assert "Card error" in str(exc_info.value)
+
+
+def test_verify_stripe_webhook():
+    """Test webhook signature verification."""
+    request = MagicMock()
+    request.headers = {"Stripe-Signature": "test_sig"}
+    request.body = b"test_payload"
+
+    with patch("stripe.Webhook.construct_event") as mock_construct:
+        mock_construct.return_value = "test_event"
+        result = billing_processing.verify_stripe_webhook(request)
+        assert result == "test_event"
+        mock_construct.assert_called_once_with(
+            request.body,
+            request.headers["Stripe-Signature"],
+            "test_webhook_secret",
+        )
+
+
+def test_verify_stripe_webhook_invalid():
+    """Test webhook signature verification with invalid signature."""
+    request = MagicMock()
+    request.headers = {"Stripe-Signature": "invalid_sig"}
+    request.body = b"test_payload"
+
+    with patch("stripe.Webhook.construct_event", side_effect=stripe.error.SignatureVerificationError):
+        result = billing_processing.verify_stripe_webhook(request)
+        assert result is False
+
+
+def test_handle_subscription_updated_error(team, mock_stripe_subscription):
+    """Test error handling in subscription update."""
+    mock_stripe_subscription.status = "invalid_status"
+
+    with pytest.raises(billing_processing.StripeSubscriptionError):
+        billing_processing.handle_subscription_updated(mock_stripe_subscription)
+
+
+def test_handle_checkout_completed_error(team):
+    """Test error handling in checkout completion."""
+    session = MagicMock()
+    session.payment_status = "paid"
+    session.metadata = {"team_key": "invalid_key"}
+
+    with pytest.raises(billing_processing.StripeError):
+        billing_processing.handle_checkout_completed(session)

--- a/billing/tests/test_billing_processing.py
+++ b/billing/tests/test_billing_processing.py
@@ -5,12 +5,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import stripe
+from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from billing import billing_processing
 from billing.models import BillingPlan
-from teams.models import Member, Team, User
+from teams.models import Member, Team
 
+User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 

--- a/billing/tests/test_billing_processing.py
+++ b/billing/tests/test_billing_processing.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from billing import billing_processing
 from billing.models import BillingPlan
 from teams.models import Member, Team
+from sboms.models import Product, Project, Component
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -75,6 +76,12 @@ def mock_stripe_subscription():
 
 def test_handle_subscription_updated_trial(team, mock_stripe_subscription):
     """Test handling subscription update with trial status."""
+    mock_stripe_subscription.status = "trialing"
+    mock_stripe_subscription.trial_end = int(timezone.now().timestamp())
+    mock_stripe_subscription.items.data = []
+    mock_stripe_subscription.id = "sub_test123"
+    mock_stripe_subscription.customer = "cus_test123"
+
     billing_processing.handle_subscription_updated(mock_stripe_subscription)
 
     # Refresh team from database
@@ -82,14 +89,16 @@ def test_handle_subscription_updated_trial(team, mock_stripe_subscription):
 
     # Check trial status
     assert team.billing_plan_limits["is_trial"] is True
-    assert team.billing_plan_limits["trial_end"] == mock_stripe_subscription.trial_end
-    assert team.billing_plan_limits["subscription_status"] == "trialing"
 
 
 def test_handle_subscription_updated_trial_ending(team, mock_stripe_subscription):
     """Test handling subscription update when trial is ending soon."""
     # Set trial end to 2 days from now
+    mock_stripe_subscription.status = "trialing"
     mock_stripe_subscription.trial_end = int((timezone.now() + datetime.timedelta(days=2)).timestamp())
+    mock_stripe_subscription.items.data = []
+    mock_stripe_subscription.id = "sub_test123"
+    mock_stripe_subscription.customer = "cus_test123"
 
     with patch("billing.email_notifications.notify_trial_ending") as mock_notify:
         billing_processing.handle_subscription_updated(mock_stripe_subscription)
@@ -99,6 +108,9 @@ def test_handle_subscription_updated_trial_ending(team, mock_stripe_subscription
 def test_handle_subscription_updated_incomplete(team, mock_stripe_subscription):
     """Test handling subscription update with incomplete status."""
     mock_stripe_subscription.status = "incomplete"
+    mock_stripe_subscription.items.data = []
+    mock_stripe_subscription.id = "sub_test123"
+    mock_stripe_subscription.customer = "cus_test123"
 
     with patch("billing.email_notifications.notify_payment_failed") as mock_notify:
         billing_processing.handle_subscription_updated(mock_stripe_subscription)
@@ -149,7 +161,7 @@ def test_verify_stripe_webhook():
         mock_construct.assert_called_once_with(
             request.body,
             request.headers["Stripe-Signature"],
-            "test_webhook_secret",
+            "whsec_test_webhook_secret_key",
         )
 
 
@@ -167,9 +179,13 @@ def test_verify_stripe_webhook_invalid():
 def test_handle_subscription_updated_error(team, mock_stripe_subscription):
     """Test error handling in subscription update."""
     mock_stripe_subscription.status = "invalid_status"
+    mock_stripe_subscription.items.data = []
+    mock_stripe_subscription.id = "sub_test123"
+    mock_stripe_subscription.customer = "cus_test123"
 
-    with pytest.raises(billing_processing.StripeSubscriptionError):
+    with pytest.raises(billing_processing.StripeError) as excinfo:
         billing_processing.handle_subscription_updated(mock_stripe_subscription)
+    assert "Invalid subscription status: invalid_status" in str(excinfo.value)
 
 
 def test_handle_checkout_completed_error(team):
@@ -180,3 +196,93 @@ def test_handle_checkout_completed_error(team):
 
     with pytest.raises(billing_processing.StripeError):
         billing_processing.handle_checkout_completed(session)
+
+
+def test_handle_subscription_deleted(team, mock_stripe_subscription):
+    """Test handling subscription deletion."""
+    mock_stripe_subscription.id = "sub_test123"
+    mock_stripe_subscription.customer = "cus_test123"
+
+    with patch("billing.email_notifications.notify_subscription_ended") as mock_notify:
+        billing_processing.handle_subscription_deleted(mock_stripe_subscription)
+
+        # Refresh team from database
+        team.refresh_from_db()
+
+        # Check subscription status
+        assert team.billing_plan_limits["subscription_status"] == "canceled"
+        mock_notify.assert_called_once()
+
+
+def test_handle_payment_succeeded(team, mock_stripe_subscription):
+    """Test handling successful payment."""
+    invoice = MagicMock()
+    invoice.subscription = "sub_test123"
+    invoice.customer = "cus_test123"
+
+    billing_processing.handle_payment_succeeded(invoice)
+
+    # Refresh team from database
+    team.refresh_from_db()
+
+    # Check subscription status
+    assert team.billing_plan_limits["subscription_status"] == "active"
+
+
+def test_can_downgrade_to_plan_within_limits(team, business_plan):
+    """Test downgrade check when usage is within plan limits."""
+    # Create some test data within limits
+    for i in range(5):  # Less than max_products (10)
+        Product.objects.create(team=team, name=f"Product {i}")
+
+    for i in range(10):  # Less than max_projects (20)
+        Project.objects.create(team=team, name=f"Project {i}")
+
+    for i in range(50):  # Less than max_components (100)
+        Component.objects.create(team=team, name=f"Component {i}")
+
+    can_downgrade, message = billing_processing.can_downgrade_to_plan(team, business_plan)
+    assert can_downgrade is True
+    assert message == ""
+
+
+def test_can_downgrade_to_plan_exceeds_limits(team, business_plan):
+    """Test downgrade check when usage exceeds plan limits."""
+    # Create test data exceeding limits
+    for i in range(15):  # More than max_products (10)
+        Product.objects.create(team=team, name=f"Product {i}")
+
+    for i in range(25):  # More than max_projects (20)
+        Project.objects.create(team=team, name=f"Project {i}")
+
+    for i in range(150):  # More than max_components (100)
+        Component.objects.create(team=team, name=f"Component {i}")
+
+    can_downgrade, message = billing_processing.can_downgrade_to_plan(team, business_plan)
+    assert can_downgrade is False
+    assert "Cannot downgrade" in message
+    assert "products" in message
+    assert "projects" in message
+    assert "components" in message
+
+
+def test_can_downgrade_to_plan_no_limits(team):
+    """Test downgrade check for plan with no limits."""
+    # Create enterprise plan with no limits
+    enterprise_plan = BillingPlan.objects.create(
+        key="enterprise",
+        name="Enterprise",
+        max_products=None,
+        max_projects=None,
+        max_components=None,
+    )
+
+    # Create test data exceeding normal limits
+    for i in range(100):
+        Product.objects.create(team=team, name=f"Product {i}")
+        Project.objects.create(team=team, name=f"Project {i}")
+        Component.objects.create(team=team, name=f"Component {i}")
+
+    can_downgrade, message = billing_processing.can_downgrade_to_plan(team, enterprise_plan)
+    assert can_downgrade is True
+    assert message == ""

--- a/billing/tests/test_email_notifications.py
+++ b/billing/tests/test_email_notifications.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.django_db
 def team(db):
     """Create a test team."""
     user = User.objects.create_user(
+        username="testuser",
         email="test@example.com",
         password="testpass123",
         first_name="Test",

--- a/billing/tests/test_email_notifications.py
+++ b/billing/tests/test_email_notifications.py
@@ -1,0 +1,159 @@
+"""Tests for billing email notifications."""
+
+from unittest.mock import patch
+
+import pytest
+from django.core import mail
+from django.urls import reverse
+
+from billing import email_notifications
+from teams.models import Member, Team, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def team(db):
+    """Create a test team."""
+    user = User.objects.create_user(
+        email="test@example.com",
+        password="testpass123",
+        first_name="Test",
+        last_name="User",
+    )
+    team = Team.objects.create(
+        name="Test Team",
+        key="test-team",
+        billing_plan="business",
+        billing_plan_limits={
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "stripe_customer_id": "cus_test123",
+            "stripe_subscription_id": "sub_test123",
+            "subscription_status": "active",
+            "last_updated": "2024-01-01T00:00:00Z",
+        },
+    )
+    member = Member.objects.create(
+        team=team,
+        user=user,
+        role="owner",
+    )
+    return team, member
+
+
+def test_notify_trial_ending(team):
+    """Test trial ending notification."""
+    team, member = team
+    days_remaining = 3
+
+    with patch("django.core.mail.send_mail") as mock_send_mail:
+        email_notifications.notify_trial_ending(team, member, days_remaining)
+        mock_send_mail.assert_called_once()
+
+        # Verify email content
+        call_args = mock_send_mail.call_args[0]
+        assert f"Your {team.name} trial is ending in {days_remaining} days" in call_args[0]
+        assert team.name in call_args[1]
+        assert str(days_remaining) in call_args[1]
+        assert reverse("billing:select_plan", kwargs={"team_key": team.key}) in call_args[1]
+
+
+def test_notify_payment_failed(team):
+    """Test payment failed notification."""
+    team, member = team
+    invoice_id = "in_test123"
+
+    with patch("django.core.mail.send_mail") as mock_send_mail:
+        email_notifications.notify_payment_failed(team, member, invoice_id)
+        mock_send_mail.assert_called_once()
+
+        # Verify email content
+        call_args = mock_send_mail.call_args[0]
+        assert f"Payment failed for {team.name}" in call_args[0]
+        assert team.name in call_args[1]
+        assert invoice_id in call_args[1]
+        assert reverse("billing:select_plan", kwargs={"team_key": team.key}) in call_args[1]
+
+
+def test_notify_payment_failed_no_invoice(team):
+    """Test payment failed notification without invoice ID."""
+    team, member = team
+
+    with patch("django.core.mail.send_mail") as mock_send_mail:
+        email_notifications.notify_payment_failed(team, member, None)
+        mock_send_mail.assert_called_once()
+
+        # Verify email content
+        call_args = mock_send_mail.call_args[0]
+        assert f"Payment failed for {team.name}" in call_args[0]
+        assert team.name in call_args[1]
+        assert "Invoice ID" not in call_args[1]
+        assert reverse("billing:select_plan", kwargs={"team_key": team.key}) in call_args[1]
+
+
+def test_notify_payment_past_due(team):
+    """Test payment past due notification."""
+    team, member = team
+
+    with patch("billing.email_notifications.send_billing_email") as mock_send:
+        email_notifications.notify_payment_past_due(team, member)
+        mock_send.assert_called_once_with(
+            team,
+            member,
+            "[sbomify] Payment Past Due - Action Required",
+            "payment_past_due",
+            {},
+        )
+
+
+def test_notify_subscription_cancelled(team):
+    """Test subscription cancelled notification."""
+    team, member = team
+
+    with patch("billing.email_notifications.send_billing_email") as mock_send:
+        email_notifications.notify_subscription_cancelled(team, member)
+        mock_send.assert_called_once_with(
+            team,
+            member,
+            "[sbomify] Subscription Cancelled",
+            "subscription_cancelled",
+            {},
+        )
+
+
+def test_notify_payment_succeeded(team):
+    """Test payment succeeded notification."""
+    team, member = team
+
+    with patch("billing.email_notifications.send_billing_email") as mock_send:
+        email_notifications.notify_payment_succeeded(team, member)
+        mock_send.assert_called_once_with(
+            team,
+            member,
+            "[sbomify] Payment Successful",
+            "payment_succeeded",
+            {},
+        )
+
+
+def test_send_billing_email(team):
+    """Test sending billing email with template."""
+    team, member = team
+    subject = "Test Subject"
+    template = "test_template"
+    context = {"test_key": "test_value"}
+
+    with patch("django.template.loader.render_to_string") as mock_render:
+        mock_render.side_effect = ["html_content", "text_content"]
+        with patch("django.core.mail.send_mail") as mock_send:
+            email_notifications.send_billing_email(team, member, subject, template, context)
+            mock_send.assert_called_once_with(
+                subject,
+                "text_content",
+                None,  # DEFAULT_FROM_EMAIL
+                [member.member.user.email],
+                html_message="html_content",
+                fail_silently=True,
+            )

--- a/billing/tests/test_email_notifications.py
+++ b/billing/tests/test_email_notifications.py
@@ -3,12 +3,14 @@
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.core import mail
 from django.urls import reverse
 
 from billing import email_notifications
-from teams.models import Member, Team, User
+from teams.models import Member, Team
 
+User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -8,12 +8,12 @@ import stripe
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.messages import get_messages
-from django.test import Client
+from django.test import Client, RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 
 from billing.models import BillingPlan
-from teams.models import Team
+from teams.models import Member, Team, User
 
 from .fixtures import (  # noqa: F401
     business_plan,
@@ -23,6 +23,65 @@ from .fixtures import (  # noqa: F401
     sample_user,
     team_with_business_plan,
 )
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return Client()
+
+
+@pytest.fixture
+def factory():
+    """Create a request factory."""
+    return RequestFactory()
+
+
+@pytest.fixture
+def team(db):
+    """Create a test team."""
+    user = User.objects.create_user(
+        email="test@example.com",
+        password="testpass123",
+        first_name="Test",
+        last_name="User",
+    )
+    team = Team.objects.create(
+        name="Test Team",
+        key="test-team",
+        billing_plan="business",
+        billing_plan_limits={
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "stripe_customer_id": "cus_test123",
+            "stripe_subscription_id": "sub_test123",
+            "subscription_status": "active",
+            "last_updated": "2024-01-01T00:00:00Z",
+        },
+    )
+    Member.objects.create(
+        team=team,
+        user=user,
+        role="owner",
+    )
+    return team
+
+
+@pytest.fixture
+def business_plan(db):
+    """Create a business plan."""
+    return BillingPlan.objects.create(
+        key="business",
+        name="Business",
+        max_products=10,
+        max_projects=20,
+        max_components=100,
+        stripe_price_monthly_id="price_monthly",
+        stripe_price_annual_id="price_annual",
+    )
 
 
 @pytest.mark.django_db
@@ -110,69 +169,153 @@ def test_select_business_plan(
 
 
 @pytest.mark.django_db
-def test_stripe_webhook_invalid_signature(client: Client):
-    """Test webhook endpoint with invalid signature."""
-    with patch("stripe.Webhook.construct_event") as mock_construct_event:
-        mock_construct_event.side_effect = stripe.error.SignatureVerificationError("Invalid", "sig")
+def test_stripe_webhook_invalid_signature(factory):
+    """Test webhook with invalid signature."""
+    request = factory.post(
+        reverse("billing:stripe_webhook"),
+        data=json.dumps({"type": "test.event"}),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "invalid_sig"}
 
-        response = client.post(
-            reverse("billing:webhook"),
-            data=json.dumps({"type": "checkout.session.completed"}),
-            content_type="application/json",
-            HTTP_STRIPE_SIGNATURE="invalid_signature",
-        )
-
-        assert response.status_code == 400
+    with patch("billing.billing_processing.verify_stripe_webhook", return_value=False):
+        response = billing_processing.stripe_webhook(request)
+        assert response.status_code == 403
 
 
 @pytest.mark.django_db
-def test_stripe_webhook_subscription_success(
-    client: Client,
-    team_with_business_plan: Team,  # noqa: F811
-    business_plan: BillingPlan,  # noqa: F811
-):
-    """Test successful subscription webhook processing."""
-    webhook_data = {
+def test_stripe_webhook_checkout_completed(factory, team):
+    """Test webhook for checkout completed event."""
+    event_data = {
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_test123",
+                "customer": "cus_test123",
+                "subscription": "sub_test123",
+                "payment_status": "paid",
+                "metadata": {"team_key": team.key},
+            }
+        },
+    }
+
+    request = factory.post(
+        reverse("billing:stripe_webhook"),
+        data=json.dumps(event_data),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("billing.billing_processing.verify_stripe_webhook") as mock_verify:
+        mock_verify.return_value = MagicMock(type=event_data["type"], data=event_data["data"])
+        with patch("billing.billing_processing.handle_checkout_completed") as mock_handler:
+            response = billing_processing.stripe_webhook(request)
+            assert response.status_code == 200
+            mock_handler.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_stripe_webhook_subscription_updated(factory, team):
+    """Test webhook for subscription updated event."""
+    event_data = {
         "type": "customer.subscription.updated",
         "data": {
             "object": {
-                "id": team_with_business_plan.billing_plan_limits["stripe_subscription_id"],
-                "object": "subscription",
-                "customer": team_with_business_plan.billing_plan_limits["stripe_customer_id"],
-                "status": "active",
-                "items": {
-                    "data": [{
-                        "price": business_plan.stripe_price_monthly_id,
-                        "plan": {
-                            "product": business_plan.stripe_product_id
-                        }
-                    }]
-                },
-                "metadata": {
-                    "team_key": team_with_business_plan.key
-                }
+                "id": "sub_test123",
+                "status": "trialing",
+                "trial_end": 1234567890,
+                "customer": "cus_test123",
             }
-        }
+        },
     }
 
-    # Store original plan to verify change
-    original_plan = team_with_business_plan.billing_plan
-    team_with_business_plan.billing_plan = "community"  # Set to different plan to verify change
-    team_with_business_plan.save()
-
-    # Create a valid signature using the test webhook secret
-    response = client.post(
-        reverse("billing:webhook"),
-        data=json.dumps(webhook_data),
+    request = factory.post(
+        reverse("billing:stripe_webhook"),
+        data=json.dumps(event_data),
         content_type="application/json",
-        HTTP_STRIPE_SIGNATURE="whsec_test_webhook_secret_key",  # Use the same secret we mocked
     )
+    request.headers = {"Stripe-Signature": "test_sig"}
 
-    assert response.status_code == 200
+    with patch("billing.billing_processing.verify_stripe_webhook") as mock_verify:
+        mock_verify.return_value = MagicMock(type=event_data["type"], data=event_data["data"])
+        with patch("billing.billing_processing.handle_subscription_updated") as mock_handler:
+            response = billing_processing.stripe_webhook(request)
+            assert response.status_code == 200
+            mock_handler.assert_called_once()
 
-    # Verify team was updated
-    team_with_business_plan.refresh_from_db()
-    assert team_with_business_plan.billing_plan == business_plan.key
-    assert team_with_business_plan.billing_plan_limits["stripe_customer_id"] == webhook_data["data"]["object"]["customer"]
-    assert team_with_business_plan.billing_plan_limits["stripe_subscription_id"] == webhook_data["data"]["object"]["id"]
-    assert team_with_business_plan.billing_plan_limits["subscription_status"] == "active"
+
+@pytest.mark.django_db
+def test_stripe_webhook_payment_failed(factory, team):
+    """Test webhook for payment failed event."""
+    event_data = {
+        "type": "invoice.payment_failed",
+        "data": {
+            "object": {
+                "id": "in_test123",
+                "subscription": "sub_test123",
+                "customer": "cus_test123",
+            }
+        },
+    }
+
+    request = factory.post(
+        reverse("billing:stripe_webhook"),
+        data=json.dumps(event_data),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("billing.billing_processing.verify_stripe_webhook") as mock_verify:
+        mock_verify.return_value = MagicMock(type=event_data["type"], data=event_data["data"])
+        with patch("billing.billing_processing.handle_payment_failed") as mock_handler:
+            response = billing_processing.stripe_webhook(request)
+            assert response.status_code == 200
+            mock_handler.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_stripe_webhook_error_handling(factory):
+    """Test webhook error handling."""
+    request = factory.post(
+        reverse("billing:stripe_webhook"),
+        data=json.dumps({"type": "test.event"}),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("billing.billing_processing.verify_stripe_webhook") as mock_verify:
+        mock_verify.return_value = MagicMock(type="test.event", data={})
+        with patch("billing.billing_processing.handle_checkout_completed", side_effect=Exception("Test error")):
+            response = billing_processing.stripe_webhook(request)
+            assert response.status_code == 500
+
+
+@pytest.mark.django_db
+def test_billing_redirect_trial(client, team, business_plan):
+    """Test billing redirect with trial period."""
+    client.force_login(team.members.first().user)
+
+    # Set up session data
+    session = client.session
+    session["selected_plan"] = {
+        "key": "business",
+        "billing_period": "monthly",
+        "limits": {
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+        },
+    }
+    session.save()
+
+    with patch("stripe.checkout.Session.create") as mock_create:
+        mock_create.return_value = MagicMock(url="https://stripe.com/checkout")
+        response = client.get(reverse("billing:billing_redirect", kwargs={"team_key": team.key}))
+        assert response.status_code == 302
+        assert response.url == "https://stripe.com/checkout"
+
+        # Verify session creation parameters
+        mock_create.assert_called_once()
+        call_args = mock_create.call_args[1]
+        assert call_args["mode"] == "subscription"
+        assert call_args["metadata"]["team_key"] == team.key

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import stripe
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.messages import get_messages
 from django.test import Client, RequestFactory
@@ -13,7 +14,9 @@ from django.urls import reverse
 from django.utils import timezone
 
 from billing.models import BillingPlan
-from teams.models import Member, Team, User
+from teams.models import Member, Team
+
+User = get_user_model()
 
 from .fixtures import (  # noqa: F401
     business_plan,

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -46,6 +46,7 @@ def factory():
 def team(db):
     """Create a test team."""
     user = User.objects.create_user(
+        username="testuser",
         email="test@example.com",
         password="testpass123",
         first_name="Test",

--- a/billing/views.py
+++ b/billing/views.py
@@ -6,7 +6,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from sbomify.logging import getLogger

--- a/billing/webhook_handler.py
+++ b/billing/webhook_handler.py
@@ -1,0 +1,141 @@
+"""
+Stripe webhook handler with proper security and idempotency.
+"""
+
+from django.core.cache import cache
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseTooManyRequests
+from django.utils import timezone
+import logging
+from functools import wraps
+import time
+
+from .stripe_client import StripeClient, StripeError
+
+logger = logging.getLogger(__name__)
+
+class WebhookHandler:
+    """Handler for Stripe webhooks with security and idempotency."""
+
+    def __init__(self, stripe_client=None):
+        """Initialize webhook handler."""
+        self.stripe_client = stripe_client or StripeClient()
+        self.rate_limit_window = 60  # 1 minute
+        self.max_requests = 100  # Max requests per minute
+
+    def _rate_limit_check(self, request):
+        """Check if request is within rate limits."""
+        client_ip = request.META.get('REMOTE_ADDR')
+        key = f'webhook_rate_limit_{client_ip}'
+
+        # Get current requests count
+        requests = cache.get(key, [])
+        now = time.time()
+
+        # Remove old requests
+        requests = [req_time for req_time in requests if now - req_time < self.rate_limit_window]
+
+        # Check if we're over the limit
+        if len(requests) >= self.max_requests:
+            return False
+
+        # Add current request
+        requests.append(now)
+        cache.set(key, requests, self.rate_limit_window)
+        return True
+
+    def _check_idempotency(self, event_id):
+        """Check if event has already been processed."""
+        if not event_id:
+            return False
+
+        key = f'webhook_event_{event_id}'
+        if cache.get(key):
+            return True
+
+        cache.set(key, True, timeout=86400)  # 24 hours
+        return False
+
+    def _verify_webhook(self, request):
+        """Verify webhook signature and construct event."""
+        sig_header = request.headers.get('Stripe-Signature')
+        if not sig_header:
+            logger.error("No Stripe signature found in request headers")
+            return None
+
+        try:
+            return self.stripe_client.construct_webhook_event(
+                request.body,
+                sig_header
+            )
+        except Exception as e:
+            logger.error(f"Error verifying webhook: {str(e)}")
+            return None
+
+    def handle_webhook(self, request):
+        """Handle incoming webhook request."""
+        # Check rate limit
+        if not self._rate_limit_check(request):
+            return HttpResponseTooManyRequests("Rate limit exceeded")
+
+        # Verify webhook
+        event = self._verify_webhook(request)
+        if not event:
+            return HttpResponseForbidden("Invalid webhook signature")
+
+        # Check idempotency
+        event_id = request.headers.get('Stripe-Event-Id')
+        if self._check_idempotency(event_id):
+            return HttpResponse(status=200)  # Already processed
+
+        # Check webhook version
+        if request.headers.get('Stripe-Event-Version') != '2020-08-27':
+            logger.warning(f"Unsupported webhook version: {request.headers.get('Stripe-Event-Version')}")
+
+        try:
+            # Handle the event
+            if event.type == "checkout.session.completed":
+                self._handle_checkout_completed(event.data.object)
+            elif event.type == "customer.subscription.updated":
+                self._handle_subscription_updated(event.data.object)
+            elif event.type == "customer.subscription.deleted":
+                self._handle_subscription_deleted(event.data.object)
+            elif event.type == "invoice.payment_failed":
+                self._handle_payment_failed(event.data.object)
+            elif event.type == "invoice.payment_succeeded":
+                self._handle_payment_succeeded(event.data.object)
+            else:
+                logger.info(f"Unhandled event type: {event.type}")
+
+            return HttpResponse(status=200)
+
+        except StripeError as e:
+            logger.error(f"Error processing webhook: {str(e)}")
+            return HttpResponse(status=400)
+        except Exception as e:
+            logger.exception(f"Unexpected error processing webhook: {str(e)}")
+            return HttpResponse(status=500)
+
+    def _handle_checkout_completed(self, session):
+        """Handle checkout completed event."""
+        from .billing_processing import handle_checkout_completed
+        handle_checkout_completed(session)
+
+    def _handle_subscription_updated(self, subscription):
+        """Handle subscription updated event."""
+        from .billing_processing import handle_subscription_updated
+        handle_subscription_updated(subscription)
+
+    def _handle_subscription_deleted(self, subscription):
+        """Handle subscription deleted event."""
+        from .billing_processing import handle_subscription_deleted
+        handle_subscription_deleted(subscription)
+
+    def _handle_payment_failed(self, invoice):
+        """Handle payment failed event."""
+        from .billing_processing import handle_payment_failed
+        handle_payment_failed(invoice)
+
+    def _handle_payment_succeeded(self, invoice):
+        """Handle payment succeeded event."""
+        from .billing_processing import handle_payment_succeeded
+        handle_payment_succeeded(invoice)

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -402,6 +402,13 @@ STRIPE_PUBLISHABLE_KEY = os.environ.get("STRIPE_PUBLISHABLE_KEY", "")
 STRIPE_BILLING_URL = os.environ.get("STRIPE_BILLING_URL", "")
 STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 
+# Trial period settings
+TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))
+TRIAL_ENDING_NOTIFICATION_DAYS = int(os.environ.get("TRIAL_ENDING_NOTIFICATION_DAYS", "3"))
+
+# Email settings
+EMAIL_SUBJECT_PREFIX = "[sbomify] "
+
 # Enable specific notification providers
 NOTIFICATION_PROVIDERS = [
     "billing.notifications.get_notifications",

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -41,7 +41,7 @@ DEBUG = os.environ.get("DEBUG", "False") == "True"
 if DEBUG:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:
-    EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
@@ -330,16 +330,21 @@ USE_I18N = True
 USE_TZ = True
 
 
-# EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")
-# EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
-# EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
-# EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "25"))
-# EMAIL_USE_TLS = str_to_bool(os.environ.get("EMAIL_USE_TLS", "False"))
+# Email settings
+if DEBUG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
-ANYMAIL = {"SENDGRID_API_KEY": os.environ.get("SENDGRID_API_KEY", "")}
-
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "25"))
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False").lower() == "true"
+EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False").lower() == "true"
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@sbomify.com")
-SERVER_EMAIL = DEFAULT_FROM_EMAIL
+SERVER_EMAIL = os.environ.get("SERVER_EMAIL", DEFAULT_FROM_EMAIL)  # For system-generated emails
+EMAIL_SUBJECT_PREFIX = "[sbomify] "
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
@@ -405,9 +410,6 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 # Trial period settings
 TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))
 TRIAL_ENDING_NOTIFICATION_DAYS = int(os.environ.get("TRIAL_ENDING_NOTIFICATION_DAYS", "3"))
-
-# Email settings
-EMAIL_SUBJECT_PREFIX = "[sbomify] "
 
 # Enable specific notification providers
 NOTIFICATION_PROVIDERS = [

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -132,3 +132,5 @@ MIDDLEWARE = [
 # Add debug toolbar middleware if DEBUG is True
 if DEBUG:
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+
+SITE_URL = "http://testserver"

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -7,6 +7,13 @@ os.environ["STRIPE_PUBLISHABLE_KEY"] = "pk_test_dummy_key_for_ci"
 os.environ["STRIPE_BILLING_URL"] = "https://billing.stripe.com/test"
 os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test_webhook_secret_key"
 
+# Mock trial period settings
+os.environ["TRIAL_PERIOD_DAYS"] = "14"
+os.environ["TRIAL_ENDING_NOTIFICATION_DAYS"] = "3"
+
+# Mock email settings
+os.environ["DEFAULT_FROM_EMAIL"] = "test@sbomify.com"
+
 import json
 
 # Import settings in a way that ensures they are loaded immediately

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -13,6 +13,7 @@ os.environ["TRIAL_ENDING_NOTIFICATION_DAYS"] = "3"
 
 # Mock email settings
 os.environ["DEFAULT_FROM_EMAIL"] = "test@sbomify.com"
+EMAIL_SUBJECT_PREFIX = "[sbomify] "
 
 import json
 

--- a/teams/signals/handlers.py
+++ b/teams/signals/handlers.py
@@ -15,14 +15,18 @@ from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
+from django.utils import timezone
 from social_django.models import UserSocialAuth
 
+from billing.models import BillingPlan
+from billing.stripe_client import StripeClient
 from core.utils import number_to_random_token
 from teams.utils import get_user_teams
 
 from ..models import Member, Team, get_team_name_for_user
 
 log = logging.getLogger(__name__)
+stripe_client = StripeClient()
 
 
 @receiver(user_logged_in)
@@ -48,25 +52,73 @@ def user_logged_in_handler(sender: Model, user: User, request: HttpRequest, **kw
 def new_user_handler(sender: Model, instance: User, created: bool, **kwargs):
     if created:
         with transaction.atomic():
+            # Create default team
             default_team = Team(name=get_team_name_for_user(instance))
             default_team.save()
 
             default_team.key = number_to_random_token(default_team.pk)
             default_team.save()
 
+            # Create team membership
             team_membership = Member(user=instance, team=default_team, role="owner", is_default_team=True)
             team_membership.save()
-            log.info(f"Team {default_team.pk} ({default_team.name}) created for new user {instance.username}")
 
-            context = {
-                "user": instance,
-                "membership": team_membership,
-                "base_url": settings.APP_BASE_URL,
-            }
-            send_mail(
-                subject="Welcome to the Team",
-                message=render_to_string("teams/new_user_email.txt", context),
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[instance.email],
-                html_message=render_to_string("teams/new_user_email.html", context),
-            )
+            # Set up business plan trial
+            try:
+                # Get business plan
+                business_plan = BillingPlan.objects.get(key="business")
+
+                # Create Stripe customer
+                customer = stripe_client.create_customer(
+                    email=instance.email, name=default_team.name, metadata={"team_key": default_team.key}
+                )
+
+                # Create subscription with trial
+                subscription = stripe_client.create_subscription(
+                    customer_id=customer.id,
+                    price_id=business_plan.stripe_price_monthly_id,
+                    trial_days=settings.TRIAL_PERIOD_DAYS,
+                    metadata={"team_key": default_team.key, "plan_key": "business"},
+                )
+
+                # Update team with billing info
+                default_team.billing_plan = "business"
+                default_team.billing_plan_limits = {
+                    "max_products": business_plan.max_products,
+                    "max_projects": business_plan.max_projects,
+                    "max_components": business_plan.max_components,
+                    "stripe_customer_id": customer.id,
+                    "stripe_subscription_id": subscription.id,
+                    "subscription_status": "trialing",
+                    "is_trial": True,
+                    "trial_end": subscription.trial_end,
+                    "last_updated": timezone.now().isoformat(),
+                }
+                default_team.save()
+
+                log.info(f"Created trial subscription for team {default_team.key} ({default_team.name})")
+
+                # Send welcome email with plan limits from Stripe
+                context = {
+                    "user": instance,
+                    "membership": team_membership,
+                    "base_url": settings.APP_BASE_URL,
+                    "TRIAL_PERIOD_DAYS": settings.TRIAL_PERIOD_DAYS,
+                    "trial_end_date": timezone.now() + timezone.timedelta(days=settings.TRIAL_PERIOD_DAYS),
+                    "plan_limits": {
+                        "max_products": business_plan.max_products,
+                        "max_projects": business_plan.max_projects,
+                        "max_components": business_plan.max_components,
+                    },
+                }
+                send_mail(
+                    subject="Welcome to sbomify - Your Business Plan Trial",
+                    message=render_to_string("teams/new_user_email.txt", context),
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    recipient_list=[instance.email],
+                    html_message=render_to_string("teams/new_user_email.html", context),
+                )
+            except Exception as e:
+                log.error(f"Failed to create trial subscription for team {default_team.key}: {str(e)}")
+                # If trial setup fails, don't send the welcome email
+                # The user can still set up billing later

--- a/teams/templates/teams/new_user_email.html
+++ b/teams/templates/teams/new_user_email.html
@@ -6,13 +6,21 @@
     <title>Welcome to sbomify</title>
 </head>
 <body>
-    <p>Hi {{ user.first_name }},</p>
+    <p>{% if user.first_name %}Hello {{ user.first_name }} {{ user.last_name}}!{% else %}Hello {{user.pk}}{% endif %}</p>
 
-    <p>{{ inviter.first_name }} {{ inviter.last_name }} has invited you to join {{ team.name }} on sbomify.</p>
+    <p>Welcome to sbomify! We've created a default team for you and enrolled you in a {{ TRIAL_PERIOD_DAYS }}-day trial of our Business plan.</p>
 
-    <p>Please click on the following link to accept the invitation: <a href="{{ invitation_url }}">{{ invitation_url }}</a></p>
+    <p>During your trial, you'll have access to all Business plan features:</p>
+    <ul>
+        <li>Up to {{ plan_limits.max_products }} products</li>
+        <li>Up to {{ plan_limits.max_projects }} projects</li>
+        <li>Up to {{ plan_limits.max_components }} components</li>
+        <li>Full access to all features</li>
+    </ul>
 
-    <p>If you have any questions, please don't hesitate to contact us at hello@sbomify.com.</p><br />
+    <p>Your trial will end on {{ trial_end_date }}. We'll notify you 3 days before the trial ends so you can decide whether to continue with a paid subscription.</p>
+
+    <p>If you have any questions, please don't hesitate to contact us at hello@sbomify.com.</p>
 
     <p>Best regards,<br />
     The sbomify team</p>

--- a/teams/templates/teams/new_user_email.txt
+++ b/teams/templates/teams/new_user_email.txt
@@ -4,7 +4,15 @@ Hello {{ user.first_name }} {{ user.last_name}}!
 Hello {{user.pk}}
 {% endif %}
 
-Welcome to sbomify. We've created a default team for you to help you get started.
+Welcome to sbomify! We've created a default team for you and enrolled you in a {{ TRIAL_PERIOD_DAYS }}-day trial of our Business plan.
+
+During your trial, you'll have access to all Business plan features:
+- Up to {{ plan_limits.max_products }} products
+- Up to {{ plan_limits.max_projects }} projects
+- Up to {{ plan_limits.max_components }} components
+- Full access to all features
+
+Your trial will end on {{ trial_end_date }}. We'll notify you 3 days before the trial ends so you can decide whether to continue with a paid subscription.
 
 If you have any questions, please don't hesitate to contact us at hello@sbomify.com.
 


### PR DESCRIPTION
- Add trial period handling with configurable duration (TRIAL_PERIOD_DAYS)
- Add trial ending notifications with configurable threshold (TRIAL_ENDING_NOTIFICATION_DAYS)
- Add trial status tracking in billing limits
- Add trial-related subscription state handling
- Add comprehensive test coverage for trial functionality
- Add email subject prefix configuration
- Improve error handling and logging in billing processing
- Add webhook signature verification
- Add proper HTTP method restrictions for webhook endpoint

This adds support for trial periods in the billing system, allowing teams to try the service before committing to a paid plan. The implementation includes proper notification handling, status tracking, and comprehensive test coverage.