### PR TITLE
Add error_code to duplicate SBOM 409 responses

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
 from sbomify.apps.core.apis import get_component_metadata, patch_component_metadata
 from sbomify.apps.core.object_store import S3Client
-from sbomify.apps.core.schemas import ErrorResponse
+from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.core.services.access_control import check_component_access
 from sbomify.apps.core.utils import ExtractSpec, build_entity_info_dict, dict_update, obj_extract, verify_item_access
 from sbomify.apps.sboms.utils import verify_download_token
@@ -202,7 +202,8 @@ def sbom_upload_cyclonedx(
         if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
             return 409, {
                 "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
-                "already exists for this component"
+                "already exists for this component",
+                "error_code": ErrorCode.DUPLICATE_ARTIFACT,
             }
 
         s3 = S3Client("SBOMS")
@@ -317,7 +318,8 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str):
         if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
             return 409, {
                 "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
-                "already exists for this component"
+                "already exists for this component",
+                "error_code": ErrorCode.DUPLICATE_ARTIFACT,
             }
 
         s3 = S3Client("SBOMS")
@@ -699,7 +701,8 @@ def sbom_upload_file(
             if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
                 return 409, {
                     "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
-                    "already exists for this component"
+                    "already exists for this component",
+                    "error_code": ErrorCode.DUPLICATE_ARTIFACT,
                 }
 
             s3 = S3Client("SBOMS")
@@ -746,7 +749,8 @@ def sbom_upload_file(
             if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
                 return 409, {
                     "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
-                    "already exists for this component"
+                    "already exists for this component",
+                    "error_code": ErrorCode.DUPLICATE_ARTIFACT,
                 }
 
             s3 = S3Client("SBOMS")

--- a/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
+++ b/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
@@ -69,6 +69,7 @@ class TestSBOMUniquenessConstraintCycloneDX:
         assert "already exists" in response.json()["detail"]
         assert "1.0.0" in response.json()["detail"]
         assert "cyclonedx" in response.json()["detail"]
+        assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
         # Verify only one SBOM was created
         assert SBOM.objects.count() == 1
@@ -250,6 +251,7 @@ class TestSBOMUniquenessConstraintSPDX:
         assert "already exists" in response.json()["detail"]
         assert "1.0.0" in response.json()["detail"]
         assert "spdx" in response.json()["detail"]
+        assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
     @pytest.mark.django_db
     def test_different_version_succeeds(
@@ -547,6 +549,7 @@ class TestSBOMUniquenessConstraintFileUpload:
         )
         assert response.status_code == 409
         assert "already exists" in response.json()["detail"]
+        assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
     @pytest.mark.django_db
     def test_spdx_duplicate_returns_409(
@@ -606,6 +609,7 @@ class TestSBOMUniquenessConstraintFileUpload:
         )
         assert response.status_code == 409
         assert "already exists" in response.json()["detail"]
+        assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
 
 class TestSBOMUniquenessConstraintErrorHandling:
@@ -655,6 +659,7 @@ class TestSBOMUniquenessConstraintErrorHandling:
         assert "5.2.1" in error_detail
         assert "cyclonedx" in error_detail
         assert "already exists" in error_detail
+        assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
     @pytest.mark.django_db
     def test_duplicate_does_not_upload_to_s3(


### PR DESCRIPTION
The GitHub action expects 409 responses to include "error_code": "DUPLICATE_ARTIFACT" to display a user-friendly error panel. This was missing from the SBOM upload endpoints.

Added error_code to all 4 duplicate SBOM detection points:
- CycloneDX upload endpoint
- SPDX upload endpoint
- File upload (SPDX detection)
- File upload (CycloneDX detection)
