### PR TITLE
Add beta badge to TEA section in settings

### DIFF
--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -96,7 +96,12 @@
                     <i class="fas {% if team_obj.tea_enabled %}fa-exchange-alt text-success{% else %}fa-exchange-alt text-text-muted{% endif %}"></i>
                 </div>
                 <div>
-                    <h5 class="text-lg font-semibold text-text m-0">Transparency Exchange API (TEA)</h5>
+                    <h5 class="text-lg font-semibold text-text m-0">
+                        Transparency Exchange API (TEA)
+                        <span class="tw-badge-info text-xs align-middle ml-2">
+                            <i class="fas fa-flask mr-1"></i>Beta
+                        </span>
+                    </h5>
                     <p class="text-text-muted text-sm m-0">Standardized access to software transparency information</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Adds a "Beta" badge next to the TEA (Transparency Exchange API) heading in the Trust Center tab of workspace settings
- Uses the same `tw-badge-info` + `fa-flask` icon pattern already used for beta plugins in the plugins settings page

## Test plan
- [x] Navigate to Workspace Settings > Trust Center
- [x] Verify the "Beta" badge appears next to the "Transparency Exchange API (TEA)" heading
- [x] Verify it renders correctly in both light and dark mode
- [x] Verify it doesn't interfere with the TEA enable/disable toggle

