### PR TITLE
Add django-htmx template tag and script to fix infinite loading

### DIFF
--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -1,5 +1,6 @@
 {% load static %}
 {% load django_vite %}
+{% load django_htmx %}
 {% load cache %}
 {% load schema_tags %}
 {% load breadcrumb_tags %}
@@ -543,5 +544,6 @@
         </div>
         {% block scripts %}{% endblock %}
         {% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
+        {% htmx_script %}
     </body>
 </html>


### PR DESCRIPTION
- Without HTMX, the hx-trigger attributes on SBOM/document tables never fired, causing permanent loading spinners