### PR TITLE
fix: prevent duplicate vulnerability scan results from dependency track

### DIFF
--- a/vulnerability_scanning/services.py
+++ b/vulnerability_scanning/services.py
@@ -571,9 +571,6 @@ class VulnerabilityScanningService:
                         }
                     )
 
-                    # Store updated results
-                    self._cache_dt_results(sbom, mapping, scan_results)
-
                     logger.info(f"Successfully polled updated vulnerabilities for SBOM {sbom.id}")
                     return scan_results
 

--- a/vulnerability_scanning/tasks.py
+++ b/vulnerability_scanning/tasks.py
@@ -587,7 +587,7 @@ def poll_dependency_track_results_task(
         }
 
 
-@cron("0 */12 * * *")  # Run every 12 hours at minute 0
+@cron("0 */6 * * *")  # Run every 6 hours at minute 0
 @dramatiq.actor(queue_name="dt_periodic_polling", max_retries=2, time_limit=1800000, store_results=True)
 @retry(
     retry=retry_if_exception_type((OperationalError, DatabaseError)),
@@ -595,11 +595,11 @@ def poll_dependency_track_results_task(
     stop=stop_after_delay(60),
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
-def periodic_dependency_track_polling_task(hours_back: int = 12) -> Dict[str, Any]:
+def periodic_dependency_track_polling_task(hours_back: int = 6) -> Dict[str, Any]:
     """
-    Periodic task to poll Dependency Track for vulnerability updates on existing projects - runs every 12 hours.
+    Periodic task to poll Dependency Track for vulnerability updates on existing projects - runs every 6 hours.
 
-    This task runs every 12 hours to check for new vulnerabilities on existing DT projects
+    This task runs every 6 hours to check for new vulnerabilities on existing DT projects
     without re-uploading SBOMs. DT continuously monitors for new CVEs, so we need to
     poll regularly to get updated vulnerability data.
 


### PR DESCRIPTION
- Remove immediate scan result creation in _scan_with_dependency_track()
- Only create VulnerabilityScanResult records when polling task completes
- Update periodic polling frequency from 12h to 6h for more timely updates

This fixes the race condition where both immediate polling and the async polling task were creating duplicate scan result records within milliseconds of each other, causing duplicate entries on the dashboard.

Fixes duplicate SBOM scan entries on the front page.