### PR TITLE
fix: Add robust timeout handling for OSV vulnerability scanning tasks

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -34,6 +34,9 @@ API_VERSION = "v1"
 # This is used for the SBOM analysis results cache
 OSV_SCANNER_RAW_RESULT_EXPIRY_SECONDS = int(os.environ.get("OSV_SCANNER_RAW_RESULT_EXPIRY_SECONDS", 7 * 24 * 3600))
 
+# OSV Scanner subprocess timeout in seconds (default: 5 minutes, less than Dramatiq's 6-minute time limit)
+OSV_SCANNER_TIMEOUT_SECONDS = int(os.environ.get("OSV_SCANNER_TIMEOUT_SECONDS", 300))
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 

--- a/sboms/tests/test_vulnerability_scanning.py
+++ b/sboms/tests/test_vulnerability_scanning.py
@@ -1,0 +1,145 @@
+"""
+Tests for vulnerability scanning functionality with timeout handling.
+"""
+
+import json
+import subprocess
+from unittest.mock import Mock, patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from core.models import User
+from sbomify.tasks import scan_sbom_for_vulnerabilities
+from sboms.models import SBOM, Component
+from teams.models import Team
+
+
+class VulnerabilityScanningTimeoutTests(TestCase):
+    """Test timeout handling in vulnerability scanning tasks."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", first_name="Test", last_name="User"
+        )
+        self.team = Team.objects.create(name="Test Team")
+        self.component = Component.objects.create(name="test-component", team=self.team, is_public=False)
+        self.sbom = SBOM.objects.create(
+            name="test-sbom",
+            component=self.component,
+            format="cyclonedx",
+            format_version="1.6",
+            version="1.0.0",
+            sbom_filename="test-sbom.cdx.json",
+            source="test",
+        )
+
+    @patch("sbomify.tasks.S3Client")
+    @patch("sbomify.tasks.subprocess.run")
+    @patch("sbomify.tasks.dramatiq.get_broker")
+    def test_subprocess_timeout_handling(self, mock_broker, mock_subprocess, mock_s3_client):
+        """Test that subprocess timeouts are handled gracefully."""
+        # Mock S3 client to return valid SBOM data
+        mock_s3_instance = Mock()
+        mock_s3_instance.get_sbom_data.return_value = b'{"bomFormat": "CycloneDX", "specVersion": "1.6"}'
+        mock_s3_client.return_value = mock_s3_instance
+
+        # Mock subprocess to raise TimeoutExpired
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd=["osv-scanner", "scan", "source"], timeout=240)
+
+        # Mock Redis client
+        mock_redis = Mock()
+        mock_broker.return_value.client = mock_redis
+
+        # Call the task
+        result = scan_sbom_for_vulnerabilities(str(self.sbom.id))
+
+        # Verify timeout was handled gracefully
+        self.assertIsInstance(result, dict)
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Vulnerability scan timed out")
+        self.assertIn("timeout_seconds", result)
+        self.assertEqual(result["timeout_seconds"], settings.OSV_SCANNER_TIMEOUT_SECONDS)
+
+        # Verify subprocess was called with timeout
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args
+        self.assertEqual(call_args.kwargs["timeout"], settings.OSV_SCANNER_TIMEOUT_SECONDS)
+
+        # Verify error was stored in Redis
+        mock_redis.set.assert_called_once()
+        redis_call_args = mock_redis.set.call_args
+        stored_data = json.loads(redis_call_args[0][1])
+        self.assertEqual(stored_data["error"], "Vulnerability scan timed out")
+
+    @patch("sbomify.tasks.S3Client")
+    @patch("sbomify.tasks.subprocess.run")
+    @patch("sbomify.tasks.dramatiq.get_broker")
+    def test_successful_scan_with_timeout_setting(self, mock_broker, mock_subprocess, mock_s3_client):
+        """Test that successful scans use the timeout setting."""
+        # Mock S3 client to return valid SBOM data
+        mock_s3_instance = Mock()
+        mock_s3_instance.get_sbom_data.return_value = b'{"bomFormat": "CycloneDX", "specVersion": "1.6"}'
+        mock_s3_client.return_value = mock_s3_instance
+
+        # Mock successful subprocess run
+        mock_process = Mock()
+        mock_process.returncode = 0
+        mock_process.stdout = '{"results": []}'
+        mock_process.stderr = ""
+        mock_subprocess.return_value = mock_process
+
+        # Mock Redis client
+        mock_redis = Mock()
+        mock_broker.return_value.client = mock_redis
+
+        # Call the task
+        result = scan_sbom_for_vulnerabilities(str(self.sbom.id))
+
+        # Verify successful result
+        self.assertIsInstance(result, dict)
+        self.assertIn("status", result)
+        self.assertEqual(result["status"], "Scan completed.")
+
+        # Verify subprocess was called with timeout
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args
+        self.assertEqual(call_args.kwargs["timeout"], settings.OSV_SCANNER_TIMEOUT_SECONDS)
+
+    @override_settings(OSV_SCANNER_TIMEOUT_SECONDS=60)
+    @patch("sbomify.tasks.S3Client")
+    @patch("sbomify.tasks.subprocess.run")
+    @patch("sbomify.tasks.dramatiq.get_broker")
+    def test_custom_timeout_setting(self, mock_broker, mock_subprocess, mock_s3_client):
+        """Test that custom timeout settings are respected."""
+        # Mock S3 client to return valid SBOM data
+        mock_s3_instance = Mock()
+        mock_s3_instance.get_sbom_data.return_value = b'{"bomFormat": "CycloneDX", "specVersion": "1.6"}'
+        mock_s3_client.return_value = mock_s3_instance
+
+        # Mock subprocess to raise TimeoutExpired with custom timeout
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd=["osv-scanner", "scan", "source"], timeout=60)
+
+        # Mock Redis client
+        mock_redis = Mock()
+        mock_broker.return_value.client = mock_redis
+
+        # Call the task
+        result = scan_sbom_for_vulnerabilities(str(self.sbom.id))
+
+        # Verify custom timeout was used
+        self.assertEqual(result["timeout_seconds"], 60)
+
+        # Verify subprocess was called with custom timeout
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args
+        self.assertEqual(call_args.kwargs["timeout"], 60)
+
+    def test_timeout_setting_default_value(self):
+        """Test that the default timeout setting is reasonable."""
+        # Default should be 300 seconds (5 minutes)
+        self.assertEqual(settings.OSV_SCANNER_TIMEOUT_SECONDS, 300)
+
+        # Should be less than Dramatiq's time limit (360 seconds)
+        self.assertLess(settings.OSV_SCANNER_TIMEOUT_SECONDS, 360)


### PR DESCRIPTION
- Add configurable OSV_SCANNER_TIMEOUT_SECONDS setting (default: 5 minutes)
- Increase Dramatiq task time limit from 5 to 6 minutes to provide buffer
- Implement graceful timeout error handling with user-friendly messages
- Store timeout errors in Redis for UI consumption
- Exclude TimeoutExpired from retry logic to prevent retry loops
- Add comprehensive test coverage for timeout scenarios

This resolves the TimeLimitExceeded exception reported in Sentry by ensuring the OSV scanner subprocess has a hard timeout limit that's less than the Dramatiq worker timeout, preventing hanging scans and improving system reliability.

Fixes: TimeLimitExceeded errors in scan_sbom_for_vulnerabilities task