### PR TITLE
fix: correct Member model query in trial subscription creation

### DIFF
--- a/sbomify/apps/core/management/commands/fix_missing_trial_subscriptions.py
+++ b/sbomify/apps/core/management/commands/fix_missing_trial_subscriptions.py
@@ -190,10 +190,14 @@ class Command(BaseCommand):
     def create_trial_subscription(self, user, stripe_client, dry_run=False):
         """Create a trial subscription for a user."""
         try:
-            # Get the user's default team
-            team = Team.objects.filter(members=user, members__is_default_team=True).first()
-            if not team:
-                team = Team.objects.filter(members=user).first()
+            # Get the user's default team through the Member model
+            default_member = Member.objects.filter(user=user, is_default_team=True).first()
+            if default_member:
+                team = default_member.team
+            else:
+                # No default team, just get the first team
+                first_member = Member.objects.filter(user=user).first()
+                team = first_member.team if first_member else None
 
             if not team:
                 self.stdout.write(self.style.WARNING(f"  No team found for user {user.username}"))


### PR DESCRIPTION
The management command was using an invalid Django ORM query syntax: `Team.objects.filter(members=user, members__is_default_team=True)`

This caused "Unsupported lookup 'is_default_team' for ForeignKey" errors because `is_default_team` is a field on the Member through model, not directly accessible via the ManyToMany relationship.

Fix:
Query the Member model directly to find the default team: `Member.objects.filter(user=user, is_default_team=True).first()`

This correctly accesses the is_default_team field on the Member model and then retrieves the associated team.