### PR TITLE
Remove current workspace display elements from team templates

### DIFF
--- a/sbomify/apps/teams/templates/teams/team_selection_dropdown.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_selection_dropdown.html.j2
@@ -26,12 +26,7 @@
                     {% endif %}
                 </span>
             </button>
-            {% if request.session.current_team %}
-                <span class="current-workspace-hint text-muted small">
-                    <i class="fas fa-info-circle" aria-hidden="true"></i>
-                    You're viewing {{ request.session.current_team.name|workspace_display }}
-                </span>
-            {% endif %}
+            {% if request.session.current_team %}{% endif %}
             <ul class="dropdown-menu shadow-sm" role="menu">
                 <li role="presentation">
                     <h6 class="dropdown-header" role="heading" aria-level="2">Switch Workspace</h6>

--- a/sbomify/apps/teams/templates/teams/team_settings.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings.html.j2
@@ -16,13 +16,6 @@
                 <p class="item-subtitle">Manage {{ team.name }} configuration, members, and preferences</p>
             </div>
             <div class="header-actions">
-                <div class="current-workspace-badge">
-                    <span class="badge bg-primary-subtle text-primary">
-                        <i class="fas fa-eye" aria-hidden="true"></i>
-                        Current workspace: {{ team.name|workspace_display }}
-                        <span class="visually-hidden">(current workspace)</span>
-                    </span>
-                </div>
                 <span class="workspace-key">
                     <span class="vc-copyable-value"
                           data-value="{{ team.key }}"


### PR DESCRIPTION
Remove the “current workspace” hint from the team switcher dropdown and the badge in team settings to declutter the UI.
Before:
<img width="1397" height="787" alt="Screenshot 2025-11-21 at 8 40 05 PM" src="https://github.com/user-attachments/assets/2c1c38b2-a882-4312-91a7-a09ea0e22bb0" />

Now:
<img width="1394" height="783" alt="Screenshot 2025-11-21 at 8 44 04 PM" src="https://github.com/user-attachments/assets/d45b35f0-6ca9-4803-9ed3-1c82847e5ae7" />
