### PR TITLE
fix: resolve N+1 query issue in vulnerability scanning APIs

### DIFF
--- a/vulnerability_scanning/apis.py
+++ b/vulnerability_scanning/apis.py
@@ -303,7 +303,7 @@ def get_team_vulnerability_stats(
                 except Component.DoesNotExist:
                     recent_results_query = recent_results_query.none()
 
-        recent_results = recent_results_query.order_by("-created_at")[:10]
+        recent_results = recent_results_query.select_related("sbom__component__team").order_by("-created_at")[:10]
 
         # Calculate statistics
         total_scans = recent_results.count()
@@ -408,7 +408,7 @@ def get_team_vulnerability_timeseries(
         # Base query for vulnerability scan results
         results_query = VulnerabilityScanResult.objects.filter(
             sbom__component__team=team, created_at__gte=start_date, created_at__lte=end_date
-        ).select_related("sbom__component")
+        ).select_related("sbom__component__team")
 
         # Filter by product if specified
         if product_id:
@@ -594,7 +594,7 @@ def get_team_vulnerability_drill_down(
         # Get only the latest results for each SBOM/provider combination
         results_query = VulnerabilityScanResult.objects.filter(
             sbom__component__team=team, created_at__gte=start_date, created_at__lte=end_date
-        ).select_related("sbom__component")
+        ).select_related("sbom__component__team")
 
         # Filter by product if specified
         if product_id:


### PR DESCRIPTION
- Add select_related('sbom__component__team') to vulnerability scan result queries
- Fixes N+1 queries when accessing team information in API responses
- Optimizes get_team_vulnerability_stats, get_team_vulnerability_timeseries, and get_team_vulnerability_drill_down endpoints
- Resolves Sentry performance alerts for vulnerability scanning operations
- No functional changes, purely performance optimization

Addresses: N+1 query performance issue reported in Sentry