### PR TITLE
fix(plugins): remove orphaned cra-compliance-2024 plugin record

### DIFF
--- a/sbomify/apps/plugins/migrations/0006_remove_cra_compliance_plugin.py
+++ b/sbomify/apps/plugins/migrations/0006_remove_cra_compliance_plugin.py
@@ -7,6 +7,7 @@ import errors at runtime.
 
 from django.db import migrations
 from django.db.models import Q
+from django.utils import timezone
 
 
 def remove_cra_plugin(apps, schema_editor):
@@ -36,6 +37,7 @@ def remove_cra_plugin(apps, schema_editor):
             updates["plugin_configs"] = new_configs
 
         if updates:
+            updates["updated_at"] = timezone.now()
             TeamPluginSettings.objects.filter(pk=settings.pk).update(**updates)
 
 


### PR DESCRIPTION
## Summary
- Adds a data migration to delete the `cra-compliance-2024` `RegisteredPlugin` record that was manually added to the database without a corresponding Python module (`sbomify.apps.plugins.builtins.cra`), causing `ModuleNotFoundError` at runtime during assessment runs.

## Test plan
- [ ] Migration runs cleanly on staging and prod
- [ ] `run_assessment` no longer errors with `No module named 'sbomify.apps.plugins.builtins.cra'`