### PR TITLE
fix(sboms): deduplicate SBOMs before adding unique constraint

### DIFF
--- a/sbomify/apps/sboms/migrations/0051_add_sbom_qualifiers.py
+++ b/sbomify/apps/sboms/migrations/0051_add_sbom_qualifiers.py
@@ -6,13 +6,14 @@ from django.db.models import Count, Exists, OuterRef
 logger = logging.getLogger(__name__)
 
 
-def deduplicate_sboms(apps, schema_editor):
-    """Remove duplicate SBOMs before adding the unique constraint.
+def mark_duplicate_sboms(apps, schema_editor):
+    """Assign unique qualifiers to duplicate SBOMs before adding the unique constraint.
 
     After adding the `qualifiers` column (default={}), rows that were previously
     unique on (component, version, format) may now collide on
     (component, version, format, qualifiers).  For each duplicate group we prefer
-    to keep an SBOM referenced by a release or assessment run; otherwise the newest.
+    to keep the SBOM referenced by a release or assessment run (otherwise the newest)
+    with qualifiers={}, and mark the rest with {"duplicate": "1"}, {"duplicate": "2"}, etc.
     """
     SBOM = apps.get_model("sboms", "SBOM")
     ReleaseArtifact = apps.get_model("core", "ReleaseArtifact")
@@ -20,7 +21,7 @@ def deduplicate_sboms(apps, schema_editor):
 
     dupes = list(SBOM.objects.values("component_id", "version", "format").annotate(cnt=Count("id")).filter(cnt__gt=1))
 
-    total_deleted = 0
+    total_marked = 0
     for group in dupes:
         siblings = SBOM.objects.filter(
             component_id=group["component_id"],
@@ -29,23 +30,22 @@ def deduplicate_sboms(apps, schema_editor):
         )
 
         # Prefer: referenced by release > referenced by assessment > newest
-        keep = (
+        ranked = list(
             siblings.annotate(
                 has_release=Exists(ReleaseArtifact.objects.filter(sbom=OuterRef("pk"))),
                 has_assessment=Exists(AssessmentRun.objects.filter(sbom=OuterRef("pk"))),
             )
             .order_by("-has_release", "-has_assessment", "-created_at")
             .values_list("id", flat=True)
-            .first()
         )
-        if keep is None:
-            continue
 
-        deleted, _ = siblings.exclude(id=keep).delete()
-        total_deleted += deleted
+        # First one keeps qualifiers={}, rest get {"duplicate": "N"}
+        for seq, sbom_id in enumerate(ranked[1:], start=1):
+            SBOM.objects.filter(id=sbom_id).update(qualifiers={"duplicate": str(seq)})
+            total_marked += 1
 
-    if total_deleted:
-        logger.info("Deduplicated %d SBOM row(s) before adding unique constraint", total_deleted)
+    if total_marked:
+        logger.info("Marked %d duplicate SBOM row(s) before adding unique constraint", total_marked)
 
 
 class Migration(migrations.Migration):
@@ -65,7 +65,7 @@ class Migration(migrations.Migration):
                 help_text="PURL qualifiers distinguishing build variants (e.g., arch, distro). Canonicalized on save.",
             ),
         ),
-        migrations.RunPython(deduplicate_sboms, migrations.RunPython.noop),
+        migrations.RunPython(mark_duplicate_sboms, migrations.RunPython.noop),
         migrations.AddConstraint(
             model_name="sbom",
             constraint=models.UniqueConstraint(


### PR DESCRIPTION
## Summary

- Adds a `RunPython` data migration step to migration 0051 between `AddField` and `AddConstraint`
- For each duplicate `(component, version, format)` group, marks non-preferred SBOMs with `{"duplicate": "1"}`, `{"duplicate": "2"}`, etc. instead of deleting them
- Preferred SBOM (release-linked > assessment-linked > newest) keeps `qualifiers={}`
- No SBOMs are deleted — all data and FK references (ReleaseArtifact, AssessmentRun) are preserved

## Context

Migration `sboms.0051_add_sbom_qualifiers` failed on staging:

```
UniqueViolation: could not create unique index "sboms_sbom_unique_component_version_format_qualifiers"
DETAIL: Key (component_id, version, format, qualifiers)=(ZS0iFQJt5Zlj, , spdx, {}) is duplicated.
```

The `qualifiers` column defaults to `{}`, so existing duplicate `(component, version, format)` rows collide on the new four-column unique constraint. Since PostgreSQL DDL is transactional, the entire migration rolled back — it's safe to modify and re-apply.

**Production impact:** 245 duplicate groups, 2833 rows marked, 1269 preferred rows keep `qualifiers={}`. Total SBOMs: 4102.

## Approach

Instead of deleting duplicates (which would cascade-delete ReleaseArtifact and AssessmentRun records), this assigns synthetic qualifier values to differentiate them:

1. `AddField` — adds `qualifiers` JSONField (all rows get `{}`)
2. `RunPython(mark_duplicate_sboms)` — marks duplicates with `{"duplicate": "N"}`
3. `AddConstraint` — unique constraint now passes since all rows are distinct

## Test plan

- [ ] Run `find_duplicate_sboms` management command on staging/prod to inspect duplicates before merging (PR #797)
- [ ] Deploy to staging — migration applies cleanly
- [ ] Verify no SBOMs are deleted — only qualifiers field updated on duplicates
- [ ] Verify duplicate SBOMs are queryable via `SBOM.objects.filter(qualifiers__has_key="duplicate")`