### PR TITLE
ci: Set top level read only permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '45 2 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
Scorecard is giving 9 out of 10 on token permissions

**- What I did**

Added top level permissions block

**- How I did it**

Copied from ci-cd workflow

**- How to verify it**

Scorecard should be 10/10 on merge

**- Description for the changelog**

ci: Set top level read only permissions
