### PR TITLE
security: implement team role validation decorator

### DIFF
--- a/teams/decorators.py
+++ b/teams/decorators.py
@@ -1,41 +1,51 @@
-# from functools import wraps
+from functools import wraps
 
-# from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden
 
-# from core.errors import error_response
+from core.errors import error_response
 
 
-# def validate_role_in_current_team(allowed_roles):
-#     """
-#     Verify that a user is logged in and current logged in user has one of the given roles
-#     within the team.
-#     """
+def validate_role_in_current_team(allowed_roles):
+    """
+    Verify that a user is logged in and current logged in user has one of the given roles
+    within the team.
 
-#     def _decorator(function):
-#         @wraps(function)
-#         def _wrapped_view(request, *args, **kwargs):
-#             if not request.user.is_authenticated:
-#                 return error_response(request, HttpResponseForbidden("Not logged in"))
+    Args:
+        allowed_roles: List of allowed roles (e.g., ['owner', 'admin'])
 
-#             # TODO: Implement this
-#             # Get user role in current team
-#             team_id: int | None = request.session.get("current_team", {}).get("id", None)
-#             if team_id is None:
-#                 return error_response(request, HttpResponseForbidden("No crruent team selected"))
+    Returns:
+        Decorator function that checks user authentication and role permissions
+    """
 
-#             if team_id not in request.session.get("user_teams", {}):
-#                 return error_response(request, HttpResponseForbidden("Unknown team"))
+    def _decorator(function):
+        @wraps(function)
+        def _wrapped_view(request, *args, **kwargs):
+            if not request.user.is_authenticated:
+                return error_response(request, HttpResponseForbidden("Not logged in"))
 
-#             if request.session["user_teams"][team_id]["role"] not in allowed_roles:
-#                 return error_response(
-#                     request,
-#                     HttpResponseForbidden(
-#                         "You don't have sufficient permissions to access this page"
-#                     ),
-#                 )
+            # Get current team from session
+            current_team = request.session.get("current_team", {})
+            team_key = current_team.get("key", None)
 
-#             return function(request, *args, **kwargs)
+            if team_key is None:
+                return error_response(request, HttpResponseForbidden("No current team selected"))
 
-#         return _wrapped_view
+            # Get user teams from session
+            user_teams = request.session.get("user_teams", {})
 
-#     return _decorator
+            if team_key not in user_teams:
+                return error_response(request, HttpResponseForbidden("Unknown team"))
+
+            # Check if user has the required role
+            user_role = user_teams[team_key].get("role", "")
+            if user_role not in allowed_roles:
+                return error_response(
+                    request,
+                    HttpResponseForbidden("You don't have sufficient permissions to access this page"),
+                )
+
+            return function(request, *args, **kwargs)
+
+        return _wrapped_view
+
+    return _decorator


### PR DESCRIPTION
- Fix critical security vulnerability where team role validation was completely commented out
- Implement validate_role_in_current_team decorator with proper session-based role checking
- Apply decorator to all team management views requiring owner/admin access:
  * team_details, team_settings, delete_team (owner only)
  * delete_member, invite, delete_invite (owner only)
  * set_default_team (owner/admin)
- Replace manual session role checks with centralized decorator approach
- Update tests to handle proper authentication/authorization flow
- Add session setup for role-based test scenarios

This resolves the TODO comment "Implement this" that left team access control unprotected, ensuring only users with appropriate roles can manage teams.