### PR TITLE
refactor: Reorganize SBOM processing and add cron scheduling for vulnerability tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ guidelines describe.
 To prepare your dedicated GitHub repository:
 
 1. Fork in GitHub <https://github.com/sbomify/sbomify>
-2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/sbomify`)
+2. Clone _your forked repository_ (e.g., `git clone git@github.com:yourname/sbomify`)
 3. Set your remotes as follows:
 
    ```sh
@@ -76,7 +76,7 @@ To prepare your dedicated GitHub repository:
 
 1. How to run tests:
 
-   ``` sh
+   ```sh
    # explain tests here
    ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@ This document outlines security procedures and general policies for the
 sbomify Open Source projects as found on the
 [sbomify GitHub org](https://github.com/sbomify).
 
-* [Reporting a Vulnerability](#reporting-a-vulnerability)
-* [Disclosure Policy](#disclosure-policy)
+- [Reporting a Vulnerability](#reporting-a-vulnerability)
+- [Disclosure Policy](#disclosure-policy)
 
 ## Reporting a Vulnerability
 
@@ -33,7 +33,7 @@ When the security team receives a security bug report, they will assign it
 to a primary handler. This person will coordinate the fix and release
 process, involving the following steps:
 
-* Confirm the problem and determine the affected versions.
-* Audit code to find any potential similar problems.
-* Prepare fixes for all releases still under maintenance. These fixes
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes
   will be released as fast as possible to pub.dev where applicable.

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,6 +48,34 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.0"
+description = "In-process task scheduler with Cron-like capabilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "APScheduler-3.11.0-py3-none-any.whl", hash = "sha256:fc134ca32e50f5eadcc4938e3a4545ab19131435e851abb40b34d63d5141c6da"},
+    {file = "apscheduler-3.11.0.tar.gz", hash = "sha256:4c622d250b0955a65d5d0eb91c33e6d43fd879834bf541e0a18661ae60460133"},
+]
+
+[package.dependencies]
+tzlocal = ">=3.0"
+
+[package.extras]
+doc = ["packaging", "sphinx", "sphinx-rtd-theme (>=1.3.0)"]
+etcd = ["etcd3", "protobuf (<=3.21.0)"]
+gevent = ["gevent"]
+mongodb = ["pymongo (>=3.0)"]
+redis = ["redis (>=3.0)"]
+rethinkdb = ["rethinkdb (>=2.4.0)"]
+sqlalchemy = ["sqlalchemy (>=1.4)"]
+test = ["APScheduler[etcd,mongodb,redis,rethinkdb,sqlalchemy,tornado,zookeeper]", "PySide6 ; platform_python_implementation == \"CPython\" and python_version < \"3.14\"", "anyio (>=4.5.2)", "gevent ; python_version < \"3.14\"", "pytest", "pytz", "twisted ; python_version < \"3.14\""]
+tornado = ["tornado (>=4.3)"]
+twisted = ["twisted"]
+zookeeper = ["kazoo"]
+
+[[package]]
 name = "argcomplete"
 version = "3.5.2"
 description = "Bash tab completion for argparse"
@@ -1137,6 +1165,29 @@ memcached = ["pylibmc (>=1.5,<2.0)"]
 rabbitmq = ["pika (>=1.0,<2.0)"]
 redis = ["redis (>=2.0,<7.0)"]
 watch = ["watchdog (>=4.0)", "watchdog_gevent (>=0.2)"]
+
+[[package]]
+name = "dramatiq-crontab"
+version = "1.0.11"
+description = "Cron style scheduler for asynchronous Dramatiq tasks in Django."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "dramatiq_crontab-1.0.11-py3-none-any.whl", hash = "sha256:727baa8be76b495e83dd9bb7750e90dc22cd14f9bb394d76463359eedc00c9d3"},
+    {file = "dramatiq_crontab-1.0.11.tar.gz", hash = "sha256:4ba88d1a47bc7084e999717c1db238f648f6afa4253e4576b1541da559369b89"},
+]
+
+[package.dependencies]
+apscheduler = "*"
+django = "*"
+dramatiq = "*"
+
+[package.extras]
+lint = ["black (==25.1.0)", "ruff (==0.12.3)"]
+redis = ["redis"]
+sentry = ["sentry-sdk"]
+test = ["backports.zoneinfo ; python_version < \"3.9\"", "dramatiq", "pytest", "pytest-cov", "pytest-django"]
 
 [[package]]
 name = "dulwich"
@@ -2446,7 +2497,6 @@ files = [
     {file = "psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4"},
     {file = "psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067"},
     {file = "psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e"},
-    {file = "psycopg2-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:91fd603a2155da8d0cfcdbf8ab24a2d54bca72795b90d2a3ed2b6da8d979dee2"},
     {file = "psycopg2-2.9.10-cp39-cp39-win32.whl", hash = "sha256:9d5b3b94b79a844a986d029eee38998232451119ad653aea42bb9220a8c5066b"},
     {file = "psycopg2-2.9.10-cp39-cp39-win_amd64.whl", hash = "sha256:88138c8dedcbfa96408023ea2b0c369eda40fe5d75002c0964c78f46f11fa442"},
     {file = "psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11"},
@@ -3692,11 +3742,29 @@ description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main", "dev"]
-markers = "sys_platform == \"win32\""
 files = [
     {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
     {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
+    {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "urllib3"
@@ -4112,4 +4180,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "972cba636c13696c5910964ac3068ae99d99b5828ae6fa237cafe64c5ba92c00"
+content-hash = "4ed9dba7155f681903ad0f249368a3dc2ec33f4aa5415de0ccf378de8ab21acc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ redis = ">=4.0.0"
 tenacity = "^9.1.2"
 license-expression = "^30.4.4"
 pyyaml = "^6.0.2"
+dramatiq-crontab = "^1.0.11"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.37.0"

--- a/vulnerability_scanning/services.py
+++ b/vulnerability_scanning/services.py
@@ -1343,3 +1343,274 @@ def _scan_sbom_for_weekly(sbom, service):
     except Exception as e:
         logger.error(f"Failed to scan SBOM {sbom.id} in weekly context: {e}")
         return None
+
+
+class DependencyTrackSetupService:
+    """
+    Service for managing Dependency Track component setup and backfill operations.
+
+    This service handles the logic for finding components that need DT setup,
+    processing their SBOMs, and ensuring proper DT mappings exist.
+    """
+
+    def __init__(self):
+        """Initialize the DT setup service."""
+        self.logger = logging.getLogger(f"{__name__}.DependencyTrackSetupService")
+        self._vuln_service = None
+
+    @property
+    def vulnerability_service(self) -> VulnerabilityScanningService:
+        """Lazy-load vulnerability scanning service."""
+        if self._vuln_service is None:
+            self._vuln_service = VulnerabilityScanningService()
+        return self._vuln_service
+
+    def find_components_needing_setup(self, team_key: str = None, max_components: int = None) -> List[Any]:
+        """
+        Find components that should use DT but have no mappings yet.
+
+        Args:
+            team_key: Only check components for a specific team
+            max_components: Maximum number of components to return
+
+        Returns:
+            List of Component objects that need DT setup
+        """
+        from core.models import Component
+
+        # Use select_for_update to prevent race conditions
+        with transaction.atomic():
+            # Start with all components that have SBOMs
+            component_queryset = Component.objects.select_related("team").prefetch_related("sbom_set")
+
+            # Filter by team if specified
+            if team_key:
+                component_queryset = component_queryset.filter(team__key=team_key)
+
+            # Only components with SBOMs
+            component_queryset = component_queryset.filter(sbom__isnull=False).distinct()
+
+            # Apply limit if specified (get extra for filtering)
+            if max_components:
+                component_queryset = component_queryset[: max_components * 2]
+
+            components = list(component_queryset)
+            components_needing_setup = []
+
+            for component in components:
+                # Use select_for_update to prevent race conditions
+                component = Component.objects.select_for_update().get(id=component.id)
+
+                # Check if team should use DT
+                if not self._team_should_use_dependency_track(component.team):
+                    continue
+
+                # Check if component already has a DT mapping
+                if ComponentDependencyTrackMapping.objects.filter(component=component).exists():
+                    continue
+
+                # Check if component has relevant SBOMs
+                relevant_sboms = self._get_relevant_sboms_for_component(component)
+                if not relevant_sboms:
+                    continue
+
+                components_needing_setup.append(component)
+
+                # Apply limit after filtering
+                if max_components and len(components_needing_setup) >= max_components:
+                    break
+
+            self.logger.info(
+                f"Found {len(components_needing_setup)} components needing DT setup "
+                f"(filtered from {len(components)} total components)"
+            )
+
+            return components_needing_setup
+
+    def process_components_for_setup(self, components: List[Any]) -> Dict[str, Any]:
+        """
+        Process components for DT setup with comprehensive error handling and monitoring.
+
+        Args:
+            components: List of Component objects to process
+
+        Returns:
+            Dictionary with detailed processing results and statistics
+        """
+        results = {
+            "components_processed": len(components),
+            "sboms_processed": 0,
+            "successful_uploads": 0,
+            "failed_uploads": 0,
+            "skipped_uploads": 0,
+            "errors": [],
+            "successful_components": [],
+            "failed_components": [],
+            "processing_time_ms": 0,
+            "performance_metrics": {
+                "avg_sbom_download_time_ms": 0,
+                "avg_upload_time_ms": 0,
+                "total_data_processed_bytes": 0,
+            },
+        }
+
+        import time
+
+        start_time = time.time()
+        download_times = []
+        upload_times = []
+        total_bytes = 0
+
+        for i, component in enumerate(components, 1):
+            self.logger.info(f"[{i}/{len(components)}] Processing component {component.name}...")
+
+            try:
+                component_result = self._process_single_component(component)
+
+                # Aggregate results
+                results["sboms_processed"] += component_result["sboms_processed"]
+                results["successful_uploads"] += component_result["successful_uploads"]
+                results["failed_uploads"] += component_result["failed_uploads"]
+                results["skipped_uploads"] += component_result["skipped_uploads"]
+
+                # Track performance metrics
+                download_times.extend(component_result.get("download_times", []))
+                upload_times.extend(component_result.get("upload_times", []))
+                total_bytes += component_result.get("bytes_processed", 0)
+
+                if component_result["success"]:
+                    results["successful_components"].append(component.name)
+                else:
+                    results["failed_components"].append(
+                        {"component": component.name, "errors": component_result["errors"]}
+                    )
+                    results["errors"].extend(component_result["errors"])
+
+            except Exception as comp_error:
+                error_msg = f"Component {component.name}: {str(comp_error)}"
+                results["errors"].append(error_msg)
+                results["failed_components"].append({"component": component.name, "errors": [str(comp_error)]})
+                self.logger.exception(f"Error processing component {component.name}: {comp_error}")
+
+        # Calculate performance metrics
+        results["processing_time_ms"] = int((time.time() - start_time) * 1000)
+        if download_times:
+            results["performance_metrics"]["avg_sbom_download_time_ms"] = int(sum(download_times) / len(download_times))
+        if upload_times:
+            results["performance_metrics"]["avg_upload_time_ms"] = int(sum(upload_times) / len(upload_times))
+        results["performance_metrics"]["total_data_processed_bytes"] = total_bytes
+
+        return results
+
+    def _process_single_component(self, component) -> Dict[str, Any]:
+        """Process a single component for DT setup."""
+        component_result = {
+            "success": False,
+            "sboms_processed": 0,
+            "successful_uploads": 0,
+            "failed_uploads": 0,
+            "skipped_uploads": 0,
+            "errors": [],
+            "download_times": [],
+            "upload_times": [],
+            "bytes_processed": 0,
+        }
+
+        # Get relevant SBOMs for this component
+        relevant_sboms = self._get_relevant_sboms_for_component(component)
+
+        if not relevant_sboms:
+            self.logger.warning(f"No relevant SBOMs found for component {component.name}")
+            component_result["skipped_uploads"] += 1
+            return component_result
+
+        import time
+
+        from core.object_store import S3Client
+
+        # Process each relevant SBOM
+        for sbom, source_type in relevant_sboms:
+            try:
+                self.logger.info(f"Processing SBOM {sbom.name} ({source_type}) for component {component.name}")
+
+                # Download SBOM data with timing
+                download_start = time.time()
+                s3_client = S3Client(bucket_type="SBOMS")
+
+                if not sbom.sbom_filename:
+                    self.logger.warning(f"SBOM {sbom.id} has no filename")
+                    continue
+
+                sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
+                if not sbom_data:
+                    self.logger.warning(f"Could not download SBOM data for {sbom.id}")
+                    continue
+
+                download_time = (time.time() - download_start) * 1000
+                component_result["download_times"].append(download_time)
+                component_result["bytes_processed"] += len(sbom_data)
+
+                # Perform upload/scan with timing
+                upload_start = time.time()
+                scan_result = self.vulnerability_service.scan_sbom_for_vulnerabilities(
+                    sbom=sbom, sbom_data=sbom_data, scan_trigger="recurring_setup"
+                )
+                upload_time = (time.time() - upload_start) * 1000
+                component_result["upload_times"].append(upload_time)
+
+                if scan_result and scan_result.get("provider") == "dependency_track":
+                    component_result["successful_uploads"] += 1
+                    component_result["success"] = True
+                    self.logger.info(f"Successfully uploaded {sbom.name} to DT")
+                else:
+                    component_result["failed_uploads"] += 1
+                    error_msg = scan_result.get("error", "Unknown error") if scan_result else "No result"
+                    component_result["errors"].append(f"SBOM {sbom.name}: {error_msg}")
+                    self.logger.error(f"Failed to upload {sbom.name}: {error_msg}")
+
+                component_result["sboms_processed"] += 1
+
+            except Exception as sbom_error:
+                component_result["failed_uploads"] += 1
+                component_result["sboms_processed"] += 1
+                error_msg = f"SBOM {sbom.name}: {str(sbom_error)}"
+                component_result["errors"].append(error_msg)
+                self.logger.exception(f"Error processing SBOM {sbom.name}: {sbom_error}")
+
+        return component_result
+
+    def _team_should_use_dependency_track(self, team) -> bool:
+        """Check if a team should use Dependency Track for vulnerability scanning."""
+        try:
+            settings = TeamVulnerabilitySettings.objects.get(team=team)
+            return settings.vulnerability_provider == "dependency_track"
+        except TeamVulnerabilitySettings.DoesNotExist:
+            # Check if team is enterprise/business tier (they can use DT)
+            # For now, default to False - teams must explicitly configure DT
+            return False
+
+    def _get_relevant_sboms_for_component(self, component):
+        """Get relevant SBOMs for a component (latest + tagged releases)."""
+        sboms_to_process = []
+
+        # 1. Latest SBOM
+        latest_sbom = component.latest_sbom
+        if latest_sbom:
+            sboms_to_process.append((latest_sbom, "component_latest"))
+
+        # 2. SBOMs from tagged releases (not just recent ones for backfill)
+        from core.models import Release
+
+        tagged_releases = Release.objects.filter(
+            product__team=component.team, artifacts__sbom__component=component
+        ).distinct()
+
+        for release in tagged_releases:
+            for artifact in release.artifacts.filter(sbom__component=component):
+                sbom = artifact.sbom
+                # Don't duplicate the latest SBOM
+                if latest_sbom and sbom.id == latest_sbom.id:
+                    continue
+                sboms_to_process.append((sbom, f"release_{release.name}"))
+
+        return sboms_to_process

--- a/vulnerability_scanning/tasks.py
+++ b/vulnerability_scanning/tasks.py
@@ -34,11 +34,17 @@ from sboms.models import SBOM  # noqa: E402
 from .models import VulnerabilityScanResult  # noqa: E402
 from .services import VulnerabilityScanningService  # noqa: E402
 
+logger = logging.getLogger(__name__)
+
 # Import cron decorator for scheduling (requires dramatiq-crontab)
 # pip install dramatiq-crontab
 try:
     from dramatiq_crontab import cron
+
+    logger.info("dramatiq-crontab available - cron scheduling enabled")
 except ImportError:
+    logger.warning("dramatiq-crontab not installed - cron scheduling disabled, tasks will need manual triggering")
+
     # Fallback for environments without dramatiq-crontab
     def cron(schedule):
         """Fallback decorator when dramatiq-crontab is not installed."""
@@ -47,9 +53,6 @@ except ImportError:
             return func
 
         return decorator
-
-
-logger = logging.getLogger(__name__)
 
 
 @dramatiq.actor(queue_name="sbom_vulnerability_scanning", max_retries=3, time_limit=360000, store_results=True)
@@ -800,239 +803,66 @@ def recurring_dependency_track_backfill_task(
     logger.info(f"[TASK_dt_hourly_setup] Starting hourly DT component check (dry_run={dry_run})")
 
     try:
-        with transaction.atomic():
-            connection.ensure_connection()
+        connection.ensure_connection()
 
-            from .services import VulnerabilityScanningService
+        from .services import DependencyTrackSetupService
 
-            service = VulnerabilityScanningService()
+        # Use the dedicated service for DT setup operations
+        setup_service = DependencyTrackSetupService()
 
-            # Find components that should use DT but have no mappings
-            components_needing_setup = _find_components_needing_dt_setup(team_key, max_components)
+        # Find components that need DT setup
+        components_needing_setup = setup_service.find_components_needing_setup(team_key, max_components)
 
-            if not components_needing_setup:
-                logger.info("[TASK_dt_hourly_setup] No components found that need DT setup")
-                return {
-                    "status": "completed",
-                    "dry_run": dry_run,
-                    "components_identified": 0,
-                    "sboms_processed": 0,
-                    "successful_uploads": 0,
-                    "failed_uploads": 0,
-                    "message": "No components need DT setup",
-                }
+        if not components_needing_setup:
+            logger.info("[TASK_dt_hourly_setup] No components found that need DT setup")
+            return {
+                "status": "completed",
+                "dry_run": dry_run,
+                "components_identified": 0,
+                "sboms_processed": 0,
+                "successful_uploads": 0,
+                "failed_uploads": 0,
+                "message": "No components need DT setup",
+            }
 
-            if dry_run:
-                # Just report what would be processed
-                logger.info(f"[TASK_dt_hourly_setup] DRY RUN: Would process {len(components_needing_setup)} components")
-                return {
-                    "status": "completed",
-                    "dry_run": True,
-                    "components_identified": len(components_needing_setup),
-                    "components": [
-                        {
-                            "id": str(comp.id),
-                            "name": comp.name,
-                            "team": comp.team.key,
-                            "sbom_count": comp.sbom_set.count(),
-                            "latest_sbom_date": comp.latest_sbom.created_at.isoformat() if comp.latest_sbom else None,
-                        }
-                        for comp in components_needing_setup
-                    ],
-                }
+        if dry_run:
+            # Just report what would be processed
+            logger.info(f"[TASK_dt_hourly_setup] DRY RUN: Would process {len(components_needing_setup)} components")
+            return {
+                "status": "completed",
+                "dry_run": True,
+                "components_identified": len(components_needing_setup),
+                "components": [
+                    {
+                        "id": str(comp.id),
+                        "name": comp.name,
+                        "team": comp.team.key,
+                        "sbom_count": comp.sbom_set.count(),
+                        "latest_sbom_date": comp.latest_sbom.created_at.isoformat() if comp.latest_sbom else None,
+                    }
+                    for comp in components_needing_setup
+                ],
+            }
 
-            # Process each component
-            results = _process_components_for_dt_setup(components_needing_setup, service)
+        # Process components using the service
+        results = setup_service.process_components_for_setup(components_needing_setup)
 
-            logger.info(
-                f"[TASK_dt_hourly_setup] Recurring check completed. "
-                f"Processed {results['components_processed']} components, "
-                f"{results['successful_uploads']} successful uploads, "
-                f"{results['failed_uploads']} failed uploads"
-            )
+        logger.info(
+            f"[TASK_dt_hourly_setup] Recurring check completed in {results['processing_time_ms']}ms. "
+            f"Processed {results['components_processed']} components, "
+            f"{results['successful_uploads']} successful uploads, "
+            f"{results['failed_uploads']} failed uploads. "
+            f"Performance: avg download {results['performance_metrics']['avg_sbom_download_time_ms']}ms, "
+            f"avg upload {results['performance_metrics']['avg_upload_time_ms']}ms, "
+            f"total data {results['performance_metrics']['total_data_processed_bytes']} bytes"
+        )
 
-            return {"status": "completed", "dry_run": False, **results}
+        return {"status": "completed", "dry_run": False, **results}
 
-    except Exception:
-        logger.exception("[TASK_dt_hourly_setup] Recurring DT component check failed")
-        return {"status": "failed", "error": "Task failed", "failed_at": timezone.now().isoformat()}
-
-
-def _find_components_needing_dt_setup(team_key: str = None, max_components: int = None) -> list:
-    """Find components that should use DT but have no mappings yet."""
-    from core.models import Component
-
-    from .models import ComponentDependencyTrackMapping
-
-    # Start with all components that have SBOMs
-    component_queryset = Component.objects.select_related("team").prefetch_related("sbom_set")
-
-    # Filter by team if specified
-    if team_key:
-        component_queryset = component_queryset.filter(team__key=team_key)
-
-    # Only components with SBOMs
-    component_queryset = component_queryset.filter(sbom__isnull=False).distinct()
-
-    # Apply limit if specified
-    if max_components:
-        component_queryset = component_queryset[: max_components * 2]  # Get extra for filtering
-
-    components = list(component_queryset)
-    components_needing_setup = []
-
-    for component in components:
-        team = component.team
-
-        # Check if team should use DT
-        if not _team_should_use_dependency_track(team):
-            continue
-
-        # Check if component already has a DT mapping
-        if ComponentDependencyTrackMapping.objects.filter(component=component).exists():
-            continue
-
-        # Check if component has relevant SBOMs (latest + tagged releases)
-        relevant_sboms = _get_relevant_sboms_for_component(component)
-        if not relevant_sboms:
-            continue
-
-        components_needing_setup.append(component)
-
-        # Apply limit after filtering
-        if max_components and len(components_needing_setup) >= max_components:
-            break
-
-    logger.info(
-        f"[TASK_dt_hourly_setup] Found {len(components_needing_setup)} components needing DT setup "
-        f"(filtered from {len(components)} total components)"
-    )
-
-    return components_needing_setup
+    except Exception as e:
+        logger.exception(f"[TASK_dt_hourly_setup] Recurring DT component check failed: {e}")
+        return {"status": "failed", "error": f"Task failed: {str(e)}", "failed_at": timezone.now().isoformat()}
 
 
-def _team_should_use_dependency_track(team) -> bool:
-    """Check if a team should use Dependency Track for vulnerability scanning."""
-    from .models import TeamVulnerabilitySettings
-
-    try:
-        settings = TeamVulnerabilitySettings.objects.get(team=team)
-        return settings.vulnerability_provider == "dependency_track"
-    except TeamVulnerabilitySettings.DoesNotExist:
-        # Check if team is enterprise/business tier (they can use DT)
-        # For now, default to False - teams must explicitly configure DT
-        return False
-
-
-def _get_relevant_sboms_for_component(component):
-    """Get relevant SBOMs for a component (latest + tagged releases, same logic as weekly scan)."""
-    sboms_to_process = []
-
-    # 1. Latest SBOM
-    latest_sbom = component.latest_sbom
-    if latest_sbom:
-        sboms_to_process.append((latest_sbom, "component_latest"))
-
-    # 2. SBOMs from tagged releases (not just recent ones for backfill)
-    from core.models import Release
-
-    tagged_releases = Release.objects.filter(
-        product__team=component.team, artifacts__sbom__component=component
-    ).distinct()
-
-    for release in tagged_releases:
-        for artifact in release.artifacts.filter(sbom__component=component):
-            sbom = artifact.sbom
-            # Don't duplicate the latest SBOM
-            if latest_sbom and sbom.id == latest_sbom.id:
-                continue
-            sboms_to_process.append((sbom, f"release_{release.name}"))
-
-    return sboms_to_process
-
-
-def _process_components_for_dt_setup(components, service) -> Dict[str, Any]:
-    """Process components for DT setup."""
-    results = {
-        "components_processed": len(components),
-        "sboms_processed": 0,
-        "successful_uploads": 0,
-        "failed_uploads": 0,
-        "skipped_uploads": 0,
-        "errors": [],
-        "successful_components": [],
-        "failed_components": [],
-    }
-
-    for i, component in enumerate(components, 1):
-        logger.info(f"[TASK_dt_hourly_setup] [{i}/{len(components)}] Processing component {component.name}...")
-
-        try:
-            # Get relevant SBOMs for this component
-            relevant_sboms = _get_relevant_sboms_for_component(component)
-
-            if not relevant_sboms:
-                logger.warning(f"[TASK_dt_hourly_setup] No relevant SBOMs found for component {component.name}")
-                results["skipped_uploads"] += 1
-                continue
-
-            component_success = False
-            component_errors = []
-
-            # Process each relevant SBOM
-            for sbom, source_type in relevant_sboms:
-                try:
-                    logger.info(
-                        f"[TASK_dt_hourly_setup] Processing SBOM {sbom.name} ({source_type}) "
-                        f"for component {component.name}"
-                    )
-
-                    # Download SBOM data
-                    s3_client = S3Client(bucket_type="SBOMS")
-                    if not sbom.sbom_filename:
-                        logger.warning(f"[TASK_dt_hourly_setup] SBOM {sbom.id} has no filename")
-                        continue
-
-                    sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
-                    if not sbom_data:
-                        logger.warning(f"[TASK_dt_hourly_setup] Could not download SBOM data for {sbom.id}")
-                        continue
-
-                    # Perform upload/scan with recurring_setup trigger
-                    scan_result = service.scan_sbom_for_vulnerabilities(
-                        sbom=sbom, sbom_data=sbom_data, scan_trigger="recurring_setup"
-                    )
-
-                    if scan_result and scan_result.get("provider") == "dependency_track":
-                        results["successful_uploads"] += 1
-                        component_success = True
-                        logger.info(f"[TASK_dt_hourly_setup] Successfully uploaded {sbom.name} to DT")
-                    else:
-                        results["failed_uploads"] += 1
-                        error_msg = scan_result.get("error", "Unknown error") if scan_result else "No result"
-                        component_errors.append(f"SBOM {sbom.name}: {error_msg}")
-                        logger.error(f"[TASK_dt_hourly_setup] Failed to upload {sbom.name}: {error_msg}")
-
-                    results["sboms_processed"] += 1
-
-                except Exception as sbom_error:
-                    results["failed_uploads"] += 1
-                    results["sboms_processed"] += 1
-                    error_msg = f"SBOM {sbom.name}: {str(sbom_error)}"
-                    component_errors.append(error_msg)
-                    logger.exception(f"[TASK_dt_hourly_setup] Error processing SBOM {sbom.name}: {sbom_error}")
-
-            # Track component-level results
-            if component_success:
-                results["successful_components"].append(component.name)
-            else:
-                results["failed_components"].append({"component": component.name, "errors": component_errors})
-                results["errors"].extend(component_errors)
-
-        except Exception as comp_error:
-            error_msg = f"Component {component.name}: {str(comp_error)}"
-            results["errors"].append(error_msg)
-            results["failed_components"].append({"component": component.name, "errors": [str(comp_error)]})
-            logger.exception(f"[TASK_dt_hourly_setup] Error processing component {component.name}: {comp_error}")
-
-    return results
+# Helper functions have been moved to DependencyTrackSetupService in services.py
+# to improve code organization and maintainability


### PR DESCRIPTION
- Rename scan_sbom_for_vulnerabilities_unified to process_sbom_and_create_components_task
  to better reflect its primary responsibility of SBOM processing
- Move vulnerability scanning tasks to dedicated vulnerability_scanning.tasks module
- Add cron scheduling to vulnerability scanning tasks (weekly, daily, every 12h, hourly)
- Remove NTIA compliance checking task (functionality moved elsewhere)
- Add recurring_dependency_track_backfill_task for hourly DT component setup
- Update queue names and task organization for better separation of concerns
- Add fallback decorator for environments without dramatiq-crontab