### PR TITLE
ci: Restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     name: Code Quality


### PR DESCRIPTION
Token permissions are (by default) too broad:

```txt
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | Token-Permissions      | detected GitHub workflow       | https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#token-permissions      |
|         |                        | tokens with excessive          |                                                                                                                       |
|         |                        | permissions                    |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
```

**- What I did**

Make token read only (unless it needs a job level override).

**- How to verify it**

CI run on this PR.

I don't _think_ Fly deploys will need any more.

**- Description for the changelog**

ci: Restrict workflow token permissions