### PR TITLE
Update delete endpoint path for SBOM to be more flexible

### DIFF
--- a/sbomify/apps/core/templates/components/sbom_danger_zone.html.j2
+++ b/sbomify/apps/core/templates/components/sbom_danger_zone.html.j2
@@ -38,5 +38,5 @@
             </div>
         </div>
     </div>
-    {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete SBOM' message='Are you sure you want to delete the SBOM' item_name=sbom_name warning_message='This action cannot be undone and will permanently remove the SBOM from the system.' confirm_text='Delete SBOM' hx_url='/api/v1/sbom/'|add:sbom_id hx_method='delete' success_message='SBOM deleted successfully!' redirect_url='/component/'|add:component_id %}
+    {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete SBOM' message='Are you sure you want to delete the SBOM' item_name=sbom_name warning_message='This action cannot be undone and will permanently remove the SBOM from the system.' confirm_text='Delete SBOM' hx_url='/api/v1/sboms/'|add:sbom_id hx_method='delete' success_message='SBOM deleted successfully!' redirect_url='/component/'|add:component_id %}
 </div>

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -684,7 +684,7 @@ router.patch(
 
 
 @router.delete(
-    "/sbom/{sbom_id}",
+    "/{sbom_id}",
     response={204: None, 403: ErrorResponse, 404: ErrorResponse},
     auth=(PersonalAccessTokenAuth(), django_auth),
 )


### PR DESCRIPTION
Standardizes the SBOM deletion API route by removing the redundant /sbom prefix