### PR TITLE
Fix GitHub attestation verification for URLs with commit refs

### DIFF
--- a/sbomify/apps/plugins/builtins/github_attestation.py
+++ b/sbomify/apps/plugins/builtins/github_attestation.py
@@ -572,7 +572,7 @@ class GitHubAttestationPlugin(AssessmentPlugin):
             raise GitHubAttestationError("cosign binary not found. Please ensure cosign is installed.")
 
         # Build cosign verify-blob-attestation command
-        # --new-bundle-format is required for Sigstore bundle v0.2+ (GitHub uses v0.3)
+        # --new-bundle-format is required for Sigstore bundle v0.3 (used by GitHub)
         cmd = [
             cosign_path,
             "verify-blob-attestation",

--- a/sbomify/apps/plugins/tests/test_github_attestation_plugin.py
+++ b/sbomify/apps/plugins/tests/test_github_attestation_plugin.py
@@ -555,7 +555,7 @@ class TestCosignVerification:
         call_args = mock_run.call_args[0][0]
         assert "verify-blob-attestation" in call_args
         assert "--bundle" in call_args
-        assert "--new-bundle-format" in call_args  # Required for Sigstore bundle v0.2+ (GitHub uses v0.3)
+        assert "--new-bundle-format" in call_args  # Required for Sigstore bundle v0.3 (used by GitHub)
         assert "/tmp/bundle.jsonl" in call_args
         assert "/tmp/sbom.json" in call_args
 


### PR DESCRIPTION
Two bugs prevented attestation verification from working:

1. VCS URLs containing commit references (e.g., github.com/org/repo@abc123) were parsed incorrectly, including the hash as part of the repo name. This caused GitHub API calls to fail with 404 errors.

2. GitHub's attestation bundles use Sigstore bundle format v0.3, which requires the --new-bundle-format flag for cosign verification. Without this flag, cosign fails with "bundle does not contain cert".

Changes:
- Strip @commit_hash suffix from repo names in _parse_github_url
- Add --new-bundle-format flag to cosign verify-blob-attestation
- Add test cases for URL parsing with commit/tag references
- Add test assertion for --new-bundle-format flag
