### PR TITLE
Extend metadata and tweaks API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sbomify"
-version = "0.12.0"
+version = "0.12.1"
 description = "sbomify - the SBOM hub"
 authors = ["sbomify <hello@sbomify.com>"]
 readme = "README.md"

--- a/sboms/js/components/ComponentMetaInfo.spec.ts
+++ b/sboms/js/components/ComponentMetaInfo.spec.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test'
+
+interface MockAxiosResponse<T = unknown> {
+  data: T
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  config: Record<string, unknown>
+}
+
+// Mock the $axios utils module using Bun's mock
+const mockAxios = {
+  get: mock<(url: string) => Promise<MockAxiosResponse<unknown>>>(),
+  put: mock<(url: string, data: unknown) => Promise<MockAxiosResponse<unknown>>>()
+}
+
+mock.module('../../../core/js/utils', () => ({
+  default: mockAxios,
+  isEmpty: mock<(value: unknown) => boolean>()
+}))
+
+// Mock alerts
+const mockShowSuccess = mock<(message: string) => void>()
+const mockShowError = mock<(message: string) => void>()
+
+mock.module('../../../core/js/alerts', () => ({
+  showSuccess: mockShowSuccess,
+  showError: mockShowError
+}))
+
+// Mock Vue components
+mock.module('./ComponentMetaInfoDisplay.vue', () => ({
+  default: {}
+}))
+
+mock.module('./ComponentMetaInfoEditor.vue', () => ({
+  default: {}
+}))
+
+mock.module('./ItemSelectModal.vue', () => ({
+  default: {}
+}))
+
+// Test the business logic of ComponentMetaInfo component
+describe('ComponentMetaInfo Business Logic', () => {
+  const mockComponentId = 'test-component-123'
+  const mockSourceComponentId = 'source-component-456'
+
+  const createMockResponse = <T>(data: T, status = 200): MockAxiosResponse<T> => ({
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {}
+  })
+
+  beforeEach(() => {
+    // Clear all mocks
+    mockAxios.get.mockClear()
+    mockAxios.put.mockClear()
+    mockShowSuccess.mockClear()
+    mockShowError.mockClear()
+
+    // Setup default mock responses
+    mockAxios.put.mockResolvedValue(createMockResponse({}))
+  })
+
+  describe('Copy Metadata Functionality', () => {
+    it('should make correct API call to copy metadata', async () => {
+      const copyMetaReq = {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      }
+
+      await mockAxios.put('/api/v1/sboms/component/copy-meta', copyMetaReq)
+
+      expect(mockAxios.put).toHaveBeenCalledWith(
+        '/api/v1/sboms/component/copy-meta',
+        copyMetaReq
+      )
+      expect(mockAxios.put).toHaveBeenCalledTimes(1)
+    })
+
+    it('should show success message on successful copy', async () => {
+      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 204))
+
+      const copyMetaReq = {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      }
+
+      await mockAxios.put('/api/v1/sboms/component/copy-meta', copyMetaReq)
+
+      // Simulate the success path
+      if (mockAxios.put.mock.results[0].type === 'return') {
+        const response = await mockAxios.put.mock.results[0].value
+        if (response.status >= 200 && response.status < 300) {
+          mockShowSuccess('Metadata copied successfully')
+        }
+      }
+
+      expect(mockShowSuccess).toHaveBeenCalledWith('Metadata copied successfully')
+    })
+
+    it('should handle API errors gracefully', async () => {
+      const errorResponse = {
+        response: {
+          status: 400,
+          statusText: 'Bad Request',
+          data: { detail: 'Invalid request' }
+        }
+      }
+
+      mockAxios.put.mockRejectedValueOnce(errorResponse)
+
+      try {
+        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
+          source_component_id: mockSourceComponentId,
+          target_component_id: mockComponentId
+        })
+        expect(true).toBe(false) // Should not reach here
+             } catch {
+         mockShowError('Failed to copy metadata')
+         expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
+       }
+    })
+
+    it('should handle axios error responses correctly', async () => {
+      const axiosError = {
+        response: {
+          status: 403,
+          statusText: 'Forbidden',
+          data: { detail: [{ msg: 'Permission denied' }] }
+        }
+      }
+
+      mockAxios.put.mockRejectedValueOnce(axiosError)
+
+      // Simulate the error handling logic
+      try {
+        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
+          source_component_id: mockSourceComponentId,
+          target_component_id: mockComponentId
+        })
+      } catch (error) {
+        // Simulate isAxiosError check and error handling
+        if (error && typeof error === 'object' && 'response' in error) {
+          const axiosErr = error as typeof axiosError
+          mockShowError(`${axiosErr.response.status} - ${axiosErr.response.statusText}: ${axiosErr.response.data.detail[0].msg}`)
+        } else {
+          mockShowError('Failed to copy metadata')
+        }
+      }
+
+      expect(mockShowError).toHaveBeenCalledWith('403 - Forbidden: Permission denied')
+    })
+
+    it('should use correct payload structure for copy request', async () => {
+      const expectedPayload = {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      }
+
+      await mockAxios.put('/api/v1/sboms/component/copy-meta', expectedPayload)
+
+      const [url, payload] = mockAxios.put.mock.calls[0]
+      expect(url).toBe('/api/v1/sboms/component/copy-meta')
+      expect(payload).toEqual(expectedPayload)
+      expect(payload).toHaveProperty('source_component_id', mockSourceComponentId)
+      expect(payload).toHaveProperty('target_component_id', mockComponentId)
+    })
+  })
+
+  describe('Copy Modal State Management', () => {
+    it('should manage copy selection state correctly', () => {
+      // Simulate the component state management
+      let selectingCopyComponent = false
+      let copyComponentId = ''
+
+      // Simulate clicking copy button
+      selectingCopyComponent = true
+      expect(selectingCopyComponent).toBe(true)
+
+      // Simulate selecting a component
+      copyComponentId = mockSourceComponentId
+      expect(copyComponentId).toBe(mockSourceComponentId)
+
+      // Simulate clearing the modal
+      selectingCopyComponent = false
+      copyComponentId = ''
+      expect(selectingCopyComponent).toBe(false)
+      expect(copyComponentId).toBe('')
+    })
+
+    it('should clear modal state on cancel', () => {
+      // Simulate component state
+      let selectingCopyComponent = true
+      let copyComponentId = mockSourceComponentId
+
+      // Simulate clearCopyComponentMetadata function
+      const clearCopyComponentMetadata = () => {
+        selectingCopyComponent = false
+        copyComponentId = ''
+      }
+
+      clearCopyComponentMetadata()
+
+      expect(selectingCopyComponent).toBe(false)
+      expect(copyComponentId).toBe('')
+    })
+  })
+
+  describe('Component Re-rendering', () => {
+    it('should trigger component re-render after successful copy', async () => {
+      let infoComponentKey = 0
+
+      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 204))
+
+      // Simulate successful copy operation
+      await mockAxios.put('/api/v1/sboms/component/copy-meta', {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      })
+
+      // Simulate incrementing the key to force re-render
+      infoComponentKey += 1
+
+      expect(infoComponentKey).toBe(1)
+    })
+  })
+
+  describe('Copy Request Validation', () => {
+    it('should ensure source and target component IDs are different', () => {
+      const sourceId = 'component-123'
+      const targetId = 'component-456'
+
+      expect(sourceId).not.toBe(targetId)
+
+      // Should not allow copying to same component
+      const sameCopyRequest = {
+        source_component_id: sourceId,
+        target_component_id: sourceId
+      }
+
+      // In a real implementation, this should be validated
+      expect(sameCopyRequest.source_component_id).toBe(sameCopyRequest.target_component_id)
+    })
+
+    it('should validate required fields in copy request', () => {
+      const validCopyRequest = {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      }
+
+      expect(validCopyRequest).toHaveProperty('source_component_id')
+      expect(validCopyRequest).toHaveProperty('target_component_id')
+      expect(validCopyRequest.source_component_id).toBeTruthy()
+      expect(validCopyRequest.target_component_id).toBeTruthy()
+    })
+  })
+
+  describe('Error Scenarios', () => {
+    it('should handle network errors', async () => {
+      const networkError = new Error('Network Error')
+      mockAxios.put.mockRejectedValueOnce(networkError)
+
+      try {
+        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
+          source_component_id: mockSourceComponentId,
+          target_component_id: mockComponentId
+        })
+             } catch {
+         mockShowError('Failed to copy metadata')
+       }
+
+      expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
+    })
+
+    it('should handle invalid response status codes', async () => {
+      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 500))
+
+      const response = await mockAxios.put('/api/v1/sboms/component/copy-meta', {
+        source_component_id: mockSourceComponentId,
+        target_component_id: mockComponentId
+      })
+
+      // Simulate status code validation
+      if (response.status < 200 || response.status >= 300) {
+        mockShowError('Network response was not ok. Internal Server Error')
+      }
+
+      expect(mockShowError).toHaveBeenCalled()
+    })
+  })
+})

--- a/sboms/js/components/ComponentMetaInfo.vue
+++ b/sboms/js/components/ComponentMetaInfo.vue
@@ -8,6 +8,7 @@
           :componentId="props.componentId"
           :showEditButton="allowEdit"
           @edit="isEditing = true"
+          @copy="selectingCopyComponent = true"
         />
         <ComponentMetaInfoEditor
           v-else
@@ -50,21 +51,9 @@
   const copyComponentId = ref("");
   const infoComponentKey = ref(0);  // To force re-render of info component
 
-  const clearCopyComponentMetadata = async () => {
+  const clearCopyComponentMetadata = () => {
     selectingCopyComponent.value = false;
     copyComponentId.value = "";
-    try {
-      await showSuccess('Metadata copied successfully');
-      // force re-render of info component
-      infoComponentKey.value += 1;
-    } catch (error) {
-      console.log(error);
-      if (isAxiosError(error)) {
-        showError(`${error.response?.status} - ${error.response?.statusText}: ${error.response?.data?.detail[0].msg}`);
-      } else {
-        showError('Failed to save metadata');
-      }
-    }
   };
 
   const copyComponentMetadata = async () => {
@@ -89,7 +78,8 @@
         throw new Error('Network response was not ok. ' + response.statusText);
       }
 
-      // force re-render of info component
+      // Show success message and refresh the display
+      showSuccess('Metadata copied successfully');
       infoComponentKey.value += 1;
 
     } catch (error) {
@@ -97,7 +87,7 @@
       if (isAxiosError(error)) {
         showError(`${error.response?.status} - ${error.response?.statusText}: ${error.response?.data?.detail[0].msg}`);
       } else {
-        showError('Failed to save metadata');
+        showError('Failed to copy metadata');
       }
     }
 

--- a/sboms/js/components/ComponentMetaInfoDisplay.vue
+++ b/sboms/js/components/ComponentMetaInfoDisplay.vue
@@ -16,10 +16,16 @@
                </span>
              </div>
           </div>
-          <button v-if="showEditButton" class="btn btn-outline-primary btn-sm" @click.stop="$emit('edit')">
-            <i class="fa-solid fa-edit me-2"></i>
-            Edit
-          </button>
+          <div v-if="showEditButton" class="d-flex gap-2">
+            <button class="btn btn-outline-secondary btn-sm" @click.stop="$emit('copy')">
+              <i class="fa-solid fa-copy me-2"></i>
+              Copy
+            </button>
+            <button class="btn btn-outline-primary btn-sm" @click.stop="$emit('edit')">
+              <i class="fa-solid fa-edit me-2"></i>
+              Edit
+            </button>
+          </div>
         </div>
         <div v-if="isExpanded">
           <div class="row gy-4">
@@ -377,6 +383,23 @@ td:first-child {
   border-color: #4f46e5;
   color: white;
   box-shadow: 0 2px 4px rgba(79, 70, 229, 0.15);
+  transform: translateY(-1px);
+}
+
+.btn-outline-secondary {
+  border: 1px solid #64748b;
+  color: #64748b;
+  background: transparent;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.btn-outline-secondary:hover {
+  background: linear-gradient(135deg, #64748b 0%, #475569 100%);
+  border-color: #64748b;
+  color: white;
+  box-shadow: 0 2px 4px rgba(100, 116, 139, 0.15);
   transform: translateY(-1px);
 }
 </style>

--- a/sboms/schemas.py
+++ b/sboms/schemas.py
@@ -256,6 +256,35 @@ class ComponentMetaDataUpdate(BaseModel):
         return v
 
 
+class ComponentMetaDataPatch(BaseModel):
+    """Schema for partially updating component metadata using PATCH (all fields optional)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    supplier: SupplierSchema | None = None
+    authors: list[cdx15.OrganizationalContact | cdx16.OrganizationalContact] | None = None
+    licenses: list[LicenseSchema | CustomLicenseSchema | str] | None = None
+    lifecycle_phase: cdx15.Phase | cdx16.Phase | None = None
+
+    @field_validator("authors", mode="before")
+    @classmethod
+    def clean_authors_contacts(cls, v):
+        """Clean author contact information by converting empty strings to None."""
+        if isinstance(v, list):
+            cleaned_authors = []
+            for author in v:
+                if isinstance(author, dict):
+                    # Convert empty strings to None for email validation
+                    cleaned_author = author.copy()
+                    if cleaned_author.get("email") == "":
+                        cleaned_author["email"] = None
+                    cleaned_authors.append(cleaned_author)
+                else:
+                    cleaned_authors.append(author)
+            return cleaned_authors
+        return v
+
+
 class ComponentMetadataRequest(BaseModel):
     version: str
 


### PR DESCRIPTION
* Exposes component name and id to metadata endpoint (used by [sbomify GitHub Action](https://github.com/sbomify/github-action))
* Introduces PATCH endpoint for metadata
* Switches method to PATCH (from PUT) for editing metadata 
* Reinstates metadata copy feature