### PR TITLE
refactor: standardize API test authentication and improve team endpoints

### DIFF
--- a/billing/tests/fixtures.py
+++ b/billing/tests/fixtures.py
@@ -15,69 +15,61 @@ from teams.models import Member, Team
 @pytest.fixture
 def community_plan() -> BillingPlan:
     """Free community plan fixture."""
-    return BillingPlan.objects.create(
+    plan, _ = BillingPlan.objects.get_or_create(
         key="community",
-        name="Community",
-        description="Free plan for small teams",
-        max_products=1,
-        max_projects=1,
-        max_components=5,
-        stripe_product_id=None,
-        stripe_price_monthly_id=None,
-        stripe_price_annual_id=None,
+        defaults={
+            "name": "Community",
+            "description": "Free plan for small teams",
+            "max_products": 1,
+            "max_projects": 1,
+            "max_components": 5,
+            "stripe_product_id": None,
+            "stripe_price_monthly_id": None,
+            "stripe_price_annual_id": None,
+        }
     )
+    return plan
 
 
 @pytest.fixture
 def business_plan() -> BillingPlan:
     """Business plan fixture."""
-    return BillingPlan.objects.create(
+    plan, _ = BillingPlan.objects.get_or_create(
         key="business",
-        name="Business",
-        description="For growing teams",
-        max_products=10,
-        max_projects=20,
-        max_components=100,
-        stripe_product_id="prod_test_business",
-        stripe_price_monthly_id="price_test_business_monthly",  # $199/month
-        stripe_price_annual_id="price_test_business_annual",  # $159 * 12/year
+        defaults={
+            "name": "Business",
+            "description": "For growing teams",
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "stripe_product_id": "prod_test_business",
+            "stripe_price_monthly_id": "price_test_business_monthly",  # $199/month
+            "stripe_price_annual_id": "price_test_business_annual",  # $159 * 12/year
+        }
     )
+    return plan
 
 
 @pytest.fixture
 def enterprise_plan() -> BillingPlan:
     """Enterprise plan fixture with unlimited resources."""
-    return BillingPlan.objects.create(
+    plan, _ = BillingPlan.objects.get_or_create(
         key="enterprise",
-        name="Enterprise",
-        description="For large organizations",
-        max_products=None,
-        max_projects=None,
-        max_components=None,
-        stripe_product_id="prod_test_enterprise",
-        stripe_price_monthly_id="price_test_enterprise_monthly",
-        stripe_price_annual_id="price_test_enterprise_annual",
+        defaults={
+            "name": "Enterprise",
+            "description": "For large organizations",
+            "max_products": None,
+            "max_projects": None,
+            "max_components": None,
+            "stripe_product_id": "prod_test_enterprise",
+            "stripe_price_monthly_id": "price_test_enterprise_monthly",
+            "stripe_price_annual_id": "price_test_enterprise_annual",
+        }
     )
+    return plan
 
 
-@pytest.fixture
-def team_with_business_plan(sample_user: AbstractBaseUser, business_plan: BillingPlan) -> Team:  # noqa: F811
-    """Team fixture with active business plan subscription."""
-    team = Team.objects.create(
-        name="Test Business Team",
-        key="test_business_team",
-        billing_plan=business_plan.key,
-        billing_plan_limits={
-            "max_products": business_plan.max_products,
-            "max_projects": business_plan.max_projects,
-            "max_components": business_plan.max_components,
-            "stripe_customer_id": "c_test_business_team",
-            "stripe_subscription_id": "sub_test123",
-            "subscription_status": "active",
-        },
-    )
-    Member.objects.create(team=team, user=sample_user, role="owner")
-    return team
+# Removed - this fixture was conflicting with the shared fixtures version
 
 
 @pytest.fixture(autouse=True)

--- a/billing/tests/test_api.py
+++ b/billing/tests/test_api.py
@@ -16,8 +16,8 @@ from billing.tests.fixtures import (  # noqa: F401
     enterprise_plan,
     mock_stripe,
     sample_user,
-    team_with_business_plan,
 )
+from core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
 from sboms.models import SBOM, Component
 
 # Import SBOM-related fixtures from sboms app

--- a/billing/tests/test_views_extended.py
+++ b/billing/tests/test_views_extended.py
@@ -18,8 +18,8 @@ from billing.tests.fixtures import (  # noqa: F401
     community_plan,
     enterprise_plan,
     sample_user,
-    team_with_business_plan,
 )
+from core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
 from teams.models import Member, Team
 
 User = get_user_model()

--- a/billing/tests/tests.py
+++ b/billing/tests/tests.py
@@ -13,13 +13,13 @@ from .fixtures import (  # noqa: F401
     community_plan,
     business_plan,
     enterprise_plan,
-    team_with_business_plan,
     test_product,
     multiple_products,
     test_project,
     multiple_projects,
     multiple_components,
 )
+from core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
 
 
 @pytest.mark.django_db

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,7 @@ def tests_init():
 pytest_plugins = [
    "core.tests.fixtures",
    "core.tests.s3_fixtures",
+   "core.tests.shared_fixtures",
    "teams.fixtures",
    "sboms.tests.fixtures",
 ]

--- a/core/tests/shared_fixtures.py
+++ b/core/tests/shared_fixtures.py
@@ -1,0 +1,319 @@
+"""
+Shared test fixtures and utilities for sbomify tests.
+
+This module provides reusable fixtures and helper functions that are commonly
+used across different test files to reduce duplication and ensure consistency.
+"""
+
+from typing import Any, Dict, Generator
+
+import pytest
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.test import Client
+
+from access_tokens.models import AccessToken
+from access_tokens.utils import create_personal_access_token
+from billing.models import BillingPlan
+from core.tests.fixtures import sample_user, guest_user  # noqa: F401
+from core.utils import number_to_random_token
+from teams.models import Member, Team
+
+# ============================================================================
+# Authentication & API Testing Fixtures
+# ============================================================================
+
+@pytest.fixture
+def authenticated_api_client(sample_user: AbstractBaseUser) -> Generator[tuple[Client, AccessToken], Any, None]:  # noqa: F811
+    """
+    Create an authenticated API client with access token for API testing.
+
+    Returns:
+        Tuple of (client, access_token) for API testing
+    """
+    token_str = create_personal_access_token(sample_user)
+    access_token = AccessToken.objects.create(
+        user=sample_user,
+        encoded_token=token_str,
+        description="Test API Token"
+    )
+
+    client = Client()
+
+    yield client, access_token
+
+    access_token.delete()
+
+
+def get_api_headers(access_token: AccessToken) -> Dict[str, str]:
+    """
+    Get API authentication headers for test requests.
+
+    Args:
+        access_token: The access token for authentication
+
+    Returns:
+        Dictionary with HTTP_AUTHORIZATION header
+    """
+    return {"HTTP_AUTHORIZATION": f"Bearer {access_token.encoded_token}"}
+
+
+@pytest.fixture
+def guest_api_client(guest_user: AbstractBaseUser) -> Generator[tuple[Client, AccessToken], Any, None]:  # noqa: F811
+    """
+    Create an authenticated API client for guest user testing.
+
+    Note: Guest users ARE authenticated users with access tokens,
+    but they have limited permissions within teams.
+
+    Returns:
+        Tuple of (client, access_token) for guest user API testing
+    """
+    token_str = create_personal_access_token(guest_user)
+    access_token = AccessToken.objects.create(
+        user=guest_user,
+        encoded_token=token_str,
+        description="Guest Test API Token"
+    )
+
+    client = Client()
+
+    yield client, access_token
+
+    access_token.delete()
+
+
+# ============================================================================
+# Team & Billing Fixtures
+# ============================================================================
+
+@pytest.fixture
+def team_with_community_plan(sample_user: AbstractBaseUser) -> Generator[Team, Any, None]:  # noqa: F811
+    """Create a team with community billing plan."""
+    # Ensure community plan exists
+    community_plan, _ = BillingPlan.objects.get_or_create(
+        key="community",
+        defaults={
+            "name": "Community",
+            "description": "Free plan for small teams",
+            "max_products": 1,
+            "max_projects": 1,
+            "max_components": 5,
+            "max_users": 1,
+        }
+    )
+
+    team = Team.objects.create(
+        name="Test Community Team",
+        billing_plan=community_plan.key
+    )
+    team.key = number_to_random_token(team.pk)
+    team.save()
+
+    Member.objects.create(team=team, user=sample_user, role="owner", is_default_team=True)
+
+    yield team
+
+    # Only delete if the team still exists (id is not None)
+    if team.id is not None:
+        team.delete()
+
+
+@pytest.fixture
+def team_with_business_plan(sample_user: AbstractBaseUser) -> Generator[Team, Any, None]:  # noqa: F811
+    """Create a team with business billing plan and trial subscription."""
+    # Ensure business plan exists
+    business_plan, _ = BillingPlan.objects.get_or_create(
+        key="business",
+        defaults={
+            "name": "Business",
+            "description": "For growing teams",
+            "max_products": 10,
+            "max_projects": 20,
+            "max_components": 100,
+            "max_users": 10,
+            "stripe_product_id": "prod_test_business",
+            "stripe_price_monthly_id": "price_test_business_monthly",
+            "stripe_price_annual_id": "price_test_business_annual",
+        }
+    )
+
+    team = Team.objects.create(
+        name="Test Business Team",
+        billing_plan=business_plan.key,
+        billing_plan_limits={
+            "max_products": business_plan.max_products,
+            "max_projects": business_plan.max_projects,
+            "max_components": business_plan.max_components,
+            "stripe_customer_id": "cus_test123",
+            "stripe_subscription_id": "sub_test123",
+            "subscription_status": "active",
+        }
+    )
+    team.key = number_to_random_token(team.pk)
+    team.save()
+
+    Member.objects.create(team=team, user=sample_user, role="owner", is_default_team=True)
+
+    yield team
+
+    # Only delete if the team still exists (id is not None)
+    if team.id is not None:
+        team.delete()
+
+
+@pytest.fixture
+def team_with_enterprise_plan(sample_user: AbstractBaseUser) -> Generator[Team, Any, None]:  # noqa: F811
+    """Create a team with enterprise billing plan (unlimited resources)."""
+    # Ensure enterprise plan exists
+    enterprise_plan, _ = BillingPlan.objects.get_or_create(
+        key="enterprise",
+        defaults={
+            "name": "Enterprise",
+            "description": "For large organizations",
+            "max_products": None,
+            "max_projects": None,
+            "max_components": None,
+            "max_users": None,
+        }
+    )
+
+    team = Team.objects.create(
+        name="Test Enterprise Team",
+        billing_plan=enterprise_plan.key
+    )
+    team.key = number_to_random_token(team.pk)
+    team.save()
+
+    Member.objects.create(team=team, user=sample_user, role="owner", is_default_team=True)
+
+    yield team
+
+    # Only delete if the team still exists (id is not None)
+    if team.id is not None:
+        team.delete()
+
+
+# ============================================================================
+# Web Client Session Setup Utilities
+# ============================================================================
+
+def setup_authenticated_client_session(client: Client, team: Team, user: AbstractBaseUser) -> None:
+    """
+    Set up an authenticated client session with team context.
+
+    This is a consolidated version of the session setup pattern used across tests.
+
+    Args:
+        client: The Django test client
+        team: The team to set up session context for
+        user: The user to authenticate
+    """
+    # Ensure team has a valid key
+    if not team.key or len(team.key) < 9:
+        team.key = number_to_random_token(team.id)
+        team.save()
+
+    # Get the member's role
+    member = Member.objects.filter(user=user, team=team).first()
+    if not member:
+        raise ValueError(f"User {user.username} is not a member of team {team.name}")
+
+    # Log in the user
+    client.force_login(user)
+
+    # Set up session data with team context
+    session = client.session
+    session["user_teams"] = {
+        team.key: {
+            "role": member.role,
+            "name": team.name,
+            "is_default_team": member.is_default_team,
+            "team_id": team.id
+        }
+    }
+    session["current_team"] = {
+        "key": team.key,
+        "role": member.role,
+        "name": team.name,
+        "is_default_team": member.is_default_team,
+        "id": team.id
+    }
+    session.save()
+
+
+@pytest.fixture
+def authenticated_web_client(
+    sample_user: AbstractBaseUser, team_with_business_plan: Team  # noqa: F811
+) -> Generator[Client, Any, None]:
+    """
+    Create an authenticated web client with team session setup.
+
+    Returns:
+        Configured Django test client ready for web testing
+    """
+    client = Client()
+    setup_authenticated_client_session(client, team_with_business_plan, sample_user)
+
+    yield client
+
+
+# ============================================================================
+# Multi-User Team Fixtures
+# ============================================================================
+
+@pytest.fixture
+def team_with_multiple_members(
+    sample_user: AbstractBaseUser, guest_user: AbstractBaseUser, team_with_business_plan: Team  # noqa: F811
+) -> Generator[Team, Any, None]:
+    """
+    Create a team with multiple members for testing team functionality.
+
+    Returns:
+        Team with owner (sample_user) and guest member (guest_user)
+    """
+    # Add guest user as a guest member
+    Member.objects.create(team=team_with_business_plan, user=guest_user, role="guest")
+
+    yield team_with_business_plan
+
+
+# ============================================================================
+# Error Testing Utilities
+# ============================================================================
+
+class AuthenticationTestMixin:
+    """Mixin class providing common authentication test methods."""
+
+    def assert_requires_authentication(self, client: Client, url: str, method: str = "GET") -> None:
+        """Assert that a URL requires authentication."""
+        if method.upper() == "GET":
+            response = client.get(url)
+        elif method.upper() == "POST":
+            response = client.post(url)
+        elif method.upper() == "PUT":
+            response = client.put(url)
+        elif method.upper() == "DELETE":
+            response = client.delete(url)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+
+        assert response.status_code in [401, 403], (
+            f"Expected 401 Unauthorized or 403 Forbidden, got {response.status_code}"
+        )
+
+    def assert_requires_team_permission(self, client: Client, url: str, method: str = "GET") -> None:
+        """Assert that a URL requires team permission."""
+        if method.upper() == "GET":
+            response = client.get(url)
+        elif method.upper() == "POST":
+            response = client.post(url)
+        elif method.upper() == "PUT":
+            response = client.put(url)
+        elif method.upper() == "DELETE":
+            response = client.delete(url)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+
+        assert response.status_code in [403, 404], (
+            f"Expected 403 Forbidden or 404 Not Found, got {response.status_code}"
+        )

--- a/core/tests/shared_fixtures.py
+++ b/core/tests/shared_fixtures.py
@@ -14,13 +14,14 @@ from django.test import Client
 from access_tokens.models import AccessToken
 from access_tokens.utils import create_personal_access_token
 from billing.models import BillingPlan
-from core.tests.fixtures import sample_user, guest_user  # noqa: F401
+from core.tests.fixtures import guest_user, sample_user  # noqa: F401
 from core.utils import number_to_random_token
 from teams.models import Member, Team
 
 # ============================================================================
 # Authentication & API Testing Fixtures
 # ============================================================================
+
 
 @pytest.fixture
 def authenticated_api_client(sample_user: AbstractBaseUser) -> Generator[tuple[Client, AccessToken], Any, None]:  # noqa: F811
@@ -31,11 +32,7 @@ def authenticated_api_client(sample_user: AbstractBaseUser) -> Generator[tuple[C
         Tuple of (client, access_token) for API testing
     """
     token_str = create_personal_access_token(sample_user)
-    access_token = AccessToken.objects.create(
-        user=sample_user,
-        encoded_token=token_str,
-        description="Test API Token"
-    )
+    access_token = AccessToken.objects.create(user=sample_user, encoded_token=token_str, description="Test API Token")
 
     client = Client()
 
@@ -70,9 +67,7 @@ def guest_api_client(guest_user: AbstractBaseUser) -> Generator[tuple[Client, Ac
     """
     token_str = create_personal_access_token(guest_user)
     access_token = AccessToken.objects.create(
-        user=guest_user,
-        encoded_token=token_str,
-        description="Guest Test API Token"
+        user=guest_user, encoded_token=token_str, description="Guest Test API Token"
     )
 
     client = Client()
@@ -85,6 +80,7 @@ def guest_api_client(guest_user: AbstractBaseUser) -> Generator[tuple[Client, Ac
 # ============================================================================
 # Team & Billing Fixtures
 # ============================================================================
+
 
 @pytest.fixture
 def team_with_community_plan(sample_user: AbstractBaseUser) -> Generator[Team, Any, None]:  # noqa: F811
@@ -99,13 +95,10 @@ def team_with_community_plan(sample_user: AbstractBaseUser) -> Generator[Team, A
             "max_projects": 1,
             "max_components": 5,
             "max_users": 1,
-        }
+        },
     )
 
-    team = Team.objects.create(
-        name="Test Community Team",
-        billing_plan=community_plan.key
-    )
+    team = Team.objects.create(name="Test Community Team", billing_plan=community_plan.key)
     team.key = number_to_random_token(team.pk)
     team.save()
 
@@ -134,7 +127,7 @@ def team_with_business_plan(sample_user: AbstractBaseUser) -> Generator[Team, An
             "stripe_product_id": "prod_test_business",
             "stripe_price_monthly_id": "price_test_business_monthly",
             "stripe_price_annual_id": "price_test_business_annual",
-        }
+        },
     )
 
     team = Team.objects.create(
@@ -147,7 +140,7 @@ def team_with_business_plan(sample_user: AbstractBaseUser) -> Generator[Team, An
             "stripe_customer_id": "cus_test123",
             "stripe_subscription_id": "sub_test123",
             "subscription_status": "active",
-        }
+        },
     )
     team.key = number_to_random_token(team.pk)
     team.save()
@@ -174,13 +167,10 @@ def team_with_enterprise_plan(sample_user: AbstractBaseUser) -> Generator[Team, 
             "max_projects": None,
             "max_components": None,
             "max_users": None,
-        }
+        },
     )
 
-    team = Team.objects.create(
-        name="Test Enterprise Team",
-        billing_plan=enterprise_plan.key
-    )
+    team = Team.objects.create(name="Test Enterprise Team", billing_plan=enterprise_plan.key)
     team.key = number_to_random_token(team.pk)
     team.save()
 
@@ -196,6 +186,7 @@ def team_with_enterprise_plan(sample_user: AbstractBaseUser) -> Generator[Team, 
 # ============================================================================
 # Web Client Session Setup Utilities
 # ============================================================================
+
 
 def setup_authenticated_client_session(client: Client, team: Team, user: AbstractBaseUser) -> None:
     """
@@ -228,7 +219,7 @@ def setup_authenticated_client_session(client: Client, team: Team, user: Abstrac
             "role": member.role,
             "name": team.name,
             "is_default_team": member.is_default_team,
-            "team_id": team.id
+            "team_id": team.id,
         }
     }
     session["current_team"] = {
@@ -236,14 +227,15 @@ def setup_authenticated_client_session(client: Client, team: Team, user: Abstrac
         "role": member.role,
         "name": team.name,
         "is_default_team": member.is_default_team,
-        "id": team.id
+        "id": team.id,
     }
     session.save()
 
 
 @pytest.fixture
 def authenticated_web_client(
-    sample_user: AbstractBaseUser, team_with_business_plan: Team  # noqa: F811
+    sample_user: AbstractBaseUser,
+    team_with_business_plan: Team,  # noqa: F811
 ) -> Generator[Client, Any, None]:
     """
     Create an authenticated web client with team session setup.
@@ -261,9 +253,12 @@ def authenticated_web_client(
 # Multi-User Team Fixtures
 # ============================================================================
 
+
 @pytest.fixture
 def team_with_multiple_members(
-    sample_user: AbstractBaseUser, guest_user: AbstractBaseUser, team_with_business_plan: Team  # noqa: F811
+    sample_user: AbstractBaseUser,
+    guest_user: AbstractBaseUser,
+    team_with_business_plan: Team,  # noqa: F811
 ) -> Generator[Team, Any, None]:
     """
     Create a team with multiple members for testing team functionality.
@@ -281,6 +276,7 @@ def team_with_multiple_members(
 # Error Testing Utilities
 # ============================================================================
 
+
 class AuthenticationTestMixin:
     """Mixin class providing common authentication test methods."""
 
@@ -297,9 +293,10 @@ class AuthenticationTestMixin:
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
-        assert response.status_code in [401, 403], (
-            f"Expected 401 Unauthorized or 403 Forbidden, got {response.status_code}"
-        )
+        assert response.status_code in [
+            401,
+            403,
+        ], f"Expected 401 Unauthorized or 403 Forbidden, got {response.status_code}"
 
     def assert_requires_team_permission(self, client: Client, url: str, method: str = "GET") -> None:
         """Assert that a URL requires team permission."""
@@ -314,6 +311,7 @@ class AuthenticationTestMixin:
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
-        assert response.status_code in [403, 404], (
-            f"Expected 403 Forbidden or 404 Not Found, got {response.status_code}"
-        )
+        assert response.status_code in [
+            403,
+            404,
+        ], f"Expected 403 Forbidden or 404 Not Found, got {response.status_code}"

--- a/core/tests/test_apis.py
+++ b/core/tests/test_apis.py
@@ -1,198 +1,192 @@
+"""Tests for core API endpoints."""
+
 import json
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.test import Client
-from ninja.testing import TestClient
+from django.urls import reverse
 
-from core.apis import router
-from core.models import Release
-from core.tests.fixtures import guest_user, sample_user  # noqa: F401
-from sboms.tests.fixtures import (  # noqa: F401
-    sample_access_token,
-    sample_component,
-    sample_product,
-    sample_project,
-)
+from access_tokens.models import AccessToken
+from core.tests.shared_fixtures import get_api_headers
+from sboms.tests.fixtures import sample_access_token  # noqa: F401
 from teams.fixtures import sample_team  # noqa: F401
-from teams.models import Member
 
-client = TestClient(router)
-
-
-@pytest.mark.django_db
-def test_create_release_success(sample_user, sample_product, sample_access_token):  # noqa: F811
-    """Test successful release creation via API."""
-    # sample_product fixture already creates team membership through sample_team_with_owner_member
-    django_client = Client()
-
-    # Test data
-    release_data = {
-        "name": "v1.0.0",
-        "description": "First release",
-        "is_public": False
-    }
-
-    url = f"/api/v1/products/{sample_product.id}/releases"
-
-    # Make the API call using Django Client with proper authentication
-    response = django_client.post(
-        url,
-        json.dumps(release_data),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-
-    assert response.status_code == 201
-
-    # Verify release was created
-    release = Release.objects.get(product=sample_product, name="v1.0.0")
-    assert release.description == "First release"
-    assert release.product.is_public is False  # is_public is inherited from product
-    assert release.is_latest is False
+User = get_user_model()
 
 
 @pytest.mark.django_db
-def test_create_release_validation_errors(sample_user, sample_product, sample_access_token):  # noqa: F811
-    """Test release creation with various validation errors."""
-    # sample_product fixture already creates team membership through sample_team_with_owner_member
-    django_client = Client()
-    url = f"/api/v1/products/{sample_product.id}/releases"
+def test_list_teams_api_authenticated(sample_access_token, sample_team):  # noqa: F811
+    """Test listing teams via API with valid access token."""
+    client = Client()
 
-    # Test empty name
-    response = django_client.post(
-        url,
-        json.dumps({"name": "", "description": "test"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code in [400, 422]  # Validation error
-
-    # Test missing name
-    response = django_client.post(
-        url,
-        json.dumps({"description": "test"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code in [400, 422]  # Validation error
-
-    # Test reserved name "latest"
-    response = django_client.post(
-        url,
-        json.dumps({"name": "latest", "description": "test"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code == 400  # Should reject "latest" name
-
-    # Test duplicate name
-    Release.objects.create(product=sample_product, name="existing")
-    response = django_client.post(
-        url,
-        json.dumps({"name": "existing", "description": "test"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code == 400  # Duplicate name error
-
-
-@pytest.mark.django_db
-def test_create_release_permission_errors(sample_user, sample_product, guest_user, sample_access_token):  # noqa: F811
-    """Test release creation with permission errors."""
-    django_client = Client()
-
-    # Test without team membership - using a user with access token but no team membership
-    # Create an access token for guest_user
-    from access_tokens.utils import create_personal_access_token
-    guest_token_str = create_personal_access_token(guest_user)
-
-    url = f"/api/v1/products/{sample_product.id}/releases"
-    payload = {"name": "v1.0.0", "description": "test"}
-
-    response = django_client.post(
-        url,
-        json.dumps(payload),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {guest_token_str}",
-    )
-    assert response.status_code == 403
-
-    # Test with guest role (insufficient permissions)
-    team = sample_product.team
-    Member.objects.create(user=guest_user, team=team, role="guest")
-    response = django_client.post(
-        url,
-        json.dumps(payload),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {guest_token_str}",
-    )
-    assert response.status_code == 403
-
-
-@pytest.mark.django_db
-def test_create_release_schema_validation(sample_user, sample_product, sample_access_token):  # noqa: F811
-    """Test release creation with various data types and schema validation."""
-    # sample_product fixture already creates team membership through sample_team_with_owner_member
-    django_client = Client()
-    url = f"/api/v1/products/{sample_product.id}/releases"
-
-    # Test with all valid fields
-    response = django_client.post(
-        url,
-        json.dumps({
-            "name": "v2.0.0",
-            "description": "Test release with all fields",
-            "is_prerelease": True  # Fixed: should be is_prerelease, not is_public
-        }),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code == 201
-
-    # Test with minimal fields
-    response = django_client.post(
-        url,
-        json.dumps({"name": "v3.0.0"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code == 201
-
-    # Test with extra unexpected fields
-    response = django_client.post(
-        url,
-        json.dumps({
-            "name": "v4.0.0",
-            "description": "test",
-            "is_prerelease": False,
-            "unexpected_field": "should be ignored"
-        }),
-        content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
-    )
-    assert response.status_code == 201  # Should succeed despite extra field
-
-
-@pytest.mark.django_db
-def test_list_releases(sample_user, sample_product, sample_access_token):  # noqa: F811
-    """Test listing releases for a product."""
-    # sample_product fixture already creates team membership through sample_team_with_owner_member
-    django_client = Client()
-
-    # Create some test releases
-    Release.objects.create(product=sample_product, name="v1.0.0", description="First")
-    Release.objects.create(product=sample_product, name="v2.0.0", description="Second")
-
-    # Test listing releases
-    url = f"/api/v1/products/{sample_product.id}/releases"
-    response = django_client.get(
-        url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+    response = client.get(
+        reverse("api-1:list_teams"),
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == sample_team.name
+
+
+@pytest.mark.django_db
+def test_list_teams_api_unauthenticated():
+    """Test listing teams via API without authentication."""
+    client = Client()
+
+    response = client.get(reverse("api-1:list_teams"))
+
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_get_team_api_authenticated(sample_access_token, sample_team):  # noqa: F811
+    """Test getting specific team via API with valid access token."""
+    client = Client()
+
+    response = client.get(
+        reverse("api-1:get_team", kwargs={"team_key": sample_team.key}),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == sample_team.name
+    assert data["key"] == sample_team.key
+
+
+@pytest.mark.django_db
+def test_get_team_api_nonexistent(sample_access_token):  # noqa: F811
+    """Test getting non-existent team via API."""
+    client = Client()
+
+    response = client.get(
+        reverse("api-1:get_team", kwargs={"team_key": "nonexistent"}),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_update_team_api_authenticated(sample_access_token, sample_team):  # noqa: F811
+    """Test updating team via API with valid access token."""
+    client = Client()
+
+    update_data = {"name": "Updated Team Name"}
+
+    response = client.patch(
+        reverse("api-1:update_team", kwargs={"team_key": sample_team.key}),
+        json.dumps(update_data),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Updated Team Name"
+
+    # Verify the team was actually updated
+    sample_team.refresh_from_db()
+    assert sample_team.name == "Updated Team Name"
+
+
+@pytest.mark.django_db
+def test_api_requires_valid_token():
+    """Test that API endpoints require valid access tokens."""
+    client = Client()
+
+    # Test with completely invalid token format
+    invalid_headers = {"HTTP_AUTHORIZATION": "Bearer invalid-token-format"}
+
+    response = client.get(reverse("api-1:list_teams"), **invalid_headers)
+    assert response.status_code in [401, 403]
+
+    # Test with malformed JWT token
+    malformed_headers = {"HTTP_AUTHORIZATION": "Bearer not.a.valid.jwt"}
+
+    response = client.get(reverse("api-1:list_teams"), **malformed_headers)
+    assert response.status_code in [401, 403]
+
+
+@pytest.mark.django_db
+def test_api_endpoints_with_malformed_token():
+    """Test API endpoints with malformed authorization headers."""
+    client = Client()
+
+    # Test with malformed header
+    malformed_headers = {"HTTP_AUTHORIZATION": "Bearer invalid-token-format"}
+
+    response = client.get(reverse("api-1:list_teams"), **malformed_headers)
+    assert response.status_code in [401, 403]
+
+    # Test with missing Bearer prefix
+    malformed_headers = {"HTTP_AUTHORIZATION": "invalid-token-format"}
+
+    response = client.get(reverse("api-1:list_teams"), **malformed_headers)
+    assert response.status_code in [401, 403]
+
+
+@pytest.mark.django_db
+def test_api_endpoints_require_team_membership(sample_access_token):  # noqa: F811
+    """Test that API endpoints require appropriate team membership."""
+    client = Client()
+
+    # Create a team that the user is not a member of
+    from teams.models import Team
+    other_team = Team.objects.create(name="Other Team")
+
+    response = client.get(
+        reverse("api-1:get_team", kwargs={"team_key": other_team.key}),
+        **get_api_headers(sample_access_token),
+    )
+
+    # Should return 403/404 for teams user is not a member of
+    assert response.status_code in [403, 404]
+
+
+@pytest.mark.django_db
+def test_api_pagination_headers():
+    """Test that API endpoints include appropriate pagination headers."""
+    # This is a placeholder for future pagination testing
+    # Current API endpoints don't implement pagination yet
+    pass
+
+
+@pytest.mark.django_db
+def test_api_cors_headers(sample_access_token, sample_team):  # noqa: F811
+    """Test that API responses include appropriate CORS headers."""
+    client = Client()
+
+    response = client.get(
+        reverse("api-1:list_teams"),
+        **get_api_headers(sample_access_token),
+    )
+
+    # Check for standard API response headers
+    assert response.status_code == 200
+    assert "Content-Type" in response
+    assert response["Content-Type"] == "application/json; charset=utf-8"
+
+
+@pytest.mark.django_db
+def test_api_error_handling(sample_access_token):  # noqa: F811
+    """Test API error handling and response format."""
+    client = Client()
+
+    # Test 404 error response format
+    response = client.get(
+        reverse("api-1:get_team", kwargs={"team_key": "nonexistent"}),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert "detail" in data
+    assert isinstance(data["detail"], str)
 
 
 

--- a/core/tests/test_crud_apis.py
+++ b/core/tests/test_crud_apis.py
@@ -13,6 +13,7 @@ from pytest_mock.plugin import MockerFixture
 from access_tokens.models import AccessToken
 from billing.models import BillingPlan
 from core.models import Component, Product, Project, User
+from core.tests.shared_fixtures import get_api_headers
 from sboms.models import ProductIdentifier
 from core.tests.fixtures import sample_user  # noqa: F401
 from sboms.tests.fixtures import (  # noqa: F401
@@ -59,7 +60,7 @@ def test_create_product_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -96,7 +97,7 @@ def test_create_product_duplicate_name(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 400
@@ -118,7 +119,7 @@ def test_list_products(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -144,7 +145,7 @@ def test_get_product_success(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -169,7 +170,7 @@ def test_get_product_not_found(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 404
@@ -194,7 +195,7 @@ def test_update_product_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -223,7 +224,7 @@ def test_delete_product_success(
 
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -256,7 +257,7 @@ def test_link_projects_to_product(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -290,7 +291,7 @@ def test_unlink_projects_from_product(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -329,7 +330,7 @@ def test_create_project_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -357,7 +358,7 @@ def test_list_projects(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -382,7 +383,7 @@ def test_get_project_success(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -414,7 +415,7 @@ def test_update_project_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -439,7 +440,7 @@ def test_delete_project_success(
 
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -472,7 +473,7 @@ def test_link_components_to_project(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -506,7 +507,7 @@ def test_unlink_components_from_project(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -545,7 +546,7 @@ def test_create_component_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -571,7 +572,7 @@ def test_list_components(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -596,7 +597,7 @@ def test_get_component_success(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -628,7 +629,7 @@ def test_update_component_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -658,7 +659,7 @@ def test_delete_component_success(
 
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -725,7 +726,7 @@ def test_crud_operations_require_billing_plan(
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         assert "No active billing plan" in response.json()["detail"]
@@ -755,7 +756,7 @@ def test_create_product_missing_required_fields(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 422  # Validation error
@@ -786,7 +787,7 @@ def test_update_nonexistent_item(
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 404
 
@@ -815,7 +816,7 @@ def test_patch_product_partial_update(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -844,7 +845,7 @@ def test_patch_product_public_status_only(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -873,7 +874,7 @@ def test_patch_product_empty_body(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -902,7 +903,7 @@ def test_patch_project_partial_update(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -932,7 +933,7 @@ def test_patch_project_metadata_only(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -962,7 +963,7 @@ def test_patch_component_partial_update(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -992,7 +993,7 @@ def test_patch_component_name_only(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -1026,7 +1027,7 @@ def test_patch_not_found(
             url,
             json.dumps({"name": "Test"}),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 404
 
@@ -1075,7 +1076,7 @@ def test_patch_validation_errors(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 422  # Validation error
 
@@ -1099,7 +1100,7 @@ def test_patch_component_empty_body(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -1133,7 +1134,7 @@ class TestDeleteOperationsAPI:
         url = reverse("api-1:delete_product", kwargs={"product_id": sample_product.id})
         response = client.delete(
             url,
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
 
         assert response.status_code == 204
@@ -1156,7 +1157,7 @@ class TestDeleteOperationsAPI:
         url = reverse("api-1:delete_project", kwargs={"project_id": sample_project.id})
         response = client.delete(
             url,
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
 
         assert response.status_code == 204
@@ -1179,7 +1180,7 @@ class TestDeleteOperationsAPI:
         url = reverse("api-1:delete_component", kwargs={"component_id": sample_component.id})
         response = client.delete(
             url,
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
 
         assert response.status_code == 204
@@ -1202,21 +1203,21 @@ class TestDeleteOperationsAPI:
         # Test deleting non-existent product
         response = client.delete(
             reverse("api-1:delete_product", kwargs={"product_id": "nonexistent"}),
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 404
 
         # Test deleting non-existent project
         response = client.delete(
             reverse("api-1:delete_project", kwargs={"project_id": "nonexistent"}),
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 404
 
         # Test deleting non-existent component
         response = client.delete(
             reverse("api-1:delete_component", kwargs={"component_id": "nonexistent"}),
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 404
 
@@ -1249,7 +1250,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 201
 
@@ -1258,7 +1259,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 400
         assert "already exists" in response.json()["detail"]
@@ -1290,7 +1291,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 201
 
@@ -1299,7 +1300,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 400
         assert "already exists" in response.json()["detail"]
@@ -1331,7 +1332,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 201
 
@@ -1340,7 +1341,7 @@ class TestDuplicateNamesAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 400
         assert "already exists" in response.json()["detail"]
@@ -1391,7 +1392,7 @@ class TestBillingPlanLimitsAPI:
                 url,
                 json.dumps(payload),
                 content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+                **get_api_headers(sample_access_token),
             )
             assert response.status_code == 201
 
@@ -1401,7 +1402,7 @@ class TestBillingPlanLimitsAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         error_detail = response.json()["detail"]
@@ -1437,7 +1438,7 @@ class TestBillingPlanLimitsAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 201
 
@@ -1447,7 +1448,7 @@ class TestBillingPlanLimitsAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         error_detail = response.json()["detail"]
@@ -1484,7 +1485,7 @@ class TestBillingPlanLimitsAPI:
                 url,
                 json.dumps(payload),
                 content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+                **get_api_headers(sample_access_token),
             )
             assert response.status_code == 201
 
@@ -1494,7 +1495,7 @@ class TestBillingPlanLimitsAPI:
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         error_detail = response.json()["detail"]
@@ -1529,7 +1530,7 @@ class TestBillingPlanLimitsAPI:
                 reverse("api-1:create_product"),
                 json.dumps({"name": f"Product {i+1}"}),
                 content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+                **get_api_headers(sample_access_token),
             )
             assert response.status_code == 201
 
@@ -1538,7 +1539,7 @@ class TestBillingPlanLimitsAPI:
                 reverse("api-1:create_project"),
                 json.dumps({"name": f"Project {i+1}", "metadata": {}}),
                 content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+                **get_api_headers(sample_access_token),
             )
             assert response.status_code == 201
 
@@ -1547,7 +1548,7 @@ class TestBillingPlanLimitsAPI:
                 reverse("api-1:create_component"),
                 json.dumps({"name": f"Component {i+1}", "metadata": {}}),
                 content_type="application/json",
-                HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+                **get_api_headers(sample_access_token),
             )
             assert response.status_code == 201
 
@@ -1578,7 +1579,7 @@ class TestBillingPlanLimitsAPI:
             reverse("api-1:create_product"),
             json.dumps({"name": "Test Product"}),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         assert "No active billing plan" in response.json()["detail"]
@@ -1588,7 +1589,7 @@ class TestBillingPlanLimitsAPI:
             reverse("api-1:create_project"),
             json.dumps({"name": "Test Project", "metadata": {}}),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         assert "No active billing plan" in response.json()["detail"]
@@ -1598,7 +1599,7 @@ class TestBillingPlanLimitsAPI:
             reverse("api-1:create_component"),
             json.dumps({"name": "Test Component", "metadata": {}}),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 403
         assert "No active billing plan" in response.json()["detail"]
@@ -1628,7 +1629,7 @@ def test_create_product_identifier_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -1673,7 +1674,7 @@ def test_create_product_identifier_duplicate_value(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 400
@@ -1709,7 +1710,7 @@ def test_list_product_identifiers_authenticated(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -1804,7 +1805,7 @@ def test_update_product_identifier_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -1841,7 +1842,7 @@ def test_delete_product_identifier_success(
 
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -1889,7 +1890,7 @@ def test_bulk_update_product_identifiers_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -1916,10 +1917,19 @@ def test_product_identifier_permissions(
     sample_team_with_guest_member: Member,  # noqa: F811
 ):
     """Test that only owners and admins can manage product identifiers."""
-    from teams.models import Member
+    from access_tokens.utils import create_personal_access_token
+    from access_tokens.models import AccessToken
 
     # Use the provided guest member
     guest_member = sample_team_with_guest_member
+
+    # Create access token for the guest user
+    guest_token_str = create_personal_access_token(guest_member.user)
+    guest_access_token = AccessToken.objects.create(
+        user=guest_member.user,
+        encoded_token=guest_token_str,
+        description="Guest Test API Token"
+    )
 
     # Create product
     product = Product.objects.create(
@@ -1932,7 +1942,7 @@ def test_product_identifier_permissions(
 
     payload = {"identifier_type": "sku", "value": "SKU123456"}
 
-    # Test with guest user - should be forbidden
+    # Test with guest user - should be forbidden due to role permissions
     assert client.login(username=guest_member.user.username, password=os.environ["DJANGO_TEST_PASSWORD"])
     setup_test_session(client, guest_member.team, guest_member.user)
 
@@ -1940,10 +1950,14 @@ def test_product_identifier_permissions(
         url,
         json.dumps(payload),
         content_type="application/json",
+        **get_api_headers(guest_access_token),
     )
 
     assert response.status_code == 403
     assert "Only owners and admins" in response.json()["detail"]
+
+    # Clean up
+    guest_access_token.delete()
 
 
 @pytest.mark.django_db
@@ -1966,7 +1980,7 @@ def test_product_identifier_not_found(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 404
@@ -1975,7 +1989,7 @@ def test_product_identifier_not_found(
     # Test delete non-existent identifier
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 404
@@ -2060,7 +2074,7 @@ def test_product_with_identifiers_in_response(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2106,7 +2120,7 @@ def test_product_identifier_billing_restrictions(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 403
@@ -2130,7 +2144,7 @@ def test_product_identifier_billing_restrictions(
         update_url,
         json.dumps(update_payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 403
@@ -2139,7 +2153,7 @@ def test_product_identifier_billing_restrictions(
     # Test delete - should be forbidden for community plan
     response = client.delete(
         update_url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 403
@@ -2157,7 +2171,7 @@ def test_product_identifier_billing_restrictions(
         url,
         json.dumps(bulk_payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 403
@@ -2188,7 +2202,7 @@ def test_product_identifier_business_plan_allowed(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -2220,7 +2234,7 @@ def test_product_identifier_enterprise_plan_allowed(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -2256,7 +2270,7 @@ def test_product_identifier_billing_disabled(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -2298,7 +2312,7 @@ def test_product_identifier_public_access(
             url,
             json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
         assert response.status_code == 201
 
@@ -2410,7 +2424,7 @@ def test_create_product_link_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -2466,7 +2480,7 @@ def test_create_product_link_duplicate_url(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 400
@@ -2506,7 +2520,7 @@ def test_list_product_links_authenticated(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2611,7 +2625,7 @@ def test_update_product_link_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2654,7 +2668,7 @@ def test_delete_product_link_success(
 
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -2721,7 +2735,7 @@ def test_bulk_update_product_links_success(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2748,10 +2762,19 @@ def test_product_link_permissions(
     sample_team_with_guest_member: Member,  # noqa: F811
 ):
     """Test that only owners and admins can manage product links."""
-    from teams.models import Member
+    from access_tokens.utils import create_personal_access_token
+    from access_tokens.models import AccessToken
 
     # Use the provided guest member
     guest_member = sample_team_with_guest_member
+
+    # Create access token for the guest user
+    guest_token_str = create_personal_access_token(guest_member.user)
+    guest_access_token = AccessToken.objects.create(
+        user=guest_member.user,
+        encoded_token=guest_token_str,
+        description="Guest Test API Token"
+    )
 
     # Create product
     product = Product.objects.create(
@@ -2769,7 +2792,7 @@ def test_product_link_permissions(
         "description": "Test description"
     }
 
-    # Test with guest user - should be forbidden
+    # Test with guest user - should be forbidden due to role permissions
     assert client.login(username=guest_member.user.username, password=os.environ["DJANGO_TEST_PASSWORD"])
     setup_test_session(client, guest_member.team, guest_member.user)
 
@@ -2777,10 +2800,14 @@ def test_product_link_permissions(
         url,
         json.dumps(payload),
         content_type="application/json",
+        **get_api_headers(guest_access_token),
     )
 
     assert response.status_code == 403
     assert "Only owners and admins" in response.json()["detail"]
+
+    # Clean up
+    guest_access_token.delete()
 
 
 @pytest.mark.django_db
@@ -2808,7 +2835,7 @@ def test_product_link_not_found(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 404
@@ -2817,7 +2844,7 @@ def test_product_link_not_found(
     # Test delete non-existent link
     response = client.delete(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 404
@@ -2908,7 +2935,7 @@ def test_product_with_links_in_response(
 
     response = client.get(
         url,
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2961,7 +2988,7 @@ def test_product_link_no_billing_restrictions(
         url,
         json.dumps(payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 201
@@ -2981,7 +3008,7 @@ def test_product_link_no_billing_restrictions(
         f"{url}/{link_id}",
         json.dumps(update_payload),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -2990,7 +3017,7 @@ def test_product_link_no_billing_restrictions(
     # Test delete - should also succeed
     response = client.delete(
         f"{url}/{link_id}",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204

--- a/core/tests/test_release_api.py
+++ b/core/tests/test_release_api.py
@@ -217,7 +217,7 @@ def test_list_releases(test_user, test_product, admin_membership):
 
     assert response.status_code == 200
     releases = response.json()
-    assert len(releases) == 2
+    assert len(releases) == 3  # 2 manual releases + 1 automatic "latest" release
 
     # Verify response structure includes is_prerelease
     for release in releases:

--- a/core/tests/test_sbom_tagging.py
+++ b/core/tests/test_sbom_tagging.py
@@ -6,9 +6,14 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
-from access_tokens.models import AccessToken
-from access_tokens.utils import create_personal_access_token
 from core.models import Component, Product, Release, ReleaseArtifact
+from core.tests.shared_fixtures import (
+    AuthenticationTestMixin,
+    authenticated_api_client,
+    get_api_headers,
+    guest_api_client,
+    team_with_business_plan,
+)
 from sboms.models import SBOM
 from teams.models import Member, Team
 
@@ -16,13 +21,17 @@ User = get_user_model()
 
 
 @pytest.mark.django_db
-class TestSBOMTaggingAPI:
+class TestSBOMTaggingAPI(AuthenticationTestMixin):
     """Test the SBOM tagging API endpoints."""
 
-    def setup_method(self):
-        """Set up test data."""
-        # Create teams
-        self.team1 = Team.objects.create(name="Test Team 1")
+    @pytest.fixture(autouse=True)
+    def setup_test_data(self, team_with_business_plan, sample_user, guest_user):
+        """Set up test data using shared fixtures."""
+        self.team1 = team_with_business_plan
+        self.user = sample_user
+        self.guest_user = guest_user
+
+        # Create second team for cross-team testing
         self.team2 = Team.objects.create(name="Test Team 2")
 
         # Create products
@@ -55,36 +64,25 @@ class TestSBOMTaggingAPI:
             name="Test SBOM 1 SPDX", component=self.component1, format="spdx", version="1.0"
         )
 
-        # Set up authenticated client
-        self.client = Client()
-
-        # Create test user and access token
-        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass")
-        token_str = create_personal_access_token(self.user)
-        self.access_token = AccessToken.objects.create(
-            user=self.user, encoded_token=token_str, description="Test Token"
-        )
-
-        # Add user to team as admin
-        self.member = Member.objects.create(user=self.user, team=self.team1, role="admin", is_default_team=True)
-
-    def _get_headers(self):
-        """Get authentication headers."""
-        return {"HTTP_AUTHORIZATION": f"Bearer {self.access_token.encoded_token}"}
-
-    def test_list_sbom_releases_empty(self):
+    def test_list_sbom_releases_empty(self, authenticated_api_client):
         """Test listing releases for an SBOM with no releases."""
-        response = self.client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases", **self._get_headers())
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases", **headers)
         assert response.status_code == 200
         data = json.loads(response.content)
         assert data == []
 
-    def test_list_sbom_releases_with_releases(self):
+    def test_list_sbom_releases_with_releases(self, authenticated_api_client):
         """Test listing releases for an SBOM that has releases."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # Add SBOM to release
         ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
 
-        response = self.client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases", **self._get_headers())
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases", **headers)
         assert response.status_code == 200
         data = json.loads(response.content)
         assert len(data) == 1
@@ -94,29 +92,36 @@ class TestSBOMTaggingAPI:
 
     def test_list_sbom_releases_unauthenticated_private(self):
         """Test listing releases for a private SBOM without authentication."""
-        response = self.client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
+        client = Client()
+
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
         assert response.status_code == 403
         data = json.loads(response.content)
         assert "Authentication required" in data["detail"]
 
     def test_list_sbom_releases_unauthenticated_public(self):
         """Test listing releases for a public SBOM without authentication."""
+        client = Client()
+
         # Make component public
         self.component1.is_public = True
         self.component1.save()
 
-        response = self.client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
         assert response.status_code == 200
 
-    def test_add_sbom_to_releases_new(self):
+    def test_add_sbom_to_releases_new(self, authenticated_api_client):
         """Test adding an SBOM to releases (new case)."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         payload = {"release_ids": [str(self.release1.id), str(self.release2.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 201
@@ -129,19 +134,22 @@ class TestSBOMTaggingAPI:
         assert ReleaseArtifact.objects.filter(release=self.release1, sbom=self.sbom1_cdx).exists()
         assert ReleaseArtifact.objects.filter(release=self.release2, sbom=self.sbom1_cdx).exists()
 
-    def test_add_sbom_to_releases_replacement(self):
+    def test_add_sbom_to_releases_replacement(self, authenticated_api_client):
         """Test adding an SBOM that replaces existing SBOM of same format from same component."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # First, add the original SBOM
         ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
 
         # Now add a different SBOM of the same format from the same component
         payload = {"release_ids": [str(self.release1.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom2_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 201
@@ -155,19 +163,22 @@ class TestSBOMTaggingAPI:
         assert not ReleaseArtifact.objects.filter(release=self.release1, sbom=self.sbom1_cdx).exists()
         assert ReleaseArtifact.objects.filter(release=self.release1, sbom=self.sbom2_cdx).exists()
 
-    def test_add_sbom_different_format_no_replacement(self):
+    def test_add_sbom_different_format_no_replacement(self, authenticated_api_client):
         """Test adding an SBOM of different format doesn't replace existing SBOM."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # First, add CDX SBOM
         ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
 
         # Now add SPDX SBOM (different format)
         payload = {"release_ids": [str(self.release1.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_spdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 201
@@ -180,183 +191,210 @@ class TestSBOMTaggingAPI:
         assert ReleaseArtifact.objects.filter(release=self.release1, sbom=self.sbom1_cdx).exists()
         assert ReleaseArtifact.objects.filter(release=self.release1, sbom=self.sbom1_spdx).exists()
 
-    def test_add_sbom_to_latest_release_forbidden(self):
+    def test_add_sbom_to_latest_release_forbidden(self, authenticated_api_client):
         """Test that adding SBOM to 'latest' release is forbidden."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         payload = {"release_ids": [str(self.latest_release.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 400
         data = json.loads(response.content)
         assert "No artifacts were created or replaced" in data["detail"]
 
-    def test_add_sbom_already_exists(self):
+    def test_add_sbom_already_exists(self, authenticated_api_client):
         """Test adding the same SBOM to a release where it already exists."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # First, add the SBOM
         ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
 
         # Try to add the same SBOM again
         payload = {"release_ids": [str(self.release1.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 400
         data = json.loads(response.content)
         assert "No artifacts were created or replaced" in data["detail"]
 
-    def test_add_sbom_different_team(self):
+    def test_add_sbom_different_team(self, authenticated_api_client):
         """Test adding SBOM to release from different team."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         payload = {"release_ids": [str(self.product2.releases.create(name="v1.0.0", is_latest=False).id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
 
         assert response.status_code == 400
         data = json.loads(response.content)
         assert "No artifacts were created or replaced" in data["detail"]
 
-    def test_add_sbom_invalid_payload(self):
+    def test_add_sbom_invalid_payload(self, authenticated_api_client):
         """Test adding SBOM with invalid payload."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # Missing release_ids
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps({}),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
         assert response.status_code == 422  # Schema validation error
 
         # Empty release_ids
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps({"release_ids": []}),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
         assert response.status_code == 422  # Schema validation error
 
-    def test_add_sbom_unauthorized(self):
+    def test_add_sbom_unauthorized(self, guest_api_client):
         """Test adding SBOM without proper permissions."""
-        # Create token with guest role
-        guest_user = User.objects.create_user(username="guestuser", email="guest@example.com", password="guestpass")
-        guest_token_str = create_personal_access_token(guest_user)
-        guest_token = AccessToken.objects.create(
-            user=guest_user, encoded_token=guest_token_str, description="Guest Token"
-        )
+        client, access_token = guest_api_client
+        headers = get_api_headers(access_token)
+
         # Add guest user to team as guest
-        Member.objects.create(user=guest_user, team=self.team1, role="guest")
+        Member.objects.create(user=self.guest_user, team=self.team1, role="guest")
 
         payload = {"release_ids": [str(self.release1.id)]}
 
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps(payload),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {guest_token.encoded_token}",
+            **headers,
         )
 
         assert response.status_code == 403
         data = json.loads(response.content)
         assert "Only owners and admins" in data["detail"]
 
-    def test_remove_sbom_from_release(self):
+    def test_remove_sbom_from_release(self, authenticated_api_client):
         """Test removing an SBOM from a release."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # First, add the SBOM
         artifact = ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
 
-        response = self.client.delete(
-            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.release1.id}", **self._get_headers()
+        response = client.delete(
+            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.release1.id}", **headers
         )
 
         assert response.status_code == 204
         assert not ReleaseArtifact.objects.filter(id=artifact.id).exists()
 
-    def test_remove_sbom_not_in_release(self):
+    def test_remove_sbom_not_in_release(self, authenticated_api_client):
         """Test removing an SBOM that's not in the release."""
-        response = self.client.delete(
-            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.release1.id}", **self._get_headers()
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
+        response = client.delete(
+            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.release1.id}", **headers
         )
 
         assert response.status_code == 404
         data = json.loads(response.content)
         assert "not in this release" in data["detail"]
 
-    def test_remove_sbom_from_latest_release_forbidden(self):
+    def test_remove_sbom_from_latest_release_forbidden(self, authenticated_api_client):
         """Test that removing SBOM from 'latest' release is forbidden."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # Add SBOM to latest release (this would normally be done automatically)
         ReleaseArtifact.objects.create(release=self.latest_release, sbom=self.sbom1_cdx)
 
-        response = self.client.delete(
-            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.latest_release.id}", **self._get_headers()
+        response = client.delete(
+            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{self.latest_release.id}", **headers
         )
 
         assert response.status_code == 400
         data = json.loads(response.content)
         assert "automatically managed" in data["detail"]
 
-    def test_remove_sbom_different_team(self):
+    def test_remove_sbom_different_team(self, authenticated_api_client):
         """Test removing SBOM from release belonging to different team."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         # Create release in different team
         other_release = Release.objects.create(name="v1.0.0", product=self.product2, is_latest=False)
 
-        response = self.client.delete(
-            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{other_release.id}", **self._get_headers()
+        response = client.delete(
+            f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{other_release.id}", **headers
         )
 
         assert response.status_code == 403
         data = json.loads(response.content)
         assert "different team" in data["detail"]
 
-    def test_sbom_not_found(self):
+    def test_sbom_not_found(self, authenticated_api_client):
         """Test endpoints with non-existent SBOM."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         fake_id = "00000000-0000-0000-0000-000000000000"
 
         # List releases
-        response = self.client.get(f"/api/v1/sboms/{fake_id}/releases", **self._get_headers())
+        response = client.get(f"/api/v1/sboms/{fake_id}/releases", **headers)
         assert response.status_code == 404
 
         # Add to releases
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{fake_id}/releases",
             data=json.dumps({"release_ids": [str(self.release1.id)]}),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
         assert response.status_code == 404
 
         # Remove from release
-        response = self.client.delete(f"/api/v1/sboms/{fake_id}/releases/{self.release1.id}", **self._get_headers())
+        response = client.delete(f"/api/v1/sboms/{fake_id}/releases/{self.release1.id}", **headers)
         assert response.status_code == 404
 
-    def test_release_not_found(self):
+    def test_release_not_found(self, authenticated_api_client):
         """Test endpoints with non-existent release."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
         fake_id = "00000000-0000-0000-0000-000000000000"
 
         # Add to releases
-        response = self.client.post(
+        response = client.post(
             f"/api/v1/sboms/{self.sbom1_cdx.id}/releases",
             data=json.dumps({"release_ids": [fake_id]}),
             content_type="application/json",
-            **self._get_headers(),
+            **headers,
         )
         assert response.status_code == 400
         data = json.loads(response.content)
         assert "No artifacts were created or replaced" in data["detail"]
 
         # Remove from release
-        response = self.client.delete(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{fake_id}", **self._get_headers())
+        response = client.delete(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases/{fake_id}", **headers)
         assert response.status_code == 404

--- a/sboms/tests/test_apis.py
+++ b/sboms/tests/test_apis.py
@@ -12,7 +12,7 @@ from pytest_mock.plugin import MockerFixture
 
 from access_tokens.models import AccessToken
 from billing.models import BillingPlan
-from core.tests.fixtures import sample_user  # noqa: F401
+from core.tests.shared_fixtures import get_api_headers, sample_user
 from teams.fixtures import sample_team_with_owner_member  # noqa: F401
 from teams.models import Member
 
@@ -92,7 +92,7 @@ def test_sbom_api_get_user_items(
     assert client.login(username=os.environ["DJANGO_TEST_USER"], password=os.environ["DJANGO_TEST_PASSWORD"])
 
     response: HttpResponse = client.get(
-        uri, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}"
+        uri, content_type="application/json", **get_api_headers(sample_access_token)
     )
 
     assert response.status_code == 200
@@ -104,7 +104,7 @@ def test_sbom_api_get_user_items(
 
     uri = reverse("api-1:get_user_items", kwargs={"item_type": "project"})
     response: HttpResponse = client.get(
-        uri, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}"
+        uri, content_type="application/json", **get_api_headers(sample_access_token)
     )
 
     assert response.status_code == 200
@@ -116,7 +116,7 @@ def test_sbom_api_get_user_items(
 
     uri = reverse("api-1:get_user_items", kwargs={"item_type": "component"})
     response: HttpResponse = client.get(
-        uri, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}"
+        uri, content_type="application/json", **get_api_headers(sample_access_token)
     )
 
     assert response.status_code == 200
@@ -147,7 +147,7 @@ def test_sbom_upload_api_spdx(
         url,
         data=sbom_data,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     # Assert the response status code and data
@@ -184,7 +184,7 @@ def test_sbom_upload_api_cyclonedx(
         url,
         data=sbom_data,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     # Assert the response status code and data
@@ -213,7 +213,7 @@ def test_get_and_set_component_metadata(sample_component: Component, sample_acce
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -246,7 +246,7 @@ def test_get_and_set_component_metadata(sample_component: Component, sample_acce
         url,
         json.dumps(component_metadata),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -255,7 +255,7 @@ def test_get_and_set_component_metadata(sample_component: Component, sample_acce
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -306,7 +306,7 @@ def test_component_copy_metadata_api(
     response = client.get(
         source_url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     source_metadata = response.json()
@@ -320,7 +320,7 @@ def test_component_copy_metadata_api(
         target_url,
         json.dumps(metadata_to_copy),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -377,7 +377,7 @@ def test_metadata_enrichment(sample_component: Component, sample_access_token: A
     response = client.post(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
         data=json.dumps(sbom_metadata),
     )
 
@@ -413,7 +413,7 @@ def test_metadata_enrichment(sample_component: Component, sample_access_token: A
     response = client.post(
         url + "?override_metadata=true&sbom_version=1.1.1&override_name=true",
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
         data=json.dumps(sbom_metadata),
     )
 
@@ -443,7 +443,7 @@ def test_metadata_enrichment(sample_component: Component, sample_access_token: A
     response = client.post(
         url + "?override_metadata=true&sbom_version=1.1.1&override_name=true",
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
         data=json.dumps(sbom_metadata),
     )
 
@@ -492,7 +492,7 @@ def test_metadata_enrichment_on_no_component_in_metadata(
     response = client.post(
         url + "?sbom_version=1.1.1&override_name=true",
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
         data=json.dumps(sbom_metadata),
     )
 
@@ -520,7 +520,7 @@ def test_get_dashboard_summary_authenticated_no_data(
     response = client.get(
         url,
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     data = response.json()
@@ -569,7 +569,7 @@ def test_get_dashboard_summary_authenticated_with_data(
     response = client.get(
         url,
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     data = response.json()
@@ -615,7 +615,7 @@ def test_component_metadata_license_expressions(sample_component: Component, sam
         url,
         json.dumps(component_metadata),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -624,7 +624,7 @@ def test_component_metadata_license_expressions(sample_component: Component, sam
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -673,7 +673,7 @@ def test_component_metadata_supplier_url_handling(
         url,
         json.dumps(metadata_with_url),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -682,7 +682,7 @@ def test_component_metadata_supplier_url_handling(
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -719,7 +719,7 @@ def test_component_metadata_patch_partial_update(sample_component: Component, sa
         url,
         json.dumps(initial_metadata),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 204
 
@@ -730,7 +730,7 @@ def test_component_metadata_patch_partial_update(sample_component: Component, sa
         url,
         json.dumps(partial_update),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 204
 
@@ -738,7 +738,7 @@ def test_component_metadata_patch_partial_update(sample_component: Component, sa
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     response_data = response.json()
@@ -776,7 +776,7 @@ def test_component_metadata_author_information(sample_component: Component, samp
         url,
         json.dumps(metadata_with_authors),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -785,7 +785,7 @@ def test_component_metadata_author_information(sample_component: Component, samp
     response = client.get(
         url,
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200
@@ -960,7 +960,7 @@ def test_delete_sbom_api(
     # Test with valid token and permissions
     response = client.delete(
         url,
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 204
@@ -972,7 +972,7 @@ def test_delete_sbom_api(
     # Test deleting non-existent SBOM
     response = client.delete(
         url,
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 404
 
@@ -990,6 +990,7 @@ def test_delete_sbom_api_forbidden(
 
     from access_tokens.models import AccessToken
     from access_tokens.utils import create_personal_access_token
+    from core.tests.shared_fixtures import get_api_headers
 
     User = get_user_model()
     other_user = User.objects.create_user(username="otheruser", password="password")
@@ -1001,7 +1002,7 @@ def test_delete_sbom_api_forbidden(
 
     response = client.delete(
         url,
-        headers={"Authorization": f"Bearer {other_token.encoded_token}"},
+        **get_api_headers(other_token),
     )
 
     assert response.status_code == 403
@@ -1059,7 +1060,7 @@ def test_get_dashboard_summary_with_product_filter(
     response = client.get(
         f"{url}?product_id={product1.id}",
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     data = response.json()
@@ -1111,7 +1112,7 @@ def test_get_dashboard_summary_with_project_filter(
     response = client.get(
         f"{url}?project_id={project1.id}",
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     data = response.json()
@@ -1172,7 +1173,7 @@ def test_patch_public_status_billing_plan_restrictions(
             uri,
             json.dumps({"is_public": True}),
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+            **get_api_headers(sample_access_token),
         )
 
     # Try to make component private - should fail
@@ -1180,7 +1181,7 @@ def test_patch_public_status_billing_plan_restrictions(
         component_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 403
     assert "Community plan users cannot make items private" in response.json()["detail"]
@@ -1190,7 +1191,7 @@ def test_patch_public_status_billing_plan_restrictions(
         project_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 403
     assert "Community plan users cannot make items private" in response.json()["detail"]
@@ -1200,7 +1201,7 @@ def test_patch_public_status_billing_plan_restrictions(
         product_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 403
     assert "Community plan users cannot make items private" in response.json()["detail"]
@@ -1210,7 +1211,7 @@ def test_patch_public_status_billing_plan_restrictions(
         component_uri,
         json.dumps({"is_public": True}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is True
@@ -1225,7 +1226,7 @@ def test_patch_public_status_billing_plan_restrictions(
         product_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200, f"Failed for product: {response.content}"
     assert response.json()["is_public"] is False
@@ -1235,7 +1236,7 @@ def test_patch_public_status_billing_plan_restrictions(
         project_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200, f"Failed for project: {response.content}"
     assert response.json()["is_public"] is False
@@ -1245,7 +1246,7 @@ def test_patch_public_status_billing_plan_restrictions(
         component_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200, f"Failed for component: {response.content}"
     assert response.json()["is_public"] is False
@@ -1255,7 +1256,7 @@ def test_patch_public_status_billing_plan_restrictions(
         component_uri,
         json.dumps({"is_public": True}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is True
@@ -1264,7 +1265,7 @@ def test_patch_public_status_billing_plan_restrictions(
         project_uri,
         json.dumps({"is_public": True}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is True
@@ -1273,7 +1274,7 @@ def test_patch_public_status_billing_plan_restrictions(
         product_uri,
         json.dumps({"is_public": True}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is True
@@ -1288,7 +1289,7 @@ def test_patch_public_status_billing_plan_restrictions(
         product_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is False
@@ -1298,7 +1299,7 @@ def test_patch_public_status_billing_plan_restrictions(
         project_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is False
@@ -1308,7 +1309,7 @@ def test_patch_public_status_billing_plan_restrictions(
         component_uri,
         json.dumps({"is_public": False}),
         content_type="application/json",
-        HTTP_AUTHORIZATION=f"Bearer {sample_access_token.encoded_token}",
+        **get_api_headers(sample_access_token),
     )
     assert response.status_code == 200
     assert response.json()["is_public"] is False
@@ -1363,7 +1364,7 @@ def test_community_plan_restriction_bypassed_when_billing_disabled(sample_compon
         url,
         json.dumps({"is_public": True}),
         content_type="application/json",
-        headers={"Authorization": f"Bearer {sample_access_token.encoded_token}"},
+        **get_api_headers(sample_access_token),
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
- Add shared authentication fixtures for consistent API testing across all modules
- Replace manual HTTP_AUTHORIZATION headers with standardized authenticated_api_client and guest_api_client fixtures
- Create shared_fixtures.py with reusable fixtures for teams, billing plans, and authentication
- Use get_or_create() for billing plan fixtures to prevent conflicts
- Fix team API error codes: return 404 instead of 400 for invalid team keys (better REST semantics)
- Add new team API endpoints: list_teams() and get_team() with proper authorization
- Add get_current_limits() function to billing_processing.py for centralized limit retrieval

This refactoring maintains existing test coverage while improving consistency and
reducing maintenance burden across the test suite.