### PR TITLE
fix: enable domain verification cron job registration

### DIFF
--- a/sbomify/apps/core/templatetags/public_url_tags.py
+++ b/sbomify/apps/core/templatetags/public_url_tags.py
@@ -240,7 +240,7 @@ def trust_center_absolute_url(context, team=None):
 
     # If custom domain is set and validated, use it
     if custom_domain and custom_domain_validated:
-        return f"https://{custom_domain}/"
+        return f"https://{custom_domain}"
 
     # Fallback to standard URL
     if team_key:

--- a/sbomify/apps/onboarding/tasks.py
+++ b/sbomify/apps/onboarding/tasks.py
@@ -175,3 +175,8 @@ def queue_first_component_sbom_reminder(user) -> str:
     logger.info(f"Queueing first component/SBOM reminder for user {user.email}")
     result = send_first_component_sbom_email_task.send(user.id)
     return result.message_id
+
+
+# Import cron module at end of file to ensure cron tasks are registered when this module is autodiscovered
+# This must be at the end to avoid circular import (cron imports from this module)
+from . import cron as _cron  # noqa: F401, E402

--- a/sbomify/apps/teams/cron.py
+++ b/sbomify/apps/teams/cron.py
@@ -18,7 +18,6 @@ from .tasks import verify_custom_domains
     queue_name="domain_verification_cron",
     max_retries=0,  # Don't retry - next cron run will handle it
     time_limit=300000,  # 5 minute timeout for the cron wrapper
-    max_age=3600000,  # 1 hour - skip if queued for too long
 )
 def periodic_domain_verification():
     """

--- a/sbomify/apps/teams/tasks.py
+++ b/sbomify/apps/teams/tasks.py
@@ -96,3 +96,8 @@ def verify_custom_domains():
 
         except Exception as e:
             logger.error(f"Error verifying domain {team.custom_domain}: {e}")
+
+
+# Import cron module at end of file to ensure cron tasks are registered when this module is autodiscovered
+# This must be at the end to avoid circular import (cron imports verify_custom_domains from this module)
+from . import cron as _cron  # noqa: F401, E402


### PR DESCRIPTION
The domain verification cron job was never running because django-dramatiq only autodiscovers modules named `tasks.py`, not `cron.py`. The cron modules in teams/ and onboarding/ were never imported, so dramatiq-crontab never registered those scheduled tasks.

Changes:
- Import cron modules at the end of tasks.py files to ensure registration (placed at EOF to avoid circular import since cron imports from tasks)
- Remove unsupported `max_age` option from teams/cron.py (requires AgeLimit middleware which is not configured)
- Remove trailing slash from custom domain URLs in trust_center_absolute_url

This fixes the bug where custom domains would show "Pending verification" indefinitely even when DNS was correctly configured and traffic was flowing.

Closes #572.