### PR TITLE
fix: resolve onboarding infinite loop and manufacturer entity conflict

### DIFF
--- a/sbomify/apps/teams/views/onboarding_wizard.py
+++ b/sbomify/apps/teams/views/onboarding_wizard.py
@@ -318,7 +318,8 @@ class OnboardingWizardView(LoginRequiredMixin, View):
                                 f'Another entity named "{company_name}" already exists — kept the previous name.',
                             )
                         entity.email = contact_email
-                        entity.website_urls = [website_url] if website_url else []
+                        if website_url:
+                            entity.website_urls = [website_url]
                         entity.is_supplier = True
                         entity.save(update_fields=["name", "email", "website_urls", "is_supplier", "updated_at"])
                     else:


### PR DESCRIPTION
## Summary
- Remove billing limit checks from onboarding wizard that caused an infinite redirect loop when teams already had assets at their plan limit (e.g. old workspaces re-running onboarding)
- Fix `ContactEntity` handling to update the existing manufacturer entity in place instead of creating a duplicate, which violated the one-manufacturer-per-profile constraint

## Root cause
Teams with `has_completed_wizard=False` that already have assets at the billing plan limit get stuck: `_check_billing_limits()` blocks → redirects to welcome → dashboard redirects back to onboarding → infinite loop. The wizard only creates assets via `get_or_create`, so limit checks are unnecessary.

Additionally, when re-running onboarding with a different company name, the `get_or_create` on `ContactEntity` fails the `get` (name mismatch) then fails `create` (one manufacturer per profile constraint).

## Test plan
- [x] Manually tested with a workspace that had pre-existing assets at plan limit (Chainguard)
- [x] Verified onboarding completes and reaches dashboard
- [x] All 310 team tests pass
- [x] All 271 billing tests pass