### PR TITLE
ci: Restore dependency pinning and minimise token permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,9 +14,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 
 jobs:
   code-quality:
@@ -211,15 +208,19 @@ jobs:
       tags: ${{ steps.meta.outputs.tags }}
     env:
       IMAGE_NAME: sbomify
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to GitHub Container Registry
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -227,7 +228,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: sbomifyhub
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -257,7 +258,7 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Build and push to registries
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: build
         with:
           context: .
@@ -268,7 +269,7 @@ jobs:
 
       - name: Attest GitHub Container Registry image
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ steps.meta.outputs.github_image_id }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -276,7 +277,7 @@ jobs:
 
       - name: Attest Docker Hub image
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ steps.meta.outputs.docker_hub_image_id }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -307,6 +308,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ success() && github.event_name == 'release' && github.event.action == 'published' }}
     needs: [code-quality, tests, frontend-tests, docker-build]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -339,7 +343,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -361,7 +365,7 @@ jobs:
 
       - name: Attest
         if: ${{ success() }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: '${{ github.workspace }}/backend.cdx.json'
 
@@ -381,7 +385,7 @@ jobs:
 
       - name: Attest
         if: ${{ success() }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: '${{ github.workspace }}/container.cdx.json'
 
@@ -401,6 +405,6 @@ jobs:
 
       - name: Attest
         if: ${{ success() }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: '${{ github.workspace }}/frontend.cdx.json'


### PR DESCRIPTION
OpenSSF Scorecard has slipped due to recent changes to the ci-cd workflow

**- What I did**

* Ensured that all actions are pinned to a SHA
* Moved workflow permissions to jobs

**- How I did it**

* StepSecurity tool for the pinning
* Permissions based on the activities done by the jobs

**- How to verify it**

Will need a release (and there's a chance that permissions aren't 100% which will then entail fixing things up before re-release).

**- Description for the changelog**

ci: Restore dependency pinning and minimise token permissions
