### PR TITLE
Fix BrandingInfo validation error for null prefer_logo_over_icon

### DIFF
--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -103,6 +103,8 @@ def _normalize_branding_payload(branding: dict | None) -> dict:
     from sbomify.apps.teams.branding import DEFAULT_ACCENT_COLOR, DEFAULT_BRAND_COLOR
 
     data = (branding or {}).copy()
+    # Strip None values so Pydantic schema defaults apply
+    data = {k: v for k, v in data.items() if v is not None}
     # Apply defaults for empty or invalid color values
     # Empty strings or legacy #000000 values should use platform defaults
     if not data.get("brand_color"):


### PR DESCRIPTION
## Summary
- Strip `None` values from branding payload in `_normalize_branding_payload` before passing to Pydantic's `BrandingInfo` schema
- Fixes crash when `prefer_logo_over_icon` (or any other field) is stored as `null` in the `branding_info` JSON — Pydantic's `bool` type rejects `None`, but stripping it lets the field default (`False`) apply instead

## Test plan
- [x] All 32 branding-related tests pass
- [ ] Manually verify `/workspaces/{key}/branding` for a workspace with `prefer_logo_over_icon: null` in stored JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)