### PR TITLE
ci: gate heavy CI jobs behind label on PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - master
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   release:
     types: [published]
 
@@ -209,11 +209,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    if: >
-      false &&
-      (github.event_name == 'push' ||
-       github.event_name == 'release' ||
-       contains(github.event.pull_request.labels.*.name, 'ci:run-tests'))
+    if: false  # Temporarily disabled — when re-enabled, gate behind ci:run-tests label
     runs-on: ubuntu-latest
     env:
       DJANGO_SETTINGS_MODULE: sbomify.test_settings
@@ -794,7 +790,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [code-quality, frontend-tests, tests, docker-build]
+    needs: [code-quality, frontend-tests, tests, docker-build, e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs
@@ -816,6 +812,13 @@ jobs:
           fi
           if [[ "${{ needs.docker-build.result }}" != "success" ]]; then
             echo "docker-build did not pass (status: ${{ needs.docker-build.result }}). Add the ci:run-tests label to run it."
+            exit 1
+          fi
+
+          # e2e-tests: currently disabled (if: false), so skipped is expected
+          # When re-enabled, this will require them to pass
+          if [[ "${{ needs.e2e-tests.result }}" != "success" && "${{ needs.e2e-tests.result }}" != "skipped" ]]; then
+            echo "e2e-tests failed"
             exit 1
           fi
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -815,8 +815,9 @@ jobs:
             exit 1
           fi
 
-          # e2e-tests: currently disabled (if: false), so skipped is expected
-          # When re-enabled, this will require them to pass
+          # e2e-tests: currently disabled (if: false) so result is always "skipped"
+          # When re-enabled behind ci:run-tests label, result will be "skipped"
+          # (no label) or "success"/"failure" (label present). Fail only on actual failures.
           if [[ "${{ needs.e2e-tests.result }}" != "success" && "${{ needs.e2e-tests.result }}" != "skipped" ]]; then
             echo "e2e-tests failed"
             exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+    types: [opened, synchronize, reopened, labeled]
   release:
     types: [published]
 
@@ -98,6 +99,10 @@ jobs:
 
   tests:
     name: Run Tests
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'release' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:run-tests')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -204,7 +209,11 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    if: false  # Temporarily disabled - tests are failing
+    if: >
+      false &&
+      (github.event_name == 'push' ||
+       github.event_name == 'release' ||
+       contains(github.event.pull_request.labels.*.name, 'ci:run-tests'))
     runs-on: ubuntu-latest
     env:
       DJANGO_SETTINGS_MODULE: sbomify.test_settings
@@ -318,6 +327,10 @@ jobs:
 
   docker-build:
     name: Docker Build
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'release' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:run-tests')
     runs-on: ubuntu-latest
     outputs:
       github-image: ${{ steps.meta.outputs.github_image_id }}
@@ -771,3 +784,39 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: '${{ github.workspace }}/${{ matrix.output_file }}'
+
+  # =========================================================================
+  # CI Gate — single required status check for branch protection
+  # Replaces individual required checks so skipped label-gated jobs don't
+  # block the merge button. Set "CI Gate" as the only required check in
+  # Settings → Branches → master protection rules.
+  # =========================================================================
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [code-quality, frontend-tests, tests, docker-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required jobs
+        run: |
+          # code-quality and frontend-tests must always pass
+          if [[ "${{ needs.code-quality.result }}" != "success" ]]; then
+            echo "code-quality failed"
+            exit 1
+          fi
+          if [[ "${{ needs.frontend-tests.result }}" != "success" ]]; then
+            echo "frontend-tests failed"
+            exit 1
+          fi
+
+          # tests and docker-build: must pass when they run, OK to skip (no label)
+          if [[ "${{ needs.tests.result }}" != "success" && "${{ needs.tests.result }}" != "skipped" ]]; then
+            echo "tests failed"
+            exit 1
+          fi
+          if [[ "${{ needs.docker-build.result }}" != "success" && "${{ needs.docker-build.result }}" != "skipped" ]]; then
+            echo "docker-build failed"
+            exit 1
+          fi
+
+          echo "All required checks passed"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -809,13 +809,13 @@ jobs:
             exit 1
           fi
 
-          # tests and docker-build: must pass when they run, OK to skip (no label)
-          if [[ "${{ needs.tests.result }}" != "success" && "${{ needs.tests.result }}" != "skipped" ]]; then
-            echo "tests failed"
+          # tests and docker-build must pass (add ci:run-tests label to trigger them)
+          if [[ "${{ needs.tests.result }}" != "success" ]]; then
+            echo "tests did not pass (status: ${{ needs.tests.result }}). Add the ci:run-tests label to run them."
             exit 1
           fi
-          if [[ "${{ needs.docker-build.result }}" != "success" && "${{ needs.docker-build.result }}" != "skipped" ]]; then
-            echo "docker-build failed"
+          if [[ "${{ needs.docker-build.result }}" != "success" ]]; then
+            echo "docker-build did not pass (status: ${{ needs.docker-build.result }}). Add the ci:run-tests label to run it."
             exit 1
           fi
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -299,6 +299,10 @@ jobs:
 
   frontend-tests:
     name: Frontend Tests
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'release' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:run-tests')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -795,17 +799,17 @@ jobs:
     steps:
       - name: Check required jobs
         run: |
-          # code-quality and frontend-tests must always pass
+          # code-quality must always pass
           if [[ "${{ needs.code-quality.result }}" != "success" ]]; then
             echo "code-quality failed"
             exit 1
           fi
+
+          # frontend-tests, tests, and docker-build must pass (add ci:run-tests label to trigger them)
           if [[ "${{ needs.frontend-tests.result }}" != "success" ]]; then
-            echo "frontend-tests failed"
+            echo "frontend-tests did not pass (status: ${{ needs.frontend-tests.result }}). Add the ci:run-tests label to run them."
             exit 1
           fi
-
-          # tests and docker-build must pass (add ci:run-tests label to trigger them)
           if [[ "${{ needs.tests.result }}" != "success" ]]; then
             echo "tests did not pass (status: ${{ needs.tests.result }}). Add the ci:run-tests label to run them."
             exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -787,9 +787,11 @@ jobs:
 
   # =========================================================================
   # CI Gate — single required status check for branch protection
-  # Replaces individual required checks so skipped label-gated jobs don't
-  # block the merge button. Set "CI Gate" as the only required check in
-  # Settings → Branches → master protection rules.
+  # Centralizes enforcement of required jobs, including label-gated ones.
+  # If label-gated jobs (frontend-tests/tests/docker-build) are skipped,
+  # this gate fails and blocks the merge button until they are run. Set
+  # "CI Gate" as the only required check in Settings → Branches → master
+  # protection rules.
   # =========================================================================
   ci-gate:
     name: CI Gate


### PR DESCRIPTION
## Summary

- Frontend tests, backend tests (9 matrix groups), and Docker build now only run on PRs when the `ci:run-tests` label is present
- E2E tests remain disabled (`if: false`) — when re-enabled, they will also be gated behind the label
- Code quality is the only check that runs on every PR commit
- Added a **CI Gate** job as the single required status check for branch protection — requires all label-gated jobs to succeed (merge is blocked until `ci:run-tests` label is added and jobs pass)
- Adding `unlabeled` event type ensures removing the label re-evaluates CI
- Created the `ci:run-tests` label on the repo

## Setup required

After merging, update **Settings → Branches → master** protection rules:
- Set **"CI Gate"** as the only required status check
- Remove individual job checks (Code Quality, Run Tests, etc.)

## Test plan

- [ ] PR without label: only code-quality runs, CI Gate fails (blocks merge)
- [ ] PR with `ci:run-tests` label: all jobs run, CI Gate passes only if all succeed
- [ ] Removing `ci:run-tests` label: CI re-runs and gate fails again
- [ ] Push to master: all jobs run unconditionally (unchanged behavior)