### PR TITLE
Add graceful shutdown for zero-downtime deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,7 +242,11 @@ USER nobody
 
 EXPOSE 8000
 # CMD for Production - Using Gunicorn with Uvicorn worker as recommended by Django docs
+# --graceful-timeout 30: Workers get 30s to finish requests on SIGTERM
+# --timeout 120: Max time for a single request (2 min for large SBOM uploads)
 CMD ["uv", "run", "gunicorn", "sbomify.asgi:application", \
      "--bind", "0.0.0.0:8000", \
      "--workers", "2", \
-     "--worker-class", "uvicorn_worker.UvicornWorker"]
+     "--worker-class", "uvicorn_worker.UvicornWorker", \
+     "--graceful-timeout", "30", \
+     "--timeout", "120"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,13 @@ services:
         condition: service_healthy
       sbomify-migrations:
         condition: service_completed_successfully
+    stop_grace_period: 30s
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/UuPha8mu/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   sbomify-caddy:
     image: ${CADDY_IMAGE:-caddy:2-alpine}
@@ -110,6 +117,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    stop_grace_period: 10s
 
   sbomify-migrations:
     image: ${SBOMIFY_IMAGE:-sbomifyhub/sbomify}:${SBOMIFY_TAG:-latest}
@@ -156,6 +164,7 @@ services:
         condition: service_healthy
       sbomify-db:
         condition: service_healthy
+    stop_grace_period: 30s
 
 volumes:
   sbomify_postgres_data:


### PR DESCRIPTION
- Add stop_grace_period to backend (30s), worker (30s), and caddy (10s)
- Add health check to backend using /UuPha8mu/ endpoint
- Add Gunicorn graceful-timeout (30s) and timeout (120s) flags
- Replace --force-recreate with rolling update strategy in deploy.sh
- Keep Redis/DB running during deployments (--no-recreate)
- Update app services in order: migrations → backend/worker → caddy

Fixes 502 errors during deployments caused by Redis being killed mid-connection.