### PR TITLE
fix(ui): make dashboard footer full-bleed under sticky sidebar; use CSS var

### DIFF
--- a/core/templates/core/components/footer.html.j2
+++ b/core/templates/core/components/footer.html.j2
@@ -2,8 +2,8 @@
 {% if debug %}
     <footer class="footer mt-auto py-3 border-top">
         <div class="container-fluid">
-            <div class="row align-items-center">
-                <div class="col-lg-6 text-lg-start text-center mb-2 mb-lg-0">
+            <div class="row align-items-center gx-0">
+                <div class="col-lg-6 col-left text-lg-start text-center mb-2 mb-lg-0">
                     <a href="https://sbomify.com" class="text-decoration-none">
                         <strong class="text-primary">sbomify</strong>
                     </a>
@@ -17,9 +17,10 @@
                         <span class="text-muted">© {% now "Y" %} sbomify, ltd</span>
                     </span>
                 </div>
-                <div class="col-lg-6 text-lg-end text-center">
+                <div class="col-lg-6 col-right text-lg-end text-center">
                     <nav class="nav justify-content-lg-end justify-content-center">
-                        <a class="nav-link px-2 text-muted" href="mailto:hello@sbomify.com">Contact Support</a>
+                        <a class="nav-link footer-link text-muted"
+                           href="mailto:hello@sbomify.com">Contact Support</a>
                     </nav>
                 </div>
             </div>
@@ -29,7 +30,7 @@
     {% cache 3600 'footer' app_version %}
     <footer class="footer mt-auto py-3 border-top">
         <div class="container-fluid">
-            <div class="row align-items-center">
+            <div class="row align-items-center gx-0">
                 <div class="col-lg-6 text-lg-start text-center mb-2 mb-lg-0">
                     <a href="https://sbomify.com" class="text-decoration-none">
                         <strong class="text-primary">sbomify</strong>

--- a/core/templates/core/dashboard_base.html.j2
+++ b/core/templates/core/dashboard_base.html.j2
@@ -12,6 +12,7 @@
                     {% block content %}{% endblock %}
                 </div>
             </main>
+            {# Keep footer inside .main for stickiness; CSS makes it full-bleed under sidebar #}
             {% include "core/components/footer.html.j2" %}
         </div>
     </div>

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -260,20 +260,29 @@ REDIS_CACHE_URL = f"{REDIS_URL}/0"
 REDIS_WORKER_URL = f"{REDIS_URL}/0"  # Also points to /0
 
 # Cache Configuration
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_CACHE_URL,  # Use cache-specific URL
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "SOCKET_CONNECT_TIMEOUT": 5,
-            "SOCKET_TIMEOUT": 5,
-            "RETRY_ON_TIMEOUT": True,
-            "MAX_CONNECTIONS": 1000,
-            "CONNECTION_POOL_KWARGS": {"max_connections": 100},
-        },
+if DEBUG:
+    # Disable caching in development mode
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
     }
-}
+else:
+    # Use Redis cache in production
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": REDIS_CACHE_URL,  # Use cache-specific URL
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "SOCKET_CONNECT_TIMEOUT": 5,
+                "SOCKET_TIMEOUT": 5,
+                "RETRY_ON_TIMEOUT": True,
+                "MAX_CONNECTIONS": 1000,
+                "CONNECTION_POOL_KWARGS": {"max_connections": 100},
+            },
+        }
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -4,6 +4,11 @@
  * Core AdminKit-style layout system for Django templates
  */
 
+/* ===== CSS VARIABLES ===== */
+:root {
+  --sidebar-width: 250px;
+}
+
 /* ===== MAIN LAYOUT CONTAINER ===== */
 .wrapper {
   display: flex;
@@ -213,7 +218,7 @@
 
 /* ===== SIDEBAR ===== */
 .sidebar {
-  width: 250px;
+  width: var(--sidebar-width);
   min-height: 100vh;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border-color);
@@ -324,7 +329,7 @@
 
 /* Adjust main content to account for fixed sidebar */
 body:not(.sidebar-collapsed) .main {
-  margin-left: 250px;
+  margin-left: var(--sidebar-width);
 }
 
 /* Responsive logo styling */
@@ -507,10 +512,49 @@ body:not(.sidebar-collapsed) .main {
 
 /* ===== FOOTER ===== */
 .footer {
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 0; /* vertical only; allow full-bleed horizontally */
   background-color: var(--bg-secondary);
   border-top: 1px solid var(--border-color);
   margin-top: auto;
+}
+
+/* Ensure footer grid consumes full width and aligns edges */
+.footer .container-fluid {
+  padding-left: 0;   /* full-bleed to viewport edges */
+  padding-right: 0;
+}
+
+.footer .row {
+  width: 100%;
+}
+
+.footer .col-left {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.footer .col-right {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* Remove default link paddings in footer edge links */
+.footer .footer-link {
+  padding: 0 !important;
+}
+
+/* Full-bleed footer background under fixed sidebar on desktop */
+@media (min-width: 992px) {
+  .main > .footer {
+    margin-left: calc(-1 * var(--sidebar-width));   /* negate .main's sidebar offset */
+    width: calc(100% + var(--sidebar-width));       /* extend background under sidebar */
+  }
+
+  body.sidebar-collapsed .main > .footer {
+    margin-left: 0;
+    width: 100%;
+  }
 }
 
 /* ===== MESSAGES CONTAINER ===== */
@@ -602,6 +646,6 @@ body:not(.sidebar-collapsed) .main {
 
   /* Make sure main content has proper margin */
   .main {
-    margin-left: 250px !important;
+    margin-left: var(--sidebar-width) !important;
   }
 }


### PR DESCRIPTION
- Introduce --sidebar-width CSS variable and replace hard-coded widths
- Make footer background full-bleed under fixed sidebar on desktop
- Tweak footer template markup (gx-0, col-left/right, footer-link) for alignment
- Keep footer inside .main; CSS handles full-bleed under sidebar
- Settings: disable Django cache in DEBUG via DummyCache; keep Redis in prod
