### PR TITLE
Add DCV delegation CNAME instructions to custom domain setup

### DIFF
--- a/sbomify/apps/teams/templates/teams/team_custom_domain.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_custom_domain.html.j2
@@ -129,7 +129,7 @@
                             </div>
                             <div class="dns-record-item">
                                 <span class="dns-record-label">Target:</span>
-                                <code class="dns-record-value">{{ dcv_hostname }}</code>
+                                <code class="dns-record-value"><span x-text="localDomain || 'trust.example.com'"></span>.{{ dcv_hostname }}</code>
                             </div>
                         </div>
                         <p class="dns-instructions-note mt-2 mb-0">

--- a/sbomify/apps/teams/tests/test_custom_domain_ui.py
+++ b/sbomify/apps/teams/tests/test_custom_domain_ui.py
@@ -230,8 +230,8 @@ class TestTeamBrandingViewCustomDomain:
         assert response.status_code == 200
 
         content = response.content.decode()
-        # Check DCV hostname appears in the instructions
-        assert "abc123.dcv.cloudflare.com" in content
+        # Check DCV hostname appears in the instructions (target is <domain>.<dcv_hostname>)
+        assert ".abc123.dcv.cloudflare.com" in content
         # Check _acme-challenge prefix is shown
         assert "_acme-challenge." in content
         # Check the DCV section title is present
@@ -271,7 +271,7 @@ class TestTeamBrandingViewCustomDomain:
         # Check both record titles are present
         assert "1. Domain CNAME Record" in content
         assert "2. SSL Certificate CNAME Record" in content
-        # Check both targets are present
+        # Check both targets are present (DCV target is <domain>.<dcv_hostname>)
         assert "app.sbomify.io" in content
-        assert "test.dcv.cloudflare.com" in content
+        assert ".test.dcv.cloudflare.com" in content
 


### PR DESCRIPTION
Add support for displaying a second CNAME record for Cloudflare's DCV (Domain Control Validation) delegation in the trust center custom domain configuration. This enables automated SSL certificate issuance and renewal for custom hostnames without manual TXT token placement.

DNS records displayed:
1. Domain CNAME: <custom-domain> -> app hostname
2. DCV CNAME: _acme-challenge.<custom-domain> -> <custom-domain>.<dcv-uuid>.dcv.cloudflare.com

The DCV instructions only appear when CLOUDFLARE_DCV_HOSTNAME environment variable is configured with the account-specific DCV delegation hostname.
