### PR TITLE
fix: Ensure that test_data SBOMs are skipped by scorecard vuln check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ fly.toml
 poetry.toml
 localstack-volume/
 test_env
+sboms/tests/test_data/osv-scanner.toml

--- a/sboms/tests/test_data/osv-scanner.toml
+++ b/sboms/tests/test_data/osv-scanner.toml
@@ -1,0 +1,5 @@
+# ignore everything in the sboms/tests/test_data directory so that scorecard
+# checks don't scan test SBOMs (and report false positives from them)
+[[PackageOverrides]]
+ignore = true
+reason = "Test SBOMs should not be included in Scorecard checks"


### PR DESCRIPTION
Repo is presently getting a 0 on vulns check as it's finding vulns in the test SBOMs

**- What I did**

* Added an `osv-scanner.toml` to the test_data directory
* Added that file to .dockerignore so it doesn't impact deployments

**- How I did it**

Ran osv-scanner locally to identify the issue, then applied workaround

**- How to verify it**

Tested locally with osv-scanner 1.9.2 (present scorecard version) and 2.1.0 (latest)

Scorecard for vulnerability check should be 10/10 once merged.

**- Description for the changelog**

fix: Ensure that test_data SBOMs are skipped by scorecard vuln check
