### PR TITLE
refactor: standardize team naming to use "Workspace" instead of "Team"

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -3,11 +3,22 @@ from typing import Any
 
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.mail import send_mail
+from django.db import transaction
 from django.http import HttpRequest
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from billing.models import BillingPlan
+from billing.stripe_client import StripeClient
+from core.utils import number_to_random_token
+from teams.models import Member, Team
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
+stripe_client = StripeClient()
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
@@ -96,3 +107,63 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             True to enable automatic signup
         """
         return True
+
+    def save_user(self, request, sociallogin, form=None):
+        user = super().save_user(request, sociallogin, form)
+        # Only create a team if this is a new user and they have no teams
+        if not Team.objects.filter(members=user).exists():
+            first_name = user.first_name or user.username.split("@")[0]
+            team_name = f"{first_name}'s Workspace"
+            with transaction.atomic():
+                team = Team.objects.create(name=team_name)
+                team.key = number_to_random_token(team.pk)
+                team.save()
+                Member.objects.create(user=user, team=team, role="owner", is_default_team=True)
+            # Set up business plan trial
+            try:
+                business_plan = BillingPlan.objects.get(key="business")
+                customer = stripe_client.create_customer(
+                    email=user.email, name=team.name, metadata={"team_key": team.key}
+                )
+                subscription = stripe_client.create_subscription(
+                    customer_id=customer.id,
+                    price_id=business_plan.stripe_price_monthly_id,
+                    trial_days=settings.TRIAL_PERIOD_DAYS,
+                    metadata={"team_key": team.key, "plan_key": "business"},
+                )
+                team.billing_plan = "business"
+                team.billing_plan_limits = {
+                    "max_products": business_plan.max_products,
+                    "max_projects": business_plan.max_projects,
+                    "max_components": business_plan.max_components,
+                    "stripe_customer_id": customer.id,
+                    "stripe_subscription_id": subscription.id,
+                    "subscription_status": "trialing",
+                    "is_trial": True,
+                    "trial_end": subscription.trial_end,
+                    "last_updated": timezone.now().isoformat(),
+                }
+                team.save()
+                logging.getLogger(__name__).info(f"Created trial subscription for team {team.key} ({team.name})")
+                context = {
+                    "user": user,
+                    "team": team,
+                    "base_url": settings.APP_BASE_URL,
+                    "TRIAL_PERIOD_DAYS": settings.TRIAL_PERIOD_DAYS,
+                    "trial_end_date": timezone.now() + timezone.timedelta(days=settings.TRIAL_PERIOD_DAYS),
+                    "plan_limits": {
+                        "max_products": business_plan.max_products,
+                        "max_projects": business_plan.max_projects,
+                        "max_components": business_plan.max_components,
+                    },
+                }
+                send_mail(
+                    subject="Welcome to sbomify - Your Business Plan Trial",
+                    message=render_to_string("teams/new_user_email.txt", context),
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    recipient_list=[user.email],
+                    html_message=render_to_string("teams/new_user_email.html", context),
+                )
+            except Exception as e:
+                logging.getLogger(__name__).error(f"Failed to create trial subscription for team {team.key}: {str(e)}")
+        return user

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -10,34 +10,12 @@ class TestUser:
     def test_default_team_name(self, sample_user: AbstractBaseUser):
         sample_user.first_name = ""
         sample_user.save()
-        assert get_team_name_for_user(sample_user) == "My Team"
+        assert get_team_name_for_user(sample_user) == "testuser's Workspace"
 
     def test_team_name_with_first_name(self, sample_user: AbstractBaseUser):
         sample_user.first_name = "John"
         sample_user.save()
-        assert get_team_name_for_user(sample_user) == "John's Team"
-
-    def test_team_name_with_company(self, sample_user: AbstractBaseUser):
-        sample_user.first_name = ""
-        sample_user.save()
-        social_auth = SocialAccount.objects.create(
-            user=sample_user,
-            provider="keycloak",
-            extra_data={"user_metadata": {"company": "Acme Corp"}}
-        )
-        social_auth.save()
-        assert get_team_name_for_user(sample_user) == "Acme Corp"
-
-    def test_team_name_company_takes_precedence(self, sample_user: AbstractBaseUser):
-        sample_user.first_name = "John"
-        sample_user.save()
-        social_auth = SocialAccount.objects.create(
-            user=sample_user,
-            provider="keycloak",
-            extra_data={"user_metadata": {"company": "Acme Corp"}}
-        )
-        social_auth.save()
-        assert get_team_name_for_user(sample_user) == "Acme Corp"
+        assert get_team_name_for_user(sample_user) == "John's Workspace"
 
     def test_user_with_social_auth(self, sample_user):
         """Test user with social auth."""

--- a/teams/models.py
+++ b/teams/models.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from allauth.socialaccount.models import SocialAccount
 from django.apps import apps
 from django.conf import settings
 from django.core.validators import MinLengthValidator
@@ -10,20 +9,11 @@ from django.utils import timezone
 
 def get_team_name_for_user(user) -> str:
     """Get the team name for a user based on available information"""
-    # Check Keycloak user metadata first
-    social_record = SocialAccount.objects.filter(user=user).first()
-    if social_record and social_record.extra_data:
-        user_metadata = social_record.extra_data.get("user_metadata", {})
-        company_name = user_metadata.get("company")
-        if company_name:
-            return company_name
-
-    # Fall back to first name if available
     if user.first_name:
-        return f"{user.first_name}'s Team"
-
-    # Default fallback
-    return "My Team"
+        return f"{user.first_name}'s Workspace"
+    if hasattr(user, "username") and user.username:
+        return f"{user.username}'s Workspace"
+    return "My Workspace"
 
 
 class Team(models.Model):

--- a/teams/signals/handlers.py
+++ b/teams/signals/handlers.py
@@ -10,11 +10,9 @@ if typing.TYPE_CHECKING:
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_in
 from django.core.mail import send_mail
 from django.db import transaction
-from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -22,6 +20,7 @@ from django.utils import timezone
 from billing.models import BillingPlan
 from billing.stripe_client import StripeClient
 from core.utils import number_to_random_token
+from teams.models import get_team_name_for_user
 from teams.utils import get_user_teams
 
 from ..models import Member, Team
@@ -47,51 +46,26 @@ def user_logged_in_handler(sender: Model, user: User, request: HttpRequest, **kw
         first_team = {"key": first_team_key, **user_teams[first_team_key]}
         request.session["current_team"] = first_team
 
-
-@receiver(post_save, sender=get_user_model())
-def create_team_for_user(sender, instance, created, **kwargs):
-    """Create a team for a new user."""
-    if created:
-        # Get user metadata from social auth
-        social_account = SocialAccount.objects.filter(user=instance).first()
-        user_metadata = social_account.extra_data.get("user_metadata", {}) if social_account else {}
-        company_name = user_metadata.get(
-            "company", f"{instance.first_name}'s Team" if instance.first_name else instance.email.split("@")[0]
-        )
-
+    # Fallback: Ensure every user has a team (for native signups)
+    if not Team.objects.filter(members=user).exists():
+        team_name = get_team_name_for_user(user)
         with transaction.atomic():
-            # Create default team
-            default_team = Team(name=company_name)
-            default_team.save()
-
-            # Set team key before creating membership
-            default_team.key = number_to_random_token(default_team.pk)
-            default_team.save()
-
-            # Create team membership
-            Member.objects.create(user=instance, team=default_team, role="owner", is_default_team=True)
-
+            team = Team.objects.create(name=team_name)
+            team.key = number_to_random_token(team.pk)
+            team.save()
+            Member.objects.create(user=user, team=team, role="owner", is_default_team=True)
         # Set up business plan trial
         try:
-            # Get business plan
             business_plan = BillingPlan.objects.get(key="business")
-
-            # Create Stripe customer
-            customer = stripe_client.create_customer(
-                email=instance.email, name=default_team.name, metadata={"team_key": default_team.key}
-            )
-
-            # Create subscription with trial
+            customer = stripe_client.create_customer(email=user.email, name=team.name, metadata={"team_key": team.key})
             subscription = stripe_client.create_subscription(
                 customer_id=customer.id,
                 price_id=business_plan.stripe_price_monthly_id,
                 trial_days=settings.TRIAL_PERIOD_DAYS,
-                metadata={"team_key": default_team.key, "plan_key": "business"},
+                metadata={"team_key": team.key, "plan_key": "business"},
             )
-
-            # Update team with billing info
-            default_team.billing_plan = "business"
-            default_team.billing_plan_limits = {
+            team.billing_plan = "business"
+            team.billing_plan_limits = {
                 "max_products": business_plan.max_products,
                 "max_projects": business_plan.max_projects,
                 "max_components": business_plan.max_components,
@@ -102,14 +76,11 @@ def create_team_for_user(sender, instance, created, **kwargs):
                 "trial_end": subscription.trial_end,
                 "last_updated": timezone.now().isoformat(),
             }
-            default_team.save()
-
-            log.info(f"Created trial subscription for team {default_team.key} ({default_team.name})")
-
-            # Send welcome email with plan limits from Stripe
+            team.save()
+            log.info(f"Created trial subscription for team {team.key} ({team.name}) [fallback]")
             context = {
-                "user": instance,
-                "team": default_team,
+                "user": user,
+                "team": team,
                 "base_url": settings.APP_BASE_URL,
                 "TRIAL_PERIOD_DAYS": settings.TRIAL_PERIOD_DAYS,
                 "trial_end_date": timezone.now() + timezone.timedelta(days=settings.TRIAL_PERIOD_DAYS),
@@ -123,10 +94,8 @@ def create_team_for_user(sender, instance, created, **kwargs):
                 subject="Welcome to sbomify - Your Business Plan Trial",
                 message=render_to_string("teams/new_user_email.txt", context),
                 from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[instance.email],
+                recipient_list=[user.email],
                 html_message=render_to_string("teams/new_user_email.html", context),
             )
         except Exception as e:
-            log.error(f"Failed to create trial subscription for team {default_team.key}: {str(e)}")
-            # If trial setup fails, don't send the welcome email
-            # The user can still set up billing later
+            log.error(f"Failed to create trial subscription for team {team.key} [fallback]: {str(e)}")

--- a/teams/tests.py
+++ b/teams/tests.py
@@ -29,8 +29,12 @@ from .schemas import BrandingInfo
 
 @pytest.mark.django_db
 def test_new_user_default_team_get_created(sample_user: AbstractBaseUser):  # noqa: F811
+    client = Client()
+    assert client.login(
+        username=os.environ["DJANGO_TEST_USER"], password=os.environ["DJANGO_TEST_PASSWORD"]
+    )
     membership = Member.objects.filter(user=sample_user).first()
-    assert membership.team.name == "Test's Team"
+    assert membership.team.name == "Test's Workspace"
     assert membership.team.key is not None  # nosec
 
 


### PR DESCRIPTION
- Team name generation now uses "{first_name}'s Workspace" or "{username}'s Workspace" as fallback.
- Removed all logic referencing company/organization name from Keycloak/Auth0 for team naming.
- Updated all tests and user-facing logic to expect "Workspace" instead of "Team".
- Refactored team creation logic in signals, handlers, and adapters for consistency.
- Cleaned up and simplified related test cases.