### PR TITLE
Fix GitLab/Bitbucket script path to use sbomify-action

### DIFF
--- a/sbomify/apps/sboms/js/ci-cd-info.spec.ts
+++ b/sbomify/apps/sboms/js/ci-cd-info.spec.ts
@@ -231,7 +231,7 @@ describe('CI/CD Info Business Logic', () => {
             if (config.enrich) lines.push('    ENRICH: true')
             if (config.outputFile) lines.push('    OUTPUT_FILE: sbom.cdx.json')
 
-            lines.push('  script:', '    - /sbomify.sh')
+            lines.push('  script:', '    - sbomify-action')
 
             return lines.join('\n')
         }
@@ -246,7 +246,7 @@ describe('CI/CD Info Business Logic', () => {
             expect(yaml).toContain('image: sbomifyhub/sbomify-action')
             expect(yaml).toContain(`COMPONENT_ID: '${testComponentId}'`)
             expect(yaml).toContain("LOCK_FILE: 'poetry.lock'")
-            expect(yaml).toContain('/sbomify.sh')
+            expect(yaml).toContain('sbomify-action')
         })
 
         test('should add Docker-in-Docker services for docker source', () => {
@@ -284,7 +284,7 @@ describe('CI/CD Info Business Logic', () => {
             }
 
             lines.push('        script:',
-                '          - /sbomify.sh',
+                '          - sbomify-action',
                 '        env:',
                 `          TOKEN: $SBOMIFY_TOKEN`,
                 `          COMPONENT_ID: '${componentId}'`,

--- a/sbomify/apps/sboms/js/ci-cd-info.ts
+++ b/sbomify/apps/sboms/js/ci-cd-info.ts
@@ -194,7 +194,7 @@ export function registerCiCdInfo() {
             if (this.config.enrich) lines.push('    ENRICH: true');
             if (this.config.outputFile) lines.push('    OUTPUT_FILE: sbom.cdx.json');
 
-            lines.push('  script:', '    - /sbomify.sh');
+            lines.push('  script:', '    - sbomify-action');
 
             return lines.join('\n');
         },
@@ -215,7 +215,7 @@ export function registerCiCdInfo() {
             }
 
             lines.push('        script:',
-                '          - /sbomify.sh',
+                '          - sbomify-action',
                 '        env:',
                 `          TOKEN: $SBOMIFY_TOKEN`,
                 `          COMPONENT_ID: '${this.componentId}'`,


### PR DESCRIPTION
The README documentation was outdated - neither /sbomify.sh nor /entrypoint.sh exist in the Docker container. The actual command is sbomify-action which is the container's default CMD.

Verified by testing against sbomifyhub/sbomify-action:latest.
