### PR TITLE
fix: correct boolean environment variable quoting in docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,8 +19,10 @@ x-minio-env: &minio-env
   AWS_MEDIA_STORAGE_BUCKET_NAME: ${AWS_MEDIA_STORAGE_BUCKET_NAME:-sbomify-media}
 
 x-dev-env: &dev-env
-  DEBUG: ${DEBUG:-"True"}
-  USE_VITE_DEV_SERVER: ${USE_VITE_DEV_SERVER:-"True"}
+  DEBUG: ${DEBUG:-True}
+  USE_VITE_DEV_SERVER: ${USE_VITE_DEV_SERVER:-True}
+  VITE_DEV_SERVER_HOST: ${VITE_DEV_SERVER_HOST:-sbomify-frontend}
+  VITE_DEV_SERVER_PORT: ${VITE_DEV_SERVER_PORT:-5170}
   BUILD_ENV: ${BUILD_ENV:-development}
 
 services:
@@ -87,6 +89,13 @@ services:
       - ./sbomify:/code/sbomify # Mount local code for development
     environment:
       <<: *dev-env
+    depends_on:
+      sbomify-db:
+        condition: service_healthy
+      sbomify-migrations:
+        condition: service_completed_successfully
+      sbomify-frontend:
+        condition: service_started
 
   sbomify-migrations:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     restart: ${SBOMIFY_RESTART_POLICY:-always}
     environment:
       <<: *common-env
-      BILLING: ${BILLING:-'False'}
+      BILLING: ${BILLING:-False}
       DATABASE_HOST: ${DATABASE_HOST:-localhost}
       KC_HOSTNAME_URL: ${KC_HOSTNAME_URL:-http://keycloak:8080/}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:-sbomify}
@@ -93,7 +93,7 @@ services:
     pull_policy: ${SBOMIFY_PULL_POLICY:-always}
     environment:
       <<: *common-env
-      BILLING: ${BILLING:-'False'}
+      BILLING: ${BILLING:-False}
     command: /code/bin/release.sh
     depends_on:
       sbomify-db:
@@ -109,7 +109,7 @@ services:
     restart: ${SBOMIFY_RESTART_POLICY:-always}
     environment:
       <<: *common-env
-      BILLING: ${BILLING:-'False'}
+      BILLING: ${BILLING:-False}
     command: uv run dramatiq sbomify.tasks
     depends_on:
       sbomify-redis:

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -197,8 +197,8 @@ if USE_VITE_DEV_SERVER:
     DJANGO_VITE = {
         "default": {
             "dev_mode": True,
-            "dev_server_host": "127.0.0.1",
-            "dev_server_port": 5170,
+            "dev_server_host": os.environ.get("VITE_DEV_SERVER_HOST", "127.0.0.1"),
+            "dev_server_port": int(os.environ.get("VITE_DEV_SERVER_PORT", "5170")),
             "static_url_prefix": "/dist/",
         }
     }


### PR DESCRIPTION
Fixes critical issue where boolean environment variables were being double-quoted in docker-compose files, causing them to evaluate incorrectly in Python. The quotes were preserved as part of the string value (e.g., '"True"' instead of 'True'), breaking boolean checks.

Changes:
- Remove quotes from DEBUG and USE_VITE_DEV_SERVER in docker-compose.dev.yml
- Remove quotes from BILLING (3 occurrences) in docker-compose.yml
- Make Vite dev server host/port configurable via environment variables
- Add VITE_DEV_SERVER_HOST and VITE_DEV_SERVER_PORT to dev environment
- Add explicit dependency in sbomify-backend on sbomify-frontend service

This fixes the 500 error during first-time signup in development mode where Django was unable to load Vite assets because USE_VITE_DEV_SERVER was evaluating to False despite being set to "True".

Impact:
- DEBUG mode now correctly enabled in development
- Vite dev server properly connected in containerized development
- BILLING feature flag now evaluates correctly in production
- Backend waits for frontend service to be ready before starting

Resolves issue where 'DjangoViteAssetNotFoundError' was thrown when attempting to access the dashboard after initial signup.
