### PR TITLE
SBOM endpointsrefactor: Consolidate and standardize API endpoints

### DIFF
--- a/core/tests/e2e/test_critical_paths.py
+++ b/core/tests/e2e/test_critical_paths.py
@@ -52,8 +52,8 @@ class TestCriticalPaths:
 
         # 4. Update component metadata via API
         metadata = {"supplier": {"name": "Updated Supplier", "url": ["http://example.com"]}}
-        response = client.put(
-            reverse("api-1:get_component_metadata", kwargs={"component_id": component["id"]}),
+        response = client.patch(
+            reverse("api-1:patch_component_metadata", kwargs={"component_id": component["id"]}),
             data=json.dumps(metadata),
             content_type="application/json",
         )
@@ -97,9 +97,7 @@ class TestCriticalPaths:
 
         # 2. Toggle public status via API
         response = client.patch(
-            reverse(
-                "api-1:patch_item_public_status", kwargs={"item_type": "component", "item_id": sample_component.id}
-            ),
+            reverse("api-1:patch_component", kwargs={"component_id": sample_component.id}),
             data=json.dumps({"is_public": True}),
             content_type="application/json",
         )
@@ -135,9 +133,7 @@ class TestCriticalPaths:
 
         # 5. Try to make component private on community plan - should fail
         response = client.patch(
-            reverse(
-                "api-1:patch_item_public_status", kwargs={"item_type": "component", "item_id": sample_component.id}
-            ),
+            reverse("api-1:patch_component", kwargs={"component_id": sample_component.id}),
             data=json.dumps({"is_public": False}),
             content_type="application/json",
         )

--- a/sboms/js/components/ComponentMetaInfo.spec.ts
+++ b/sboms/js/components/ComponentMetaInfo.spec.ts
@@ -1,3 +1,5 @@
+// TODO: This test file needs to be updated to match the new GET + PATCH copy-meta implementation
+// The copy-meta endpoint was removed and replaced with GET source metadata + PATCH target
 import { describe, it, expect, mock, beforeEach } from 'bun:test'
 
 interface MockAxiosResponse<T = unknown> {
@@ -11,7 +13,7 @@ interface MockAxiosResponse<T = unknown> {
 // Mock the $axios utils module using Bun's mock
 const mockAxios = {
   get: mock<(url: string) => Promise<MockAxiosResponse<unknown>>>(),
-  put: mock<(url: string, data: unknown) => Promise<MockAxiosResponse<unknown>>>()
+  patch: mock<(url: string, data: unknown) => Promise<MockAxiosResponse<unknown>>>()
 }
 
 mock.module('../../../core/js/utils', () => ({
@@ -57,117 +59,171 @@ describe('ComponentMetaInfo Business Logic', () => {
   beforeEach(() => {
     // Clear all mocks
     mockAxios.get.mockClear()
-    mockAxios.put.mockClear()
+    mockAxios.patch.mockClear()
     mockShowSuccess.mockClear()
     mockShowError.mockClear()
 
     // Setup default mock responses
-    mockAxios.put.mockResolvedValue(createMockResponse({}))
+    mockAxios.get.mockResolvedValue(createMockResponse({}))
+    mockAxios.patch.mockResolvedValue(createMockResponse({}))
   })
 
   describe('Copy Metadata Functionality', () => {
-    it('should make correct API call to copy metadata', async () => {
-      const copyMetaReq = {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
+    it('should make correct API calls to copy metadata using GET + PATCH', async () => {
+      const sourceMetadata = {
+        id: mockSourceComponentId,
+        name: 'Source Component',
+        description: 'Test description',
+        licenses: ['MIT'],
+        supplier: {
+          name: 'Test Supplier',
+          url: ['https://example.com']
+        }
       }
 
-      await mockAxios.put('/api/v1/sboms/component/copy-meta', copyMetaReq)
+      const expectedPatchData = {
+        description: 'Test description',
+        licenses: ['MIT'],
+        supplier: {
+          name: 'Test Supplier',
+          url: ['https://example.com']
+        }
+      }
 
-      expect(mockAxios.put).toHaveBeenCalledWith(
-        '/api/v1/sboms/component/copy-meta',
-        copyMetaReq
-      )
-      expect(mockAxios.put).toHaveBeenCalledTimes(1)
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}))
+
+      // Simulate the new copy logic: GET source + PATCH target
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+
+      expect(mockAxios.get).toHaveBeenCalledWith(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      expect(mockAxios.patch).toHaveBeenCalledWith(`/api/v1/components/${mockComponentId}/metadata`, expectedPatchData)
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(mockAxios.patch).toHaveBeenCalledTimes(1)
     })
 
     it('should show success message on successful copy', async () => {
-      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 204))
-
-      const copyMetaReq = {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
+      const sourceMetadata = {
+        id: mockSourceComponentId,
+        name: 'Source Component',
+        description: 'Test description'
       }
 
-      await mockAxios.put('/api/v1/sboms/component/copy-meta', copyMetaReq)
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}, 204))
 
-      // Simulate the success path
-      if (mockAxios.put.mock.results[0].type === 'return') {
-        const response = await mockAxios.put.mock.results[0].value
-        if (response.status >= 200 && response.status < 300) {
-          mockShowSuccess('Metadata copied successfully')
-        }
+      // Simulate the copy process
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      const patchResponse = await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+
+      // Simulate success handling
+      if (patchResponse.status >= 200 && patchResponse.status < 300) {
+        mockShowSuccess('Metadata copied successfully')
       }
 
       expect(mockShowSuccess).toHaveBeenCalledWith('Metadata copied successfully')
     })
 
-    it('should handle API errors gracefully', async () => {
+    it('should handle GET API errors gracefully', async () => {
       const errorResponse = {
         response: {
-          status: 400,
-          statusText: 'Bad Request',
-          data: { detail: 'Invalid request' }
+          status: 404,
+          statusText: 'Not Found',
+          data: { detail: 'Source component not found' }
         }
       }
 
-      mockAxios.put.mockRejectedValueOnce(errorResponse)
+      mockAxios.get.mockRejectedValueOnce(errorResponse)
 
       try {
-        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
-          source_component_id: mockSourceComponentId,
-          target_component_id: mockComponentId
-        })
+        await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
         expect(true).toBe(false) // Should not reach here
-             } catch {
-         mockShowError('Failed to copy metadata')
-         expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
-       }
+      } catch {
+        mockShowError('Failed to copy metadata')
+      }
+
+      expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
     })
 
-    it('should handle axios error responses correctly', async () => {
-      const axiosError = {
+    it('should handle PATCH API errors gracefully', async () => {
+      const sourceMetadata = { id: mockSourceComponentId, name: 'Test', description: 'Test desc' }
+      const patchError = {
         response: {
           status: 403,
           statusText: 'Forbidden',
-          data: { detail: [{ msg: 'Permission denied' }] }
+          data: { detail: 'Permission denied' }
         }
       }
 
-      mockAxios.put.mockRejectedValueOnce(axiosError)
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockRejectedValueOnce(patchError)
 
-      // Simulate the error handling logic
       try {
-        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
-          source_component_id: mockSourceComponentId,
-          target_component_id: mockComponentId
-        })
-      } catch (error) {
-        // Simulate isAxiosError check and error handling
-        if (error && typeof error === 'object' && 'response' in error) {
-          const axiosErr = error as typeof axiosError
-          mockShowError(`${axiosErr.response.status} - ${axiosErr.response.statusText}: ${axiosErr.response.data.detail[0].msg}`)
-        } else {
-          mockShowError('Failed to copy metadata')
-        }
+        const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+        const sourceData = sourceResponse.data as typeof sourceMetadata
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { id, name, ...metadataToCopy } = sourceData
+        await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+        expect(true).toBe(false) // Should not reach here
+      } catch {
+        mockShowError('Failed to copy metadata')
       }
 
-      expect(mockShowError).toHaveBeenCalledWith('403 - Forbidden: Permission denied')
+      expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
     })
 
-    it('should use correct payload structure for copy request', async () => {
-      const expectedPayload = {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
+    it('should exclude id and name fields from copied metadata', async () => {
+      const sourceMetadata = {
+        id: mockSourceComponentId,
+        name: 'Source Component Name',
+        description: 'Test description',
+        licenses: ['MIT'],
+        supplier: { name: 'Test Supplier' }
       }
 
-      await mockAxios.put('/api/v1/sboms/component/copy-meta', expectedPayload)
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}))
 
-      const [url, payload] = mockAxios.put.mock.calls[0]
-      expect(url).toBe('/api/v1/sboms/component/copy-meta')
-      expect(payload).toEqual(expectedPayload)
-      expect(payload).toHaveProperty('source_component_id', mockSourceComponentId)
-      expect(payload).toHaveProperty('target_component_id', mockComponentId)
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+
+      // Verify the PATCH call excludes id and name
+      const [, patchData] = mockAxios.patch.mock.calls[0]
+      expect(patchData).not.toHaveProperty('id')
+      expect(patchData).not.toHaveProperty('name')
+      expect(patchData).toHaveProperty('description', 'Test description')
+      expect(patchData).toHaveProperty('licenses', ['MIT'])
+      expect(patchData).toHaveProperty('supplier', { name: 'Test Supplier' })
+    })
+
+    it('should handle empty metadata gracefully', async () => {
+      const sourceMetadata = {
+        id: mockSourceComponentId,
+        name: 'Source Component'
+        // No other metadata fields
+      }
+
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}))
+
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+
+      // Should still make the PATCH call even with empty metadata
+      expect(mockAxios.patch).toHaveBeenCalledWith(`/api/v1/components/${mockComponentId}/metadata`, {})
     })
   })
 
@@ -214,13 +270,16 @@ describe('ComponentMetaInfo Business Logic', () => {
     it('should trigger component re-render after successful copy', async () => {
       let infoComponentKey = 0
 
-      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 204))
+      const sourceMetadata = { id: mockSourceComponentId, name: 'Source' }
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}, 204))
 
       // Simulate successful copy operation
-      await mockAxios.put('/api/v1/sboms/component/copy-meta', {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
-      })
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
 
       // Simulate incrementing the key to force re-render
       infoComponentKey += 1
@@ -236,56 +295,65 @@ describe('ComponentMetaInfo Business Logic', () => {
 
       expect(sourceId).not.toBe(targetId)
 
-      // Should not allow copying to same component
-      const sameCopyRequest = {
-        source_component_id: sourceId,
-        target_component_id: sourceId
-      }
-
-      // In a real implementation, this should be validated
-      expect(sameCopyRequest.source_component_id).toBe(sameCopyRequest.target_component_id)
+      // Should not allow copying to same component (this would be validated in the actual component)
+      // In a real implementation, this should prevent sourceId === targetId
     })
 
-    it('should validate required fields in copy request', () => {
-      const validCopyRequest = {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
-      }
-
-      expect(validCopyRequest).toHaveProperty('source_component_id')
-      expect(validCopyRequest).toHaveProperty('target_component_id')
-      expect(validCopyRequest.source_component_id).toBeTruthy()
-      expect(validCopyRequest.target_component_id).toBeTruthy()
+    it('should validate required component IDs', () => {
+      expect(mockSourceComponentId).toBeTruthy()
+      expect(mockComponentId).toBeTruthy()
+      expect(mockSourceComponentId).not.toBe(mockComponentId)
     })
   })
 
   describe('Error Scenarios', () => {
-    it('should handle network errors', async () => {
+    it('should handle network errors during GET', async () => {
       const networkError = new Error('Network Error')
-      mockAxios.put.mockRejectedValueOnce(networkError)
+      mockAxios.get.mockRejectedValueOnce(networkError)
 
       try {
-        await mockAxios.put('/api/v1/sboms/component/copy-meta', {
-          source_component_id: mockSourceComponentId,
-          target_component_id: mockComponentId
-        })
-             } catch {
-         mockShowError('Failed to copy metadata')
-       }
+        await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      } catch {
+        mockShowError('Failed to copy metadata')
+      }
+
+      expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
+    })
+
+    it('should handle network errors during PATCH', async () => {
+      const sourceMetadata = { id: mockSourceComponentId, name: 'Source' }
+      const networkError = new Error('Network Error')
+
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockRejectedValueOnce(networkError)
+
+      try {
+        const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+        const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+        await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
+      } catch {
+        mockShowError('Failed to copy metadata')
+      }
 
       expect(mockShowError).toHaveBeenCalledWith('Failed to copy metadata')
     })
 
     it('should handle invalid response status codes', async () => {
-      mockAxios.put.mockResolvedValueOnce(createMockResponse({}, 500))
+      const sourceMetadata = { id: mockSourceComponentId, name: 'Source' }
 
-      const response = await mockAxios.put('/api/v1/sboms/component/copy-meta', {
-        source_component_id: mockSourceComponentId,
-        target_component_id: mockComponentId
-      })
+      mockAxios.get.mockResolvedValueOnce(createMockResponse(sourceMetadata))
+      mockAxios.patch.mockResolvedValueOnce(createMockResponse({}, 500))
+
+      const sourceResponse = await mockAxios.get(`/api/v1/components/${mockSourceComponentId}/metadata`)
+      const sourceData = sourceResponse.data as typeof sourceMetadata
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, name, ...metadataToCopy } = sourceData
+      const patchResponse = await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, metadataToCopy)
 
       // Simulate status code validation
-      if (response.status < 200 || response.status >= 300) {
+      if (patchResponse.status < 200 || patchResponse.status >= 300) {
         mockShowError('Network response was not ok. Internal Server Error')
       }
 

--- a/sboms/js/components/ComponentMetaInfoDisplay.vue
+++ b/sboms/js/components/ComponentMetaInfoDisplay.vue
@@ -153,7 +153,7 @@
     message: null,
   });
 
-  const apiUrl = '/api/v1/sboms/component/' + props.componentId + '/meta';
+  const apiUrl = '/api/v1/components/' + props.componentId + '/metadata';
 
   const formatLifecyclePhase = (phase: string): string => {
     // Special case for pre/post-build to keep the hyphen

--- a/sboms/js/components/ComponentMetaInfoEditor.spec.ts
+++ b/sboms/js/components/ComponentMetaInfoEditor.spec.ts
@@ -74,7 +74,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
 
       mockAxios.get.mockResolvedValueOnce(createMockResponse(metadataWithNullLifecycle))
 
-      const response = await mockAxios.get(`/api/v1/sboms/component/${mockComponentId}/meta`)
+      const response = await mockAxios.get(`/api/v1/components/${mockComponentId}/metadata`)
 
       expect(response.data.lifecycle_phase).toBeNull()
       expect(response.status).toBe(200)
@@ -85,10 +85,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
       const updatePayload = {
         lifecycle_phase: LifecyclePhase.Build
       }
-      await mockAxios.patch(`/api/v1/sboms/component/${mockComponentId}/meta`, updatePayload)
+          await mockAxios.patch(`/api/v1/components/${mockComponentId}/metadata`, updatePayload)
 
-      expect(mockAxios.patch).toHaveBeenCalledWith(
-        `/api/v1/sboms/component/${mockComponentId}/meta`,
+    expect(mockAxios.patch).toHaveBeenCalledWith(
+      `/api/v1/components/${mockComponentId}/metadata`,
         updatePayload
       )
     })
@@ -106,10 +106,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         licenses: metadataWithNullLifecycle.licenses,
         lifecycle_phase: metadataWithNullLifecycle.lifecycle_phase
       }
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, updatePayload)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, updatePayload)
 
       expect(mockAxios.put).toHaveBeenCalledWith(
-        `/api/v1/sboms/component/${mockComponentId}/meta`,
+        `/api/v1/components/${mockComponentId}/metadata`,
         updatePayload
       )
       expect(updatePayload.lifecycle_phase).toBeNull()
@@ -132,10 +132,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
           lifecycle_phase: phase
         }
 
-        await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, metadataWithPhase)
+        await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, metadataWithPhase)
 
         expect(mockAxios.put).toHaveBeenCalledWith(
-          `/api/v1/sboms/component/${mockComponentId}/meta`,
+          `/api/v1/components/${mockComponentId}/metadata`,
           metadataWithPhase
         )
       }
@@ -157,10 +157,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         lifecycle_phase: LifecyclePhase.Operations
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, metadataWithSupplier)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, metadataWithSupplier)
 
       expect(mockAxios.put).toHaveBeenCalledWith(
-        `/api/v1/sboms/component/${mockComponentId}/meta`,
+        `/api/v1/components/${mockComponentId}/metadata`,
         metadataWithSupplier
       )
 
@@ -229,9 +229,9 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
 
   describe('API Integration', () => {
     it('should get component metadata from correct endpoint', async () => {
-      await mockAxios.get(`/api/v1/sboms/component/${mockComponentId}/meta`)
+      await mockAxios.get(`/api/v1/components/${mockComponentId}/metadata`)
 
-      expect(mockAxios.get).toHaveBeenCalledWith(`/api/v1/sboms/component/${mockComponentId}/meta`)
+      expect(mockAxios.get).toHaveBeenCalledWith(`/api/v1/components/${mockComponentId}/metadata`)
       expect(mockAxios.get).toHaveBeenCalledTimes(1)
     })
 
@@ -241,10 +241,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         lifecycle_phase: LifecyclePhase.Build
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, updatedMetadata)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, updatedMetadata)
 
       expect(mockAxios.put).toHaveBeenCalledWith(
-        `/api/v1/sboms/component/${mockComponentId}/meta`,
+        `/api/v1/components/${mockComponentId}/metadata`,
         updatedMetadata
       )
       expect(mockAxios.put).toHaveBeenCalledTimes(1)
@@ -262,7 +262,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
       mockAxios.put.mockRejectedValueOnce(errorResponse)
 
       try {
-        await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, mockMetadata)
+        await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, mockMetadata)
         expect(true).toBe(false) // Should not reach here
       } catch (error) {
         const errorData = error as typeof errorResponse
@@ -323,10 +323,10 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         }
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, supplierWithMultipleUrls)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, supplierWithMultipleUrls)
 
       expect(mockAxios.put).toHaveBeenCalledWith(
-        `/api/v1/sboms/component/${mockComponentId}/meta`,
+        `/api/v1/components/${mockComponentId}/metadata`,
         supplierWithMultipleUrls
       )
 
@@ -349,7 +349,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         }
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, supplierWithEmptyUrls)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, supplierWithEmptyUrls)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       const typedCallData = callData as ComponentMetaInfo
@@ -368,7 +368,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         }
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, supplierWithNullUrl)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, supplierWithNullUrl)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       const typedCallData = callData as ComponentMetaInfo
@@ -390,7 +390,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         }
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, supplierWithContactsAndUrls)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, supplierWithContactsAndUrls)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       const typedCallData = callData as ComponentMetaInfo
@@ -412,7 +412,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         ]
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, metadataWithAuthors)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, metadataWithAuthors)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       expect(callData.authors).toHaveLength(3)
@@ -431,7 +431,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         ]
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, metadataWithPartialAuthors)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, metadataWithPartialAuthors)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       expect(callData.authors).toHaveLength(3)
@@ -453,7 +453,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         ]
       }
 
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, metadataWithMixedAuthors)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, metadataWithMixedAuthors)
 
       const [, callData] = mockAxios.put.mock.calls[0]
       expect(callData.authors).toHaveLength(3)
@@ -551,7 +551,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         licenses: completeMetadata.licenses,
         lifecycle_phase: completeMetadata.lifecycle_phase
       }
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, updatePayload)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, updatePayload)
 
       const [, callData] = mockAxios.put.mock.calls[0]
 
@@ -589,7 +589,7 @@ describe('ComponentMetaInfoEditor Business Logic', () => {
         licenses: fullMetadata.licenses,
         lifecycle_phase: fullMetadata.lifecycle_phase
       }
-      await mockAxios.put(`/api/v1/sboms/component/${mockComponentId}/meta`, updateData)
+      await mockAxios.put(`/api/v1/components/${mockComponentId}/metadata`, updateData)
 
       const [, sentData] = mockAxios.put.mock.calls[0]
 

--- a/sboms/js/components/ComponentMetaInfoEditor.vue
+++ b/sboms/js/components/ComponentMetaInfoEditor.vue
@@ -328,7 +328,7 @@
     };
 
     try {
-      const response = await $axios.get(`/api/v1/sboms/component/${props.componentId}/meta`);
+      const response = await $axios.get(`/api/v1/components/${props.componentId}/metadata`);
       if (response.status < 200 || response.status >= 300) {
         throw new Error('Network response was not ok. ' + response.statusText);
       }
@@ -423,7 +423,7 @@
         return;
       }
 
-      const response = await $axios.patch(`/api/v1/sboms/component/${props.componentId}/meta`, updatePayload)
+      const response = await $axios.patch(`/api/v1/components/${props.componentId}/metadata`, updatePayload)
 
       if (response.status < 200 || response.status >= 300) {
         throw new Error('Network response was not ok. ' + response.statusText);

--- a/sboms/js/components/DashboardStats.vue
+++ b/sboms/js/components/DashboardStats.vue
@@ -116,7 +116,7 @@ const getStats = async () => {
   isLoading.value = true;
   errorMessage.value = null;
 
-  let apiUrl = '/api/v1/sboms/dashboard/summary/';
+      let apiUrl = '/api/v1/dashboard/summary';
   const params = new URLSearchParams();
 
   // Add appropriate filter parameters based on context

--- a/sboms/tests/test_apis.py
+++ b/sboms/tests/test_apis.py
@@ -1282,6 +1282,28 @@ def test_patch_public_status_billing_plan_restrictions(
     team.billing_plan = None
     team.save()
 
+    # Need to handle hierarchy constraints: make product private first, then project, then component
+    # Product can be made private independently
+    response = client.patch(
+        product_uri,
+        json.dumps({"is_public": False}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}"
+    )
+    assert response.status_code == 200
+    assert response.json()["is_public"] is False
+
+    # Project can be made private independently
+    response = client.patch(
+        project_uri,
+        json.dumps({"is_public": False}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}"
+    )
+    assert response.status_code == 200
+    assert response.json()["is_public"] is False
+
+    # Now component can be made private since project is private
     response = client.patch(
         component_uri,
         json.dumps({"is_public": False}),


### PR DESCRIPTION
- Move component metadata endpoints from `/api/v1/sboms/component/{id}/meta` to `/api/v1/components/{id}/metadata`
- Replace copy metadata single endpoint with GET source + PATCH target pattern
- Move dashboard summary endpoint from `/api/v1/sboms/dashboard/summary/` to `/api/v1/dashboard/summary`
- Remove duplicate public status endpoints, use core API PATCH with `is_public` field instead
- Update all frontend components to use new API endpoints
- Update tests to reflect new endpoint structure and patterns
- Add backward compatibility aliases for removed endpoints

This refactoring improves API consistency by moving endpoints to appropriate namespaces
and following REST conventions more closely. The component metadata endpoints are now
part of the core API rather than being scattered across different modules.