### PR TITLE
Fix namespace collision between legacy and primary teams URLs

### DIFF
--- a/sbomify/urls.py
+++ b/sbomify/urls.py
@@ -28,7 +28,8 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("enterprise-contact/", public_enterprise_contact, name="public_enterprise_contact"),
     path("", include("sbomify.apps.core.urls")),
-    path("workspace/", include("sbomify.apps.teams.urls")),  # legacy prefix
+    # Keep the legacy prefix but avoid clashing namespaces with the primary teams URLs
+    path("workspace/", include(("sbomify.apps.teams.urls", "teams"), namespace="teams-legacy")),
     path("workspaces/", include("sbomify.apps.teams.urls")),
     path("", include("sbomify.apps.sboms.urls")),
     path("", include("sbomify.apps.documents.urls")),


### PR DESCRIPTION
Fixese:
```
2025-11-24 13:00:38.879error?: (urls.W005) URL namespace 'teams' isn't unique. You may not be able to reverse all URLs in this namespace
2025-11-24 13:00:38.879errorWARNINGS:
2025-11-24 13:00:38.879error
 ```