### PR TITLE
Wrap popovers in Teleport components to fix positioning issues

### DIFF
--- a/sbomify/apps/core/js/components/ItemSelectModal.vue
+++ b/sbomify/apps/core/js/components/ItemSelectModal.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="modal fade show" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-      <div class="modal-content item-select-modal">
+  <Teleport to="body">
+    <div class="modal fade show" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content item-select-modal">
         <div class="modal-header">
           <h3 class="modal-title text-black">Select {{ titledItemType }}</h3>
           <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Close"
@@ -48,9 +49,10 @@
           </button>
           <button type="button" class="btn btn-primary" @click="$emit('selected')">Select</button>
         </div>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">

--- a/sbomify/apps/core/js/components/ProductIdentifiers.vue
+++ b/sbomify/apps/core/js/components/ProductIdentifiers.vue
@@ -141,51 +141,61 @@
     </div>
 
     <!-- Add/Edit Modal -->
-    <div v-if="showAddModal || showEditModal" class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5)">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">
-              {{ showEditModal ? 'Edit Identifier' : 'Add Identifier' }}
-            </h5>
-            <button type="button" class="btn-close" @click="closeModal"></button>
-          </div>
-          <div class="modal-body">
-            <form @submit.prevent="submitForm">
-              <div class="mb-3">
-                <label class="form-label">Identifier Type <span class="text-danger">*</span></label>
-                <select v-model="form.identifier_type" class="form-select" required>
-                  <option value="">Select type...</option>
-                  <option v-for="(label, value) in identifierTypes" :key="value" :value="value">
-                    {{ label }}
-                  </option>
-                </select>
-              </div>
-              <div class="mb-3">
-                <label class="form-label">Value <span class="text-danger">*</span></label>
-                <input
-                  v-model="form.value"
-                  type="text"
-                  class="form-control"
-                  :class="{ 'is-invalid': formError }"
-                  required
-                  placeholder="Enter identifier value"
-                />
-                <div v-if="formError" class="invalid-feedback">
-                  {{ formError }}
+    <Teleport to="body">
+      <div
+        v-if="showAddModal || showEditModal"
+        class="modal fade show d-block"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        style="background-color: rgba(0,0,0,0.5)"
+        @click.self="closeModal"
+      >
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">
+                {{ showEditModal ? 'Edit Identifier' : 'Add Identifier' }}
+              </h5>
+              <button type="button" class="btn-close" @click="closeModal"></button>
+            </div>
+            <div class="modal-body">
+              <form @submit.prevent="submitForm">
+                <div class="mb-3">
+                  <label class="form-label">Identifier Type <span class="text-danger">*</span></label>
+                  <select v-model="form.identifier_type" class="form-select" required>
+                    <option value="">Select type...</option>
+                    <option v-for="(label, value) in identifierTypes" :key="value" :value="value">
+                      {{ label }}
+                    </option>
+                  </select>
                 </div>
-              </div>
-            </form>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" @click="closeModal">Cancel</button>
-            <button type="button" class="btn btn-primary" :disabled="isSubmitting" @click="submitForm">
-              {{ isSubmitting ? 'Saving...' : (showEditModal ? 'Update' : 'Add') }}
-            </button>
+                <div class="mb-3">
+                  <label class="form-label">Value <span class="text-danger">*</span></label>
+                  <input
+                    v-model="form.value"
+                    type="text"
+                    class="form-control"
+                    :class="{ 'is-invalid': formError }"
+                    required
+                    placeholder="Enter identifier value"
+                  />
+                  <div v-if="formError" class="invalid-feedback">
+                    {{ formError }}
+                  </div>
+                </div>
+              </form>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="closeModal">Cancel</button>
+              <button type="button" class="btn btn-primary" :disabled="isSubmitting" @click="submitForm">
+                {{ isSubmitting ? 'Saving...' : (showEditModal ? 'Update' : 'Add') }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </StandardCard>
 </template>
 

--- a/sbomify/apps/core/js/components/ProductLinks.vue
+++ b/sbomify/apps/core/js/components/ProductLinks.vue
@@ -95,71 +95,81 @@
     </div>
 
     <!-- Add/Edit Modal -->
-    <div v-if="showAddModal || showEditModal" class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5)">
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">
-              {{ showEditModal ? 'Edit Link' : 'Add Link' }}
-            </h5>
-            <button type="button" class="btn-close" @click="closeModal"></button>
-          </div>
-          <div class="modal-body">
-            <form @submit.prevent="submitForm">
-              <div class="mb-3">
-                <label class="form-label">Link Type <span class="text-danger">*</span></label>
-                <select v-model="form.link_type" class="form-select" required>
-                  <option value="">Select type...</option>
-                  <option v-for="(label, value) in linkTypes" :key="value" :value="value">
-                    {{ label }}
-                  </option>
-                </select>
-              </div>
-              <div class="mb-3">
-                <label class="form-label">Title <span class="text-danger">*</span></label>
-                <input
-                  v-model="form.title"
-                  type="text"
-                  class="form-control"
-                  :class="{ 'is-invalid': formError }"
-                  required
-                  placeholder="Enter link title"
-                />
-              </div>
-              <div class="mb-3">
-                <label class="form-label">URL <span class="text-danger">*</span></label>
-                <input
-                  v-model="form.url"
-                  type="url"
-                  class="form-control"
-                  :class="{ 'is-invalid': formError }"
-                  required
-                  placeholder="https://example.com"
-                />
-              </div>
-              <div class="mb-3">
-                <label class="form-label">Description</label>
-                <textarea
-                  v-model="form.description"
-                  class="form-control"
-                  rows="3"
-                  placeholder="Optional description of this link"
-                ></textarea>
-              </div>
-              <div v-if="formError" class="alert alert-danger">
-                {{ formError }}
-              </div>
-            </form>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" @click="closeModal">Cancel</button>
-            <button type="button" class="btn btn-primary" :disabled="isSubmitting" @click="submitForm">
-              {{ isSubmitting ? 'Saving...' : (showEditModal ? 'Update' : 'Add') }}
-            </button>
+    <Teleport to="body">
+      <div
+        v-if="showAddModal || showEditModal"
+        class="modal fade show d-block"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        style="background-color: rgba(0,0,0,0.5)"
+        @click.self="closeModal"
+      >
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">
+                {{ showEditModal ? 'Edit Link' : 'Add Link' }}
+              </h5>
+              <button type="button" class="btn-close" @click="closeModal"></button>
+            </div>
+            <div class="modal-body">
+              <form @submit.prevent="submitForm">
+                <div class="mb-3">
+                  <label class="form-label">Link Type <span class="text-danger">*</span></label>
+                  <select v-model="form.link_type" class="form-select" required>
+                    <option value="">Select type...</option>
+                    <option v-for="(label, value) in linkTypes" :key="value" :value="value">
+                      {{ label }}
+                    </option>
+                  </select>
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">Title <span class="text-danger">*</span></label>
+                  <input
+                    v-model="form.title"
+                    type="text"
+                    class="form-control"
+                    :class="{ 'is-invalid': formError }"
+                    required
+                    placeholder="Enter link title"
+                  />
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">URL <span class="text-danger">*</span></label>
+                  <input
+                    v-model="form.url"
+                    type="url"
+                    class="form-control"
+                    :class="{ 'is-invalid': formError }"
+                    required
+                    placeholder="https://example.com"
+                  />
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">Description</label>
+                  <textarea
+                    v-model="form.description"
+                    class="form-control"
+                    rows="3"
+                    placeholder="Optional description of this link"
+                  ></textarea>
+                </div>
+                <div v-if="formError" class="alert alert-danger">
+                  {{ formError }}
+                </div>
+              </form>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="closeModal">Cancel</button>
+              <button type="button" class="btn btn-primary" :disabled="isSubmitting" @click="submitForm">
+                {{ isSubmitting ? 'Saving...' : (showEditModal ? 'Update' : 'Add') }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </StandardCard>
 </template>
 

--- a/sbomify/apps/core/js/components/ProductReleases.vue
+++ b/sbomify/apps/core/js/components/ProductReleases.vue
@@ -176,84 +176,88 @@
       :show-page-size-selector="true"
     />
 
-    <!-- Add Release Modal (only for private view) -->
-    <div
-      v-if="hasCrudPermissions && !isPublicView"
-      id="addReleaseModal"
-      class="modal fade"
-      tabindex="-1"
-    >
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">
-              {{ editingRelease ? 'Edit Release' : 'Create New Release' }}
-            </h5>
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-            ></button>
-          </div>
-          <div class="modal-body">
-            <form @submit.prevent="submitRelease">
-              <div class="mb-3">
-                <label for="releaseName" class="form-label">Release Name</label>
-                <input
-                  id="releaseName"
-                  v-model="releaseForm.name"
-                  type="text"
-                  class="form-control"
-                  required
-                  placeholder="e.g., v1.0.0, 2024.1, beta-3"
-                >
-                <div class="form-text">Enter a unique name for this release</div>
-              </div>
-              <div class="mb-3">
-                <label for="releaseDescription" class="form-label">Description (Optional)</label>
-                <textarea
-                  id="releaseDescription"
-                  v-model="releaseForm.description"
-                  class="form-control"
-                  rows="3"
-                  placeholder="Describe what's included in this release..."
-                ></textarea>
-              </div>
-              <div class="form-check">
-                <input
-                  id="releaseIsPrerelease"
-                  v-model="releaseForm.is_prerelease"
-                  class="form-check-input"
-                  type="checkbox"
-                >
-                <label for="releaseIsPrerelease" class="form-check-label">
-                  Mark as pre-release
-                </label>
-                <div class="form-text">Pre-releases are typically alpha, beta, or release candidate versions</div>
-              </div>
-            </form>
-          </div>
-          <div class="modal-footer">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              data-bs-dismiss="modal"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              class="btn btn-primary"
-              :disabled="isSubmitting"
-              @click="submitRelease"
-            >
-              <span v-if="isSubmitting" class="spinner-border spinner-border-sm me-2"></span>
-              {{ editingRelease ? 'Update Release' : 'Create Release' }}
-            </button>
+    <Teleport to="body">
+      <!-- Add Release Modal (only for private view) -->
+      <div
+        v-if="hasCrudPermissions && !isPublicView"
+        id="addReleaseModal"
+        class="modal fade"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">
+                {{ editingRelease ? 'Edit Release' : 'Create New Release' }}
+              </h5>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+              ></button>
+            </div>
+            <div class="modal-body">
+              <form @submit.prevent="submitRelease">
+                <div class="mb-3">
+                  <label for="releaseName" class="form-label">Release Name</label>
+                  <input
+                    id="releaseName"
+                    v-model="releaseForm.name"
+                    type="text"
+                    class="form-control"
+                    required
+                    placeholder="e.g., v1.0.0, 2024.1, beta-3"
+                  >
+                  <div class="form-text">Enter a unique name for this release</div>
+                </div>
+                <div class="mb-3">
+                  <label for="releaseDescription" class="form-label">Description (Optional)</label>
+                  <textarea
+                    id="releaseDescription"
+                    v-model="releaseForm.description"
+                    class="form-control"
+                    rows="3"
+                    placeholder="Describe what's included in this release..."
+                  ></textarea>
+                </div>
+                <div class="form-check">
+                  <input
+                    id="releaseIsPrerelease"
+                    v-model="releaseForm.is_prerelease"
+                    class="form-check-input"
+                    type="checkbox"
+                  >
+                  <label for="releaseIsPrerelease" class="form-check-label">
+                    Mark as pre-release
+                  </label>
+                  <div class="form-text">Pre-releases are typically alpha, beta, or release candidate versions</div>
+                </div>
+              </form>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn btn-primary"
+                :disabled="isSubmitting"
+                @click="submitRelease"
+              >
+                <span v-if="isSubmitting" class="spinner-border spinner-border-sm me-2"></span>
+                {{ editingRelease ? 'Update Release' : 'Create Release' }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </StandardCard>
 </template>
 

--- a/sbomify/apps/core/js/components/ReleaseArtifacts.vue
+++ b/sbomify/apps/core/js/components/ReleaseArtifacts.vue
@@ -191,24 +191,27 @@
       />
     </div>
 
-    <!-- Add Artifact Modal -->
-    <div
-      v-if="canModifyArtifacts"
-      id="addArtifactModal"
-      class="modal fade"
-      tabindex="-1"
-    >
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Add Artifact to Release</h5>
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-            ></button>
-          </div>
-          <div class="modal-body">
+    <Teleport to="body">
+      <!-- Add Artifact Modal -->
+      <div
+        v-if="canModifyArtifacts"
+        id="addArtifactModal"
+        class="modal fade"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Add Artifact to Release</h5>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+              ></button>
+            </div>
+            <div class="modal-body">
             <!-- Search and Filter Controls -->
             <div class="mb-3">
               <div class="row g-2">
@@ -374,27 +377,28 @@
               />
             </div>
           </div>
-          <div class="modal-footer">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              data-bs-dismiss="modal"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              class="btn btn-primary"
-              :disabled="selectedArtifacts.length === 0 || isSubmitting"
-              @click="addSelectedArtifacts"
-            >
-              <span v-if="isSubmitting" class="spinner-border spinner-border-sm me-2"></span>
-              Add {{ selectedArtifacts.length }} Artifact{{ selectedArtifacts.length === 1 ? '' : 's' }}
-            </button>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn btn-primary"
+                :disabled="selectedArtifacts.length === 0 || isSubmitting"
+                @click="addSelectedArtifacts"
+              >
+                <span v-if="isSubmitting" class="spinner-border spinner-border-sm me-2"></span>
+                Add {{ selectedArtifacts.length }} Artifact{{ selectedArtifacts.length === 1 ? '' : 's' }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </StandardCard>
 </template>
 

--- a/sbomify/apps/documents/js/components/DocumentsTable.vue
+++ b/sbomify/apps/documents/js/components/DocumentsTable.vue
@@ -199,105 +199,120 @@
   />
 
   <!-- Edit Document Modal -->
-  <div v-if="showEditModal" class="modal fade show d-block" tabindex="-1" style="z-index: var(--z-index-modal);">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Edit Document</h5>
-          <button type="button" class="btn-close" aria-label="Close" @click="cancelEdit"></button>
-        </div>
-        <div class="modal-body">
-          <form @submit.prevent="updateDocument">
-            <div class="row">
-              <div class="col-md-6">
-                <div class="mb-3">
-                  <label for="editDocumentName" class="form-label">Name <span class="text-danger">*</span></label>
-                  <input
-                    id="editDocumentName"
-                    v-model="editForm.name"
-                    type="text"
-                    class="form-control"
-                    required
-                    placeholder="Enter document name"
-                  />
+  <Teleport to="body">
+    <div
+      v-if="showEditModal"
+      class="modal fade show d-block"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      style="z-index: var(--z-index-modal); background-color: rgba(0,0,0,0.5);"
+      @click.self="cancelEdit"
+    >
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Edit Document</h5>
+            <button type="button" class="btn-close" aria-label="Close" @click="cancelEdit"></button>
+          </div>
+          <div class="modal-body">
+            <form @submit.prevent="updateDocument">
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="mb-3">
+                    <label for="editDocumentName" class="form-label">Name <span class="text-danger">*</span></label>
+                    <input
+                      id="editDocumentName"
+                      v-model="editForm.name"
+                      type="text"
+                      class="form-control"
+                      required
+                      placeholder="Enter document name"
+                    />
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="mb-3">
+                    <label for="editDocumentVersion" class="form-label">Version <span class="text-danger">*</span></label>
+                    <input
+                      id="editDocumentVersion"
+                      v-model="editForm.version"
+                      type="text"
+                      class="form-control"
+                      required
+                      placeholder="Enter version (e.g., 1.0)"
+                    />
+                  </div>
                 </div>
               </div>
-              <div class="col-md-6">
-                <div class="mb-3">
-                  <label for="editDocumentVersion" class="form-label">Version <span class="text-danger">*</span></label>
-                  <input
-                    id="editDocumentVersion"
-                    v-model="editForm.version"
-                    type="text"
-                    class="form-control"
-                    required
-                    placeholder="Enter version (e.g., 1.0)"
-                  />
-                </div>
+              <div class="mb-3">
+                <label for="editDocumentType" class="form-label">Document Type</label>
+                <select
+                  id="editDocumentType"
+                  v-model="editForm.document_type"
+                  class="form-select"
+                >
+                  <option value="">Select document type</option>
+                  <option value="specification">Specification</option>
+                  <option value="manual">Manual</option>
+                  <option value="readme">README</option>
+                  <option value="documentation">Documentation</option>
+                  <option value="build-instructions">Build Instructions</option>
+                  <option value="configuration">Configuration</option>
+                  <option value="license">License</option>
+                  <option value="compliance">Compliance</option>
+                  <option value="evidence">Evidence</option>
+                  <option value="changelog">Changelog</option>
+                  <option value="release-notes">Release Notes</option>
+                  <option value="security-advisory">Security Advisory</option>
+                  <option value="vulnerability-report">Vulnerability Report</option>
+                  <option value="threat-model">Threat Model</option>
+                  <option value="risk-assessment">Risk Assessment</option>
+                  <option value="pentest-report">Penetration Test Report</option>
+                  <option value="static-analysis">Static Analysis Report</option>
+                  <option value="dynamic-analysis">Dynamic Analysis Report</option>
+                  <option value="quality-metrics">Quality Metrics</option>
+                  <option value="maturity-report">Maturity Report</option>
+                  <option value="report">Report</option>
+                  <option value="other">Other</option>
+                </select>
               </div>
-            </div>
-            <div class="mb-3">
-              <label for="editDocumentType" class="form-label">Document Type</label>
-              <select
-                id="editDocumentType"
-                v-model="editForm.document_type"
-                class="form-select"
-              >
-                <option value="">Select document type</option>
-                <option value="specification">Specification</option>
-                <option value="manual">Manual</option>
-                <option value="readme">README</option>
-                <option value="documentation">Documentation</option>
-                <option value="build-instructions">Build Instructions</option>
-                <option value="configuration">Configuration</option>
-                <option value="license">License</option>
-                <option value="compliance">Compliance</option>
-                <option value="evidence">Evidence</option>
-                <option value="changelog">Changelog</option>
-                <option value="release-notes">Release Notes</option>
-                <option value="security-advisory">Security Advisory</option>
-                <option value="vulnerability-report">Vulnerability Report</option>
-                <option value="threat-model">Threat Model</option>
-                <option value="risk-assessment">Risk Assessment</option>
-                <option value="pentest-report">Penetration Test Report</option>
-                <option value="static-analysis">Static Analysis Report</option>
-                <option value="dynamic-analysis">Dynamic Analysis Report</option>
-                <option value="quality-metrics">Quality Metrics</option>
-                <option value="maturity-report">Maturity Report</option>
-                <option value="report">Report</option>
-                <option value="other">Other</option>
-              </select>
-            </div>
-            <div class="mb-3">
-              <label for="editDocumentDescription" class="form-label">Description</label>
-              <textarea
-                id="editDocumentDescription"
-                v-model="editForm.description"
-                class="form-control"
-                rows="3"
-                placeholder="Enter description (optional)"
-              ></textarea>
-            </div>
-          </form>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" @click="cancelEdit">Cancel</button>
-          <button
-            type="button"
-            class="btn btn-primary"
-            :disabled="isUpdating || !editForm.name || !editForm.version"
-            @click="updateDocument"
-          >
-            <span v-if="isUpdating" class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-            Update Document
-          </button>
+              <div class="mb-3">
+                <label for="editDocumentDescription" class="form-label">Description</label>
+                <textarea
+                  id="editDocumentDescription"
+                  v-model="editForm.description"
+                  class="form-control"
+                  rows="3"
+                  placeholder="Enter description (optional)"
+                ></textarea>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="cancelEdit">Cancel</button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              :disabled="isUpdating || !editForm.name || !editForm.version"
+              @click="updateDocument"
+            >
+              <span v-if="isUpdating" class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+              Update Document
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Modal Backdrop -->
-  <div v-if="showEditModal" class="modal-backdrop fade show" style="z-index: var(--z-index-modal-backdrop);" @click="cancelEdit"></div>
+    <!-- Modal Backdrop -->
+    <div
+      v-if="showEditModal"
+      class="modal-backdrop fade show"
+      style="z-index: var(--z-index-modal-backdrop);"
+      @click="cancelEdit"
+    ></div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
- Wrap each Vue modal in a `<Teleport to="body">` so popovers and overlays escape component stacking contexts and render with the expected z-order.