### PR TITLE
Add Sentry release and environment tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ SECRET_KEY=change-me-in-production
 DEBUG=True
 LOG_LEVEL=DEBUG
 
+# Sentry Error Tracking
+# SENTRY_DSN=https://your-dsn@sentry.io/project
+# SENTRY_ENVIRONMENT=development  # Options: development, staging, production
+
 # Auth0 settings
 SOCIAL_AUTH_AUTH0_DOMAIN=your-domain.auth0.com
 SOCIAL_AUTH_AUTH0_KEY=your-auth0-key

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -22,6 +22,8 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
+from sbomify.apps.plugins.utils import get_sbomify_version
+
 ENV_FILE = find_dotenv()
 if ENV_FILE:
     load_dotenv(ENV_FILE)
@@ -581,6 +583,8 @@ def _sentry_traces_sampler(sampling_context: dict) -> float:
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
+    release=get_sbomify_version(),
+    environment=os.environ.get("SENTRY_ENVIRONMENT", "development"),
     integrations=[
         DjangoIntegration(),
         DramatiqIntegration(),


### PR DESCRIPTION
Configure sentry_sdk.init() with release and environment parameters to enable tracking errors by version and deployment environment in the Sentry dashboard.

- Use get_sbomify_version() for release tagging (supports package metadata, CI build env vars, and git commit fallbacks)
- Add SENTRY_ENVIRONMENT config with "development" default
- Document Sentry env vars in .env.example

