### PR TITLE
feat(sboms): add PURL qualifier support for build variants

### DIFF
--- a/sbomify/apps/core/purl.py
+++ b/sbomify/apps/core/purl.py
@@ -85,6 +85,30 @@ def parse_purl(purl: str) -> PURLComponents:
     }
 
 
+def canonicalize_qualifiers(qualifiers: dict[str, str]) -> dict[str, str]:
+    """Canonicalize PURL qualifiers per ECMA-427.
+
+    Lowercase keys, strip whitespace from values, remove empty values, sort by key.
+    """
+    return dict(
+        sorted(
+            ((k.lower(), v.strip()) for k, v in qualifiers.items() if v and v.strip()),
+        )
+    )
+
+
+def extract_purl_qualifiers(purl: str) -> dict[str, str]:
+    """Parse a PURL and return its canonicalized qualifiers dict.
+
+    Returns empty dict if PURL is invalid or has no qualifiers.
+    """
+    try:
+        parts = parse_purl(purl)
+        return canonicalize_qualifiers(parts["qualifiers"])
+    except PURLParseError:
+        return {}
+
+
 def strip_purl_version(purl: str) -> str:
     """Strip the version component from a PURL, preserving all other parts.
 

--- a/sbomify/apps/core/tests/test_purl.py
+++ b/sbomify/apps/core/tests/test_purl.py
@@ -1,0 +1,60 @@
+"""Tests for PURL parsing and qualifier utilities."""
+
+from __future__ import annotations
+
+from sbomify.apps.core.purl import (
+    canonicalize_qualifiers,
+    extract_purl_qualifiers,
+)
+
+
+class TestCanonicalizeQualifiers:
+    def test_sorts_keys(self) -> None:
+        result = canonicalize_qualifiers({"distro": "jessie", "arch": "arm64"})
+        assert list(result.keys()) == ["arch", "distro"]
+        assert result == {"arch": "arm64", "distro": "jessie"}
+
+    def test_lowercases_keys(self) -> None:
+        result = canonicalize_qualifiers({"Arch": "arm64", "DISTRO": "jessie"})
+        assert result == {"arch": "arm64", "distro": "jessie"}
+
+    def test_removes_empty_values(self) -> None:
+        result = canonicalize_qualifiers({"arch": "arm64", "distro": "", "os": ""})
+        assert result == {"arch": "arm64"}
+
+    def test_empty_input(self) -> None:
+        assert canonicalize_qualifiers({}) == {}
+
+    def test_preserves_value_case(self) -> None:
+        result = canonicalize_qualifiers({"arch": "ARM64"})
+        assert result == {"arch": "ARM64"}
+
+
+class TestExtractPurlQualifiers:
+    def test_valid_purl_with_qualifiers(self) -> None:
+        purl = "pkg:deb/debian/curl@7.50.3-1?arch=arm64&distro=jessie"
+        result = extract_purl_qualifiers(purl)
+        assert result == {"arch": "arm64", "distro": "jessie"}
+
+    def test_valid_purl_without_qualifiers(self) -> None:
+        purl = "pkg:npm/@scope/package@1.0.0"
+        result = extract_purl_qualifiers(purl)
+        assert result == {}
+
+    def test_invalid_purl(self) -> None:
+        result = extract_purl_qualifiers("not-a-purl")
+        assert result == {}
+
+    def test_empty_string(self) -> None:
+        result = extract_purl_qualifiers("")
+        assert result == {}
+
+    def test_qualifiers_are_canonicalized(self) -> None:
+        purl = "pkg:deb/debian/curl@7.50.3-1?distro=jessie&arch=arm64"
+        result = extract_purl_qualifiers(purl)
+        assert list(result.keys()) == ["arch", "distro"]
+
+    def test_single_qualifier(self) -> None:
+        purl = "pkg:deb/debian/curl@7.50.3-1?arch=amd64"
+        result = extract_purl_qualifiers(purl)
+        assert result == {"arch": "amd64"}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Any
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 from ninja import File, Query, Router, UploadedFile
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
 from sbomify.apps.core.apis import get_component_metadata, patch_component_metadata
 from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.purl import extract_purl_qualifiers
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.core.services.access_control import check_component_access
 from sbomify.apps.core.utils import (
@@ -145,15 +146,24 @@ def _build_component_metadata_from_native_fields(component: Component) -> Compon
     )
 
 
+def _extract_cdx_purl(payload: Any) -> str | None:
+    """Extract PURL from a CycloneDX payload's metadata.component.purl."""
+    try:
+        purl = payload.metadata.component.purl
+        return str(purl) if purl else None
+    except AttributeError:
+        return None
+
+
 def _extract_spdx_primary_package(
     payload: SPDXSchema | SPDX3Schema,
-) -> tuple[str, str] | tuple[None, str]:
-    """Extract primary package version from an SPDX payload.
+) -> tuple[SPDXPackage | SPDX3Package, str] | tuple[None, str]:
+    """Extract primary package from an SPDX payload.
 
     Dispatches to SPDX 2.x or 3.0 extraction logic based on payload type.
 
     Returns:
-        Tuple of (version, "") on success, or (None, error_message) on failure.
+        Tuple of (package, "") on success, or (None, error_message) on failure.
     """
     if isinstance(payload, SPDX3Schema):
         return _extract_spdx3_primary_package(payload)
@@ -162,7 +172,7 @@ def _extract_spdx_primary_package(
 
 def _extract_spdx2_primary_package(
     payload: SPDXSchema,
-) -> tuple[str, str] | tuple[None, str]:
+) -> tuple[SPDXPackage, str] | tuple[None, str]:
     """Extract primary package from SPDX 2.x document.
 
     Strategy:
@@ -192,12 +202,12 @@ def _extract_spdx2_primary_package(
     if not package:
         return None, f"No package found with name '{payload.name}' in SPDX document"
 
-    return package.version, ""
+    return package, ""
 
 
 def _extract_spdx3_primary_package(
     payload: SPDX3Schema,
-) -> tuple[str, str] | tuple[None, str]:
+) -> tuple[SPDX3Package, str] | tuple[None, str]:
     """Extract primary package from SPDX 3.0 document.
 
     Strategy:
@@ -236,7 +246,7 @@ def _extract_spdx3_primary_package(
     if not package:
         package = packages[0]
 
-    return package.version, ""
+    return package, ""
 
 
 # Removed duplicate component creation endpoint - use /api/v1/components instead
@@ -325,8 +335,14 @@ def sbom_upload_cyclonedx(
         sbom_version = sbom_dict.get("version", "")
         sbom_format = "cyclonedx"
 
-        # Check for duplicate SBOM (same component + version + format)
-        if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
+        # Extract PURL qualifiers from metadata.component.purl
+        cdx_purl = _extract_cdx_purl(payload)
+        sbom_qualifiers = extract_purl_qualifiers(cdx_purl) if cdx_purl else {}
+
+        # Check for duplicate SBOM (same component + version + format + qualifiers)
+        if SBOM.objects.filter(
+            component=component, version=sbom_version, format=sbom_format, qualifiers=sbom_qualifiers
+        ).exists():
             return 409, {
                 "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
                 "already exists for this component",
@@ -341,10 +357,18 @@ def sbom_upload_cyclonedx(
         sbom_dict["component"] = component
         sbom_dict["source"] = "api"
         sbom_dict["sha256_hash"] = sha256_hash
+        sbom_dict["qualifiers"] = sbom_qualifiers
 
-        with transaction.atomic():
-            sbom = SBOM(**sbom_dict)
-            sbom.save()
+        try:
+            with transaction.atomic():
+                sbom = SBOM(**sbom_dict)
+                sbom.save()
+        except IntegrityError:
+            return 409, {
+                "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
+                "already exists for this component",
+                "error_code": ErrorCode.DUPLICATE_ARTIFACT,
+            }
 
         # Broadcast to workspace for real-time UI updates
         _broadcast_sbom_uploaded(component, sbom)
@@ -415,13 +439,19 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str) -> tuple[int, dict
         sbom_dict["format_version"] = spdx_version  # Already extracted from validation
         sbom_dict["sha256_hash"] = sha256_hash
 
-        # Extract primary package version using format-aware helper
-        sbom_version, error = _extract_spdx_primary_package(payload)
-        if sbom_version is None:
+        # Extract primary package using format-aware helper
+        primary_package, error = _extract_spdx_primary_package(payload)
+        if primary_package is None:
             return 400, {"detail": error}
+        sbom_version = primary_package.version
 
-        # Check for duplicate SBOM (same component + version + format)
-        if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
+        # Extract PURL qualifiers from primary package
+        sbom_qualifiers = extract_purl_qualifiers(primary_package.purl)
+
+        # Check for duplicate SBOM (same component + version + format + qualifiers)
+        if SBOM.objects.filter(
+            component=component, version=sbom_version, format=sbom_format, qualifiers=sbom_qualifiers
+        ).exists():
             return 409, {
                 "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
                 "already exists for this component",
@@ -433,10 +463,18 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str) -> tuple[int, dict
 
         sbom_dict["version"] = sbom_version
         sbom_dict["sbom_filename"] = filename
+        sbom_dict["qualifiers"] = sbom_qualifiers
 
-        with transaction.atomic():
-            sbom = SBOM(**sbom_dict)
-            sbom.save()
+        try:
+            with transaction.atomic():
+                sbom = SBOM(**sbom_dict)
+                sbom.save()
+        except IntegrityError:
+            return 409, {
+                "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
+                "already exists for this component",
+                "error_code": ErrorCode.DUPLICATE_ARTIFACT,
+            }
 
         # Broadcast to workspace for real-time UI updates
         _broadcast_sbom_uploaded(component, sbom)
@@ -794,13 +832,19 @@ def sbom_upload_file(
             sbom_dict["format_version"] = spdx_version  # Already extracted from validation
             sbom_dict["sha256_hash"] = sha256_hash
 
-            # Extract primary package version using format-aware helper
-            sbom_version, error = _extract_spdx_primary_package(payload)
-            if sbom_version is None:
+            # Extract primary package using format-aware helper
+            primary_package, error = _extract_spdx_primary_package(payload)
+            if primary_package is None:
                 return 400, {"detail": error}
+            sbom_version = primary_package.version
 
-            # Check for duplicate SBOM (same component + version + format)
-            if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
+            # Extract PURL qualifiers from primary package
+            sbom_qualifiers = extract_purl_qualifiers(primary_package.purl)
+
+            # Check for duplicate SBOM (same component + version + format + qualifiers)
+            if SBOM.objects.filter(
+                component=component, version=sbom_version, format=sbom_format, qualifiers=sbom_qualifiers
+            ).exists():
                 return 409, {
                     "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
                     "already exists for this component",
@@ -812,10 +856,18 @@ def sbom_upload_file(
 
             sbom_dict["version"] = sbom_version
             sbom_dict["sbom_filename"] = filename
+            sbom_dict["qualifiers"] = sbom_qualifiers
 
-            with transaction.atomic():
-                sbom = SBOM(**sbom_dict)
-                sbom.save()
+            try:
+                with transaction.atomic():
+                    sbom = SBOM(**sbom_dict)
+                    sbom.save()
+            except IntegrityError:
+                return 409, {
+                    "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
+                    "already exists for this component",
+                    "error_code": ErrorCode.DUPLICATE_ARTIFACT,
+                }
 
             # Broadcast to workspace for real-time UI updates
             _broadcast_sbom_uploaded(component, sbom)
@@ -850,8 +902,14 @@ def sbom_upload_file(
             sbom_version = sbom_dict.get("version", "")
             sbom_format = "cyclonedx"
 
-            # Check for duplicate SBOM (same component + version + format)
-            if SBOM.objects.filter(component=component, version=sbom_version, format=sbom_format).exists():
+            # Extract PURL qualifiers from metadata.component.purl
+            cdx_purl = _extract_cdx_purl(cdx_payload)
+            sbom_qualifiers = extract_purl_qualifiers(cdx_purl) if cdx_purl else {}
+
+            # Check for duplicate SBOM (same component + version + format + qualifiers)
+            if SBOM.objects.filter(
+                component=component, version=sbom_version, format=sbom_format, qualifiers=sbom_qualifiers
+            ).exists():
                 return 409, {
                     "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
                     "already exists for this component",
@@ -866,10 +924,18 @@ def sbom_upload_file(
             sbom_dict["component"] = component
             sbom_dict["source"] = "manual_upload"
             sbom_dict["sha256_hash"] = sha256_hash
+            sbom_dict["qualifiers"] = sbom_qualifiers
 
-            with transaction.atomic():
-                sbom = SBOM(**sbom_dict)
-                sbom.save()
+            try:
+                with transaction.atomic():
+                    sbom = SBOM(**sbom_dict)
+                    sbom.save()
+            except IntegrityError:
+                return 409, {
+                    "detail": f"An SBOM with version '{sbom_version}' and format '{sbom_format}' "
+                    "already exists for this component",
+                    "error_code": ErrorCode.DUPLICATE_ARTIFACT,
+                }
 
             # Broadcast to workspace for real-time UI updates
             _broadcast_sbom_uploaded(component, sbom)

--- a/sbomify/apps/sboms/migrations/0051_add_sbom_qualifiers.py
+++ b/sbomify/apps/sboms/migrations/0051_add_sbom_qualifiers.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sboms", "0050_component_uuid_product_uuid_sbom_uuid"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sbom",
+            name="qualifiers",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="PURL qualifiers distinguishing build variants (e.g., arch, distro). Canonicalized on save.",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="sbom",
+            index=models.Index(
+                fields=["component", "version", "format"],
+                name="sboms_sboms_compone_7f5e3a_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="sbom",
+            constraint=models.UniqueConstraint(
+                fields=["component", "version", "format", "qualifiers"],
+                name="sboms_sbom_unique_component_version_format_qualifiers",
+            ),
+        ),
+    ]

--- a/sbomify/apps/sboms/models.py
+++ b/sbomify/apps/sboms/models.py
@@ -770,12 +770,24 @@ class SBOM(models.Model):
         indexes = [
             models.Index(fields=["created_at"]),
             models.Index(fields=["component", "created_at"]),
+            models.Index(fields=["component", "version", "format"]),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["component", "version", "format", "qualifiers"],
+                name="sboms_sbom_unique_component_version_format_qualifiers",
+            ),
         ]
 
     id = models.CharField(max_length=20, primary_key=True, default=generate_id)
     uuid = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
     name = models.CharField(max_length=255, blank=False)  # qualified sbom name like com.github.sbomify/backend
     version = models.CharField(max_length=255, default="")
+    qualifiers = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="PURL qualifiers distinguishing build variants (e.g., arch, distro). Canonicalized on save.",
+    )
     format = models.CharField(max_length=255, default="spdx")  # spdx, cyclonedx, etc
     format_version = models.CharField(max_length=20, default="")
     sbom_filename = models.CharField(max_length=255, default="")
@@ -795,6 +807,13 @@ class SBOM(models.Model):
         help_text="URL to a detached cryptographic signature for this SBOM",
     )
     component = models.ForeignKey(Component, on_delete=models.CASCADE)
+
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        if self.qualifiers:
+            from sbomify.apps.core.purl import canonicalize_qualifiers
+
+            self.qualifiers = canonicalize_qualifiers(self.qualifiers)
+        super().save(*args, **kwargs)
 
     def __str__(self) -> str:
         return self.name

--- a/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
+++ b/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
@@ -1,10 +1,11 @@
 """Tests for SBOM uniqueness constraint.
 
 The uniqueness constraint ensures that the combination of
-(component, version, format) is unique. This prevents duplicate
+(component, version, format, qualifiers) is unique. This prevents duplicate
 SBOM uploads while allowing:
 - Same version with different format (CycloneDX vs SPDX)
 - Different versions with same format
+- Same version+format with different PURL qualifiers (build variants)
 """
 
 from __future__ import annotations
@@ -612,6 +613,95 @@ class TestSBOMUniquenessConstraintFileUpload:
         assert response.json()["error_code"] == "DUPLICATE_ARTIFACT"
 
 
+class TestSBOMUniquenessConstraintFileUploadQualifiers:
+    """Tests for file upload qualifier-aware dedup."""
+
+    @pytest.mark.django_db
+    def test_cyclonedx_file_different_qualifiers_accepted(
+        self,
+        sample_user,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """File upload of CycloneDX SBOMs with different qualifiers should both succeed."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        client = Client()
+        client.force_login(sample_user)
+
+        url = reverse("api-1:sbom_upload_file", kwargs={"component_id": sample_component.id})
+
+        def make_cdx(arch: str) -> bytes:
+            return json.dumps(
+                {
+                    "bomFormat": "CycloneDX",
+                    "specVersion": "1.5",
+                    "version": 1,
+                    "metadata": {
+                        "component": {
+                            "type": "application",
+                            "name": "curl",
+                            "version": "7.50.3-1",
+                            "purl": f"pkg:deb/debian/curl@7.50.3-1?arch={arch}&distro=jessie",
+                        }
+                    },
+                }
+            ).encode("utf-8")
+
+        # Upload ARM64 variant
+        response = client.post(url, data={"sbom_file": BytesIO(make_cdx("arm64"))}, format="multipart")
+        assert response.status_code == 201
+
+        # Upload AMD64 variant — should succeed (different qualifiers)
+        response = client.post(url, data={"sbom_file": BytesIO(make_cdx("amd64"))}, format="multipart")
+        assert response.status_code == 201
+
+        assert SBOM.objects.count() == 2
+
+    @pytest.mark.django_db
+    def test_cyclonedx_file_same_qualifiers_returns_409(
+        self,
+        sample_user,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """File upload of duplicate CycloneDX SBOMs with same qualifiers should return 409."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        client = Client()
+        client.force_login(sample_user)
+
+        url = reverse("api-1:sbom_upload_file", kwargs={"component_id": sample_component.id})
+
+        file_content = json.dumps(
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.5",
+                "version": 1,
+                "metadata": {
+                    "component": {
+                        "type": "application",
+                        "name": "curl",
+                        "version": "7.50.3-1",
+                        "purl": "pkg:deb/debian/curl@7.50.3-1?arch=arm64&distro=jessie",
+                    }
+                },
+            }
+        ).encode("utf-8")
+
+        response = client.post(url, data={"sbom_file": BytesIO(file_content)}, format="multipart")
+        assert response.status_code == 201
+
+        response = client.post(url, data={"sbom_file": BytesIO(file_content)}, format="multipart")
+        assert response.status_code == 409
+
+
 class TestSBOMUniquenessConstraintErrorHandling:
     """Tests for error handling and edge cases."""
 
@@ -703,3 +793,220 @@ class TestSBOMUniquenessConstraintErrorHandling:
         )
         assert response.status_code == 409
         assert mock_upload.call_count == 1  # Still 1, not 2
+
+
+class TestSBOMQualifierDedup:
+    """Tests for PURL qualifier-aware duplicate detection."""
+
+    @pytest.mark.django_db
+    def test_cyclonedx_different_qualifiers_accepted(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """Two CycloneDX SBOMs with same version but different PURL qualifiers should both be accepted."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        client = Client()
+        url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+
+        # Upload ARM64 variant
+        arm64_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "metadata": {
+                "component": {
+                    "type": "application",
+                    "name": "curl",
+                    "version": "7.50.3-1",
+                    "purl": "pkg:deb/debian/curl@7.50.3-1?arch=arm64&distro=jessie",
+                }
+            },
+        }
+        response = client.post(
+            url,
+            data=json.dumps(arm64_data),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        # Upload AMD64 variant — should succeed (different qualifiers)
+        amd64_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "metadata": {
+                "component": {
+                    "type": "application",
+                    "name": "curl",
+                    "version": "7.50.3-1",
+                    "purl": "pkg:deb/debian/curl@7.50.3-1?arch=amd64&distro=jessie",
+                }
+            },
+        }
+        response = client.post(
+            url,
+            data=json.dumps(amd64_data),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        assert SBOM.objects.count() == 2
+        sboms = list(SBOM.objects.order_by("id"))
+        assert sboms[0].qualifiers == {"arch": "arm64", "distro": "jessie"}
+        assert sboms[1].qualifiers == {"arch": "amd64", "distro": "jessie"}
+
+    @pytest.mark.django_db
+    def test_cyclonedx_same_qualifiers_returns_409(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """Two CycloneDX SBOMs with same version and same qualifiers should return 409."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        client = Client()
+        url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "metadata": {
+                "component": {
+                    "type": "application",
+                    "name": "curl",
+                    "version": "7.50.3-1",
+                    "purl": "pkg:deb/debian/curl@7.50.3-1?arch=arm64&distro=jessie",
+                }
+            },
+        }
+
+        response = client.post(
+            url,
+            data=json.dumps(sbom_data),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        # Same qualifiers → 409
+        response = client.post(
+            url,
+            data=json.dumps(sbom_data),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.django_db
+    def test_cyclonedx_no_purl_stores_empty_qualifiers(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """CycloneDX SBOM without a PURL should store empty qualifiers."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "metadata": {"component": {"type": "application", "name": "test-component", "version": "1.0.0"}},
+        }
+
+        client = Client()
+        url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+
+        response = client.post(
+            url,
+            data=json.dumps(sbom_data),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        sbom = SBOM.objects.first()
+        assert sbom is not None
+        assert sbom.qualifiers == {}
+
+    @pytest.mark.django_db
+    def test_spdx_different_qualifiers_accepted(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+        mocker: MockerFixture,
+    ) -> None:
+        """Two SPDX SBOMs with same version but different PURL qualifiers should both be accepted."""
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+        SBOM.objects.all().delete()
+
+        client = Client()
+        url = reverse("api-1:sbom_upload_spdx", kwargs={"component_id": sample_component.id})
+
+        def create_spdx_data(arch: str) -> dict:
+            return {
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "spdxVersion": "SPDX-2.3",
+                "creationInfo": {
+                    "created": "2024-06-06T07:48:34Z",
+                    "creators": ["Tool: Test"],
+                },
+                "name": "curl",
+                "dataLicense": "CC0-1.0",
+                "documentNamespace": f"https://example.com/curl-{arch}",
+                "documentDescribes": ["SPDXRef-Package"],
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-Package",
+                        "name": "curl",
+                        "versionInfo": "7.50.3-1",
+                        "downloadLocation": "NOASSERTION",
+                        "filesAnalyzed": False,
+                        "externalRefs": [
+                            {
+                                "referenceCategory": "PACKAGE-MANAGER",
+                                "referenceType": "purl",
+                                "referenceLocator": f"pkg:deb/debian/curl@7.50.3-1?arch={arch}&distro=jessie",
+                            }
+                        ],
+                    }
+                ],
+            }
+
+        # Upload ARM64 variant
+        response = client.post(
+            url,
+            data=json.dumps(create_spdx_data("arm64")),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        # Upload AMD64 variant — should succeed
+        response = client.post(
+            url,
+            data=json.dumps(create_spdx_data("amd64")),
+            content_type="application/json",
+            **get_api_headers(sample_access_token),
+        )
+        assert response.status_code == 201
+
+        assert SBOM.objects.count() == 2

--- a/sbomify/apps/tea/apis.py
+++ b/sbomify/apps/tea/apis.py
@@ -7,6 +7,7 @@ All endpoints are public and workspace-scoped.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from django.conf import settings
@@ -372,11 +373,12 @@ def _build_sbom_collection_response(
     artifacts: list[TEAArtifact] = []
     latest_date = sbom.created_at
 
-    # Include all SBOMs for the same component + version
+    # Include SBOMs for same component + version + qualifiers (same build variant)
     sibling_sboms = list(
         SBOM.objects.filter(
             component=sbom.component,
             version=sbom.version,
+            qualifiers=sbom.qualifiers,
             component__visibility=Component.Visibility.PUBLIC,
         )
         .select_related("component")
@@ -824,12 +826,14 @@ def get_component_releases(
         .prefetch_related("component__identifiers")
         .order_by("-created_at", "id")
     )
-    seen_versions: set[str] = set()
+    seen: set[tuple[str, str]] = set()
     results = []
     for sbom in sboms:
         version_key = sbom.version or "unknown"
-        if version_key not in seen_versions:
-            seen_versions.add(version_key)
+        qualifiers_key = json.dumps(sbom.qualifiers or {}, sort_keys=True)
+        dedup_key = (version_key, qualifiers_key)
+        if dedup_key not in seen:
+            seen.add(dedup_key)
             results.append(_build_component_release_response(sbom))
 
     return 200, results


### PR DESCRIPTION
## Summary

- Adds PURL qualifier support to distinguish SBOM build variants (e.g., ARM64 vs AMD64) that share the same component+version+format
- Extracts qualifiers from SBOM content on upload (CycloneDX `metadata.component.purl`, SPDX external refs) and includes them in duplicate detection
- Updates TEA API to be qualifier-aware for component release dedup and collection scoping

## Changes

**Core utilities** (`core/purl.py`):
- `canonicalize_qualifiers()` — lowercase keys, strip whitespace, remove empty values, sort by key per ECMA-427
- `extract_purl_qualifiers()` — parse PURL and return canonicalized qualifiers dict

**SBOM model** (`sboms/models.py`):
- Add `qualifiers` JSONField with `default=dict` (no NULL — avoids comparison issues)
- Add `UniqueConstraint` on `(component, version, format, qualifiers)` to prevent race conditions
- Add `save()` override to enforce canonicalization before persistence

**Upload endpoints** (`sboms/apis.py`):
- Extract qualifiers in all 4 upload paths (CycloneDX API, SPDX API, file upload CycloneDX, file upload SPDX)
- Include qualifiers in duplicate detection filter
- Add `IntegrityError` catch as safety net for concurrent uploads
- Refactor `_extract_spdx_primary_package()` to return package object (enables `.purl` access)
- Extract `_extract_cdx_purl()` helper to eliminate duplicated triple-`getattr` chains

**TEA API** (`tea/apis.py`):
- `get_component_releases()` dedup key now includes qualifiers
- `_build_sbom_collection_response()` scopes sibling SBOMs by qualifiers

**Migration**: `0051_add_sbom_qualifiers` — adds field, composite index, and unique constraint

## Test plan

- [x] `test_purl.py` — canonicalize_qualifiers and extract_purl_qualifiers unit tests
- [x] `test_sbom_uniqueness.py` — qualifier-aware dedup tests:
  - Different qualifiers accepted (no 409) for both CycloneDX and SPDX
  - Same qualifiers returns 409
  - No PURL stores empty qualifiers `{}`
  - File upload qualifier dedup (both accept and reject paths)

```bash
docker compose -f docker-compose.tests.yml exec tests uv run pytest \
  sbomify/apps/core/tests/test_purl.py \
  sbomify/apps/sboms/tests/test_sbom_uniqueness.py -v
```

Closes #789