### PR TITLE
Configure dramatiq worker processes and threads via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,6 @@ STRIPE_WEBHOOK_SECRET=whsec_dummy_key_for_ci
 STRIPE_ENDPOINT_SECRET=whsec_dummy_key_for_ci
 STRIPE_BILLING_URL=https://billing.stripe.com/p/login/mock-url
 
+# Dramatiq worker settings
+DRAMATIQ_PROCESSES=2
+DRAMATIQ_THREADS=4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,17 @@ services:
     environment:
       <<: *common-env
       BILLING: ${BILLING:-False}
-    command: uv run dramatiq sbomify.tasks
+    command:
+      [
+        "uv",
+        "run",
+        "dramatiq",
+        "--processes",
+        "${DRAMATIQ_PROCESSES:-2}",
+        "--threads",
+        "${DRAMATIQ_THREADS:-4}",
+        "sbomify.tasks",
+      ]
     depends_on:
       sbomify-redis:
         condition: service_healthy


### PR DESCRIPTION
- Updated the worker container command to pass those env-driven values to dramatiq, keeping the old 2×4 defaults via parameter expansion and documenting the arguments inline.

<img width="276" height="256" alt="Screenshot 2025-11-18 at 11 10 34 AM" src="https://github.com/user-attachments/assets/41545e8a-b0de-4695-a07f-b11bf0fcdb9f" />