### PR TITLE
fix: verify SBOM exists before creating assessment run

### DIFF
--- a/sbomify/apps/plugins/orchestrator.py
+++ b/sbomify/apps/plugins/orchestrator.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from django.utils import timezone
 
+from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.sboms.utils import SBOMDataError, get_sbom_data_bytes
 from sbomify.logging import getLogger
 
@@ -89,8 +90,6 @@ class PluginOrchestrator:
                 other orchestration errors occur.
         """
         # Verify SBOM exists before creating the run
-        from sbomify.apps.sboms.models import SBOM
-
         if not SBOM.objects.filter(id=sbom_id).exists():
             raise PluginOrchestratorError(f"SBOM '{sbom_id}' not found - it may have been deleted")
 

--- a/sbomify/apps/plugins/tests/test_orchestrator.py
+++ b/sbomify/apps/plugins/tests/test_orchestrator.py
@@ -169,6 +169,25 @@ class TestPluginOrchestrator:
         assert run.started_at is not None
         assert run.completed_at is not None
 
+    def test_run_assessment_sbom_not_found(self, db) -> None:
+        """Test error when SBOM does not exist in database."""
+        orchestrator = PluginOrchestrator()
+        plugin = MockPlugin()
+
+        non_existent_sbom_id = "nonexistent123"
+
+        with pytest.raises(PluginOrchestratorError) as exc_info:
+            orchestrator.run_assessment(
+                sbom_id=non_existent_sbom_id,
+                plugin=plugin,
+                run_reason=RunReason.ON_UPLOAD,
+            )
+
+        assert "not found" in str(exc_info.value).lower()
+        assert non_existent_sbom_id in str(exc_info.value)
+        # Verify no AssessmentRun was created
+        assert AssessmentRun.objects.filter(sbom_id=non_existent_sbom_id).count() == 0
+
     def test_run_assessment_sbom_fetch_error(self, test_sbom, mocker) -> None:
         """Test handling of SBOM fetch error."""
         mocker.patch(


### PR DESCRIPTION
Add validation to check if SBOM exists before attempting to create an assessment run. This prevents errors when SBOMs are deleted while assessments are being processed.