### PR TITLE
Release v0.25.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbomify"
-version = "0.25"
+version = "0.25.1"
 description = "sbomify - the security artifact hub"
 authors = [{ name = "sbomify", email = "hello@sbomify.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2727,7 +2727,7 @@ wheels = [
 
 [[package]]
 name = "sbomify"
-version = "0.25"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bug fixes:
- Fix social banner URLs for public Trust Center pages
- Fix SPDX SBOMs not being tagged to releases
- Fix missing component context in component item view
- Fix social cards with proper 1200x630 image and meta tags
- Fix admin dashboard sidebar being pushed down
- Fix plugin enable to not queue all historical SBOMs and block web server

Improvements:
- Comprehensive Django admin theme matching webapp design system
- Simplify admin theme with color overrides only, preserve original sizing
- Reduce admin table and header sizes for better density
- Fix dashboard paying teams count and restyle admin to match webapp
- Simplify footer by removing version badges and moving build info to HTML comment
- Enhance billing processing and webhook handling for Stripe events
- Refactor webhook ID generation in subscription deletion handling
- Address PR review feedback for plugin queue optimization

Files changed: 30 files, +1755/-577 lines
