### PR TITLE
Fix scoped dashboard stats

### DIFF
--- a/sboms/js/components/DashboardStats.vue
+++ b/sboms/js/components/DashboardStats.vue
@@ -65,9 +65,9 @@ const isLoading = ref(true);
 const errorMessage = ref<string | null>(null);
 
 const stats = ref<DashboardStats>({
-  total_products: 0,
-  total_projects: 0,
-  total_components: 0,
+  total_products: null,
+  total_projects: null,
+  total_components: null,
   latest_uploads: [],
 });
 
@@ -86,8 +86,8 @@ const getStats = async () => {
 
   let apiUrl = '/api/v1/sboms/dashboard/summary/';
 
-  if (props.itemType === 'component' && props.itemId) {
-    apiUrl += `?component_id=${props.itemId}`;
+  if (props.itemType && props.itemId) {
+    apiUrl += `?${props.itemType}_id=${props.itemId}`;
   }
 
   try {

--- a/sboms/js/type_defs.d.ts
+++ b/sboms/js/type_defs.d.ts
@@ -49,8 +49,8 @@ export interface DashboardSBOMUploadInfo {
 }
 
 export interface DashboardStats {
-  total_products: number;
-  total_projects: number;
-  total_components: number;
+  total_products: number | null;
+  total_projects: number | null;
+  total_components: number | null;
   latest_uploads: DashboardSBOMUploadInfo[];
 }

--- a/sboms/schemas.py
+++ b/sboms/schemas.py
@@ -30,9 +30,9 @@ class DashboardSBOMUploadInfo(Schema):
 
 
 class DashboardStatsResponse(Schema):
-    total_products: int
-    total_projects: int
-    total_components: int
+    total_products: int | None = None
+    total_projects: int | None = None
+    total_components: int | None = None
     latest_uploads: list[DashboardSBOMUploadInfo]
 
 


### PR DESCRIPTION
## Summary
- make `DashboardStatsResponse` fields optional
- allow filtering dashboard summary API by product or project
- refine DashboardStats component for scoped fetching
- update type definitions
- add API tests for product and project filters
- format `get_dashboard_summary`

## Testing
- `ruff format .`
- `ruff check .`
- `bun lint`
- `bun run type-check`
- `pytest -q` *(fails: ModuleNotFoundError: pytest_django)*

------
https://chatgpt.com/codex/tasks/task_e_685a99ea1da08324a738650305db2a13