### PR TITLE
fix: use $schema alias in CycloneDX SBOM serialization

### DIFF
--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1473,7 +1473,7 @@ def get_project_sbom_package(project: Project, target_folder: Path, user=None) -
 
     # Save project SBOM with clean serialization (exclude null values)
     sbom_path = target_folder / f"{project.name}.cdx.json"
-    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True))
+    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True))
 
     return sbom_path
 
@@ -1511,7 +1511,7 @@ def get_product_sbom_package(product: Product, target_folder: Path, user=None) -
 
     # Save product SBOM with clean serialization (exclude null values)
     sbom_path = target_folder / f"{product.name}.cdx.json"
-    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True))
+    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True))
 
     return sbom_path
 
@@ -1538,7 +1538,7 @@ def get_release_sbom_package(release, target_folder: Path, user=None) -> Path:
 
     # Save release SBOM with clean serialization (exclude null values)
     sbom_path = target_folder / f"{release.product.name}-{release.name}.cdx.json"
-    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True))
+    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True))
 
     return sbom_path
 


### PR DESCRIPTION
Generated product/project/release SBOMs were outputting 'field_schema' instead of '$schema' in the JSON. This caused validation errors when the SBOMs were re-uploaded or validated against the CycloneDX schema, which has additionalProperties: false.

The Pydantic models correctly define field_schema with alias='$schema', but model_dump_json() requires by_alias=True to use the alias in output.

Added regression test to prevent this from recurring.

Fixes validation error:
  Extra inputs are not permitted [type=extra_forbidden,
  input_value='http://cyclonedx.org/schema/bom-1.6.schema.json']
