### PR TITLE
feat: improve Dependency Track server availability with just-in-time health checks

### DIFF
--- a/vulnerability_scanning/services.py
+++ b/vulnerability_scanning/services.py
@@ -680,6 +680,7 @@ class VulnerabilityScanningService:
         - Enterprise teams: Can use custom server OR shared pool
         - Business teams: Can only use shared pool
         - Uses round-robin selection from available servers in the pool
+        - Performs just-in-time health checks if no healthy servers are available
 
         Args:
             team: Team instance
@@ -706,18 +707,50 @@ class VulnerabilityScanningService:
             .order_by("priority", "current_scan_count")
         )
 
-        if not available_servers.exists():
-            raise VulnerabilityProviderError("No available Dependency Track servers")
+        if available_servers.exists():
+            # Select server with lowest load in highest priority group
+            selected_server = available_servers.first()
 
-        # Select server with lowest load in highest priority group
-        selected_server = available_servers.first()
+            # Increment scan count atomically
+            DependencyTrackServer.objects.filter(id=selected_server.id).update(
+                current_scan_count=models.F("current_scan_count") + 1
+            )
 
-        # Increment scan count atomically
-        DependencyTrackServer.objects.filter(id=selected_server.id).update(
-            current_scan_count=models.F("current_scan_count") + 1
+            return selected_server
+
+        # No healthy servers found - try just-in-time health checks
+        logger.warning("No healthy DT servers found, attempting just-in-time health checks")
+
+        # Get all active servers regardless of health status, but still respect capacity limits
+        candidate_servers = (
+            DependencyTrackServer.objects.filter(is_active=True)
+            .exclude(current_scan_count__gte=models.F("max_concurrent_scans"))
+            .order_by("priority", "current_scan_count")
         )
 
-        return selected_server
+        for server in candidate_servers:
+            try:
+                # Perform quick health check
+                logger.info(f"Performing just-in-time health check for DT server: {server.name}")
+                health_result = self.check_dependency_track_server_health(server)
+
+                if health_result["status"] in ["healthy", "degraded"]:
+                    # Server is available, increment scan count and return
+                    DependencyTrackServer.objects.filter(id=server.id).update(
+                        current_scan_count=models.F("current_scan_count") + 1
+                    )
+                    logger.info(f"Successfully validated DT server {server.name} via just-in-time health check")
+                    return server
+                else:
+                    error_msg = health_result.get("error", "Unknown error")
+                    logger.warning(f"DT server {server.name} failed just-in-time health check: {error_msg}")
+
+            except Exception as e:
+                logger.warning(f"Just-in-time health check failed for DT server {server.name}: {e}")
+                continue
+
+        # If we get here, no servers are available
+        raise VulnerabilityProviderError("No available Dependency Track servers")
 
     def get_or_create_component_mapping(
         self, component, dt_server: DependencyTrackServer
@@ -1063,20 +1096,26 @@ class VulnerabilityScanningService:
             # Perform health check
             health_result = client.health_check()
 
+            # Determine status based on client response
+            if health_result.get("status") == "degraded":
+                server_status = "degraded"
+            else:
+                server_status = "healthy"
+
             # Update server status
-            server.health_status = "healthy"
+            server.health_status = server_status
             server.last_health_check = timezone.now()
             server.save(update_fields=["health_status", "last_health_check"])
 
-            logger.info(f"Health check successful for DT server: {server.name}")
+            logger.info(f"Health check successful for DT server: {server.name} (status: {server_status})")
 
             return {
                 "server_id": str(server.id),
                 "server_name": server.name,
-                "status": "healthy",
-                "application": health_result.get("application", "Unknown"),
-                "version": health_result.get("version", "Unknown"),
-                "timestamp": health_result.get("timestamp"),
+                "status": server_status,
+                "application": health_result.get("details", {}).get("application", "Unknown"),
+                "version": health_result.get("details", {}).get("version", "Unknown"),
+                "timestamp": health_result.get("details", {}).get("timestamp"),
                 "message": "Health check successful",
             }
 

--- a/vulnerability_scanning/tasks.py
+++ b/vulnerability_scanning/tasks.py
@@ -328,7 +328,7 @@ def _scan_sbom_comprehensive(sbom: SBOM, service: VulnerabilityScanningService, 
         return {"status": "error", "error": "Processing error"}
 
 
-@cron("0 3 * * *")  # Run daily at 3 AM
+@cron("0 */6 * * *")  # Run every 6 hours
 @dramatiq.actor(queue_name="dt_health_check", max_retries=2, time_limit=60000, store_results=True)
 @retry(
     retry=retry_if_exception_type((OperationalError, DatabaseError)),
@@ -338,7 +338,7 @@ def _scan_sbom_comprehensive(sbom: SBOM, service: VulnerabilityScanningService, 
 )
 def check_dependency_track_health_task(server_id: str = None) -> Dict[str, Any]:
     """
-    Task to check Dependency Track server health and update status - runs daily at 3 AM.
+    Task to check Dependency Track server health and update status - runs every 6 hours.
 
     Args:
         server_id: Specific server ID to check. If None, checks all active servers.

--- a/vulnerability_scanning/tests/test_services.py
+++ b/vulnerability_scanning/tests/test_services.py
@@ -2,7 +2,10 @@ import pytest
 from django.test import override_settings
 from unittest.mock import patch, Mock
 
-from ..services import VulnerabilityScanningService
+from teams.models import Team
+from billing.models import BillingPlan
+from ..services import VulnerabilityScanningService, VulnerabilityProviderError
+from ..models import DependencyTrackServer
 
 
 class TestEnvironmentPrefix:
@@ -88,3 +91,213 @@ class TestEnvironmentPrefix:
             result = service._get_environment_prefix()
             assert result == "unknown"
             mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestServerSelection:
+    """Test Dependency Track server selection logic."""
+
+    def test_select_server_with_healthy_servers_available(self):
+        """Test server selection when healthy servers are available."""
+        service = VulnerabilityScanningService()
+
+        # Create a team
+        team = Team.objects.create(
+            name="Test Team",
+            key="test-team-1",
+            billing_plan="business"
+        )
+
+        # Create healthy servers
+        server1 = DependencyTrackServer.objects.create(
+            name="Server 1",
+            url="https://dt1.example.com",
+            api_key="key1",
+            health_status="healthy",
+            priority=1,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        server2 = DependencyTrackServer.objects.create(
+            name="Server 2",
+            url="https://dt2.example.com",
+            api_key="key2",
+            health_status="healthy",
+            priority=2,
+            current_scan_count=5,
+            max_concurrent_scans=10
+        )
+
+        # Should select server1 (higher priority, lower load)
+        selected = service.select_dependency_track_server(team)
+        assert selected.id == server1.id
+
+        # Verify scan count was incremented
+        server1.refresh_from_db()
+        assert server1.current_scan_count == 1
+
+    def test_select_server_with_degraded_servers(self):
+        """Test server selection includes degraded servers."""
+        service = VulnerabilityScanningService()
+
+        team = Team.objects.create(
+            name="Test Team",
+            key="test-team-2",
+            billing_plan="business"
+        )
+
+        # Create degraded server
+        server = DependencyTrackServer.objects.create(
+            name="Degraded Server",
+            url="https://dt.example.com",
+            api_key="key",
+            health_status="degraded",
+            priority=1,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        # Should select degraded server
+        selected = service.select_dependency_track_server(team)
+        assert selected.id == server.id
+
+    def test_select_server_at_capacity_excluded(self):
+        """Test servers at capacity are excluded."""
+        service = VulnerabilityScanningService()
+
+        team = Team.objects.create(
+            name="Test Team",
+            unique_id="test-team",
+            billing_plan="business"
+        )
+
+        # Create server at capacity
+        DependencyTrackServer.objects.create(
+            name="Full Server",
+            url="https://dt.example.com",
+            api_key="key",
+            health_status="healthy",
+            priority=1,
+            current_scan_count=10,
+            max_concurrent_scans=10
+        )
+
+        # Should raise error when no available servers
+        with pytest.raises(VulnerabilityProviderError) as exc_info:
+            service.select_dependency_track_server(team)
+        assert "No available Dependency Track servers" in str(exc_info.value)
+
+    @patch('vulnerability_scanning.services.VulnerabilityScanningService.check_dependency_track_server_health')
+    def test_just_in_time_health_check_success(self, mock_health_check):
+        """Test just-in-time health check when no healthy servers found."""
+        service = VulnerabilityScanningService()
+
+        team = Team.objects.create(
+            name="Test Team",
+            key="test-team-2",
+            billing_plan="business"
+        )
+
+        # Create server with unknown status
+        server = DependencyTrackServer.objects.create(
+            name="Unknown Server",
+            url="https://dt.example.com",
+            api_key="key",
+            health_status="unknown",
+            priority=1,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        # Mock health check to return healthy
+        mock_health_check.return_value = {"status": "healthy"}
+
+        # Should perform health check and select server
+        selected = service.select_dependency_track_server(team)
+        assert selected.id == server.id
+
+        # Verify health check was called
+        mock_health_check.assert_called_once_with(server)
+
+        # Verify scan count incremented
+        server.refresh_from_db()
+        assert server.current_scan_count == 1
+
+    @patch('vulnerability_scanning.services.VulnerabilityScanningService.check_dependency_track_server_health')
+    def test_just_in_time_health_check_failure(self, mock_health_check):
+        """Test just-in-time health check when server fails."""
+        service = VulnerabilityScanningService()
+
+        team = Team.objects.create(
+            name="Test Team",
+            key="test-team-2",
+            billing_plan="business"
+        )
+
+        # Create server with unknown status
+        DependencyTrackServer.objects.create(
+            name="Unknown Server",
+            url="https://dt.example.com",
+            api_key="key",
+            health_status="unknown",
+            priority=1,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        # Mock health check to return unhealthy
+        mock_health_check.return_value = {"status": "unhealthy", "error": "Connection failed"}
+
+        # Should raise error when health check fails
+        with pytest.raises(VulnerabilityProviderError) as exc_info:
+            service.select_dependency_track_server(team)
+        assert "No available Dependency Track servers" in str(exc_info.value)
+
+        # Verify health check was called
+        mock_health_check.assert_called_once()
+
+    @patch('vulnerability_scanning.services.VulnerabilityScanningService.check_dependency_track_server_health')
+    def test_just_in_time_health_check_with_multiple_servers(self, mock_health_check):
+        """Test just-in-time health check tries multiple servers."""
+        service = VulnerabilityScanningService()
+
+        team = Team.objects.create(
+            name="Test Team",
+            key="test-team-2",
+            billing_plan="business"
+        )
+
+        # Create servers with unknown status
+        server1 = DependencyTrackServer.objects.create(
+            name="Server 1",
+            url="https://dt1.example.com",
+            api_key="key1",
+            health_status="unknown",
+            priority=1,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        server2 = DependencyTrackServer.objects.create(
+            name="Server 2",
+            url="https://dt2.example.com",
+            api_key="key2",
+            health_status="unknown",
+            priority=2,
+            current_scan_count=0,
+            max_concurrent_scans=10
+        )
+
+        # Mock health check - first fails, second succeeds
+        mock_health_check.side_effect = [
+            {"status": "unhealthy", "error": "Connection failed"},
+            {"status": "healthy"}
+        ]
+
+        # Should select second server after first fails health check
+        selected = service.select_dependency_track_server(team)
+        assert selected.id == server2.id
+
+        # Verify both health checks were called
+        assert mock_health_check.call_count == 2


### PR DESCRIPTION
- Add just-in-time health checks when no healthy servers are found in pool
- Increase health check frequency from daily to every 6 hours for more timely status updates
- Enhance health check method to properly handle degraded server status
- Improve server selection robustness to prevent "No available Dependency Track servers" errors
- Add comprehensive test coverage for new server selection logic

This resolves issues where working DT servers were incorrectly marked as unavailable due to stale health status, particularly impacting staging environment scans.

Fixes: Dependency Track scan failures with "No available servers" error