### PR TITLE
security: hide Dependency Track server details from end users

### DIFF
--- a/teams/js/components/VulnerabilitySettings.vue
+++ b/teams/js/components/VulnerabilitySettings.vue
@@ -143,7 +143,7 @@
                   <span v-if="!server.is_active" class="badge bg-warning ms-2">Inactive</span>
                 </div>
                 <div class="server-description">
-                  {{ server.url }}
+                  Managed Dependency Track server
                 </div>
                 <div v-if="server.description" class="server-meta">
                   {{ server.description }}
@@ -236,10 +236,10 @@ interface VulnerabilityProvider {
 interface DependencyTrackServer {
   id: string
   name: string
-  url: string
   health_status: string
   is_active: boolean
   description?: string
+  // Note: url field removed to prevent server exposure to end users
 }
 
 interface VulnerabilitySettings {

--- a/vulnerability_scanning/apis.py
+++ b/vulnerability_scanning/apis.py
@@ -83,10 +83,10 @@ class DependencyTrackServerInfo(BaseModel):
 
     id: str
     name: str
-    url: str
     health_status: str
     is_active: bool
     description: Optional[str] = None
+    # Note: URL field removed to prevent server exposure to end users
 
 
 class TeamVulnerabilitySettingsResponse(BaseModel):
@@ -148,7 +148,6 @@ def get_team_vulnerability_settings(request: HttpRequest, team_key: str):
             DependencyTrackServerInfo(
                 id=str(server.id),
                 name=server.name,
-                url=server.url,
                 health_status=server.health_status,
                 is_active=server.is_active,
                 description=(
@@ -164,7 +163,6 @@ def get_team_vulnerability_settings(request: HttpRequest, team_key: str):
         custom_dt_server = DependencyTrackServerInfo(
             id=str(team_settings.custom_dt_server.id),
             name=team_settings.custom_dt_server.name,
-            url=team_settings.custom_dt_server.url,
             health_status=team_settings.custom_dt_server.health_status,
             is_active=team_settings.custom_dt_server.is_active,
         )
@@ -332,7 +330,7 @@ def get_team_vulnerability_stats(
             dt_mappings = [
                 {
                     "component_name": mapping.component.name,
-                    "dt_server_name": mapping.dt_server.name,
+                    "dt_server_id": str(mapping.dt_server.id),  # Use ID instead of name to prevent server name exposure
                     "dt_project_name": mapping.dt_project_name,
                     "last_upload": mapping.last_sbom_upload.isoformat() if mapping.last_sbom_upload else None,
                     "last_sync": mapping.last_metrics_sync.isoformat() if mapping.last_metrics_sync else None,

--- a/vulnerability_scanning/models.py
+++ b/vulnerability_scanning/models.py
@@ -81,7 +81,7 @@ class DependencyTrackServer(models.Model):
 
     def __str__(self) -> str:
         """Return string representation."""
-        return f"{self.name} ({self.url})"
+        return f"{self.name} (ID: {self.id})"
 
     def clean(self) -> None:
         """Validate the model data."""

--- a/vulnerability_scanning/services.py
+++ b/vulnerability_scanning/services.py
@@ -1109,12 +1109,12 @@ class VulnerabilityScanningService:
 
             return {
                 "server_id": str(server.id),
-                "server_name": server.name,
                 "status": server_status,
                 "application": health_result.get("details", {}).get("application", "Unknown"),
                 "version": health_result.get("details", {}).get("version", "Unknown"),
                 "timestamp": health_result.get("details", {}).get("timestamp"),
                 "message": "Health check successful",
+                # Note: server_name removed to prevent server exposure
             }
 
         except Exception as e:
@@ -1127,10 +1127,10 @@ class VulnerabilityScanningService:
 
             return {
                 "server_id": str(server.id),
-                "server_name": server.name,
                 "status": "unhealthy",
                 "error": str(e),
                 "message": "Health check failed",
+                # Note: server_name removed to prevent server exposure
             }
 
     def check_all_dependency_track_servers_health(self) -> List[Dict[str, Any]]:

--- a/vulnerability_scanning/tests/test_models.py
+++ b/vulnerability_scanning/tests/test_models.py
@@ -48,7 +48,7 @@ class TestDependencyTrackServer:
             url="https://example.com",
             api_key="key123"
         )
-        assert str(server) == "My Server (https://example.com)"
+        assert str(server) == f"My Server (ID: {server.id})"
 
     def test_url_uniqueness(self, db) -> None:
         """Test that server URLs must be unique."""

--- a/vulnerability_scanning/tests/test_security_fixes.py
+++ b/vulnerability_scanning/tests/test_security_fixes.py
@@ -1,0 +1,199 @@
+"""
+Tests to verify security fixes for preventing server exposure to end users.
+"""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from core.tests.shared_fixtures import (
+    authenticated_api_client,
+    get_api_headers,
+    sample_user,
+)
+from teams.fixtures import sample_team
+from teams.models import Member
+from vulnerability_scanning.models import DependencyTrackServer, TeamVulnerabilitySettings
+
+
+@pytest.mark.django_db
+class TestServerExposurePrevention:
+    """Test that shared server information is not exposed to end users."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test_data(self, sample_team, sample_user):
+        """Set up test data for security tests."""
+        self.team = sample_team
+        self.user = sample_user
+
+        # Set team to enterprise plan to access custom servers
+        self.team.billing_plan = "enterprise"
+        self.team.save()
+
+        # Ensure user is owner of the team
+        member, created = Member.objects.get_or_create(
+            user=self.user,
+            team=self.team,
+            defaults={'role': 'owner'}
+        )
+        if not created:
+            member.role = 'owner'
+            member.save()
+
+        # Create test Dependency Track servers
+        self.dt_server1 = DependencyTrackServer.objects.create(
+            name="Production Server",
+            url="https://dt-prod.internal.company.com",
+            api_key="secret-api-key-1",
+            is_active=True,
+            priority=10
+        )
+
+        self.dt_server2 = DependencyTrackServer.objects.create(
+            name="Staging Server",
+            url="https://dt-staging.internal.company.com",
+            api_key="secret-api-key-2",
+            is_active=True,
+            priority=20
+        )
+
+        # Create team settings
+        TeamVulnerabilitySettings.objects.create(
+            team=self.team,
+            vulnerability_provider="dependency_track",
+            custom_dt_server=self.dt_server1
+        )
+
+    def test_vulnerability_settings_api_does_not_expose_server_urls(self, authenticated_api_client):
+        """Test that the vulnerability settings API does not expose server URLs."""
+        client, access_token = authenticated_api_client
+
+        response = client.get(
+            f"/api/v1/vulnerability-scanning/teams/{self.team.key}/vulnerability-settings",
+            **get_api_headers(access_token)
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check that available_dt_servers don't contain URLs
+        available_servers = data.get("available_dt_servers", [])
+        for server in available_servers:
+            assert "url" not in server, f"Server {server.get('name')} exposes URL field"
+            assert server.get("name") == "Production Server" or server.get("name") == "Staging Server"
+            assert "id" in server
+            assert "health_status" in server
+            assert "is_active" in server
+
+        # Check that custom_dt_server doesn't contain URL
+        custom_server = data.get("custom_dt_server")
+        if custom_server:
+            assert "url" not in custom_server, "Custom server exposes URL field"
+            assert custom_server.get("name") == "Production Server"
+
+    def test_vulnerability_stats_api_does_not_expose_server_names(self, authenticated_api_client):
+        """Test that the vulnerability stats API does not expose server names."""
+        client, access_token = authenticated_api_client
+
+        response = client.get(
+            f"/api/v1/vulnerability-scanning/teams/{self.team.key}/vulnerability-stats",
+            **get_api_headers(access_token)
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check that dt_mappings use server IDs instead of names
+        dt_mappings = data.get("dt_mappings", [])
+        for mapping in dt_mappings:
+            assert "dt_server_name" not in mapping, "DT mapping exposes server name"
+            if "dt_server_id" in mapping:
+                # Verify it's a UUID format (server ID)
+                server_id = mapping["dt_server_id"]
+                assert len(server_id) == 36, f"Server ID {server_id} doesn't look like a UUID"
+                assert "-" in server_id, f"Server ID {server_id} doesn't look like a UUID"
+
+    def test_model_string_representation_does_not_expose_urls(self):
+        """Test that model string representations don't expose URLs."""
+        server_str = str(self.dt_server1)
+
+        # Should contain name and ID, but not URL
+        assert "Production Server" in server_str
+        assert str(self.dt_server1.id) in server_str
+        assert "https://dt-prod.internal.company.com" not in server_str
+        assert "ID:" in server_str
+
+    def test_frontend_component_interface_updated(self, authenticated_api_client):
+        """Test that the frontend TypeScript interface doesn't expect URL field."""
+        # This is more of a documentation test - the interface should not have url field
+        # We can verify this by checking that our API response matches what the frontend expects
+        client, access_token = authenticated_api_client
+
+        response = client.get(
+            f"/api/v1/vulnerability-scanning/teams/{self.team.key}/vulnerability-settings",
+            **get_api_headers(access_token)
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify the response structure matches the updated TypeScript interface
+        available_servers = data.get("available_dt_servers", [])
+        if available_servers:
+            server = available_servers[0]
+            expected_fields = {"id", "name", "health_status", "is_active"}
+            actual_fields = set(server.keys())
+
+            # Should have expected fields
+            assert expected_fields.issubset(actual_fields), f"Missing expected fields: {expected_fields - actual_fields}"
+
+            # Should NOT have url field
+            assert "url" not in actual_fields, "Server data still contains URL field"
+
+    def test_community_plan_cannot_see_server_details(self, authenticated_api_client):
+        """Test that community plan users cannot see any server details."""
+        # Change team to community plan
+        self.team.billing_plan = "community"
+        self.team.save()
+
+        # Clear any existing custom server settings for community plan
+        settings = TeamVulnerabilitySettings.objects.filter(team=self.team).first()
+        if settings:
+            settings.custom_dt_server = None
+            settings.vulnerability_provider = "osv"  # Community plans use OSV
+            settings.save()
+
+        client, access_token = authenticated_api_client
+
+        response = client.get(
+            f"/api/v1/vulnerability-scanning/teams/{self.team.key}/vulnerability-settings",
+            **get_api_headers(access_token)
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Community plans should not see any server details
+        assert data.get("available_dt_servers") == []
+        assert data.get("can_use_custom_dt") is False
+        assert data.get("custom_dt_server") is None
+
+    def test_business_plan_cannot_use_custom_servers(self, authenticated_api_client):
+        """Test that business plan users cannot use custom servers (only enterprise can)."""
+        # Change team to business plan
+        self.team.billing_plan = "business"
+        self.team.save()
+
+        client, access_token = authenticated_api_client
+
+        response = client.get(
+            f"/api/v1/vulnerability-scanning/teams/{self.team.key}/vulnerability-settings",
+            **get_api_headers(access_token)
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Business plans should not see custom server options
+        assert data.get("available_dt_servers") == []
+        assert data.get("can_use_custom_dt") is False


### PR DESCRIPTION
Prevent exposure of internal Dependency Track server information (URLs and names) to end users through API responses and UI.

Changes:
- Remove server URLs from vulnerability settings API responses
- Replace server names with server IDs in vulnerability stats
- Update frontend to show generic "Managed Dependency Track server" text
- Modify model string representation to use ID instead of URL
- Remove server names from health check service responses

Security impact:
- Prevents leakage of internal infrastructure details
- Maintains functionality while improving information security
- Server IDs still allow internal tracking and debugging

Testing:
- Add comprehensive security tests to prevent regression
- Verify API responses don't expose sensitive server information
- Test billing plan access controls for server visibility
- Update existing model tests for new string representation