### PR TITLE
Fix barcode rendering on private product identifiers page

### DIFF
--- a/sbomify/apps/core/templates/core/components/product_identifiers_card.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_identifiers_card.html.j2
@@ -52,7 +52,7 @@
                                         <div class="barcode-wrapper"
                                              x-data="productIdentifiersBarcodes()"
                                              x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value }}', '{{ identifier.identifier_type }}')">
-                                            <svg :id="'barcode-' + '{{ identifier.id }}'" class="barcode-svg">
+                                            <svg data-barcode-id="{{ identifier.id }}" class="barcode-svg">
                                             </svg>
                                             <template x-if="barcodeErrors['{{ identifier.id }}']">
                                                 <div class="barcode-error-state">


### PR DESCRIPTION
The SVG element used :id attribute instead of data-barcode-id, causing the renderBarcode function to fail finding the element. The public page worked because it correctly used data-barcode-id.
