### PR TITLE
Add Sentry error tracking to frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ LOG_LEVEL=DEBUG
 
 # Sentry Error Tracking
 # SENTRY_DSN=https://your-dsn@sentry.io/project
+# SENTRY_DSN_FRONTEND=https://your-frontend-dsn@sentry.io/project
 # SENTRY_ENVIRONMENT=development  # Options: development, staging, production
 
 # Auth0 settings

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@alpinejs/persist": "^3.15.4",
         "@fortawesome/fontawesome-free": "^7.1.0",
         "@mdi/font": "^7.4.47",
+        "@sentry/browser": "^10.36.0",
         "@types/bun": "^1.3.2",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^25.0.0",
@@ -402,6 +403,18 @@
     "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.45.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.45.1", "", { "os": "win32", "cpu": "x64" }, "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA=="],
+
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.36.0", "", { "dependencies": { "@sentry/core": "10.36.0" } }, "sha512-WILVR8HQBWOxbqLRuTxjzRCMIACGsDTo6jXvzA8rz6ezElElLmIrn3CFAswrESLqEEUa4CQHl5bLgSVJCRNweA=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.36.0", "", { "dependencies": { "@sentry/core": "10.36.0" } }, "sha512-zPjz7AbcxEyx8AHj8xvp28fYtPTPWU1XcNtymhAHJLS9CXOblqSC7W02Jxz6eo3eR1/pLyOo6kJBUjvLe9EoFA=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.36.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.36.0", "@sentry/core": "10.36.0" } }, "sha512-nLMkJgvHq+uCCrQKV2KgSdVHxTsmDk0r2hsAoTcKCbzUpXyW5UhCziMRS6ULjBlzt5sbxoIIplE25ZpmIEeNgg=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.36.0", "", { "dependencies": { "@sentry-internal/replay": "10.36.0", "@sentry/core": "10.36.0" } }, "sha512-DLGIwmT2LX+O6TyYPtOQL5GiTm2rN0taJPDJ/Lzg2KEJZrdd5sKkzTckhh2x+vr4JQyeaLmnb8M40Ch1hvG/vQ=="],
+
+    "@sentry/browser": ["@sentry/browser@10.36.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.36.0", "@sentry-internal/feedback": "10.36.0", "@sentry-internal/replay": "10.36.0", "@sentry-internal/replay-canvas": "10.36.0", "@sentry/core": "10.36.0" } }, "sha512-yHhXbgdGY1s+m8CdILC9U/II7gb6+s99S2Eh8VneEn/JG9wHc+UOzrQCeFN0phFP51QbLkjkiQbbanjT1HP8UQ=="],
+
+    "@sentry/core": ["@sentry/core@10.36.0", "", {}, "sha512-EYJjZvofI+D93eUsPLDIUV0zQocYqiBRyXS6CCV6dHz64P/Hob5NJQOwPa8/v6nD+UvJXvwsFfvXOHhYZhZJOQ=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@alpinejs/persist": "^3.15.4",
     "@fortawesome/fontawesome-free": "^7.1.0",
     "@mdi/font": "^7.4.47",
+    "@sentry/browser": "^10.36.0",
     "@types/bun": "^1.3.2",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^25.0.0",

--- a/sbomify/apps/core/context_processors.py
+++ b/sbomify/apps/core/context_processors.py
@@ -222,3 +222,17 @@ def team_context(request):
     except Exception:
         # Fail silently to avoid crashing unrelated pages if session is stale
         return {}
+
+
+def sentry_context(request):
+    """Add Sentry configuration for frontend.
+
+    Provides the DSN and version for frontend Sentry initialization.
+    The DSN is injected at runtime so the same Docker image works across environments.
+    """
+    from sbomify.apps.plugins.utils import get_sbomify_version
+
+    return {
+        "sentry_dsn_frontend": os.environ.get("SENTRY_DSN_FRONTEND", ""),
+        "sbomify_version": get_sbomify_version(),
+    }

--- a/sbomify/apps/core/js/main.ts
+++ b/sbomify/apps/core/js/main.ts
@@ -1,3 +1,7 @@
+// Sentry must be initialized first
+import { initSentry } from './sentry';
+initSentry();
+
 import 'vite/modulepreload-polyfill';
 import './layout-interactions';
 import './navbar-search';

--- a/sbomify/apps/core/js/sentry.ts
+++ b/sbomify/apps/core/js/sentry.ts
@@ -1,0 +1,26 @@
+import * as Sentry from "@sentry/browser";
+
+declare global {
+  interface Window {
+    __SENTRY_CONFIG__?: {
+      dsn: string;
+      release: string;
+    };
+  }
+}
+
+export function initSentry(): void {
+  const config = window.__SENTRY_CONFIG__;
+
+  if (!config?.dsn) {
+    return; // Sentry disabled if no DSN provided
+  }
+
+  Sentry.init({
+    dsn: config.dsn,
+    release: config.release || undefined,
+    sendDefaultPii: true,
+  });
+}
+
+export { Sentry };

--- a/sbomify/apps/core/templates/core/base.html.j2
+++ b/sbomify/apps/core/templates/core/base.html.j2
@@ -91,6 +91,13 @@
         <!-- HTMX Alpine-Morph Extension -->
         <!-- TODO: Self-host this script or add SRI hash for security -->
         <script src="https://unpkg.com/htmx-ext-alpine-morph@2.0.0/alpine-morph.js"></script>
+        <!-- Sentry configuration (injected at runtime) -->
+        <script>
+            window.__SENTRY_CONFIG__ = {
+                dsn: "{{ sentry_dsn_frontend }}",
+                release: "{{ sbomify_version }}"
+            };
+        </script>
         {% vite_asset 'sbomify/apps/core/js/main.ts' %}
     </body>
 </html>

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -203,6 +203,7 @@ TEMPLATES = [
                 "sbomify.apps.core.context_processors.pending_access_requests_context",
                 "sbomify.apps.core.context_processors.global_modals_context",
                 "sbomify.apps.core.context_processors.team_context",
+                "sbomify.apps.core.context_processors.sentry_context",
             ],
         },
     },


### PR DESCRIPTION
Integrate @sentry/browser for frontend error tracking with runtime configuration injection via Django templates. This allows the same Docker image to work across environments with different Sentry DSNs.

- Add @sentry/browser dependency
- Create sentry.ts initialization module
- Add sentry_context processor exposing SENTRY_DSN_FRONTEND
- Inject config via base.html.j2 before main.ts loads
- Gracefully disable when DSN not configured
- Add tests for context processor
