### PR TITLE
security: Run Docker containers as non-root user (nobody)

### DIFF
--- a/bin/developer_mode.sh
+++ b/bin/developer_mode.sh
@@ -4,20 +4,20 @@ set -euo pipefail
 DOCKER_ARGS=(-f docker-compose.yml -f docker-compose.dev.yml)
 
 restart() {
-    docker-compose "${DOCKER_ARGS[@]}" restart sbomify-backend sbomify-frontend
+    docker compose "${DOCKER_ARGS[@]}" restart sbomify-backend sbomify-frontend
 }
 
 start() {
-    docker-compose "${DOCKER_ARGS[@]}" up "$@"
+    docker compose "${DOCKER_ARGS[@]}" up "$@"
 }
 
 build() {
-    docker-compose "${DOCKER_ARGS[@]}" build "$@"
+    docker compose "${DOCKER_ARGS[@]}" build "$@"
 }
 
 clean() {
-    docker-compose "${DOCKER_ARGS[@]}" kill "$@"
-    docker-compose "${DOCKER_ARGS[@]}" rm "$@"
+    docker compose "${DOCKER_ARGS[@]}" kill "$@"
+    docker compose "${DOCKER_ARGS[@]}" rm "$@"
     docker volume rm -f \
         sbomify_keycloak_data \
         sbomify_sbomify_minio_data \


### PR DESCRIPTION
- Configure both development and production stages to run as 'nobody' user
- Set proper permissions for /tmp directory (1777) for temporary files
- Configure Poetry to use system Python without creating virtual environments
- Keep application code read-only for enhanced security
- Maintain functionality while following container security best practices

This change reduces the attack surface by dropping root privileges at runtime while preserving all application functionality including vulnerability scanning temporary file operations.