### PR TITLE
feat: implement server-side pagination for SBOMs and Documents tables

### DIFF
--- a/core/js/components/PaginationControls.spec.ts
+++ b/core/js/components/PaginationControls.spec.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect } from 'bun:test'
+
+describe('PaginationControls Business Logic', () => {
+  describe('Pagination Calculations', () => {
+    test('should calculate start and end items correctly', () => {
+      const calculateStartItem = (currentPage: number, pageSize: number, totalItems: number): number => {
+        return totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1
+      }
+
+      const calculateEndItem = (currentPage: number, pageSize: number, totalItems: number): number => {
+        return Math.min(currentPage * pageSize, totalItems)
+      }
+
+      // Test with normal pagination
+      expect(calculateStartItem(1, 15, 100)).toBe(1)
+      expect(calculateEndItem(1, 15, 100)).toBe(15)
+
+      expect(calculateStartItem(2, 15, 100)).toBe(16)
+      expect(calculateEndItem(2, 15, 100)).toBe(30)
+
+      // Test with last page (partial)
+      expect(calculateStartItem(7, 15, 100)).toBe(91)
+      expect(calculateEndItem(7, 15, 100)).toBe(100)
+
+      // Test with empty data
+      expect(calculateStartItem(1, 15, 0)).toBe(0)
+      expect(calculateEndItem(1, 15, 0)).toBe(0)
+    })
+
+    test('should generate visible pages correctly', () => {
+      const generateVisiblePages = (currentPage: number, totalPages: number): (number | string)[] => {
+        const pages: (number | string)[] = []
+        const maxVisiblePages = 7
+
+        if (totalPages <= maxVisiblePages) {
+          // Show all pages if total is small
+          for (let i = 1; i <= totalPages; i++) {
+            pages.push(i)
+          }
+        } else {
+          // Show pages with ellipsis for large page counts
+          const start = Math.max(1, currentPage - 2)
+          const end = Math.min(totalPages, currentPage + 2)
+
+          if (start > 1) {
+            pages.push(1)
+            if (start > 2) {
+              pages.push('...')
+            }
+          }
+
+          for (let i = start; i <= end; i++) {
+            pages.push(i)
+          }
+
+          if (end < totalPages) {
+            if (end < totalPages - 1) {
+              pages.push('...')
+            }
+            pages.push(totalPages)
+          }
+        }
+
+        return pages
+      }
+
+      // Test with small number of pages (show all)
+      expect(generateVisiblePages(1, 5)).toEqual([1, 2, 3, 4, 5])
+      expect(generateVisiblePages(3, 7)).toEqual([1, 2, 3, 4, 5, 6, 7])
+
+      // Test with large number of pages (show ellipsis)
+      expect(generateVisiblePages(1, 20)).toEqual([1, 2, 3, '...', 20])
+      expect(generateVisiblePages(5, 20)).toEqual([1, '...', 3, 4, 5, 6, 7, '...', 20])
+      expect(generateVisiblePages(20, 20)).toEqual([1, '...', 18, 19, 20])
+
+      // Test middle pages
+      expect(generateVisiblePages(10, 20)).toEqual([1, '...', 8, 9, 10, 11, 12, '...', 20])
+    })
+  })
+
+  describe('Page Navigation Logic', () => {
+    test('should validate page navigation correctly', () => {
+      const canGoToPage = (page: number, currentPage: number, totalPages: number): boolean => {
+        return page >= 1 && page <= totalPages && page !== currentPage
+      }
+
+      // Test valid navigation
+      expect(canGoToPage(2, 1, 10)).toBe(true)
+      expect(canGoToPage(1, 2, 10)).toBe(true)
+      expect(canGoToPage(10, 5, 10)).toBe(true)
+
+      // Test invalid navigation
+      expect(canGoToPage(0, 1, 10)).toBe(false) // Page too low
+      expect(canGoToPage(11, 1, 10)).toBe(false) // Page too high
+      expect(canGoToPage(5, 5, 10)).toBe(false) // Same page
+    })
+
+    test('should handle page size validation', () => {
+      const validatePageSize = (pageSize: number): number => {
+        return Math.min(Math.max(1, pageSize), 100)
+      }
+
+      // Test valid page sizes
+      expect(validatePageSize(15)).toBe(15)
+      expect(validatePageSize(50)).toBe(50)
+
+      // Test page size limits
+      expect(validatePageSize(0)).toBe(1) // Too small
+      expect(validatePageSize(-5)).toBe(1) // Negative
+      expect(validatePageSize(150)).toBe(100) // Too large
+    })
+  })
+
+  describe('Event Handling Logic', () => {
+    test('should handle page size change events', () => {
+      const handlePageSizeChange = (eventValue: string): number => {
+        return parseInt(eventValue, 10)
+      }
+
+      expect(handlePageSizeChange('25')).toBe(25)
+      expect(handlePageSizeChange('10')).toBe(10)
+      expect(handlePageSizeChange('100')).toBe(100)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    test('should handle edge cases correctly', () => {
+      const calculateStartItem = (currentPage: number, pageSize: number, totalItems: number): number => {
+        return totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1
+      }
+
+      const calculateEndItem = (currentPage: number, pageSize: number, totalItems: number): number => {
+        return Math.min(currentPage * pageSize, totalItems)
+      }
+
+      // Test with single item
+      expect(calculateStartItem(1, 15, 1)).toBe(1)
+      expect(calculateEndItem(1, 15, 1)).toBe(1)
+
+      // Test with exactly page size items
+      expect(calculateStartItem(1, 15, 15)).toBe(1)
+      expect(calculateEndItem(1, 15, 15)).toBe(15)
+
+      // Test with page size of 1
+      expect(calculateStartItem(5, 1, 10)).toBe(5)
+      expect(calculateEndItem(5, 1, 10)).toBe(5)
+    })
+
+    test('should handle visible pages edge cases', () => {
+      const generateVisiblePages = (currentPage: number, totalPages: number): (number | string)[] => {
+        const pages: (number | string)[] = []
+        const maxVisiblePages = 7
+
+        if (totalPages <= maxVisiblePages) {
+          for (let i = 1; i <= totalPages; i++) {
+            pages.push(i)
+          }
+        } else {
+          const start = Math.max(1, currentPage - 2)
+          const end = Math.min(totalPages, currentPage + 2)
+
+          if (start > 1) {
+            pages.push(1)
+            if (start > 2) {
+              pages.push('...')
+            }
+          }
+
+          for (let i = start; i <= end; i++) {
+            pages.push(i)
+          }
+
+          if (end < totalPages) {
+            if (end < totalPages - 1) {
+              pages.push('...')
+            }
+            pages.push(totalPages)
+          }
+        }
+
+        return pages
+      }
+
+      // Test with single page
+      expect(generateVisiblePages(1, 1)).toEqual([1])
+
+      // Test near boundaries without ellipsis
+      expect(generateVisiblePages(2, 8)).toEqual([1, 2, 3, 4, '...', 8])
+      expect(generateVisiblePages(7, 8)).toEqual([1, '...', 5, 6, 7, 8])
+    })
+  })
+})

--- a/core/js/components/PaginationControls.vue
+++ b/core/js/components/PaginationControls.vue
@@ -1,0 +1,207 @@
+<template>
+  <div v-if="totalPages > 1" class="pagination-controls">
+    <div class="d-flex justify-content-between align-items-center">
+      <!-- Page info and items per page selector -->
+      <div class="d-flex align-items-center gap-3">
+        <small class="text-muted">
+          Showing {{ startItem }}-{{ endItem }} of {{ totalItems }} items
+        </small>
+
+        <div v-if="showPageSizeSelector" class="d-flex align-items-center gap-2">
+          <label class="small text-muted mb-0">Items per page:</label>
+          <select
+            :value="pageSize"
+            class="form-select form-select-sm"
+            style="width: auto;"
+            @change="handlePageSizeChange"
+          >
+            <option v-for="size in pageSizeOptions" :key="size" :value="size">
+              {{ size }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Pagination navigation -->
+      <nav v-if="totalPages > 1">
+        <ul class="pagination pagination-sm mb-0">
+          <li class="page-item" :class="{ disabled: currentPage === 1 }">
+            <button
+              class="page-link"
+              :disabled="currentPage === 1"
+              title="First page"
+              @click="goToPage(1)"
+            >
+              First
+            </button>
+          </li>
+          <li class="page-item" :class="{ disabled: currentPage === 1 }">
+            <button
+              class="page-link"
+              :disabled="currentPage === 1"
+              title="Previous page"
+              @click="goToPage(currentPage - 1)"
+            >
+              Previous
+            </button>
+          </li>
+
+          <!-- Page numbers (show ellipsis for large page counts) -->
+          <template v-for="page in visiblePages" :key="page">
+            <li v-if="page === '...'" class="page-item disabled">
+              <span class="page-link">...</span>
+            </li>
+            <li v-else class="page-item" :class="{ active: page === currentPage }">
+              <button
+                class="page-link"
+                :title="`Go to page ${page}`"
+                @click="typeof page === 'number' ? goToPage(page) : undefined"
+              >
+                {{ page }}
+              </button>
+            </li>
+          </template>
+
+          <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+            <button
+              class="page-link"
+              :disabled="currentPage === totalPages"
+              title="Next page"
+              @click="goToPage(currentPage + 1)"
+            >
+              Next
+            </button>
+          </li>
+          <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+            <button
+              class="page-link"
+              :disabled="currentPage === totalPages"
+              title="Last page"
+              @click="goToPage(totalPages)"
+            >
+              Last
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  pageSize: number
+  showPageSizeSelector?: boolean
+  pageSizeOptions?: number[]
+}
+
+interface Emits {
+  (e: 'update:currentPage', value: number): void
+  (e: 'update:pageSize', value: number): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showPageSizeSelector: true,
+  pageSizeOptions: () => [10, 15, 25, 50, 100]
+})
+
+const emit = defineEmits<Emits>()
+
+// Computed properties
+const startItem = computed(() => {
+  return props.totalItems === 0 ? 0 : (props.currentPage - 1) * props.pageSize + 1
+})
+
+const endItem = computed(() => {
+  return Math.min(props.currentPage * props.pageSize, props.totalItems)
+})
+
+const visiblePages = computed(() => {
+  const pages: (number | string)[] = []
+  const maxVisiblePages = 7
+
+  if (props.totalPages <= maxVisiblePages) {
+    // Show all pages if total is small
+    for (let i = 1; i <= props.totalPages; i++) {
+      pages.push(i)
+    }
+  } else {
+    // Show pages with ellipsis for large page counts
+    const start = Math.max(1, props.currentPage - 2)
+    const end = Math.min(props.totalPages, props.currentPage + 2)
+
+    if (start > 1) {
+      pages.push(1)
+      if (start > 2) {
+        pages.push('...')
+      }
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i)
+    }
+
+    if (end < props.totalPages) {
+      if (end < props.totalPages - 1) {
+        pages.push('...')
+      }
+      pages.push(props.totalPages)
+    }
+  }
+
+  return pages
+})
+
+// Event handlers
+const goToPage = (page: number) => {
+  if (page >= 1 && page <= props.totalPages && page !== props.currentPage) {
+    emit('update:currentPage', page)
+  }
+}
+
+const handlePageSizeChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  const newPageSize = parseInt(target.value, 10)
+  emit('update:pageSize', newPageSize)
+}
+</script>
+
+<style scoped>
+.pagination-controls {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e9ecef;
+}
+
+.page-link {
+  border: none;
+  background: none;
+  color: #6c757d;
+  padding: 0.375rem 0.75rem;
+  transition: all 0.15s ease-in-out;
+}
+
+.page-link:hover:not(:disabled) {
+  background-color: #e9ecef;
+  color: #495057;
+}
+
+.page-item.active .page-link {
+  background-color: #007bff;
+  color: white;
+}
+
+.page-item.disabled .page-link {
+  color: #6c757d;
+  cursor: not-allowed;
+}
+
+.form-select-sm {
+  min-width: 60px;
+}
+</style>

--- a/core/management/commands/create_pagination_test_data.py
+++ b/core/management/commands/create_pagination_test_data.py
@@ -1,0 +1,153 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.http import HttpRequest
+
+from core.models import Component
+from sboms.apis import sbom_upload_cyclonedx, sbom_upload_spdx
+from sboms.schemas import SPDXSchema, cdx15, cdx16
+from teams.models import Team
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Creates 100 SBOMs for pagination testing"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--username",
+            type=str,
+            default="ssmith",
+            help="Username to create test data for (default: ssmith)",
+        )
+        parser.add_argument(
+            "--count",
+            type=int,
+            default=100,
+            help="Number of SBOMs to create (default: 100)",
+        )
+
+    def handle(self, *args, **options):
+        username = options["username"]
+        count = options["count"]
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            self.stdout.write(self.style.ERROR(f"User '{username}' not found"))
+            return
+
+        # Get the user's team
+        team = Team.objects.filter(member__user=user).first()
+        if not team:
+            self.stdout.write(self.style.ERROR(f"User '{username}' is not a member of any team"))
+            return
+
+        self.stdout.write(f"Creating {count} SBOMs for user '{username}' in team '{team.name}'...")
+
+        # Find or create a test component
+        component_name = "pagination-test-component"
+        component, created = Component.objects.get_or_create(
+            name=component_name,
+            team=team,
+            defaults={
+                "component_type": "sbom",
+                "is_public": True,
+                "metadata": {"description": "Component for pagination testing"},
+            },
+        )
+
+        if created:
+            self.stdout.write(self.style.SUCCESS(f"Created component: {component.name}"))
+        else:
+            self.stdout.write(f"Using existing component: {component.name}")
+
+        # Available test SBOM files
+        test_files = [
+            "hello-world_syft.cdx.json",
+            "hello-world_syft.spdx.json",
+            "sbomify_syft.cdx.json",
+            "sbomify_syft.spdx.json",
+            "sbomify_trivy.cdx.json",
+            "sbomify_trivy.spdx.json",
+            "protobom-v0.5.2.spdx.json",
+        ]
+
+        created_count = 0
+        with transaction.atomic():
+            for i in range(count):
+                # Cycle through test files
+                test_file = test_files[i % len(test_files)]
+                sbom_path = Path(__file__).parent.parent.parent.parent / "sboms" / "tests" / "test_data" / test_file
+
+                if not sbom_path.exists():
+                    self.stdout.write(self.style.WARNING(f"Test file not found: {sbom_path}"))
+                    continue
+
+                try:
+                    with open(sbom_path) as f_json:
+                        sbom_data_dict = json.load(f_json)
+
+                    # Modify the SBOM name to make it unique
+                    if "spdxVersion" in sbom_data_dict:
+                        # SPDX format
+                        sbom_data_dict["name"] = f"test-sbom-{i+1:03d}-{test_file.replace('.json', '')}"
+                        if "documentName" in sbom_data_dict:
+                            sbom_data_dict["documentName"] = sbom_data_dict["name"]
+                    else:
+                        # CycloneDX format
+                        if "metadata" not in sbom_data_dict:
+                            sbom_data_dict["metadata"] = {}
+                        if "component" not in sbom_data_dict["metadata"]:
+                            sbom_data_dict["metadata"]["component"] = {}
+                        sbom_data_dict["metadata"]["component"]["name"] = (
+                            f"test-sbom-{i+1:03d}-{test_file.replace('.json', '')}"
+                        )
+
+                    # Prepare mock request for API call
+                    mock_request = MagicMock(spec=HttpRequest)
+                    mock_request.body = json.dumps(sbom_data_dict).encode()
+                    mock_request.user = user
+                    mock_request.session = MagicMock()
+
+                    # Upload SBOM via API
+                    with patch("sboms.apis.verify_item_access", return_value=True):
+                        if "spdxVersion" in sbom_data_dict:
+                            # SPDX format
+                            payload = SPDXSchema(**sbom_data_dict)
+                            status_code, response_data = sbom_upload_spdx(mock_request, component.id, payload)
+                        else:
+                            # CycloneDX format
+                            spec_version = sbom_data_dict.get("specVersion", "1.5")
+                            if spec_version == "1.5":
+                                payload = cdx15.CyclonedxSoftwareBillOfMaterialsStandard(**sbom_data_dict)
+                            elif spec_version == "1.6":
+                                payload = cdx16.CyclonedxSoftwareBillOfMaterialsStandard(**sbom_data_dict)
+                            else:
+                                self.stdout.write(self.style.WARNING(f"Unsupported CycloneDX version: {spec_version}"))
+                                continue
+                            status_code, response_data = sbom_upload_cyclonedx(mock_request, component.id, payload)
+
+                        if status_code == 201:
+                            created_count += 1
+                            if created_count % 10 == 0:  # Progress update every 10 SBOMs
+                                self.stdout.write(f"Created {created_count}/{count} SBOMs...")
+                        else:
+                            self.stdout.write(self.style.WARNING(f"Failed to create SBOM {i+1}: Status {status_code}"))
+
+                except Exception as e:
+                    self.stdout.write(self.style.WARNING(f"Error creating SBOM {i+1}: {e}"))
+                    continue
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Successfully created {created_count} SBOMs for component '{component.name}'")
+        )
+        self.stdout.write(
+            f"You can now test pagination by visiting the components page at /components/ "
+            f"or the component details page at /component/{component.id}/"
+        )

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -320,6 +320,38 @@ class ItemTypes(str, Enum):
     product = "product"
 
 
+class PaginationMeta(BaseModel):
+    """Pagination metadata for list responses."""
+
+    total: int = Field(..., description="Total number of items")
+    page: int = Field(..., description="Current page number (1-based)")
+    page_size: int = Field(..., description="Number of items per page")
+    total_pages: int = Field(..., description="Total number of pages")
+    has_previous: bool = Field(..., description="Whether there is a previous page")
+    has_next: bool = Field(..., description="Whether there is a next page")
+
+
+class PaginatedProductsResponse(BaseModel):
+    """Paginated response for products list."""
+
+    items: list[ProductResponseSchema]
+    pagination: PaginationMeta
+
+
+class PaginatedProjectsResponse(BaseModel):
+    """Paginated response for projects list."""
+
+    items: list[ProjectResponseSchema]
+    pagination: PaginationMeta
+
+
+class PaginatedComponentsResponse(BaseModel):
+    """Paginated response for components list."""
+
+    items: list[ComponentResponseSchema]
+    pagination: PaginationMeta
+
+
 class CopyComponentMetadataRequest(BaseModel):
     """Schema for copying metadata from one component to another."""
 

--- a/core/tests/test_apis.py
+++ b/core/tests/test_apis.py
@@ -149,11 +149,182 @@ def test_api_endpoints_require_team_membership(sample_access_token):  # noqa: F8
 
 
 @pytest.mark.django_db
-def test_api_pagination_headers():
-    """Test that API endpoints include appropriate pagination headers."""
-    # This is a placeholder for future pagination testing
-    # Current API endpoints don't implement pagination yet
-    pass
+def test_api_pagination_products(sample_access_token, sample_team):  # noqa: F811
+    """Test that products API endpoint supports pagination."""
+    from core.models import Product
+
+    client = Client()
+
+    # Create multiple products to test pagination
+    products = []
+    for i in range(25):
+        product = Product.objects.create(
+            name=f"Test Product {i+1}",
+            team=sample_team
+        )
+        products.append(product)
+
+    # Test first page with default page size
+    response = client.get(
+        reverse("api-1:list_products"),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check paginated response structure
+    assert "items" in data
+    assert "pagination" in data
+
+    pagination = data["pagination"]
+    assert "total" in pagination
+    assert "page" in pagination
+    assert "page_size" in pagination
+    assert "total_pages" in pagination
+    assert "has_previous" in pagination
+    assert "has_next" in pagination
+
+    assert pagination["total"] == 25
+    assert pagination["page"] == 1
+    assert pagination["page_size"] == 15
+    assert pagination["total_pages"] == 2
+    assert pagination["has_previous"] is False
+    assert pagination["has_next"] is True
+    assert len(data["items"]) == 15
+
+    # Test second page
+    response = client.get(
+        reverse("api-1:list_products") + "?page=2",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    pagination = data["pagination"]
+    assert pagination["page"] == 2
+    assert pagination["has_previous"] is True
+    assert pagination["has_next"] is False
+    assert len(data["items"]) == 10  # Remaining items on last page
+
+    # Test custom page size
+    response = client.get(
+        reverse("api-1:list_products") + "?page=1&page_size=10",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    pagination = data["pagination"]
+    assert pagination["page_size"] == 10
+    assert pagination["total_pages"] == 3
+    assert len(data["items"]) == 10
+
+
+@pytest.mark.django_db
+def test_api_pagination_projects(sample_access_token, sample_team):  # noqa: F811
+    """Test that projects API endpoint supports pagination."""
+    from core.models import Project
+
+    client = Client()
+
+    # Create multiple projects to test pagination
+    for i in range(30):
+        Project.objects.create(
+            name=f"Test Project {i+1}",
+            team=sample_team
+        )
+
+    # Test first page
+    response = client.get(
+        reverse("api-1:list_projects"),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "items" in data
+    assert "pagination" in data
+    assert data["pagination"]["total"] == 30
+    assert len(data["items"]) == 15  # Default page size
+
+
+@pytest.mark.django_db
+def test_api_pagination_components(sample_access_token, sample_team):  # noqa: F811
+    """Test that components API endpoint supports pagination."""
+    from core.models import Component
+
+    client = Client()
+
+    # Create multiple components to test pagination
+    for i in range(20):
+        Component.objects.create(
+            name=f"Test Component {i+1}",
+            component_type="sbom",
+            team=sample_team
+        )
+
+    # Test first page
+    response = client.get(
+        reverse("api-1:list_components"),
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "items" in data
+    assert "pagination" in data
+    assert data["pagination"]["total"] == 20
+    assert len(data["items"]) == 15  # Default page size
+
+
+@pytest.mark.django_db
+def test_api_pagination_invalid_params(sample_access_token, sample_team):  # noqa: F811
+    """Test pagination with invalid parameters."""
+    from core.models import Product
+
+    client = Client()
+
+    # Create a few products
+    for i in range(5):
+        Product.objects.create(
+            name=f"Test Product {i+1}",
+            team=sample_team
+        )
+
+    # Test with invalid page number (should default to page 1)
+    response = client.get(
+        reverse("api-1:list_products") + "?page=999",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pagination"]["page"] == 1
+
+    # Test with invalid page size (should be clamped to valid range)
+    response = client.get(
+        reverse("api-1:list_products") + "?page_size=999",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pagination"]["page_size"] == 100  # Max allowed
+
+    # Test with zero page size (should default to 1)
+    response = client.get(
+        reverse("api-1:list_products") + "?page_size=0",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pagination"]["page_size"] == 1  # Min allowed
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Add comprehensive pagination support to improve performance and UX when viewing large lists of SBOMs and documents on component detail pages.

Backend changes:
- Add pagination schemas (PaginationMeta, PaginatedResponse types)
- Create reusable _paginate_queryset() helper with validation
- Update /api/v1/products, /api/v1/projects, /api/v1/components endpoints
- Add new paginated endpoints:
  * GET /api/v1/components/{id}/sboms
  * GET /api/v1/components/{id}/documents
- Implement proper authentication and team access controls
- Include vulnerability status and release information in responses

Frontend changes:
- Create reusable PaginationControls.vue component with:
  * Page navigation (Previous/Next, page numbers)
  * Configurable page sizes (15, 25, 50, 100 items)
  * Item count display and responsive design
- Update SbomsTable.vue and DocumentsTable.vue to:
  * Use server-side API calls instead of static JSON data
  * Add loading states and error handling
  * Include pagination controls
  * Maintain backward compatibility with static data
- Update ItemsListTable.vue for paginated product/project/component lists

Features:
- Default 15 items per page with user-selectable page sizes
- Efficient server-side pagination prevents performance issues
- Consistent pagination UI across all tables
- Proper loading states and error handling
- Maintains existing functionality and styling

Security:
- All new endpoints require authentication via PersonalAccessTokenAuth
- Strict team membership validation prevents unauthorized access
- No public access to private component data

This enables efficient browsing of large datasets (e.g., 57+ SBOMs) without frontend performance degradation.