### PR TITLE
fix(admin): correct admin dashboard permission decorator

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -23,10 +23,10 @@ def admin_dashboard_required(view_func):
     """Decorator to check if user has permission to view dashboard."""
 
     @wraps(view_func)
-    def wrapper(request, *args, **kwargs):
+    def wrapper(self, request, *args, **kwargs):
         if not request.user.is_staff:
             raise PermissionDenied
-        return view_func(request, *args, **kwargs)
+        return view_func(self, request, *args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
The admin_dashboard_required decorator was not properly handling class methods, causing a 500 error when accessing the admin dashboard. The decorator was trying to access request.user directly from the class instance instead of from the request object.

- Modified decorator to accept 'self' parameter for class methods
- Fixed request object access in the wrapper function
- Ensures proper permission checking for admin dashboard access

This fixes the AttributeError: 'DashboardView' object has no attribute 'user' error that was occurring when trying to access the admin dashboard.