### PR TITLE
fix: register confirmModal Alpine component in teams bundle

### DIFF
--- a/sbomify/apps/teams/js/main.ts
+++ b/sbomify/apps/teams/js/main.ts
@@ -1,6 +1,7 @@
 import 'vite/modulepreload-polyfill';
 import '../../core/js/layout-interactions';
 import { registerTeamBranding, registerCustomDomain } from './team-branding';
+import { registerConfirmModal } from '../../core/js/components/confirm-modal';
 import { registerCopyableValue } from '../../core/js/components/copyable-value';
 import { registerFileDragAndDrop } from '../../core/js/components/file-drag-and-drop';
 import { registerWorkspaceSwitcher } from '../../core/js/components/workspace-switcher';
@@ -9,6 +10,7 @@ import { registerOnboardingWizard } from './onboarding-wizard';
 import { registerTeamGeneral } from './team-general';
 import { initializeAlpine } from '../../core/js/alpine-init';
 
+registerConfirmModal();
 registerCopyableValue();
 registerFileDragAndDrop();
 registerWorkspaceSwitcher();


### PR DESCRIPTION
## Summary

- Registered `confirmModal` Alpine.js component in the teams JS entry point (`teams/js/main.ts`)
- Fixes `ReferenceError: type is not defined` on all pages using the teams bundle (onboarding, team settings, etc.)

## Root Cause

The `base.html.j2` template includes `confirm_modal.html.j2` which uses `x-data="confirmModal()"`. This component defines a `type` property used in `:class` bindings. The teams bundle never called `registerConfirmModal()`, so Alpine fell back to an empty scope where `type` was undefined.

## Test plan

- [x] `bun lint` passes
- [x] `bun run build` succeeds
- [x] `bun test sbomify/apps/teams` — 34 tests pass
- [x] Manual: open onboarding page, verify no console errors
- [ ] Manual: trigger confirm modal on team settings, verify styled correctly