### PR TITLE
fix: replace Jinja2 macro with Django include in assessment_results_card template

### DIFF
--- a/sbomify/apps/plugins/templates/plugins/components/_plugin_accordion_items.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_plugin_accordion_items.html.j2
@@ -1,0 +1,168 @@
+<template x-for="run in {{ runs }}" :key="run.id">
+    <div class="accordion-item" :id="'plugin-' + run.plugin_name">
+        <h2 class="accordion-header">
+            <button class="accordion-button"
+                    :class="{ 'collapsed': !isExpanded(run.id) }"
+                    type="button"
+                    @click="toggleExpanded(run.id)"
+                    :aria-expanded="isExpanded(run.id)"
+                    :aria-controls="'collapse-' + run.id">
+                <div class="d-flex align-items-center justify-content-between w-100 me-3">
+                    <div class="plugin-header">
+                        <span class="plugin-name fw-medium"
+                              x-text="run.plugin_display_name || run.plugin_name"></span>
+                        <span class="badge ms-2" :class="getRunStatusBadgeClass(run)">
+                            {% if not show_details %}<i class="fas fa-spinner fa-spin me-1"></i>{% endif %}
+                            <span x-text="getRunStatusText(run)"></span>
+                        </span>
+                    </div>
+                    <div class="plugin-meta text-muted small">
+                        {% if show_details %}
+                            <span x-show="run.result?.summary" class="me-3">
+                                <span x-text="run.result?.summary?.total_findings || 0"></span> findings
+                            </span>
+                            <span x-text="formatDate(run.completed_at || run.created_at)"></span>
+                        {% else %}
+                            <span x-text="formatDate(run.created_at)"></span>
+                        {% endif %}
+                    </div>
+                </div>
+            </button>
+        </h2>
+        <div class="accordion-collapse"
+             :id="'collapse-' + run.id"
+             :class="{ 'collapse': true, 'show': isExpanded(run.id) }">
+            <div class="accordion-body">
+                {% if show_details %}
+                    <!-- Run Metadata -->
+                    <div class="run-metadata mb-3 small text-muted">
+                        <span class="me-3">
+                            <i class="fas fa-code-branch me-1"></i>
+                            Version: <span x-text="run.plugin_version"></span>
+                        </span>
+                        <span class="me-3">
+                            <i class="fas fa-play-circle me-1"></i>
+                            Reason: <span x-text="formatRunReason(run.run_reason)"></span>
+                        </span>
+                        <span x-show="run.completed_at">
+                            <i class="fas fa-clock me-1"></i>
+                            Completed: <span x-text="formatDate(run.completed_at)"></span>
+                        </span>
+                    </div>
+                    {% if show_error %}
+                        <!-- Error Message (if failed) -->
+                        <div x-show="run.status === 'failed' && run.error_message"
+                             class="alert alert-danger mb-3">
+                            <i class="fas fa-exclamation-circle me-2"></i>
+                            <span x-text="run.error_message"></span>
+                        </div>
+                    {% endif %}
+                    <!-- Findings Summary -->
+                    <div x-show="run.result?.summary" class="findings-summary mb-3">
+                        <div class="row g-2">
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-success-subtle">
+                                    <div class="fw-bold text-success"
+                                         x-text="run.result?.summary?.pass_count || 0"></div>
+                                    <small class="text-muted">Pass</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-warning-subtle">
+                                    <div class="fw-bold text-warning"
+                                         x-text="run.result?.summary?.fail_count || 0"></div>
+                                    <small class="text-muted">Fail</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-info-subtle">
+                                    <div class="fw-bold text-info"
+                                         x-text="run.result?.summary?.warning_count || 0"></div>
+                                    <small class="text-muted">Warning</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-secondary-subtle">
+                                    <div class="fw-bold text-secondary"
+                                         x-text="run.result?.summary?.info_count || 0"></div>
+                                    <small class="text-muted">Info</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-danger-subtle">
+                                    <div class="fw-bold text-danger"
+                                         x-text="run.result?.summary?.error_count || 0"></div>
+                                    <small class="text-muted">Error</small>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="finding-stat text-center p-2 rounded bg-light">
+                                    <div class="fw-bold" x-text="run.result?.summary?.total_findings || 0"></div>
+                                    <small class="text-muted">Total</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Findings List -->
+                    <div x-show="run.result?.findings?.length > 0" class="findings-list">
+                        <h6 class="mb-2">
+                            <i class="fas fa-list me-1"></i>
+                            Findings
+                        </h6>
+                        <template x-for="finding in run.result?.findings || []" :key="finding.id">
+                            <div class="finding-item p-3 mb-2 rounded border"
+                                 :class="getFindingBorderClass(finding.status)">
+                                <div class="d-flex align-items-start">
+                                    <span class="finding-status-icon me-2"
+                                          :class="getFindingIconClass(finding.status)">
+                                        <i :class="getFindingIcon(finding.status)"></i>
+                                    </span>
+                                    <div class="flex-grow-1">
+                                        <div class="finding-title fw-medium" x-text="finding.title"></div>
+                                        <div class="finding-description text-muted small"
+                                             x-text="finding.description"></div>
+                                        <div x-show="finding.remediation" class="finding-remediation mt-2 small">
+                                            <i class="fas fa-lightbulb text-info me-1"></i>
+                                            <span class="text-info" x-text="finding.remediation"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                    <!-- Standard Info (for compliance plugins) -->
+                    <div x-show="run.result?.metadata?.standard_name"
+                         class="standard-info mt-3 p-3 bg-light rounded">
+                        <h6 class="mb-2">
+                            <i class="fas fa-book me-1"></i>
+                            Standard Reference
+                        </h6>
+                        <div class="small">
+                            <div>
+                                <strong>Standard:</strong> <span x-text="run.result?.metadata?.standard_name"></span>
+                            </div>
+                            <div>
+                                <strong>Version:</strong> <span x-text="run.result?.metadata?.standard_version"></span>
+                            </div>
+                            <div x-show="run.result?.metadata?.standard_url">
+                                <strong>Reference:</strong>
+                                <a :href="run.result?.metadata?.standard_url"
+                                   target="_blank"
+                                   rel="noopener"
+                                   class="text-decoration-none">
+                                    View Standard <i class="fas fa-external-link-alt ms-1"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                {% else %}
+                    <!-- Pending state -->
+                    <div class="text-center text-muted py-3">
+                        <i class="fas fa-spinner fa-spin fa-2x mb-2"></i>
+                        <p class="mb-0">Assessment in progress...</p>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</template>

--- a/sbomify/apps/plugins/templates/plugins/components/assessment_results_card.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/assessment_results_card.html.j2
@@ -2,177 +2,6 @@
 {% load json_extras %}
 <link rel="stylesheet"
       href="{% static 'css/components/assessment-results-card.css' %}">
-{# Macro for plugin accordion items - avoids code duplication #}
-{% macro plugin_accordion_items(runs, show_error=true, show_details=true) %}
-    <template x-for="run in {{ runs }}" :key="run.id">
-        <div class="accordion-item" :id="'plugin-' + run.plugin_name">
-            <h2 class="accordion-header">
-                <button class="accordion-button"
-                        :class="{ 'collapsed': !isExpanded(run.id) }"
-                        type="button"
-                        @click="toggleExpanded(run.id)"
-                        :aria-expanded="isExpanded(run.id)"
-                        :aria-controls="'collapse-' + run.id">
-                    <div class="d-flex align-items-center justify-content-between w-100 me-3">
-                        <div class="plugin-header">
-                            <span class="plugin-name fw-medium"
-                                  x-text="run.plugin_display_name || run.plugin_name"></span>
-                            <span class="badge ms-2" :class="getRunStatusBadgeClass(run)">
-                                {% if not show_details %}<i class="fas fa-spinner fa-spin me-1"></i>{% endif %}
-                                <span x-text="getRunStatusText(run)"></span>
-                            </span>
-                        </div>
-                        <div class="plugin-meta text-muted small">
-                            {% if show_details %}
-                                <span x-show="run.result?.summary" class="me-3">
-                                    <span x-text="run.result?.summary?.total_findings || 0"></span> findings
-                                </span>
-                                <span x-text="formatDate(run.completed_at || run.created_at)"></span>
-                            {% else %}
-                                <span x-text="formatDate(run.created_at)"></span>
-                            {% endif %}
-                        </div>
-                    </div>
-                </button>
-            </h2>
-            <div class="accordion-collapse"
-                 :id="'collapse-' + run.id"
-                 :class="{ 'collapse': true, 'show': isExpanded(run.id) }">
-                <div class="accordion-body">
-                    {% if show_details %}
-                        <!-- Run Metadata -->
-                        <div class="run-metadata mb-3 small text-muted">
-                            <span class="me-3">
-                                <i class="fas fa-code-branch me-1"></i>
-                                Version: <span x-text="run.plugin_version"></span>
-                            </span>
-                            <span class="me-3">
-                                <i class="fas fa-play-circle me-1"></i>
-                                Reason: <span x-text="formatRunReason(run.run_reason)"></span>
-                            </span>
-                            <span x-show="run.completed_at">
-                                <i class="fas fa-clock me-1"></i>
-                                Completed: <span x-text="formatDate(run.completed_at)"></span>
-                            </span>
-                        </div>
-                        {% if show_error %}
-                            <!-- Error Message (if failed) -->
-                            <div x-show="run.status === 'failed' && run.error_message"
-                                 class="alert alert-danger mb-3">
-                                <i class="fas fa-exclamation-circle me-2"></i>
-                                <span x-text="run.error_message"></span>
-                            </div>
-                        {% endif %}
-                        <!-- Findings Summary -->
-                        <div x-show="run.result?.summary" class="findings-summary mb-3">
-                            <div class="row g-2">
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-success-subtle">
-                                        <div class="fw-bold text-success"
-                                             x-text="run.result?.summary?.pass_count || 0"></div>
-                                        <small class="text-muted">Pass</small>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-warning-subtle">
-                                        <div class="fw-bold text-warning"
-                                             x-text="run.result?.summary?.fail_count || 0"></div>
-                                        <small class="text-muted">Fail</small>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-info-subtle">
-                                        <div class="fw-bold text-info"
-                                             x-text="run.result?.summary?.warning_count || 0"></div>
-                                        <small class="text-muted">Warning</small>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-secondary-subtle">
-                                        <div class="fw-bold text-secondary"
-                                             x-text="run.result?.summary?.info_count || 0"></div>
-                                        <small class="text-muted">Info</small>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-danger-subtle">
-                                        <div class="fw-bold text-danger"
-                                             x-text="run.result?.summary?.error_count || 0"></div>
-                                        <small class="text-muted">Error</small>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-2">
-                                    <div class="finding-stat text-center p-2 rounded bg-light">
-                                        <div class="fw-bold" x-text="run.result?.summary?.total_findings || 0"></div>
-                                        <small class="text-muted">Total</small>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Findings List -->
-                        <div x-show="run.result?.findings?.length > 0" class="findings-list">
-                            <h6 class="mb-2">
-                                <i class="fas fa-list me-1"></i>
-                                Findings
-                            </h6>
-                            <template x-for="finding in run.result?.findings || []" :key="finding.id">
-                                <div class="finding-item p-3 mb-2 rounded border"
-                                     :class="getFindingBorderClass(finding.status)">
-                                    <div class="d-flex align-items-start">
-                                        <span class="finding-status-icon me-2"
-                                              :class="getFindingIconClass(finding.status)">
-                                            <i :class="getFindingIcon(finding.status)"></i>
-                                        </span>
-                                        <div class="flex-grow-1">
-                                            <div class="finding-title fw-medium" x-text="finding.title"></div>
-                                            <div class="finding-description text-muted small"
-                                                 x-text="finding.description"></div>
-                                            <div x-show="finding.remediation" class="finding-remediation mt-2 small">
-                                                <i class="fas fa-lightbulb text-info me-1"></i>
-                                                <span class="text-info" x-text="finding.remediation"></span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </template>
-                        </div>
-                        <!-- Standard Info (for compliance plugins) -->
-                        <div x-show="run.result?.metadata?.standard_name"
-                             class="standard-info mt-3 p-3 bg-light rounded">
-                            <h6 class="mb-2">
-                                <i class="fas fa-book me-1"></i>
-                                Standard Reference
-                            </h6>
-                            <div class="small">
-                                <div>
-                                    <strong>Standard:</strong> <span x-text="run.result?.metadata?.standard_name"></span>
-                                </div>
-                                <div>
-                                    <strong>Version:</strong> <span x-text="run.result?.metadata?.standard_version"></span>
-                                </div>
-                                <div x-show="run.result?.metadata?.standard_url">
-                                    <strong>Reference:</strong>
-                                    <a :href="run.result?.metadata?.standard_url"
-                                       target="_blank"
-                                       rel="noopener"
-                                       class="text-decoration-none">
-                                        View Standard <i class="fas fa-external-link-alt ms-1"></i>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    {% else %}
-                        <!-- Pending state -->
-                        <div class="text-center text-muted py-3">
-                            <i class="fas fa-spinner fa-spin fa-2x mb-2"></i>
-                            <p class="mb-0">Assessment in progress...</p>
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </template>
-{% endmacro %}
 <div id="assessment-results"
      class="standard-card mt-3"
      x-data="assessmentResultsCard('{{ sbom_id }}', '{{ assessment_runs|jsonify|escapejs }}')"
@@ -235,7 +64,7 @@
                                    x-text="failedRuns.length + ' plugin' + (failedRuns.length !== 1 ? 's' : '')"></small>
                         </div>
                         <div class="accordion" id="failedAccordion">
-                            {{ plugin_accordion_items('failedRuns', show_error=true, show_details=true) }}
+                            {% include 'plugins/components/_plugin_accordion_items.html.j2' with runs='failedRuns' show_error=True show_details=True %}
                         </div>
                     </div>
                 </template>
@@ -251,7 +80,7 @@
                                    x-text="passedRuns.length + ' plugin' + (passedRuns.length !== 1 ? 's' : '')"></small>
                         </div>
                         <div class="accordion" id="passedAccordion">
-                            {{ plugin_accordion_items('passedRuns', show_error=false, show_details=true) }}
+                            {% include 'plugins/components/_plugin_accordion_items.html.j2' with runs='passedRuns' show_error=False show_details=True %}
                         </div>
                     </div>
                 </template>
@@ -267,7 +96,7 @@
                                    x-text="pendingRuns.length + ' plugin' + (pendingRuns.length !== 1 ? 's' : '')"></small>
                         </div>
                         <div class="accordion" id="pendingAccordion">
-                            {{ plugin_accordion_items('pendingRuns', show_error=false, show_details=false) }}
+                            {% include 'plugins/components/_plugin_accordion_items.html.j2' with runs='pendingRuns' show_error=False show_details=False %}
                         </div>
                     </div>
                 </template>


### PR DESCRIPTION
The component item page (/components/{id}/sboms/{sbom_id}/) was failing with TemplateSyntaxError because assessment_results_card.html.j2 used a Jinja2 {% macro %} tag, which Django's template engine doesn't support.

Changes:
- Extract macro content to new partial _plugin_accordion_items.html.j2
- Replace macro calls with Django {% include %} statements
- Add test to verify templates parse without syntax errors

Fixes the 500 error on SBOM detail pages.
