### PR TITLE
fix: add static_url_prefix to django-vite configuration

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -186,6 +186,7 @@ DJANGO_VITE = {
         "dev_server_host": "127.0.0.1",
         "dev_server_port": 5170,
         "manifest_path": str(BASE_DIR / "static" / "dist" / "manifest.json"),
+        "static_url_prefix": "/static/dist/",
     }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ const STATIC_URL = process.env.STATIC_URL || '/static/'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: `${STATIC_URL}`,
+  base: `${STATIC_URL}dist/`,
   css: {
     devSourcemap: true,
   },


### PR DESCRIPTION
Django-vite was generating incorrect URLs like /static/assets/file.css instead of /static/dist/assets/file.css because it didn't know the base path for Vite-built assets.

This (should) fix the NS_ERROR_CORRUPTED_CONTENT and MIME type mismatch errors in production by ensuring static assets resolve to correct URLs.