### PR TITLE
Fix releases table artifact count always showing 0

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3188,8 +3188,6 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
             "slug": release.product.slug,
         },
         "has_crud_permissions": has_crud_permissions,
-        # Keep backward compatibility fields
-        "artifact_count": artifact_count,
     }
 
     if include_artifacts:

--- a/sbomify/apps/core/js/components/product-releases.spec.ts
+++ b/sbomify/apps/core/js/components/product-releases.spec.ts
@@ -40,7 +40,7 @@ interface Release {
     is_latest: boolean
     release_date?: string
     created_at?: string
-    artifact_count?: number
+    artifacts_count?: number
 }
 
 interface ReleaseForm {
@@ -335,10 +335,10 @@ describe('Product Releases', () => {
                 name: 'v1.0.0',
                 is_prerelease: false,
                 is_latest: true,
-                artifact_count: 5
+                artifacts_count: 5
             }
 
-            expect(release.artifact_count).toBe(5)
+            expect(release.artifacts_count).toBe(5)
         })
 
         test('should handle missing artifact count', () => {
@@ -349,7 +349,7 @@ describe('Product Releases', () => {
                 is_latest: true
             }
 
-            expect(release.artifact_count).toBeUndefined()
+            expect(release.artifacts_count).toBeUndefined()
         })
     })
 
@@ -412,9 +412,9 @@ describe('Product Releases', () => {
 
     describe('Sorting (sortedReleases)', () => {
         const testReleases: Release[] = [
-            { id: 'rel-1', name: 'Zebra', is_prerelease: false, is_latest: false, created_at: '2024-01-15T12:00:00Z', artifact_count: 3 },
-            { id: 'rel-2', name: 'Alpha', is_prerelease: true, is_latest: false, created_at: '2024-01-10T12:00:00Z', artifact_count: 5 },
-            { id: 'rel-3', name: 'Beta', is_prerelease: false, is_latest: true, created_at: '2024-01-20T12:00:00Z', artifact_count: 1 }
+            { id: 'rel-1', name: 'Zebra', is_prerelease: false, is_latest: false, created_at: '2024-01-15T12:00:00Z', artifacts_count: 3 },
+            { id: 'rel-2', name: 'Alpha', is_prerelease: true, is_latest: false, created_at: '2024-01-10T12:00:00Z', artifacts_count: 5 },
+            { id: 'rel-3', name: 'Beta', is_prerelease: false, is_latest: true, created_at: '2024-01-20T12:00:00Z', artifacts_count: 1 }
         ]
 
         const sortReleases = (
@@ -437,8 +437,8 @@ describe('Product Releases', () => {
                         bVal = b.is_prerelease ? 1 : 0
                         break
                     case 'artifacts':
-                        aVal = a.artifact_count || 0
-                        bVal = b.artifact_count || 0
+                        aVal = a.artifacts_count || 0
+                        bVal = b.artifacts_count || 0
                         break
                     case 'created_at':
                         aVal = a.created_at || ''
@@ -478,16 +478,16 @@ describe('Product Releases', () => {
 
         test('should sort by artifact count ascending', () => {
             const result = sortReleases(testReleases, 'artifacts', 'asc')
-            expect(result[0].artifact_count).toBe(1)
-            expect(result[1].artifact_count).toBe(3)
-            expect(result[2].artifact_count).toBe(5)
+            expect(result[0].artifacts_count).toBe(1)
+            expect(result[1].artifacts_count).toBe(3)
+            expect(result[2].artifacts_count).toBe(5)
         })
 
         test('should sort by artifact count descending', () => {
             const result = sortReleases(testReleases, 'artifacts', 'desc')
-            expect(result[0].artifact_count).toBe(5)
-            expect(result[1].artifact_count).toBe(3)
-            expect(result[2].artifact_count).toBe(1)
+            expect(result[0].artifacts_count).toBe(5)
+            expect(result[1].artifacts_count).toBe(3)
+            expect(result[2].artifacts_count).toBe(1)
         })
 
         test('should sort by created_at ascending', () => {

--- a/sbomify/apps/core/js/components/product-releases.ts
+++ b/sbomify/apps/core/js/components/product-releases.ts
@@ -14,7 +14,7 @@ interface Release {
     is_latest: boolean;
     release_date?: string;
     created_at?: string;
-    artifact_count?: number;
+    artifacts_count?: number;
 }
 
 interface ReleaseForm {
@@ -129,8 +129,8 @@ export function registerProductReleases() {
                             bVal = b.is_prerelease ? 1 : 0;
                             break;
                         case 'artifacts':
-                            aVal = a.artifact_count || 0;
-                            bVal = b.artifact_count || 0;
+                            aVal = a.artifacts_count || 0;
+                            bVal = b.artifacts_count || 0;
                             break;
                         case 'created_at':
                             aVal = a.created_at || '';

--- a/sbomify/apps/core/schemas.py
+++ b/sbomify/apps/core/schemas.py
@@ -730,7 +730,7 @@ class ReleaseResponseSchema(BaseModel):
     is_public: bool
     created_at: datetime
     released_at: datetime | None = None
-    artifact_count: int | None = None
+    artifacts_count: int | None = None
     artifacts: list[ReleaseArtifactDetailSchema] | None = None
 
 

--- a/sbomify/apps/core/templates/core/components/product_releases.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_releases.html.j2
@@ -138,7 +138,7 @@
                                 </td>
                                 <td>
                                     <span class="text-text-muted"
-                                          x-text="(release.artifact_count || 0) + ' artifacts'"></span>
+                                          x-text="(release.artifacts_count || 0) + ' artifacts'"></span>
                                 </td>
                                 <td>
                                     <span class="text-text-muted text-sm"


### PR DESCRIPTION
## Summary
- The product page (`/product/{id}/`) Releases table always shows "0 artifacts" due to a key name mismatch
- The API returns `artifacts_count` (plural) but the frontend TypeScript interface, template, and schema used `artifact_count` (singular)
- Standardizes all frontend references to use `artifacts_count`, matching the API

## Changes
- `product-releases.ts`: interface field `artifact_count` → `artifacts_count`, sort logic updated
- `product_releases.html.j2`: template binding updated
- `schemas.py`: `ReleaseDetailSchema.artifact_count` → `artifacts_count`
- `apis.py`: removed redundant backward-compat `artifact_count` key from `_build_release_response()`
- `product-releases.spec.ts`: test references updated

## Test plan
- [x] Navigate to `/product/{id}/` with a product that has releases with artifacts
- [x] Verify the "Artifacts" column now shows the correct count instead of 0
- [x] Verify the releases dashboard (`/releases/`) still works correctly
- [x] Verify sorting by artifacts column works