### PR TITLE
Add dependency on sbomify-redis service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     depends_on:
       sbomify-db:
         condition: service_healthy
+      sbomify-redis:
+        condition: service_healthy
       sbomify-migrations:
         condition: service_completed_successfully
 


### PR DESCRIPTION
- Ensures backend waits for Redis to be healthy before starting, preventing startup failures when Redis isn't ready
- Aligns backend service with `sbomify-worker`, which already had the Redis dependency declared
- Backend requires Redis for production caching, Dramatiq message broker, and result backend
- Verified Redis container health and backend connectivity after fix
