### PR TITLE
build(deps): Dependabot config for actions, npm and PyPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: 'npm'
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: 'pip'
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,6 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      npm:
+      pip:
         patterns:
           - "*"


### PR DESCRIPTION
Bumps to vulnerable packages are having to be initiated manually because there's presently no Dependabot config.