### PR TITLE
fix: resolve static file conflicts and staging CSS corruption

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -170,13 +170,22 @@ STATIC_URL = "static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
-# Django Vite
+# Enable WhiteNoise compression and proper headers for production
+if not DEBUG:
+    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+# WhiteNoise configuration for better static file serving
+WHITENOISE_USE_FINDERS = True
+WHITENOISE_AUTOREFRESH = DEBUG
+WHITENOISE_MAX_AGE = 31536000 if not DEBUG else 0  # 1 year cache for production
+
+# Django Vite - now outputs to static/dist/ to avoid conflicts
 DJANGO_VITE = {
     "default": {
         "dev_mode": DEBUG,
         "dev_server_host": "127.0.0.1",
         "dev_server_port": 5170,
-        "manifest_path": str(STATIC_ROOT / "manifest.json"),
+        "manifest_path": str(BASE_DIR / "static" / "dist" / "manifest.json"),
     }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,9 +74,9 @@ export default defineConfig({
   ],
   build: {
     target: 'esnext',
-    outDir: resolve('./staticfiles/'),
-    emptyOutDir: false,
-    assetsDir: '',
+    outDir: resolve('./static/dist/'),
+    emptyOutDir: true,
+    assetsDir: 'assets',
     manifest: 'manifest.json',
     rollupOptions: {
       input: {


### PR DESCRIPTION
- Separate Vite build output to static/dist/ to avoid Django collectstatic conflicts
- Add WhiteNoise compression and proper caching configuration for production
- Update Dockerfile to use new static file directory structure
- Fix staging CSS loading errors (NS_ERROR_CORRUPTED_CONTENT) with proper MIME types

This resolves file overwrites between Vite and Django static systems while maintaining TypeScript compilation and improving production performance.

Fixes staging deployment CSS issues and provides foundation for Vue → Django migration.

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
