### PR TITLE
feat: Filter component uploads by component ID

### DIFF
--- a/sboms/js/components/DashboardStats.vue
+++ b/sboms/js/components/DashboardStats.vue
@@ -111,7 +111,11 @@
   });
 
   const getStats = async () => {
-    const apiUrl = '/api/v1/sboms/dashboard/summary/';
+    let apiUrl = '/api/v1/sboms/dashboard/summary/';
+
+    if (props.itemType === 'component' && props.itemId) {
+      apiUrl += `?component_id=${props.itemId}`;
+    }
 
     try {
       const response = await $axios.get(apiUrl);


### PR DESCRIPTION
This commit updates the component details page to display only the uploads relevant to the currently viewed component.

- Modified `DashboardStats.vue` to include `itemId` (component_id) as a query parameter when fetching dashboard summary data if the `itemType` is 'component'.
- Updated the `/api/v1/sboms/dashboard/summary/` endpoint in `sboms/apis.py` to accept an optional `component_id` query parameter and filter the `latest_uploads` accordingly.