### PR TITLE
fix: add missing slug to TeamSchema for trust center URL

### DIFF
--- a/sbomify/apps/core/tests/test_apis.py
+++ b/sbomify/apps/core/tests/test_apis.py
@@ -32,6 +32,7 @@ def test_list_teams_api_authenticated(sample_access_token, sample_team):  # noqa
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["name"] == sample_team.name
+    assert "slug" in data[0]
 
 
 @pytest.mark.django_db
@@ -58,6 +59,8 @@ def test_get_team_api_authenticated(sample_access_token, sample_team):  # noqa: 
     data = response.json()
     assert data["name"] == sample_team.name
     assert data["key"] == sample_team.key
+    assert "slug" in data
+    assert data["slug"] == sample_team.slug
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_public_url_tags.py
+++ b/sbomify/apps/core/tests/test_public_url_tags.py
@@ -207,3 +207,133 @@ class TestPublicUrlTag:
         result = template.render(context).strip()
 
         assert result == f"/public/product/{product.id}/"
+
+
+@pytest.mark.django_db
+class TestTrustCenterAbsoluteUrlTag:
+    """Test trust_center_absolute_url template tag."""
+
+    def test_returns_custom_domain_when_validated(self, sample_team_with_owner_member):
+        """Custom domain takes highest priority when validated."""
+        team = sample_team_with_owner_member.team
+        team.custom_domain = "trust.example.com"
+        team.custom_domain_validated = True
+        team.save()
+
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        template = Template("""
+            {% load public_url_tags %}
+            {% trust_center_absolute_url team as url %}{{ url }}
+        """)
+
+        context = Context({"request": request, "team": team})
+        result = template.render(context).strip()
+
+        assert result == "https://trust.example.com"
+
+    def test_returns_subdomain_url_when_slug_set(self, sample_team_with_owner_member, settings):
+        """Trust center subdomain URL is returned when team has slug and TRUST_CENTER_DOMAIN is set."""
+        team = sample_team_with_owner_member.team
+        team.slug = "acme"
+        team.custom_domain = None
+        team.custom_domain_validated = False
+        team.save()
+
+        settings.TRUST_CENTER_DOMAIN = "trustcenters.io"
+
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        template = Template("""
+            {% load public_url_tags %}
+            {% trust_center_absolute_url team as url %}{{ url }}
+        """)
+
+        context = Context({"request": request, "team": team})
+        result = template.render(context).strip()
+
+        assert result == "https://acme.trustcenters.io"
+
+    def test_returns_subdomain_url_from_dict(self, sample_team_with_owner_member, settings):
+        """Trust center subdomain URL works when team is passed as a dict (as in settings view)."""
+        team = sample_team_with_owner_member.team
+        team.slug = "acme"
+        team.custom_domain = None
+        team.custom_domain_validated = False
+        team.save()
+
+        settings.TRUST_CENTER_DOMAIN = "trustcenters.io"
+
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        team_dict = {
+            "key": team.key,
+            "slug": "acme",
+            "custom_domain": None,
+            "custom_domain_validated": False,
+        }
+
+        template = Template("""
+            {% load public_url_tags %}
+            {% trust_center_absolute_url team as url %}{{ url }}
+        """)
+
+        context = Context({"request": request, "team": team_dict})
+        result = template.render(context).strip()
+
+        assert result == "https://acme.trustcenters.io"
+
+    def test_falls_back_to_app_base_url_without_slug(self, sample_team_with_owner_member, settings):
+        """Falls back to APP_BASE_URL when no slug and no custom domain."""
+        team = sample_team_with_owner_member.team
+        team.slug = ""
+        team.custom_domain = None
+        team.custom_domain_validated = False
+        team.save()
+
+        settings.TRUST_CENTER_DOMAIN = "trustcenters.io"
+        settings.APP_BASE_URL = "https://app.sbomify.com"
+
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        template = Template("""
+            {% load public_url_tags %}
+            {% trust_center_absolute_url team as url %}{{ url }}
+        """)
+
+        context = Context({"request": request, "team": team})
+        result = template.render(context).strip()
+
+        assert result == f"https://app.sbomify.com/public/workspace/{team.key}"
+
+    def test_dict_without_slug_falls_back(self, sample_team_with_owner_member, settings):
+        """Dict missing slug key falls back to APP_BASE_URL (the original bug scenario)."""
+        team = sample_team_with_owner_member.team
+
+        settings.TRUST_CENTER_DOMAIN = "trustcenters.io"
+        settings.APP_BASE_URL = "https://app.sbomify.com"
+
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        # Dict without slug — simulates the bug before the fix
+        team_dict = {
+            "key": team.key,
+            "custom_domain": None,
+            "custom_domain_validated": False,
+        }
+
+        template = Template("""
+            {% load public_url_tags %}
+            {% trust_center_absolute_url team as url %}{{ url }}
+        """)
+
+        context = Context({"request": request, "team": team_dict})
+        result = template.render(context).strip()
+
+        # Without slug, should fall back to standard URL
+        assert result == f"https://app.sbomify.com/public/workspace/{team.key}"

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -87,6 +87,7 @@ def _build_team_response(request: HttpRequest, team: Team) -> TeamSchema:
     return TeamSchema(
         key=team.key or "",
         name=team.name,
+        slug=team.slug,
         is_public=team.is_public,
         created_at=team.created_at,
         billing_plan=team.billing_plan,

--- a/sbomify/apps/teams/schemas.py
+++ b/sbomify/apps/teams/schemas.py
@@ -72,6 +72,7 @@ class InvitationSchema(BaseModel):
 class TeamSchema(BaseModel):
     key: str
     name: str
+    slug: str | None = None
     is_public: bool
     created_at: datetime
     has_completed_wizard: bool


### PR DESCRIPTION
## Summary
- `TeamSchema` (Pydantic) was missing the `slug` field, so the `trust_center_absolute_url` template tag could never build the subdomain URL (`https://{slug}.{TRUST_CENTER_DOMAIN}`) — it always fell through to the `APP_BASE_URL/public/workspace/{key}` fallback
- Added `slug: str | None = None` to `TeamSchema` and `slug=team.slug` to `_build_team_response()`
- Added assertions in existing API tests to verify slug presence in responses
- Added 5 new tests for the `trust_center_absolute_url` template tag covering custom domain priority, subdomain URL from object and dict, and fallback behavior

## Test plan
- [x] Existing API tests updated with slug assertions (126 tests pass)
- [x] New `TestTrustCenterAbsoluteUrlTag` test class with 5 tests covering all URL priority tiers
- [ ] Manual: verify trust center URL displays correctly in workspace settings