### PR TITLE
feat(plugins): add CISA 2025 Minimum Elements compliance plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ For more information, see [sbomify.com](https://sbomify.com).
 
 ### Compliance Plugins
 
-| Plugin                                   | Type       | Standard                                                                                                          |
-|------------------------------------------|------------|-------------------------------------------------------------------------------------------------------------------|
-| NTIA Minimum Elements (2021)             | Compliance | [NTIA Minimum Elements for SBOM](https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom)  |
-| FDA Medical Device Cybersecurity (2025)  | Compliance | [FDA Cybersecurity in Medical Devices](https://www.fda.gov/media/119933/download)                                 |
+| Plugin                                   | Type       | Standard                                                                                                                                         |
+|------------------------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| NTIA Minimum Elements (2021)             | Compliance | [NTIA Minimum Elements for SBOM](https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom)                                 |
+| CISA Minimum Elements (2025 Draft)       | Compliance | [CISA 2025 SBOM Minimum Elements](https://www.cisa.gov/sites/default/files/2025-08/2025_CISA_SBOM_Minimum_Elements.pdf) *(Public Comment Draft)* |
+| FDA Medical Device Cybersecurity (2025)  | Compliance | [FDA Cybersecurity in Medical Devices](https://www.fda.gov/media/119933/download)                                                                |
 
 ### Document Management
 

--- a/sbomify/apps/plugins/builtins/__init__.py
+++ b/sbomify/apps/plugins/builtins/__init__.py
@@ -1,7 +1,8 @@
 """Built-in assessment plugins."""
 
 from .checksum import ChecksumPlugin
+from .cisa import CISAMinimumElementsPlugin
 from .fda_medical_device_cybersecurity import FDAMedicalDevicePlugin
 from .ntia import NTIAMinimumElementsPlugin
 
-__all__ = ["ChecksumPlugin", "FDAMedicalDevicePlugin", "NTIAMinimumElementsPlugin"]
+__all__ = ["ChecksumPlugin", "CISAMinimumElementsPlugin", "FDAMedicalDevicePlugin", "NTIAMinimumElementsPlugin"]

--- a/sbomify/apps/plugins/builtins/cisa.py
+++ b/sbomify/apps/plugins/builtins/cisa.py
@@ -1,0 +1,792 @@
+"""CISA 2025 Minimum Elements compliance plugin.
+
+This plugin validates SBOMs against the CISA Minimum Elements for a Software
+Bill of Materials as defined in the August 2025 public comment draft.
+
+IMPORTANT: This standard is based on the PUBLIC COMMENT DRAFT released in
+August 2025. It is NOT a finalized standard. The requirements may change
+when the final version is published by CISA. This plugin will be updated
+accordingly when the final standard is released.
+
+Standard Reference:
+    - Name: CISA 2025 Minimum Elements for a Software Bill of Materials (SBOM)
+    - Version: 2025-08 (August 2025 Public Comment Draft)
+    - URL: https://www.cisa.gov/sites/default/files/2025-08/2025_CISA_SBOM_Minimum_Elements.pdf
+    - Status: PUBLIC COMMENT DRAFT (Pre-decisional)
+
+The eleven CISA 2025 minimum data fields are:
+    1. SBOM Author - Name of entity that creates the SBOM data for this component
+    2. Software Producer - Name of entity that creates, defines, and identifies components
+       (replaces NTIA "Supplier Name")
+    3. Component Name - Name assigned by the Software Producer to a software component
+    4. Component Version - Identifier used to specify a change from previous version
+    5. Software Identifiers - At least one identifier for component lookup (PURL, CPE preferred)
+    6. Component Hash (NEW) - Cryptographic hash value of the software component
+    7. License (NEW) - License(s) under which the software component is made available
+    8. Dependency Relationship - Relationship between software components
+    9. Tool Name (NEW) - Name of tool(s) used by SBOM Author to generate the SBOM
+    10. Timestamp - Date and time of SBOM data assembly (ISO 8601)
+    11. Generation Context (NEW) - Software lifecycle phase (before build, build, after build)
+
+Key differences from NTIA 2021:
+    - 4 new required elements: Component Hash, License, Tool Name, Generation Context
+    - Software Producer replaces Supplier Name
+    - Software Identifiers requires at least one (not optional)
+    - Stricter timestamp validation (ISO 8601 enforced)
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sbomify.apps.plugins.sdk.base import AssessmentPlugin
+from sbomify.apps.plugins.sdk.enums import AssessmentCategory
+from sbomify.apps.plugins.sdk.results import (
+    AssessmentResult,
+    AssessmentSummary,
+    Finding,
+    PluginMetadata,
+)
+from sbomify.logging import getLogger
+
+logger = getLogger(__name__)
+
+
+# Valid generation context values
+# CISA defines: "before build, during build, after build"
+# We also accept common synonyms used in tooling:
+#   - "source" = before_build (source code analysis)
+#   - "analyzed" = post_build (binary analysis)
+GENERATION_CONTEXT_VALUES = {
+    "before_build",
+    "build",
+    "post_build",
+    # Synonyms
+    "source",  # equivalent to before_build
+    "analyzed",  # equivalent to post_build
+}
+
+
+class CISAMinimumElementsPlugin(AssessmentPlugin):
+    """CISA 2025 Minimum Elements compliance plugin (PUBLIC COMMENT DRAFT).
+
+    This plugin checks SBOMs for compliance with the eleven minimum data fields
+    defined in the CISA August 2025 public comment draft. It supports both SPDX
+    and CycloneDX formats.
+
+    IMPORTANT: This is based on a PUBLIC COMMENT DRAFT, not a finalized standard.
+    The requirements may change when the final version is published by CISA.
+
+    Attributes:
+        VERSION: Plugin version (semantic versioning).
+        STANDARD_NAME: Official name of the standard being checked.
+        STANDARD_VERSION: Version identifier of the standard (YYYY-MM format).
+        STANDARD_URL: Official URL to the standard documentation.
+
+    Example:
+        >>> plugin = CISAMinimumElementsPlugin()
+        >>> result = plugin.assess("sbom123", Path("/tmp/sbom.json"))
+        >>> print(f"Compliant: {result.summary.fail_count == 0}")
+    """
+
+    VERSION = "1.0.0"
+    STANDARD_NAME = "CISA 2025 Minimum Elements for a Software Bill of Materials (SBOM) - Public Comment Draft"
+    STANDARD_VERSION = "2025-08-draft"  # August 2025 public comment draft
+    STANDARD_URL = "https://www.cisa.gov/sites/default/files/2025-08/2025_CISA_SBOM_Minimum_Elements.pdf"
+
+    # Finding IDs for each CISA element (prefixed with standard version)
+    FINDING_IDS = {
+        "sbom_author": "cisa-2025:sbom-author",
+        "software_producer": "cisa-2025:software-producer",
+        "component_name": "cisa-2025:component-name",
+        "component_version": "cisa-2025:component-version",
+        "software_identifiers": "cisa-2025:software-identifiers",
+        "component_hash": "cisa-2025:component-hash",
+        "license": "cisa-2025:license",
+        "dependency_relationship": "cisa-2025:dependency-relationship",
+        "tool_name": "cisa-2025:tool-name",
+        "timestamp": "cisa-2025:timestamp",
+        "generation_context": "cisa-2025:generation-context",
+    }
+
+    # Human-readable titles for findings
+    FINDING_TITLES = {
+        "sbom_author": "SBOM Author",
+        "software_producer": "Software Producer",
+        "component_name": "Component Name",
+        "component_version": "Component Version",
+        "software_identifiers": "Software Identifiers",
+        "component_hash": "Component Hash",
+        "license": "License",
+        "dependency_relationship": "Dependency Relationship",
+        "tool_name": "Tool Name",
+        "timestamp": "Timestamp",
+        "generation_context": "Generation Context",
+    }
+
+    # Descriptions for each element per CISA 2025 standard
+    FINDING_DESCRIPTIONS = {
+        "sbom_author": "Name of entity that creates the SBOM data for this component",
+        "software_producer": "Name of entity that creates, defines, and identifies components",
+        "component_name": "Name assigned by the Software Producer to a software component",
+        "component_version": "Identifier used by Software Producer to specify a change from previous version",
+        "software_identifiers": "At least one identifier for component lookup (PURL, CPE preferred)",
+        "component_hash": "Cryptographic hash value generated from the software component",
+        "license": "License(s) under which the software component is made available",
+        "dependency_relationship": "Relationship between software components (includes/derived from)",
+        "tool_name": "Name of tool(s) used by SBOM Author to generate the SBOM",
+        "timestamp": "Record of date and time of SBOM data assembly (ISO 8601)",
+        "generation_context": "Software lifecycle phase at SBOM generation (before build, build, after build)",
+    }
+
+    def get_metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata with name, version, and category.
+        """
+        return PluginMetadata(
+            name="cisa-minimum-elements-2025",
+            version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE,
+        )
+
+    def assess(self, sbom_id: str, sbom_path: Path) -> AssessmentResult:
+        """Run CISA 2025 Minimum Elements compliance check against the SBOM.
+
+        Args:
+            sbom_id: The SBOM's primary key (for logging/reference).
+            sbom_path: Path to the SBOM file on disk.
+
+        Returns:
+            AssessmentResult with findings for each of the 11 CISA elements.
+        """
+        logger.info(f"[CISA-2025] Starting compliance check for SBOM {sbom_id}")
+
+        # Read and parse the SBOM
+        try:
+            sbom_data = json.loads(sbom_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            logger.error(f"[CISA-2025] Failed to parse SBOM JSON: {e}")
+            return self._create_error_result(f"Invalid JSON format: {e}")
+        except Exception as e:
+            logger.error(f"[CISA-2025] Failed to read SBOM file: {e}")
+            return self._create_error_result(f"Failed to read SBOM: {e}")
+
+        # Detect format and validate
+        sbom_format = self._detect_format(sbom_data)
+        if sbom_format == "spdx":
+            findings = self._validate_spdx(sbom_data)
+        elif sbom_format == "cyclonedx":
+            findings = self._validate_cyclonedx(sbom_data)
+        else:
+            logger.warning(f"[CISA-2025] Unknown SBOM format for {sbom_id}")
+            return self._create_error_result("Unable to detect SBOM format (expected SPDX or CycloneDX)")
+
+        # Calculate summary
+        pass_count = sum(1 for f in findings if f.status == "pass")
+        fail_count = sum(1 for f in findings if f.status == "fail")
+
+        summary = AssessmentSummary(
+            total_findings=len(findings),
+            pass_count=pass_count,
+            fail_count=fail_count,
+            warning_count=0,
+            error_count=0,
+        )
+
+        logger.info(f"[CISA-2025] Completed compliance check for SBOM {sbom_id}: {pass_count} pass, {fail_count} fail")
+
+        return AssessmentResult(
+            plugin_name="cisa-minimum-elements-2025",
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=summary,
+            findings=findings,
+            metadata={
+                "standard_name": self.STANDARD_NAME,
+                "standard_version": self.STANDARD_VERSION,
+                "standard_url": self.STANDARD_URL,
+                "standard_status": "public_comment_draft",
+                "sbom_format": sbom_format,
+            },
+        )
+
+    def _detect_format(self, sbom_data: dict[str, Any]) -> str:
+        """Detect SBOM format from the data.
+
+        Args:
+            sbom_data: Parsed SBOM dictionary.
+
+        Returns:
+            Format string: "spdx", "cyclonedx", or "unknown".
+        """
+        if "spdxVersion" in sbom_data:
+            return "spdx"
+        elif "bomFormat" in sbom_data and sbom_data.get("bomFormat", "").lower() == "cyclonedx":
+            return "cyclonedx"
+        elif "specVersion" in sbom_data and "components" in sbom_data:
+            # CycloneDX without explicit bomFormat
+            return "cyclonedx"
+        return "unknown"
+
+    def _validate_spdx(self, data: dict[str, Any]) -> list[Finding]:
+        """Validate SPDX format SBOM against CISA 2025 minimum elements.
+
+        Args:
+            data: Parsed SPDX SBOM dictionary.
+
+        Returns:
+            List of findings for each CISA element.
+        """
+        findings: list[Finding] = []
+        packages = data.get("packages", [])
+        relationships = data.get("relationships", [])
+        creation_info = data.get("creationInfo", {})
+
+        # Track element-level failures across all packages
+        producer_failures: list[str] = []
+        component_name_failures: list[str] = []
+        version_failures: list[str] = []
+        identifier_failures: list[str] = []
+        hash_failures: list[str] = []
+        license_failures: list[str] = []
+
+        # Check each package for required elements
+        for i, package in enumerate(packages):
+            package_name = package.get("name", f"Package {i + 1}")
+
+            # 2. Software Producer (was Supplier Name)
+            if not package.get("supplier"):
+                producer_failures.append(package_name)
+
+            # 3. Component name
+            if not package.get("name"):
+                component_name_failures.append(f"Package at index {i}")
+
+            # 4. Component Version
+            if not package.get("versionInfo"):
+                version_failures.append(package_name)
+
+            # 5. Software Identifiers (at least one required)
+            has_identifier = bool(package.get("externalRefs"))
+            if not has_identifier:
+                identifier_failures.append(package_name)
+
+            # 6. Component Hash (NEW - check checksums)
+            has_hash = bool(package.get("checksums"))
+            if not has_hash:
+                hash_failures.append(package_name)
+
+            # 7. License (NEW - check licenseConcluded or licenseDeclared)
+            # CISA: "If the SBOM author is not aware of the license information,
+            # then the SBOM author should indicate that license information is unknown."
+            # NOASSERTION is acceptable as it explicitly indicates unknown license.
+            license_concluded = package.get("licenseConcluded", "")
+            license_declared = package.get("licenseDeclared", "")
+            has_license = bool(license_concluded or license_declared)
+            if not has_license:
+                license_failures.append(package_name)
+
+        # Create findings for per-package elements
+
+        # 2. Software Producer
+        findings.append(
+            self._create_finding(
+                "software_producer",
+                status="fail" if producer_failures else "pass",
+                details=f"Missing for: {', '.join(producer_failures[:5])}"
+                + (f" and {len(producer_failures) - 5} more" if len(producer_failures) > 5 else "")
+                if producer_failures
+                else None,
+                remediation="Add supplier field to packages. Use 'Organization: <name>' format.",
+            )
+        )
+
+        # 3. Component Name
+        findings.append(
+            self._create_finding(
+                "component_name",
+                status="fail" if component_name_failures else "pass",
+                details=f"Missing for: {', '.join(component_name_failures[:5])}"
+                + (f" and {len(component_name_failures) - 5} more" if len(component_name_failures) > 5 else "")
+                if component_name_failures
+                else None,
+                remediation="Add name field to all packages.",
+            )
+        )
+
+        # 4. Component Version
+        findings.append(
+            self._create_finding(
+                "component_version",
+                status="fail" if version_failures else "pass",
+                details=f"Missing for: {', '.join(version_failures[:5])}"
+                + (f" and {len(version_failures) - 5} more" if len(version_failures) > 5 else "")
+                if version_failures
+                else None,
+                remediation="Add versionInfo field. Use file creation date if version is unknown.",
+            )
+        )
+
+        # 5. Software Identifiers
+        findings.append(
+            self._create_finding(
+                "software_identifiers",
+                status="fail" if identifier_failures else "pass",
+                details=f"Missing for: {', '.join(identifier_failures[:5])}"
+                + (f" and {len(identifier_failures) - 5} more" if len(identifier_failures) > 5 else "")
+                if identifier_failures
+                else None,
+                remediation="Add externalRefs with at least one identifier (PURL or CPE preferred).",
+            )
+        )
+
+        # 6. Component Hash (NEW)
+        findings.append(
+            self._create_finding(
+                "component_hash",
+                status="fail" if hash_failures else "pass",
+                details=f"Missing for: {', '.join(hash_failures[:5])}"
+                + (f" and {len(hash_failures) - 5} more" if len(hash_failures) > 5 else "")
+                if hash_failures
+                else None,
+                remediation="Add checksums field with cryptographic hash (SHA-256 recommended).",
+            )
+        )
+
+        # 7. License (NEW)
+        findings.append(
+            self._create_finding(
+                "license",
+                status="fail" if license_failures else "pass",
+                details=f"Missing for: {', '.join(license_failures[:5])}"
+                + (f" and {len(license_failures) - 5} more" if len(license_failures) > 5 else "")
+                if license_failures
+                else None,
+                remediation="Add licenseConcluded or licenseDeclared field with SPDX license expression.",
+            )
+        )
+
+        # 8. Dependency relationships (document-level)
+        has_dependencies = any(
+            rel.get("relationshipType", "").upper() in ["DEPENDS_ON", "CONTAINS", "DESCENDANT_OF"]
+            for rel in relationships
+        )
+        findings.append(
+            self._create_finding(
+                "dependency_relationship",
+                status="pass" if has_dependencies else "fail",
+                details=None if has_dependencies else "No DEPENDS_ON, CONTAINS, or DESCENDANT_OF relationships found",
+                remediation="Add relationships section with DEPENDS_ON, CONTAINS, or DESCENDANT_OF relationships.",
+            )
+        )
+
+        # 1. SBOM Author (document-level)
+        creators = creation_info.get("creators", [])
+        findings.append(
+            self._create_finding(
+                "sbom_author",
+                status="pass" if creators else "fail",
+                details=None if creators else "No creators found in creationInfo",
+                remediation="Add creators field in creationInfo with tool or person information.",
+            )
+        )
+
+        # 9. Tool Name (NEW - document-level, check for Tool: entries)
+        tool_entries = [c for c in creators if c.startswith("Tool:")]
+        findings.append(
+            self._create_finding(
+                "tool_name",
+                status="pass" if tool_entries else "fail",
+                details=None if tool_entries else "No Tool entries found in creators",
+                remediation="Add 'Tool: <tool-name>' entry in creationInfo.creators.",
+            )
+        )
+
+        # 10. Timestamp (document-level)
+        timestamp = creation_info.get("created")
+        timestamp_valid = self._validate_timestamp(timestamp)
+        findings.append(
+            self._create_finding(
+                "timestamp",
+                status="pass" if timestamp_valid else "fail",
+                details=None
+                if timestamp_valid
+                else ("Missing timestamp" if not timestamp else "Invalid ISO-8601 format"),
+                remediation="Add created field in creationInfo with ISO-8601 timestamp.",
+            )
+        )
+
+        # 11. Generation Context (NEW - check annotations)
+        has_generation_context = self._spdx_has_generation_context(data)
+        findings.append(
+            self._create_finding(
+                "generation_context",
+                status="pass" if has_generation_context else "fail",
+                details=None if has_generation_context else "No generation context annotation found",
+                remediation=(
+                    "Add annotation with comment 'cisa:generationContext=<context>' "
+                    "where context is: before_build, build, post_build, source, or analyzed."
+                ),
+            )
+        )
+
+        return findings
+
+    def _spdx_has_generation_context(self, data: dict[str, Any]) -> bool:
+        """Check if SPDX document has generation context annotation.
+
+        Args:
+            data: Full SPDX document dictionary.
+
+        Returns:
+            True if valid generation context annotation found.
+        """
+        # Check document-level annotations
+        for annotation in data.get("annotations", []):
+            if annotation.get("annotationType") == "OTHER":
+                comment = annotation.get("comment", "")
+                if "cisa:generationContext=" in comment:
+                    for part in comment.split():
+                        if part.startswith("cisa:generationContext="):
+                            context = part.split("=", 1)[1].lower().strip()
+                            if context in GENERATION_CONTEXT_VALUES:
+                                return True
+        return False
+
+    def _validate_cyclonedx(self, data: dict[str, Any]) -> list[Finding]:
+        """Validate CycloneDX format SBOM against CISA 2025 minimum elements.
+
+        Args:
+            data: Parsed CycloneDX SBOM dictionary.
+
+        Returns:
+            List of findings for each CISA element.
+        """
+        findings: list[Finding] = []
+        components = data.get("components", [])
+        dependencies = data.get("dependencies", [])
+        metadata = data.get("metadata", {})
+
+        # Track element-level failures across all components
+        producer_failures: list[str] = []
+        component_name_failures: list[str] = []
+        version_failures: list[str] = []
+        identifier_failures: list[str] = []
+        hash_failures: list[str] = []
+        license_failures: list[str] = []
+
+        # Check each component for required elements
+        for i, component in enumerate(components):
+            component_name = component.get("name", f"Component {i + 1}")
+
+            # 2. Software Producer (publisher or supplier.name)
+            supplier = component.get("publisher") or component.get("supplier", {}).get("name")
+            if not supplier:
+                producer_failures.append(component_name)
+
+            # 3. Component name
+            if not component.get("name"):
+                component_name_failures.append(f"Component at index {i}")
+
+            # 4. Component Version
+            if not component.get("version"):
+                version_failures.append(component_name)
+
+            # 5. Software Identifiers (at least one required - purl, cpe, swid)
+            has_identifier = bool(component.get("purl") or component.get("cpe") or component.get("swid"))
+            if not has_identifier:
+                identifier_failures.append(component_name)
+
+            # 6. Component Hash (NEW)
+            has_hash = bool(component.get("hashes"))
+            if not has_hash:
+                hash_failures.append(component_name)
+
+            # 7. License (NEW)
+            licenses = component.get("licenses", [])
+            has_license = bool(licenses)
+            if not has_license:
+                license_failures.append(component_name)
+
+        # Create findings for per-component elements
+
+        # 2. Software Producer
+        findings.append(
+            self._create_finding(
+                "software_producer",
+                status="fail" if producer_failures else "pass",
+                details=f"Missing for: {', '.join(producer_failures[:5])}"
+                + (f" and {len(producer_failures) - 5} more" if len(producer_failures) > 5 else "")
+                if producer_failures
+                else None,
+                remediation="Add publisher field or supplier.name to components.",
+            )
+        )
+
+        # 3. Component Name
+        findings.append(
+            self._create_finding(
+                "component_name",
+                status="fail" if component_name_failures else "pass",
+                details=f"Missing for: {', '.join(component_name_failures[:5])}"
+                + (f" and {len(component_name_failures) - 5} more" if len(component_name_failures) > 5 else "")
+                if component_name_failures
+                else None,
+                remediation="Add name field to all components.",
+            )
+        )
+
+        # 4. Component Version
+        findings.append(
+            self._create_finding(
+                "component_version",
+                status="fail" if version_failures else "pass",
+                details=f"Missing for: {', '.join(version_failures[:5])}"
+                + (f" and {len(version_failures) - 5} more" if len(version_failures) > 5 else "")
+                if version_failures
+                else None,
+                remediation="Add version field. Use file creation date if version is unknown.",
+            )
+        )
+
+        # 5. Software Identifiers
+        findings.append(
+            self._create_finding(
+                "software_identifiers",
+                status="fail" if identifier_failures else "pass",
+                details=f"Missing for: {', '.join(identifier_failures[:5])}"
+                + (f" and {len(identifier_failures) - 5} more" if len(identifier_failures) > 5 else "")
+                if identifier_failures
+                else None,
+                remediation="Add at least one identifier: purl (preferred), cpe, or swid.",
+            )
+        )
+
+        # 6. Component Hash (NEW)
+        findings.append(
+            self._create_finding(
+                "component_hash",
+                status="fail" if hash_failures else "pass",
+                details=f"Missing for: {', '.join(hash_failures[:5])}"
+                + (f" and {len(hash_failures) - 5} more" if len(hash_failures) > 5 else "")
+                if hash_failures
+                else None,
+                remediation="Add hashes field with cryptographic hash (SHA-256 recommended).",
+            )
+        )
+
+        # 7. License (NEW)
+        findings.append(
+            self._create_finding(
+                "license",
+                status="fail" if license_failures else "pass",
+                details=f"Missing for: {', '.join(license_failures[:5])}"
+                + (f" and {len(license_failures) - 5} more" if len(license_failures) > 5 else "")
+                if license_failures
+                else None,
+                remediation="Add licenses field with license information.",
+            )
+        )
+
+        # 8. Dependency relationships (document-level)
+        has_valid_dependencies = any(dep.get("ref") for dep in dependencies)
+        findings.append(
+            self._create_finding(
+                "dependency_relationship",
+                status="pass" if has_valid_dependencies else "fail",
+                details=None if has_valid_dependencies else "No valid dependency relationships found",
+                remediation="Add dependencies section with dependency relationships.",
+            )
+        )
+
+        # 1. SBOM author (document-level)
+        authors = metadata.get("authors", [])
+        tools = metadata.get("tools", [])
+        has_author = bool(authors or tools)
+        findings.append(
+            self._create_finding(
+                "sbom_author",
+                status="pass" if has_author else "fail",
+                details=None if has_author else "No authors or tools found in metadata",
+                remediation="Add authors or tools field in metadata section.",
+            )
+        )
+
+        # 9. Tool Name (NEW - document-level)
+        # CycloneDX 1.5+ uses tools as array of objects or tools.components
+        has_tool = self._cyclonedx_has_tool(metadata)
+        findings.append(
+            self._create_finding(
+                "tool_name",
+                status="pass" if has_tool else "fail",
+                details=None if has_tool else "No tool information found in metadata",
+                remediation="Add tools field in metadata with tool name and version.",
+            )
+        )
+
+        # 10. Timestamp (document-level)
+        timestamp = metadata.get("timestamp")
+        timestamp_valid = self._validate_timestamp(timestamp)
+        findings.append(
+            self._create_finding(
+                "timestamp",
+                status="pass" if timestamp_valid else "fail",
+                details=None
+                if timestamp_valid
+                else ("Missing timestamp" if not timestamp else "Invalid ISO-8601 format"),
+                remediation="Add timestamp field in metadata with ISO-8601 format.",
+            )
+        )
+
+        # 11. Generation Context (NEW)
+        has_generation_context = self._cyclonedx_has_generation_context(metadata)
+        findings.append(
+            self._create_finding(
+                "generation_context",
+                status="pass" if has_generation_context else "fail",
+                details=None if has_generation_context else "No generation context found in metadata properties",
+                remediation=(
+                    "Add property 'cdx:sbom:generationContext' in metadata.properties "
+                    "with value: before_build, build, post_build, source, or analyzed."
+                ),
+            )
+        )
+
+        return findings
+
+    def _cyclonedx_has_tool(self, metadata: dict[str, Any]) -> bool:
+        """Check if CycloneDX metadata has tool information.
+
+        Supports both CycloneDX 1.4 (tools as array of objects) and
+        CycloneDX 1.5+ (tools.components array).
+
+        Args:
+            metadata: CycloneDX metadata dictionary.
+
+        Returns:
+            True if tool information found.
+        """
+        tools = metadata.get("tools", [])
+        if isinstance(tools, list) and tools:
+            # CycloneDX 1.4 format: array of tool objects
+            return any(tool.get("name") or tool.get("vendor") for tool in tools)
+        elif isinstance(tools, dict):
+            # CycloneDX 1.5+ format: tools.components array
+            components = tools.get("components", [])
+            return any(comp.get("name") for comp in components)
+        return False
+
+    def _cyclonedx_has_generation_context(self, metadata: dict[str, Any]) -> bool:
+        """Check if CycloneDX metadata has generation context property.
+
+        Args:
+            metadata: CycloneDX metadata dictionary.
+
+        Returns:
+            True if valid generation context property found.
+        """
+        properties = metadata.get("properties", [])
+        for prop in properties:
+            if prop.get("name") == "cdx:sbom:generationContext":
+                value = prop.get("value", "").lower().strip()
+                if value in GENERATION_CONTEXT_VALUES:
+                    return True
+        return False
+
+    def _validate_timestamp(self, timestamp: str | None) -> bool:
+        """Validate that a timestamp is in valid ISO-8601 format.
+
+        Args:
+            timestamp: Timestamp string to validate.
+
+        Returns:
+            True if valid ISO-8601 format, False otherwise.
+        """
+        if not timestamp:
+            return False
+        try:
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    def _create_finding(
+        self,
+        element: str,
+        status: str,
+        details: str | None = None,
+        remediation: str | None = None,
+    ) -> Finding:
+        """Create a finding for a CISA element.
+
+        Args:
+            element: Element key (e.g., "software_producer").
+            status: Status string ("pass" or "fail").
+            details: Additional details about the finding.
+            remediation: Suggested fix for failures.
+
+        Returns:
+            Finding object for the element.
+        """
+        description = self.FINDING_DESCRIPTIONS[element]
+        if details:
+            description = f"{description}. {details}"
+
+        return Finding(
+            id=self.FINDING_IDS[element],
+            title=self.FINDING_TITLES[element],
+            description=description,
+            status=status,
+            severity="info" if status == "pass" else "medium",
+            remediation=remediation if status == "fail" else None,
+            metadata={
+                "standard": "CISA",
+                "standard_version": self.STANDARD_VERSION,
+                "element": element,
+            },
+        )
+
+    def _create_error_result(self, error_message: str) -> AssessmentResult:
+        """Create an error result when assessment cannot be completed.
+
+        Args:
+            error_message: Description of the error.
+
+        Returns:
+            AssessmentResult with error finding.
+        """
+        finding = Finding(
+            id="cisa-2025:error",
+            title="Assessment Error",
+            description=error_message,
+            status="error",
+            severity="high",
+        )
+
+        summary = AssessmentSummary(
+            total_findings=1,
+            pass_count=0,
+            fail_count=0,
+            warning_count=0,
+            error_count=1,
+        )
+
+        return AssessmentResult(
+            plugin_name="cisa-minimum-elements-2025",
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=summary,
+            findings=[finding],
+            metadata={
+                "standard_name": self.STANDARD_NAME,
+                "standard_version": self.STANDARD_VERSION,
+                "standard_url": self.STANDARD_URL,
+                "standard_status": "public_comment_draft",
+                "error": True,
+            },
+        )

--- a/sbomify/apps/plugins/tests/test_cisa_integration.py
+++ b/sbomify/apps/plugins/tests/test_cisa_integration.py
@@ -1,0 +1,521 @@
+"""Integration tests for CISA 2025 compliance plugin workflow.
+
+Tests the complete workflow from SBOM creation through plugin assessment.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import TestCase
+from django.utils import timezone
+
+from sbomify.apps.billing.models import BillingPlan
+from sbomify.apps.plugins.models import AssessmentRun, RegisteredPlugin
+from sbomify.apps.plugins.sdk.enums import RunReason, RunStatus
+from sbomify.apps.plugins.tasks import run_assessment_task
+from sbomify.apps.sboms.models import SBOM, Component
+from sbomify.apps.sboms.signals import trigger_plugin_assessments
+from sbomify.apps.teams.models import Team
+
+
+@pytest.mark.django_db
+class TestCISAPluginIntegration:
+    """Integration tests for CISA 2025 plugin workflow."""
+
+    @pytest.fixture
+    def team(self) -> Team:
+        """Create a test team with business plan."""
+        BillingPlan.objects.get_or_create(
+            key="business",
+            defaults={"name": "Business Plan"},
+        )
+        return Team.objects.create(
+            name="Test Team",
+            key="test-team-cisa",
+            billing_plan="business",
+        )
+
+    @pytest.fixture
+    def component(self, team: Team) -> Component:
+        """Create a test component."""
+        return Component.objects.create(
+            name="test-component",
+            team=team,
+            component_type="sbom",
+        )
+
+    @pytest.fixture
+    def cisa_plugin(self) -> RegisteredPlugin:
+        """Register the CISA plugin."""
+        plugin, _ = RegisteredPlugin.objects.update_or_create(
+            name="cisa-minimum-elements-2025",
+            defaults={
+                "display_name": "CISA Minimum Elements (2025)",
+                "description": "CISA 2025 SBOM compliance checking",
+                "category": "compliance",
+                "version": "1.0.0",
+                "plugin_class_path": "sbomify.apps.plugins.builtins.cisa.CISAMinimumElementsPlugin",
+                "is_enabled": True,
+            },
+        )
+        return plugin
+
+    @pytest.fixture
+    def compliant_cyclonedx_sbom(self) -> dict:
+        """Sample compliant CycloneDX SBOM with all CISA 2025 elements."""
+        return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example-component",
+                    "version": "1.0.0",
+                    "publisher": "Example Corp",
+                    "purl": "pkg:pypi/example-component@1.0.0",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123def456"}],
+                    "licenses": [{"license": {"id": "MIT"}}],
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example-component@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Example Developer"}],
+                "tools": [{"name": "sbom-generator", "version": "1.0.0"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+    @pytest.fixture
+    def non_compliant_cyclonedx_sbom(self) -> dict:
+        """Sample non-compliant CycloneDX SBOM missing CISA 2025 elements."""
+        return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example-component",
+                    # Missing: version, publisher, purl/cpe/swid, hashes, licenses
+                }
+            ],
+            # Missing dependencies
+            "metadata": {
+                # Missing: authors, tools, timestamp, generation context
+            },
+        }
+
+    def test_signal_triggers_plugin_assessments(
+        self, team: Team, component: Component, cisa_plugin: RegisteredPlugin
+    ) -> None:
+        """Test that SBOM creation signal triggers plugin assessments."""
+        from sbomify.apps.plugins.models import TeamPluginSettings
+
+        # Enable the CISA plugin for this team
+        TeamPluginSettings.objects.create(
+            team=team,
+            enabled_plugins=["cisa-minimum-elements-2025"],
+        )
+
+        sbom = SBOM.objects.create(
+            name="test-sbom",
+            component=component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="test.json",
+            source="test",
+        )
+
+        with patch("sbomify.apps.plugins.tasks.enqueue_assessments_for_sbom") as mock_enqueue:
+            trigger_plugin_assessments(sender=SBOM, instance=sbom, created=True)
+
+            mock_enqueue.assert_called_once()
+            call_kwargs = mock_enqueue.call_args[1]
+            assert call_kwargs["sbom_id"] == sbom.id
+            assert call_kwargs["team_id"] == team.id
+            assert call_kwargs["run_reason"] == RunReason.ON_UPLOAD
+
+    def test_full_assessment_workflow_compliant(
+        self,
+        team: Team,
+        component: Component,
+        cisa_plugin: RegisteredPlugin,
+        compliant_cyclonedx_sbom: dict,
+    ) -> None:
+        """Test complete workflow for compliant SBOM assessment."""
+        sbom = SBOM.objects.create(
+            name="compliant-sbom",
+            component=component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="compliant.json",
+            source="test",
+        )
+
+        # Mock SBOM data retrieval
+        mock_sbom_bytes = json.dumps(compliant_cyclonedx_sbom).encode("utf-8")
+
+        with patch(
+            "sbomify.apps.plugins.orchestrator.get_sbom_data_bytes",
+            return_value=(sbom, mock_sbom_bytes),
+        ):
+            run_assessment_task(
+                sbom_id=str(sbom.id),
+                plugin_name="cisa-minimum-elements-2025",
+                run_reason=RunReason.ON_UPLOAD.value,
+            )
+
+        # Verify assessment completed successfully
+        assessment_run = AssessmentRun.objects.filter(sbom=sbom, plugin_name="cisa-minimum-elements-2025").first()
+        assert assessment_run is not None
+        assert assessment_run.status == RunStatus.COMPLETED.value
+        assert assessment_run.result is not None
+        assert assessment_run.result["summary"]["fail_count"] == 0
+        assert assessment_run.result["summary"]["pass_count"] == 11  # All 11 CISA elements
+        assert assessment_run.completed_at is not None
+
+    def test_full_assessment_workflow_non_compliant(
+        self,
+        team: Team,
+        component: Component,
+        cisa_plugin: RegisteredPlugin,
+        non_compliant_cyclonedx_sbom: dict,
+    ) -> None:
+        """Test complete workflow for non-compliant SBOM assessment."""
+        sbom = SBOM.objects.create(
+            name="non-compliant-sbom",
+            component=component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="non-compliant.json",
+            source="test",
+        )
+
+        # Mock SBOM data retrieval
+        mock_sbom_bytes = json.dumps(non_compliant_cyclonedx_sbom).encode("utf-8")
+
+        with patch(
+            "sbomify.apps.plugins.orchestrator.get_sbom_data_bytes",
+            return_value=(sbom, mock_sbom_bytes),
+        ):
+            run_assessment_task(
+                sbom_id=str(sbom.id),
+                plugin_name="cisa-minimum-elements-2025",
+                run_reason=RunReason.ON_UPLOAD.value,
+            )
+
+        # Verify assessment completed with failures
+        assessment_run = AssessmentRun.objects.filter(sbom=sbom, plugin_name="cisa-minimum-elements-2025").first()
+        assert assessment_run is not None
+        assert assessment_run.status == RunStatus.COMPLETED.value
+        assert assessment_run.result is not None
+        assert assessment_run.result["summary"]["fail_count"] > 0
+
+    def test_assessment_run_preserves_history(
+        self,
+        team: Team,
+        component: Component,
+        cisa_plugin: RegisteredPlugin,
+        compliant_cyclonedx_sbom: dict,
+    ) -> None:
+        """Test that multiple assessment runs are preserved for audit trail."""
+        sbom = SBOM.objects.create(
+            name="history-test-sbom",
+            component=component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="history.json",
+            source="test",
+        )
+
+        mock_sbom_bytes = json.dumps(compliant_cyclonedx_sbom).encode("utf-8")
+
+        with patch(
+            "sbomify.apps.plugins.orchestrator.get_sbom_data_bytes",
+            return_value=(sbom, mock_sbom_bytes),
+        ):
+            # Run first assessment
+            run_assessment_task(
+                sbom_id=str(sbom.id),
+                plugin_name="cisa-minimum-elements-2025",
+                run_reason=RunReason.ON_UPLOAD.value,
+            )
+
+            # Run second assessment (manual re-run)
+            run_assessment_task(
+                sbom_id=str(sbom.id),
+                plugin_name="cisa-minimum-elements-2025",
+                run_reason=RunReason.MANUAL.value,
+            )
+
+        # Verify both runs exist
+        runs = AssessmentRun.objects.filter(sbom=sbom, plugin_name="cisa-minimum-elements-2025")
+        assert runs.count() == 2
+
+        # Both should be completed
+        for run in runs:
+            assert run.status == RunStatus.COMPLETED.value
+
+    def test_cisa_validates_new_elements(
+        self,
+        team: Team,
+        component: Component,
+        cisa_plugin: RegisteredPlugin,
+    ) -> None:
+        """Test that CISA plugin validates the 4 new elements (hash, license, tool, context)."""
+        # Create SBOM missing only the new CISA 2025 elements
+        sbom_missing_new_elements = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example-component",
+                    "version": "1.0.0",
+                    "publisher": "Example Corp",
+                    "purl": "pkg:pypi/example-component@1.0.0",
+                    # Missing: hashes, licenses
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example-component@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Example Developer"}],
+                # Missing: tools, properties (generation context)
+                "timestamp": "2023-01-01T00:00:00Z",
+            },
+        }
+
+        sbom = SBOM.objects.create(
+            name="new-elements-test-sbom",
+            component=component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="new-elements.json",
+            source="test",
+        )
+
+        mock_sbom_bytes = json.dumps(sbom_missing_new_elements).encode("utf-8")
+
+        with patch(
+            "sbomify.apps.plugins.orchestrator.get_sbom_data_bytes",
+            return_value=(sbom, mock_sbom_bytes),
+        ):
+            run_assessment_task(
+                sbom_id=str(sbom.id),
+                plugin_name="cisa-minimum-elements-2025",
+                run_reason=RunReason.ON_UPLOAD.value,
+            )
+
+        assessment_run = AssessmentRun.objects.filter(sbom=sbom, plugin_name="cisa-minimum-elements-2025").first()
+        assert assessment_run is not None
+
+        # Check that the new elements failed
+        findings = assessment_run.result["findings"]
+        failed_ids = [f["id"] for f in findings if f.get("status") == "fail"]
+
+        # Should fail on: component_hash, license, tool_name, generation_context
+        assert "cisa-2025:component-hash" in failed_ids
+        assert "cisa-2025:license" in failed_ids
+        assert "cisa-2025:tool-name" in failed_ids
+        assert "cisa-2025:generation-context" in failed_ids
+
+
+class TestCISAPluginAPIIntegration(TestCase):
+    """Integration tests for CISA plugin API endpoints."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.team = Team.objects.create(
+            name="API Test Team",
+            key="api-test-team-cisa",
+            billing_plan="business",
+        )
+        BillingPlan.objects.get_or_create(
+            key="business",
+            defaults={"name": "Business Plan"},
+        )
+        self.component = Component.objects.create(
+            name="api-test-component",
+            team=self.team,
+            component_type="sbom",
+        )
+        RegisteredPlugin.objects.update_or_create(
+            name="cisa-minimum-elements-2025",
+            defaults={
+                "display_name": "CISA Minimum Elements (2025)",
+                "description": "CISA 2025 compliance checking",
+                "category": "compliance",
+                "version": "1.0.0",
+                "plugin_class_path": "sbomify.apps.plugins.builtins.cisa.CISAMinimumElementsPlugin",
+                "is_enabled": True,
+            },
+        )
+
+    def test_assessment_api_returns_cisa_results(self) -> None:
+        """Test that assessment API returns CISA plugin results."""
+        from sbomify.apps.plugins.apis import get_sbom_assessments
+
+        sbom = SBOM.objects.create(
+            name="api-test-sbom",
+            component=self.component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="api-test.json",
+            source="test",
+        )
+
+        # Create completed assessment run with all required fields
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="cisa-minimum-elements-2025",
+            plugin_version="1.0.0",
+            category="compliance",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status=RunStatus.COMPLETED.value,
+            completed_at=timezone.now(),
+            result={
+                "plugin_name": "cisa-minimum-elements-2025",
+                "plugin_version": "1.0.0",
+                "category": "compliance",
+                "assessed_at": timezone.now().isoformat(),
+                "summary": {
+                    "total_findings": 11,
+                    "pass_count": 11,
+                    "fail_count": 0,
+                    "error_count": 0,
+                    "info_count": 0,
+                },
+                "findings": [],
+                "metadata": {
+                    "standard_name": "CISA 2025 Minimum Elements",
+                    "standard_version": "2025-08",
+                },
+            },
+        )
+
+        # Mock request
+        mock_request = MagicMock()
+
+        response = get_sbom_assessments(mock_request, str(sbom.id))
+
+        assert response.status_summary.overall_status == "all_pass"
+        assert len(response.latest_runs) == 1
+        assert response.latest_runs[0].plugin_name == "cisa-minimum-elements-2025"
+
+    def test_badge_api_returns_status_summary(self) -> None:
+        """Test that badge API returns correct status summary for CISA plugin."""
+        from sbomify.apps.plugins.apis import get_sbom_assessment_badge
+
+        sbom = SBOM.objects.create(
+            name="badge-test-sbom",
+            component=self.component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="badge-test.json",
+            source="test",
+        )
+
+        # Create completed assessment with failures
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="cisa-minimum-elements-2025",
+            plugin_version="1.0.0",
+            category="compliance",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status=RunStatus.COMPLETED.value,
+            completed_at=timezone.now(),
+            result={
+                "summary": {
+                    "total_findings": 11,
+                    "pass_count": 7,
+                    "fail_count": 4,  # 4 new CISA elements failing
+                    "error_count": 0,
+                    "info_count": 0,
+                },
+            },
+        )
+
+        mock_request = MagicMock()
+        response = get_sbom_assessment_badge(mock_request, str(sbom.id))
+
+        assert response.overall_status == "has_failures"
+        assert response.failing_count == 1
+
+    def test_cisa_and_ntia_plugins_can_run_together(self) -> None:
+        """Test that CISA and NTIA plugins can both run on the same SBOM."""
+        from sbomify.apps.plugins.apis import get_sbom_assessments
+
+        # Also register NTIA plugin
+        RegisteredPlugin.objects.update_or_create(
+            name="ntia-minimum-elements-2021",
+            defaults={
+                "display_name": "NTIA Minimum Elements (2021)",
+                "description": "NTIA compliance checking",
+                "category": "compliance",
+                "version": "1.0.0",
+                "plugin_class_path": "sbomify.apps.plugins.builtins.ntia.NTIAMinimumElementsPlugin",
+                "is_enabled": True,
+            },
+        )
+
+        sbom = SBOM.objects.create(
+            name="multi-plugin-test-sbom",
+            component=self.component,
+            format="cyclonedx",
+            format_version="1.5",
+            sbom_filename="multi-plugin.json",
+            source="test",
+        )
+
+        # Create CISA assessment
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="cisa-minimum-elements-2025",
+            plugin_version="1.0.0",
+            category="compliance",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status=RunStatus.COMPLETED.value,
+            completed_at=timezone.now(),
+            result={
+                "plugin_name": "cisa-minimum-elements-2025",
+                "plugin_version": "1.0.0",
+                "category": "compliance",
+                "assessed_at": timezone.now().isoformat(),
+                "summary": {
+                    "total_findings": 11,
+                    "pass_count": 7,
+                    "fail_count": 4,
+                },
+                "findings": [],
+            },
+        )
+
+        # Create NTIA assessment
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="ntia-minimum-elements-2021",
+            plugin_version="1.0.0",
+            category="compliance",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status=RunStatus.COMPLETED.value,
+            completed_at=timezone.now(),
+            result={
+                "plugin_name": "ntia-minimum-elements-2021",
+                "plugin_version": "1.0.0",
+                "category": "compliance",
+                "assessed_at": timezone.now().isoformat(),
+                "summary": {
+                    "total_findings": 7,
+                    "pass_count": 7,
+                    "fail_count": 0,
+                },
+                "findings": [],
+            },
+        )
+
+        mock_request = MagicMock()
+        response = get_sbom_assessments(mock_request, str(sbom.id))
+
+        # Should have both plugins in results
+        assert len(response.latest_runs) == 2
+        plugin_names = {run.plugin_name for run in response.latest_runs}
+        assert "cisa-minimum-elements-2025" in plugin_names
+        assert "ntia-minimum-elements-2021" in plugin_names

--- a/sbomify/apps/plugins/tests/test_cisa_plugin.py
+++ b/sbomify/apps/plugins/tests/test_cisa_plugin.py
@@ -1,0 +1,772 @@
+"""Tests for the CISA 2025 Minimum Elements compliance plugin.
+
+Tests validation of SBOMs against the CISA Minimum Elements for a Software
+Bill of Materials as defined in the August 2025 public comment draft.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from sbomify.apps.plugins.builtins.cisa import CISAMinimumElementsPlugin
+from sbomify.apps.plugins.sdk.enums import AssessmentCategory
+from sbomify.apps.plugins.sdk.results import AssessmentResult
+
+
+class TestCISAPluginMetadata:
+    """Tests for plugin metadata."""
+
+    def test_plugin_metadata(self) -> None:
+        """Test that plugin returns correct metadata."""
+        plugin = CISAMinimumElementsPlugin()
+        metadata = plugin.get_metadata()
+
+        assert metadata.name == "cisa-minimum-elements-2025"
+        assert metadata.version == "1.0.0"
+        assert metadata.category == AssessmentCategory.COMPLIANCE
+
+    def test_plugin_standard_info(self) -> None:
+        """Test that plugin has correct standard information."""
+        plugin = CISAMinimumElementsPlugin()
+
+        assert (
+            plugin.STANDARD_NAME
+            == "CISA 2025 Minimum Elements for a Software Bill of Materials (SBOM) - Public Comment Draft"
+        )
+        assert plugin.STANDARD_VERSION == "2025-08-draft"
+        assert (
+            plugin.STANDARD_URL
+            == "https://www.cisa.gov/sites/default/files/2025-08/2025_CISA_SBOM_Minimum_Elements.pdf"
+        )
+
+    def test_finding_ids_match_standard(self) -> None:
+        """Test that finding IDs are properly formatted with standard version."""
+        plugin = CISAMinimumElementsPlugin()
+
+        for key, finding_id in plugin.FINDING_IDS.items():
+            assert finding_id.startswith("cisa-2025:"), f"Finding ID {finding_id} should start with 'cisa-2025:'"
+
+    def test_all_eleven_elements_have_finding_ids(self) -> None:
+        """Test that all 11 CISA 2025 elements have finding IDs."""
+        plugin = CISAMinimumElementsPlugin()
+
+        expected_elements = {
+            "sbom_author",
+            "software_producer",
+            "component_name",
+            "component_version",
+            "software_identifiers",
+            "component_hash",
+            "license",
+            "dependency_relationship",
+            "tool_name",
+            "timestamp",
+            "generation_context",
+        }
+
+        assert set(plugin.FINDING_IDS.keys()) == expected_elements
+
+
+class TestCycloneDXValidation:
+    """Tests for CycloneDX SBOM validation."""
+
+    def test_compliant_cyclonedx_sbom(self) -> None:
+        """Test validation of a fully compliant CycloneDX SBOM."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example-component",
+                    "version": "1.0.0",
+                    "publisher": "Example Corp",
+                    "purl": "pkg:pypi/example-component@1.0.0",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123def456"}],
+                    "licenses": [{"license": {"id": "MIT"}}],
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example-component@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Example Developer"}],
+                "tools": [{"name": "sbom-generator", "version": "1.0.0"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+        result = self._assess_sbom(sbom_data)
+
+        assert result.summary.fail_count == 0
+        assert result.summary.pass_count == 11  # All 11 CISA elements
+        assert result.summary.total_findings == 11
+
+    def test_cyclonedx_missing_software_producer(self) -> None:
+        """Test CycloneDX SBOM missing software producer information."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        # Remove publisher and supplier
+        del sbom_data["components"][0]["publisher"]
+
+        result = self._assess_sbom(sbom_data)
+
+        producer_finding = next(f for f in result.findings if "software-producer" in f.id)
+        assert producer_finding.status == "fail"
+
+    def test_cyclonedx_missing_component_version(self) -> None:
+        """Test CycloneDX SBOM missing component version."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["version"]
+
+        result = self._assess_sbom(sbom_data)
+
+        version_finding = next(f for f in result.findings if "component-version" in f.id)
+        assert version_finding.status == "fail"
+
+    def test_cyclonedx_missing_software_identifiers(self) -> None:
+        """Test CycloneDX SBOM missing software identifiers."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["purl"]
+
+        result = self._assess_sbom(sbom_data)
+
+        identifier_finding = next(f for f in result.findings if "software-identifiers" in f.id)
+        assert identifier_finding.status == "fail"
+
+    def test_cyclonedx_missing_component_hash(self) -> None:
+        """Test CycloneDX SBOM missing component hash (NEW element)."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["hashes"]
+
+        result = self._assess_sbom(sbom_data)
+
+        hash_finding = next(f for f in result.findings if "component-hash" in f.id)
+        assert hash_finding.status == "fail"
+
+    def test_cyclonedx_missing_license(self) -> None:
+        """Test CycloneDX SBOM missing license (NEW element)."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["licenses"]
+
+        result = self._assess_sbom(sbom_data)
+
+        license_finding = next(f for f in result.findings if f.id == "cisa-2025:license")
+        assert license_finding.status == "fail"
+
+    def test_cyclonedx_missing_dependencies(self) -> None:
+        """Test CycloneDX SBOM missing dependency relationships."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["dependencies"]
+
+        result = self._assess_sbom(sbom_data)
+
+        dep_finding = next(f for f in result.findings if "dependency-relationship" in f.id)
+        assert dep_finding.status == "fail"
+
+    def test_cyclonedx_missing_sbom_author(self) -> None:
+        """Test CycloneDX SBOM missing SBOM author."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["metadata"]["authors"]
+        del sbom_data["metadata"]["tools"]
+
+        result = self._assess_sbom(sbom_data)
+
+        author_finding = next(f for f in result.findings if "sbom-author" in f.id)
+        assert author_finding.status == "fail"
+
+    def test_cyclonedx_missing_tool_name(self) -> None:
+        """Test CycloneDX SBOM missing tool name (NEW element)."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["metadata"]["tools"]
+
+        result = self._assess_sbom(sbom_data)
+
+        tool_finding = next(f for f in result.findings if "tool-name" in f.id)
+        assert tool_finding.status == "fail"
+
+    def test_cyclonedx_missing_timestamp(self) -> None:
+        """Test CycloneDX SBOM missing timestamp."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["metadata"]["timestamp"]
+
+        result = self._assess_sbom(sbom_data)
+
+        timestamp_finding = next(f for f in result.findings if "timestamp" in f.id)
+        assert timestamp_finding.status == "fail"
+
+    def test_cyclonedx_missing_generation_context(self) -> None:
+        """Test CycloneDX SBOM missing generation context (NEW element)."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["metadata"]["properties"]
+
+        result = self._assess_sbom(sbom_data)
+
+        context_finding = next(f for f in result.findings if "generation-context" in f.id)
+        assert context_finding.status == "fail"
+
+    def test_cyclonedx_with_supplier_object(self) -> None:
+        """Test CycloneDX SBOM with supplier.name instead of publisher."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["publisher"]
+        sbom_data["components"][0]["supplier"] = {"name": "Example Corp"}
+
+        result = self._assess_sbom(sbom_data)
+
+        producer_finding = next(f for f in result.findings if "software-producer" in f.id)
+        assert producer_finding.status == "pass"
+
+    def test_cyclonedx_with_cpe_identifier(self) -> None:
+        """Test CycloneDX SBOM with CPE instead of PURL."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["purl"]
+        sbom_data["components"][0]["cpe"] = "cpe:2.3:a:example:component:1.0.0:*:*:*:*:*:*:*"
+
+        result = self._assess_sbom(sbom_data)
+
+        identifier_finding = next(f for f in result.findings if "software-identifiers" in f.id)
+        assert identifier_finding.status == "pass"
+
+    def test_cyclonedx_with_swid_identifier(self) -> None:
+        """Test CycloneDX SBOM with SWID instead of PURL."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        del sbom_data["components"][0]["purl"]
+        sbom_data["components"][0]["swid"] = {"tagId": "example-swid-tag"}
+
+        result = self._assess_sbom(sbom_data)
+
+        identifier_finding = next(f for f in result.findings if "software-identifiers" in f.id)
+        assert identifier_finding.status == "pass"
+
+    def test_cyclonedx_tools_1_5_format(self) -> None:
+        """Test CycloneDX 1.5+ tools format with components array."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        sbom_data["metadata"]["tools"] = {"components": [{"name": "sbom-tool", "version": "2.0.0"}]}
+
+        result = self._assess_sbom(sbom_data)
+
+        tool_finding = next(f for f in result.findings if "tool-name" in f.id)
+        assert tool_finding.status == "pass"
+
+    def test_cyclonedx_generation_context_values(self) -> None:
+        """Test all valid generation context values."""
+        valid_contexts = ["before_build", "build", "post_build", "source", "analyzed"]
+
+        for context in valid_contexts:
+            sbom_data = self._create_base_cyclonedx_sbom()
+            sbom_data["metadata"]["properties"] = [{"name": "cdx:sbom:generationContext", "value": context}]
+
+            result = self._assess_sbom(sbom_data)
+
+            context_finding = next(f for f in result.findings if "generation-context" in f.id)
+            assert context_finding.status == "pass", f"Context '{context}' should be valid"
+
+    def test_cyclonedx_invalid_generation_context(self) -> None:
+        """Test invalid generation context value."""
+        sbom_data = self._create_base_cyclonedx_sbom()
+        sbom_data["metadata"]["properties"] = [{"name": "cdx:sbom:generationContext", "value": "invalid_context"}]
+
+        result = self._assess_sbom(sbom_data)
+
+        context_finding = next(f for f in result.findings if "generation-context" in f.id)
+        assert context_finding.status == "fail"
+
+    def _create_base_cyclonedx_sbom(self) -> dict:
+        """Create a base compliant CycloneDX SBOM for testing."""
+        return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example-component",
+                    "version": "1.0.0",
+                    "publisher": "Example Corp",
+                    "purl": "pkg:pypi/example-component@1.0.0",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123def456"}],
+                    "licenses": [{"license": {"id": "MIT"}}],
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example-component@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Example Developer"}],
+                "tools": [{"name": "sbom-generator", "version": "1.0.0"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+    def _assess_sbom(self, sbom_data: dict) -> AssessmentResult:
+        """Helper to write SBOM to temp file and assess it."""
+        plugin = CISAMinimumElementsPlugin()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            return plugin.assess("test-sbom-id", Path(f.name))
+
+
+class TestSPDXValidation:
+    """Tests for SPDX SBOM validation."""
+
+    def test_compliant_spdx_sbom(self) -> None:
+        """Test validation of a fully compliant SPDX SBOM."""
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package",
+                    "name": "example-package",
+                    "supplier": "Organization: Example Corp",
+                    "versionInfo": "1.0.0",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/example-package@1.0.0",
+                        }
+                    ],
+                    "checksums": [{"algorithm": "SHA256", "checksumValue": "abc123def456"}],
+                    "licenseConcluded": "MIT",
+                }
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DEPENDS_ON",
+                    "relatedSpdxElement": "SPDXRef-Package",
+                }
+            ],
+            "creationInfo": {
+                "creators": ["Tool: example-tool (1.0.0)", "Person: Developer"],
+                "created": "2023-01-01T00:00:00Z",
+            },
+            "annotations": [
+                {
+                    "annotationType": "OTHER",
+                    "comment": "cisa:generationContext=build",
+                    "annotator": "Tool: example-tool",
+                    "annotationDate": "2023-01-01T00:00:00Z",
+                }
+            ],
+        }
+
+        result = self._assess_sbom(sbom_data)
+
+        assert result.summary.fail_count == 0
+        assert result.summary.pass_count == 11
+
+    def test_spdx_missing_software_producer(self) -> None:
+        """Test SPDX SBOM missing software producer (supplier)."""
+        sbom_data = self._create_base_spdx_sbom()
+        del sbom_data["packages"][0]["supplier"]
+
+        result = self._assess_sbom(sbom_data)
+
+        producer_finding = next(f for f in result.findings if "software-producer" in f.id)
+        assert producer_finding.status == "fail"
+
+    def test_spdx_missing_component_hash(self) -> None:
+        """Test SPDX SBOM missing component hash (checksums)."""
+        sbom_data = self._create_base_spdx_sbom()
+        del sbom_data["packages"][0]["checksums"]
+
+        result = self._assess_sbom(sbom_data)
+
+        hash_finding = next(f for f in result.findings if "component-hash" in f.id)
+        assert hash_finding.status == "fail"
+
+    def test_spdx_missing_license(self) -> None:
+        """Test SPDX SBOM missing license."""
+        sbom_data = self._create_base_spdx_sbom()
+        del sbom_data["packages"][0]["licenseConcluded"]
+
+        result = self._assess_sbom(sbom_data)
+
+        license_finding = next(f for f in result.findings if f.id == "cisa-2025:license")
+        assert license_finding.status == "fail"
+
+    def test_spdx_with_license_declared(self) -> None:
+        """Test SPDX SBOM with licenseDeclared instead of licenseConcluded."""
+        sbom_data = self._create_base_spdx_sbom()
+        del sbom_data["packages"][0]["licenseConcluded"]
+        sbom_data["packages"][0]["licenseDeclared"] = "Apache-2.0"
+
+        result = self._assess_sbom(sbom_data)
+
+        license_finding = next(f for f in result.findings if f.id == "cisa-2025:license")
+        assert license_finding.status == "pass"
+
+    def test_spdx_noassertion_license_passes(self) -> None:
+        """Test SPDX SBOM with NOASSERTION license passes validation.
+
+        CISA says: "If the SBOM author is not aware of the license information,
+        then the SBOM author should indicate that license information is unknown."
+        NOASSERTION explicitly indicates unknown license, so it should pass.
+        """
+        sbom_data = self._create_base_spdx_sbom()
+        sbom_data["packages"][0]["licenseConcluded"] = "NOASSERTION"
+
+        result = self._assess_sbom(sbom_data)
+
+        license_finding = next(f for f in result.findings if f.id == "cisa-2025:license")
+        assert license_finding.status == "pass"
+
+    def test_spdx_missing_tool_name(self) -> None:
+        """Test SPDX SBOM missing Tool: entry in creators."""
+        sbom_data = self._create_base_spdx_sbom()
+        sbom_data["creationInfo"]["creators"] = ["Person: Developer"]
+
+        result = self._assess_sbom(sbom_data)
+
+        tool_finding = next(f for f in result.findings if "tool-name" in f.id)
+        assert tool_finding.status == "fail"
+
+    def test_spdx_missing_generation_context(self) -> None:
+        """Test SPDX SBOM missing generation context annotation."""
+        sbom_data = self._create_base_spdx_sbom()
+        del sbom_data["annotations"]
+
+        result = self._assess_sbom(sbom_data)
+
+        context_finding = next(f for f in result.findings if "generation-context" in f.id)
+        assert context_finding.status == "fail"
+
+    def test_spdx_with_contains_relationship(self) -> None:
+        """Test SPDX SBOM with CONTAINS relationship."""
+        sbom_data = self._create_base_spdx_sbom()
+        sbom_data["relationships"][0]["relationshipType"] = "CONTAINS"
+
+        result = self._assess_sbom(sbom_data)
+
+        dep_finding = next(f for f in result.findings if "dependency-relationship" in f.id)
+        assert dep_finding.status == "pass"
+
+    def test_spdx_with_descendant_of_relationship(self) -> None:
+        """Test SPDX SBOM with DESCENDANT_OF relationship (for forks/backports)."""
+        sbom_data = self._create_base_spdx_sbom()
+        sbom_data["relationships"][0]["relationshipType"] = "DESCENDANT_OF"
+
+        result = self._assess_sbom(sbom_data)
+
+        dep_finding = next(f for f in result.findings if "dependency-relationship" in f.id)
+        assert dep_finding.status == "pass"
+
+    def test_spdx_invalid_timestamp_format(self) -> None:
+        """Test SPDX SBOM with invalid timestamp format."""
+        sbom_data = self._create_base_spdx_sbom()
+        sbom_data["creationInfo"]["created"] = "invalid-timestamp"
+
+        result = self._assess_sbom(sbom_data)
+
+        timestamp_finding = next(f for f in result.findings if "timestamp" in f.id)
+        assert timestamp_finding.status == "fail"
+
+    def test_spdx_generation_context_values(self) -> None:
+        """Test all valid generation context values in SPDX."""
+        valid_contexts = ["before_build", "build", "post_build", "source", "analyzed"]
+
+        for context in valid_contexts:
+            sbom_data = self._create_base_spdx_sbom()
+            sbom_data["annotations"][0]["comment"] = f"cisa:generationContext={context}"
+
+            result = self._assess_sbom(sbom_data)
+
+            context_finding = next(f for f in result.findings if "generation-context" in f.id)
+            assert context_finding.status == "pass", f"Context '{context}' should be valid"
+
+    def _create_base_spdx_sbom(self) -> dict:
+        """Create a base compliant SPDX SBOM for testing."""
+        return {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package",
+                    "name": "example-package",
+                    "supplier": "Organization: Example Corp",
+                    "versionInfo": "1.0.0",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/example-package@1.0.0",
+                        }
+                    ],
+                    "checksums": [{"algorithm": "SHA256", "checksumValue": "abc123def456"}],
+                    "licenseConcluded": "MIT",
+                }
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DEPENDS_ON",
+                    "relatedSpdxElement": "SPDXRef-Package",
+                }
+            ],
+            "creationInfo": {
+                "creators": ["Tool: example-tool (1.0.0)", "Person: Developer"],
+                "created": "2023-01-01T00:00:00Z",
+            },
+            "annotations": [
+                {
+                    "annotationType": "OTHER",
+                    "comment": "cisa:generationContext=build",
+                    "annotator": "Tool: example-tool",
+                    "annotationDate": "2023-01-01T00:00:00Z",
+                }
+            ],
+        }
+
+    def _assess_sbom(self, sbom_data: dict) -> AssessmentResult:
+        """Helper to write SBOM to temp file and assess it."""
+        plugin = CISAMinimumElementsPlugin()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            return plugin.assess("test-sbom-id", Path(f.name))
+
+
+class TestErrorHandling:
+    """Tests for error handling in the plugin."""
+
+    def test_invalid_json(self) -> None:
+        """Test handling of invalid JSON file."""
+        plugin = CISAMinimumElementsPlugin()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{ invalid json }")
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.summary.error_count == 1
+        assert result.metadata.get("error") is True
+
+    def test_unknown_format(self) -> None:
+        """Test handling of unknown SBOM format."""
+        plugin = CISAMinimumElementsPlugin()
+        sbom_data = {"some": "data", "without": "format indicators"}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.summary.error_count == 1
+        assert "format" in result.findings[0].description.lower()
+
+    def test_empty_components(self) -> None:
+        """Test handling of SBOM with empty components list."""
+        plugin = CISAMinimumElementsPlugin()
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [],
+            "dependencies": [],
+            "metadata": {
+                "authors": [{"name": "Example Developer"}],
+                "tools": [{"name": "sbom-generator"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        # With empty components, per-component checks pass (nothing to fail)
+        # but dependencies should fail
+        dep_finding = next(f for f in result.findings if "dependency" in f.id)
+        assert dep_finding.status == "fail"
+
+
+class TestFindingDetails:
+    """Tests for finding details and remediation suggestions."""
+
+    def test_findings_have_remediation(self) -> None:
+        """Test that failed findings include remediation suggestions."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [{"name": "example"}],  # Missing most required fields
+            "metadata": {},
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        for finding in result.findings:
+            if finding.status == "fail":
+                assert finding.remediation is not None, f"Finding {finding.id} should have remediation"
+
+    def test_findings_have_standard_metadata(self) -> None:
+        """Test that findings include standard version metadata."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example",
+                    "version": "1.0.0",
+                    "publisher": "Example",
+                    "purl": "pkg:npm/example@1.0.0",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123"}],
+                    "licenses": [{"license": {"id": "MIT"}}],
+                }
+            ],
+            "dependencies": [{"ref": "pkg:npm/example@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Author"}],
+                "tools": [{"name": "tool"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        for finding in result.findings:
+            assert finding.metadata is not None
+            assert finding.metadata.get("standard") == "CISA"
+            assert finding.metadata.get("standard_version") == "2025-08-draft"
+
+    def test_result_includes_standard_info(self) -> None:
+        """Test that assessment result includes standard reference information."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [],
+            "metadata": {"timestamp": "2023-01-01T00:00:00Z"},
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.metadata["standard_name"] == plugin.STANDARD_NAME
+        assert result.metadata["standard_version"] == plugin.STANDARD_VERSION
+        assert result.metadata["standard_url"] == plugin.STANDARD_URL
+
+
+class TestMultipleComponentFailures:
+    """Tests for handling multiple component failures."""
+
+    def test_multiple_components_missing_fields(self) -> None:
+        """Test SBOM with multiple components missing various fields."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {"name": "comp1"},  # Missing version, producer, hash, license, identifier
+                {"name": "comp2", "version": "1.0"},  # Missing producer, hash, license, identifier
+                {"name": "comp3", "version": "1.0", "publisher": "Pub"},  # Missing hash, license, identifier
+            ],
+            "dependencies": [{"ref": "comp1", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Author"}],
+                "tools": [{"name": "tool"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        # Check that failures are reported for components
+        producer_finding = next(f for f in result.findings if "software-producer" in f.id)
+        assert producer_finding.status == "fail"
+        assert "comp1" in producer_finding.description
+        assert "comp2" in producer_finding.description
+
+        version_finding = next(f for f in result.findings if "component-version" in f.id)
+        assert version_finding.status == "fail"
+        assert "comp1" in version_finding.description
+
+    def test_failure_message_truncation(self) -> None:
+        """Test that failure messages are truncated when many components fail."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [{"name": f"comp{i}"} for i in range(10)],  # 10 components, all missing fields
+            "dependencies": [{"ref": "comp0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Author"}],
+                "tools": [{"name": "tool"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [{"name": "cdx:sbom:generationContext", "value": "build"}],
+            },
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        # Check that failure message indicates "and X more"
+        producer_finding = next(f for f in result.findings if "software-producer" in f.id)
+        assert "and 5 more" in producer_finding.description
+
+
+class TestFormatDetection:
+    """Tests for SBOM format detection."""
+
+    def test_detect_cyclonedx_with_bomformat(self) -> None:
+        """Test detection of CycloneDX format via bomFormat field."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [],
+            "metadata": {"timestamp": "2023-01-01T00:00:00Z"},
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.metadata["sbom_format"] == "cyclonedx"
+
+    def test_detect_cyclonedx_without_bomformat(self) -> None:
+        """Test detection of CycloneDX format without explicit bomFormat."""
+        sbom_data = {
+            "specVersion": "1.5",
+            "components": [],
+            "metadata": {"timestamp": "2023-01-01T00:00:00Z"},
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.metadata["sbom_format"] == "cyclonedx"
+
+    def test_detect_spdx_format(self) -> None:
+        """Test detection of SPDX format."""
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [],
+            "creationInfo": {"created": "2023-01-01T00:00:00Z"},
+        }
+
+        plugin = CISAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test-sbom-id", Path(f.name))
+
+        assert result.metadata["sbom_format"] == "spdx"

--- a/sbomify/apps/plugins/tests/test_models.py
+++ b/sbomify/apps/plugins/tests/test_models.py
@@ -171,6 +171,21 @@ class TestTeamPluginSettings:
 
         assert config == {}
 
+    def test_plugins_disabled_by_default(self, test_team: Team) -> None:
+        """Test that all plugins are disabled by default when TeamPluginSettings is created.
+
+        This ensures teams must explicitly opt-in to enable plugins.
+        """
+        # Create settings with defaults (simulating get_or_create behavior)
+        settings = TeamPluginSettings.objects.create(team=test_team)
+
+        # Verify no plugins are enabled by default
+        assert settings.enabled_plugins == []
+        assert settings.is_plugin_enabled("ntia-minimum-elements-2021") is False
+        assert settings.is_plugin_enabled("cisa-minimum-elements-2025") is False
+        assert settings.is_plugin_enabled("checksum") is False
+        assert settings.is_plugin_enabled("fda-medical-device-2025") is False
+
 
 @pytest.mark.django_db
 class TestAssessmentRun:
@@ -279,4 +294,3 @@ class TestAssessmentRun:
         )
 
         assert run.is_successful is False
-


### PR DESCRIPTION
Implement a new plugin to validate SBOMs against the CISA 2025 Minimum Elements for a Software Bill of Materials (August 2025 Public Comment Draft).

The plugin validates all 11 required data fields:
- SBOM Author, Software Producer, Component Name/Version
- Software Identifiers, Component Hash (new), License (new)
- Dependency Relationship, Tool Name (new), Timestamp
- Generation Context (new)

Key implementation details:
- Supports both CycloneDX and SPDX formats
- NOASSERTION accepted for SPDX licenses (indicates unknown)
- Generation context accepts official terms and common synonyms
- Clearly annotated as PUBLIC COMMENT DRAFT throughout

Also includes:
- 44 unit tests covering all validation scenarios
- 8 integration tests for workflow and API compatibility
- Test verifying plugins are disabled by default for new teams
- README documentation with draft status notice
