### PR TITLE
fix: Enable session auth for component SBOM/document API endpoints

### DIFF
--- a/core/apis.py
+++ b/core/apis.py
@@ -2914,7 +2914,7 @@ def remove_sbom_from_release(request: HttpRequest, sbom_id: str, release_id: str
 @router.get(
     "/components/{component_id}/sboms",
     response={200: dict, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
-    auth=PersonalAccessTokenAuth(),
+    auth=(PersonalAccessTokenAuth(), django_auth),
     tags=["Components"],
 )
 def list_component_sboms(request: HttpRequest, component_id: str, page: int = Query(1), page_size: int = Query(15)):
@@ -2998,7 +2998,7 @@ def list_component_sboms(request: HttpRequest, component_id: str, page: int = Qu
 @router.get(
     "/components/{component_id}/documents",
     response={200: dict, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
-    auth=PersonalAccessTokenAuth(),
+    auth=(PersonalAccessTokenAuth(), django_auth),
     tags=["Components"],
 )
 def list_component_documents(request: HttpRequest, component_id: str, page: int = Query(1), page_size: int = Query(15)):

--- a/core/tests/integration/test_ui_workflows.py
+++ b/core/tests/integration/test_ui_workflows.py
@@ -158,5 +158,5 @@ class TestUIWorkflows:
         response = client.get(reverse("api-1:list_components"))
         assert response.status_code == 200
         components_data = response.json()
-        component_names = [c["name"] for c in components_data]
+        component_names = [c["name"] for c in components_data["items"]]
         assert component_name in component_names

--- a/core/tests/test_crud_apis.py
+++ b/core/tests/test_crud_apis.py
@@ -577,9 +577,11 @@ def test_list_components(
 
     assert response.status_code == 200
     data = response.json()
-    assert isinstance(data, list)
-    assert len(data) == 1
-    assert data[0]["id"] == sample_component.id
+    assert isinstance(data, dict)
+    assert "items" in data
+    assert "pagination" in data
+    assert len(data["items"]) == 1
+    assert data["items"][0]["id"] == sample_component.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Add django_auth support to /api/v1/components/{id}/sboms endpoint
- Add django_auth support to /api/v1/components/{id}/documents endpoint
- Update tests to handle new paginated response format for list_components

This resolves 401 authentication errors when Vue components try to load SBOM data from the web interface, where users are authenticated via Django sessions rather than personal access tokens.

Both endpoints now support both authentication methods:
- PersonalAccessTokenAuth (for programmatic API access)
- django_auth (for web interface users)