### PR TITLE
fix: resolve datetime serialization error in vulnerability scanning tasks

### DIFF
--- a/vulnerability_scanning/tasks.py
+++ b/vulnerability_scanning/tasks.py
@@ -94,9 +94,10 @@ def scan_sbom_for_vulnerabilities_unified(sbom_id: str) -> Dict[str, Any]:
     logger.info(f"[TASK_scan_sbom_for_vulnerabilities_unified] Starting vulnerability scan for SBOM ID: {sbom_id}")
 
     # Track task execution metadata
+    start_time = timezone.now()
     task_metadata = {
         "sbom_id": sbom_id,
-        "start_time": timezone.now(),
+        "start_time": start_time,  # Will be converted to ISO format before return
         "provider": None,
         "sbom_size_mb": 0,
         "error_type": None,
@@ -131,10 +132,11 @@ def scan_sbom_for_vulnerabilities_unified(sbom_id: str) -> Dict[str, Any]:
             results = service.scan_sbom_for_vulnerabilities(sbom_instance, sbom_data_bytes, scan_trigger="upload")
 
             task_metadata["provider"] = results.get("provider", "unknown")
-            task_metadata["end_time"] = timezone.now()
-            task_metadata["duration_seconds"] = (
-                task_metadata["end_time"] - task_metadata["start_time"]
-            ).total_seconds()
+            end_time = timezone.now()
+            task_metadata["end_time"] = end_time.isoformat()
+            task_metadata["duration_seconds"] = (end_time - start_time).total_seconds()
+            # Convert start_time to ISO format for JSON serialization
+            task_metadata["start_time"] = start_time.isoformat()
 
             logger.info(
                 f"[TASK_scan_sbom_for_vulnerabilities_unified] Completed vulnerability scan for SBOM ID: {sbom_id}. "
@@ -178,7 +180,7 @@ def scan_sbom_for_vulnerabilities_unified(sbom_id: str) -> Dict[str, Any]:
     finally:
         # Log task completion metadata
         end_time = timezone.now()
-        total_duration = (end_time - task_metadata["start_time"]).total_seconds()
+        total_duration = (end_time - start_time).total_seconds()
         logger.info(
             f"[TASK_scan_sbom_for_vulnerabilities_unified] Task finished for SBOM {sbom_id}. "
             f"Total duration: {total_duration:.1f}s, Error type: {task_metadata.get('error_type', 'none')}"


### PR DESCRIPTION
Convert datetime objects to ISO format strings in task metadata to prevent JSON serialization failures when Dramatiq stores task results in Redis.

The scan_sbom_for_vulnerabilities_unified task was returning raw datetime objects in task_metadata, causing "Object of type datetime is not JSON serializable" errors when Dramatiq attempted to store results.

Changes:
- Extract start_time variable to avoid datetime object in metadata
- Convert start_time and end_time to ISO format strings before return
- Fix duration calculation to use original datetime objects
- Update finally block to use start_time variable instead of metadata

Fixes production errors:
"TypeError: Object of type datetime is not JSON serializable" "CRITICAL: Unexpected failure in after_process_message"