### PR TITLE
feat: storage backend abstraction (ADR-0007 Phase 1)

### DIFF
--- a/sbomify/apps/compliance/services/document_generation_service.py
+++ b/sbomify/apps/compliance/services/document_generation_service.py
@@ -273,9 +273,9 @@ def generate_document(
 
     # Upload to S3
     try:
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        s3 = S3Client("DOCUMENTS")
+        s3 = StorageClient("DOCUMENTS")
         from django.conf import settings as django_settings
 
         s3.upload_data_as_file(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, storage_key, content_bytes)

--- a/sbomify/apps/compliance/services/export_service.py
+++ b/sbomify/apps/compliance/services/export_service.py
@@ -1,4 +1,4 @@
-"""CRA export service — build ZIP package with all compliance artifacts."""
+"""CRA export service -- build ZIP package with all compliance artifacts."""
 
 from __future__ import annotations
 
@@ -55,31 +55,31 @@ _DOC_CRA_REF: dict[str, str] = {
     "declaration_of_conformity": "Article 28, Annex V",
 }
 
-# SBOM format → file extension for ZIP packaging
+# SBOM format -> file extension for ZIP packaging
 _FORMAT_EXT_MAP: dict[str, str] = {"cyclonedx": "cdx.json", "spdx": "spdx.json"}
 
 
-def _get_generated_doc_content(doc: CRAGeneratedDocument, s3_client: StorageClient | None = None) -> bytes | None:
-    """Fetch document content from S3."""
+def _get_generated_doc_content(doc: CRAGeneratedDocument, storage_client: StorageClient | None = None) -> bytes | None:
+    """Fetch document content from object storage."""
     try:
-        if s3_client is None:
-            s3_client = StorageClient("DOCUMENTS")
-        return s3_client.get_file_data(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, doc.storage_key)
+        if storage_client is None:
+            storage_client = StorageClient("DOCUMENTS")
+        return storage_client.get_file_data(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, doc.storage_key)
     except Exception:
-        logger.exception("Failed to fetch document %s from S3", doc.storage_key)
+        logger.exception("Failed to fetch document %s from storage", doc.storage_key)
         return None
 
 
-def _get_sbom_content(sbom: SBOM, s3_client: StorageClient | None = None) -> bytes | None:
-    """Fetch SBOM content from S3."""
+def _get_sbom_content(sbom: SBOM, storage_client: StorageClient | None = None) -> bytes | None:
+    """Fetch SBOM content from object storage."""
     if not sbom.sbom_filename:
         return None
     try:
-        if s3_client is None:
-            s3_client = StorageClient("SBOMS")
-        return s3_client.get_sbom_data(sbom.sbom_filename)
+        if storage_client is None:
+            storage_client = StorageClient("SBOMS")
+        return storage_client.get_sbom_data(sbom.sbom_filename)
     except Exception:
-        logger.exception("Failed to fetch SBOM %s from S3", sbom.sbom_filename)
+        logger.exception("Failed to fetch SBOM %s from storage", sbom.sbom_filename)
         return None
 
 
@@ -118,9 +118,9 @@ def build_export_package(
     # Spool to disk if ZIP exceeds 10MB to avoid OOM on large products
     buf = tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024)
 
-    # Create S3 clients once for reuse across all fetches
-    docs_s3 = StorageClient("DOCUMENTS")
-    sboms_s3 = StorageClient("SBOMS")
+    # Create storage clients once for reuse across all fetches
+    docs_storage = StorageClient("DOCUMENTS")
+    sboms_storage = StorageClient("SBOMS")
 
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         # 1. OSCAL catalog
@@ -139,12 +139,12 @@ def build_export_package(
             zip_path = _DOC_PATH_MAP.get(doc.document_kind)
             if not zip_path:
                 continue
-            content = _get_generated_doc_content(doc, s3_client=docs_s3)
+            content = _get_generated_doc_content(doc, storage_client=docs_storage)
             if content:
                 cra_ref = _DOC_CRA_REF.get(doc.document_kind, "")
                 _write_to_zip(zf, f"{prefix}/{zip_path}", content, manifest_files, cra_ref)
 
-        # 4. SBOMs from product components — fetch only the latest SBOM per component
+        # 4. SBOMs from product components -- fetch only the latest SBOM per component
         from django.db.models import OuterRef, Subquery
 
         latest_sbom_subquery = SBOM.objects.filter(component=OuterRef("pk")).order_by("-created_at").values("pk")[:1]
@@ -160,13 +160,13 @@ def build_export_package(
             latest_sbom = sboms_by_id.get(component.latest_sbom_id) if component.latest_sbom_id else None
             if not latest_sbom:
                 continue
-            sbom_content = _get_sbom_content(latest_sbom, s3_client=sboms_s3)
+            sbom_content = _get_sbom_content(latest_sbom, storage_client=sboms_storage)
             if sbom_content:
                 ext = _FORMAT_EXT_MAP.get(latest_sbom.format, "json")
                 sbom_path = f"{prefix}/sboms/{slugify(component.name)}-{component.id}.{ext}"
                 _write_to_zip(zf, sbom_path, sbom_content, manifest_files, "Annex VII, §2")
 
-        # 5. Manifest — built after all other files are written so manifest_files
+        # 5. Manifest -- built after all other files are written so manifest_files
         #    is complete. The manifest itself is NOT included in its own files list.
         manufacturer = ContactEntity.objects.filter(profile__team=assessment.team, is_manufacturer=True).first()
 
@@ -194,18 +194,18 @@ def build_export_package(
     # Read entire ZIP into memory for hashing and upload. This is acceptable because
     # CRA export packages are typically <1MB (documents + SBOMs). The SpooledTemporaryFile
     # already spills to disk above 10MB, and we need the full bytes for SHA-256 hashing
-    # and the subsequent S3 upload anyway — streaming would require two passes.
+    # and the subsequent storage upload anyway -- streaming would require two passes.
     buf.seek(0)
     zip_bytes = buf.read()
     buf.close()
     content_hash = hashlib.sha256(zip_bytes).hexdigest()
     storage_key = f"compliance/exports/{assessment.id}/{content_hash}.zip"
 
-    # Upload to S3 (reuse the docs_s3 client)
+    # Upload to object storage (reuse the docs_storage client)
     try:
-        docs_s3.upload_data_as_file(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, storage_key, zip_bytes)
+        docs_storage.upload_data_as_file(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, storage_key, zip_bytes)
     except Exception:
-        logger.exception("Failed to upload export package to S3")
+        logger.exception("Failed to upload export package to storage")
         return ServiceResult.failure("Failed to upload export package to storage", status_code=502)
 
     package = CRAExportPackage.objects.create(

--- a/sbomify/apps/compliance/services/export_service.py
+++ b/sbomify/apps/compliance/services/export_service.py
@@ -1,4 +1,4 @@
-"""CRA export service -- build ZIP package with all compliance artifacts."""
+"""CRA export service — build ZIP package with all compliance artifacts."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ _DOC_CRA_REF: dict[str, str] = {
     "declaration_of_conformity": "Article 28, Annex V",
 }
 
-# SBOM format -> file extension for ZIP packaging
+# SBOM format → file extension for ZIP packaging
 _FORMAT_EXT_MAP: dict[str, str] = {"cyclonedx": "cdx.json", "spdx": "spdx.json"}
 
 
@@ -144,7 +144,7 @@ def build_export_package(
                 cra_ref = _DOC_CRA_REF.get(doc.document_kind, "")
                 _write_to_zip(zf, f"{prefix}/{zip_path}", content, manifest_files, cra_ref)
 
-        # 4. SBOMs from product components -- fetch only the latest SBOM per component
+        # 4. SBOMs from product components — fetch only the latest SBOM per component
         from django.db.models import OuterRef, Subquery
 
         latest_sbom_subquery = SBOM.objects.filter(component=OuterRef("pk")).order_by("-created_at").values("pk")[:1]
@@ -166,7 +166,7 @@ def build_export_package(
                 sbom_path = f"{prefix}/sboms/{slugify(component.name)}-{component.id}.{ext}"
                 _write_to_zip(zf, sbom_path, sbom_content, manifest_files, "Annex VII, §2")
 
-        # 5. Manifest -- built after all other files are written so manifest_files
+        # 5. Manifest — built after all other files are written so manifest_files
         #    is complete. The manifest itself is NOT included in its own files list.
         manufacturer = ContactEntity.objects.filter(profile__team=assessment.team, is_manufacturer=True).first()
 
@@ -194,7 +194,7 @@ def build_export_package(
     # Read entire ZIP into memory for hashing and upload. This is acceptable because
     # CRA export packages are typically <1MB (documents + SBOMs). The SpooledTemporaryFile
     # already spills to disk above 10MB, and we need the full bytes for SHA-256 hashing
-    # and the subsequent storage upload anyway -- streaming would require two passes.
+    # and the subsequent storage upload anyway — streaming would require two passes.
     buf.seek(0)
     zip_bytes = buf.read()
     buf.close()

--- a/sbomify/apps/compliance/services/export_service.py
+++ b/sbomify/apps/compliance/services/export_service.py
@@ -18,7 +18,7 @@ from sbomify.apps.compliance.models import (
 )
 from sbomify.apps.compliance.services.oscal_service import serialize_assessment_results
 from sbomify.apps.core.models import Component
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import ContactEntity
@@ -59,24 +59,24 @@ _DOC_CRA_REF: dict[str, str] = {
 _FORMAT_EXT_MAP: dict[str, str] = {"cyclonedx": "cdx.json", "spdx": "spdx.json"}
 
 
-def _get_generated_doc_content(doc: CRAGeneratedDocument, s3_client: S3Client | None = None) -> bytes | None:
+def _get_generated_doc_content(doc: CRAGeneratedDocument, s3_client: StorageClient | None = None) -> bytes | None:
     """Fetch document content from S3."""
     try:
         if s3_client is None:
-            s3_client = S3Client("DOCUMENTS")
+            s3_client = StorageClient("DOCUMENTS")
         return s3_client.get_file_data(django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, doc.storage_key)
     except Exception:
         logger.exception("Failed to fetch document %s from S3", doc.storage_key)
         return None
 
 
-def _get_sbom_content(sbom: SBOM, s3_client: S3Client | None = None) -> bytes | None:
+def _get_sbom_content(sbom: SBOM, s3_client: StorageClient | None = None) -> bytes | None:
     """Fetch SBOM content from S3."""
     if not sbom.sbom_filename:
         return None
     try:
         if s3_client is None:
-            s3_client = S3Client("SBOMS")
+            s3_client = StorageClient("SBOMS")
         return s3_client.get_sbom_data(sbom.sbom_filename)
     except Exception:
         logger.exception("Failed to fetch SBOM %s from S3", sbom.sbom_filename)
@@ -119,8 +119,8 @@ def build_export_package(
     buf = tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024)
 
     # Create S3 clients once for reuse across all fetches
-    docs_s3 = S3Client("DOCUMENTS")
-    sboms_s3 = S3Client("SBOMS")
+    docs_s3 = StorageClient("DOCUMENTS")
+    sboms_s3 = StorageClient("SBOMS")
 
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         # 1. OSCAL catalog
@@ -238,24 +238,12 @@ def _write_to_zip(
 
 
 def get_download_url(package: CRAExportPackage) -> ServiceResult[str]:
-    """Generate a presigned S3 URL for ZIP download (1 hour expiry)."""
+    """Generate a presigned URL for ZIP download (1 hour expiry)."""
     try:
-        import boto3
-
-        s3_client = boto3.client(
-            "s3",
-            region_name=django_settings.AWS_REGION,
-            endpoint_url=django_settings.AWS_ENDPOINT_URL_S3,
-            aws_access_key_id=django_settings.AWS_DOCUMENTS_ACCESS_KEY_ID,
-            aws_secret_access_key=django_settings.AWS_DOCUMENTS_SECRET_ACCESS_KEY,
-        )
-        url: str = s3_client.generate_presigned_url(
-            "get_object",
-            Params={
-                "Bucket": django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME,
-                "Key": package.storage_key,
-            },
-            ExpiresIn=3600,
+        client = StorageClient("DOCUMENTS")
+        url = client.generate_presigned_url(
+            django_settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME,
+            package.storage_key,
         )
         return ServiceResult.success(url)
     except Exception:

--- a/sbomify/apps/compliance/tests/test_apis.py
+++ b/sbomify/apps/compliance/tests/test_apis.py
@@ -285,7 +285,7 @@ class TestCreateObservation:
 
 
 class TestGenerateDocument:
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_vdp(self, mock_s3_cls, authenticated_api_client, assessment_with_contacts):
         client, token = authenticated_api_client
 
@@ -336,8 +336,8 @@ class TestPreviewDocument:
 
 
 class TestCreateExport:
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_creates_export_package(
         self, mock_get_content, mock_s3_cls, mock_export_s3_cls, authenticated_api_client, assessment_with_contacts

--- a/sbomify/apps/compliance/tests/test_document_generation.py
+++ b/sbomify/apps/compliance/tests/test_document_generation.py
@@ -65,7 +65,7 @@ def assessment(sample_team_with_owner_member, sample_user, product):
 class TestGenerateDocument:
     """Test document generation for each kind."""
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_vdp(self, mock_s3_cls, assessment):
         result = generate_document(assessment, CRAGeneratedDocument.DocumentKind.VDP)
 
@@ -77,7 +77,7 @@ class TestGenerateDocument:
         assert doc.content_hash
         assert doc.storage_key.endswith(".md")
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_security_txt(self, mock_s3_cls, assessment):
         result = generate_document(assessment, CRAGeneratedDocument.DocumentKind.SECURITY_TXT)
 
@@ -86,7 +86,7 @@ class TestGenerateDocument:
         assert doc.document_kind == "security_txt"
         assert doc.storage_key.endswith(".txt")
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_risk_assessment(self, mock_s3_cls, assessment):
         result = generate_document(assessment, CRAGeneratedDocument.DocumentKind.RISK_ASSESSMENT)
 
@@ -94,7 +94,7 @@ class TestGenerateDocument:
         doc = result.value
         assert doc.document_kind == "risk_assessment"
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_declaration_of_conformity(self, mock_s3_cls, assessment):
         result = generate_document(assessment, CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY)
 
@@ -102,7 +102,7 @@ class TestGenerateDocument:
         doc = result.value
         assert doc.document_kind == "declaration_of_conformity"
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_all_9_kinds(self, mock_s3_cls, assessment):
         for kind, _ in CRAGeneratedDocument.DocumentKind.choices:
             result = generate_document(assessment, kind)
@@ -118,7 +118,7 @@ class TestGenerateDocument:
 class TestVersioning:
     """Test document version increments and stale flag resets."""
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_version_increments_on_regeneration(self, mock_s3_cls, assessment):
         result1 = generate_document(assessment, CRAGeneratedDocument.DocumentKind.VDP)
         assert result1.ok
@@ -129,7 +129,7 @@ class TestVersioning:
         assert result2.value.version == 2
         assert result2.value.id == result1.value.id  # Same record, updated
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_stale_flag_resets_on_regeneration(self, mock_s3_cls, assessment):
         result = generate_document(assessment, CRAGeneratedDocument.DocumentKind.VDP)
         assert result.ok
@@ -144,7 +144,7 @@ class TestVersioning:
         assert result2.ok
         assert result2.value.is_stale is False
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_content_hash_changes_when_data_changes(self, mock_s3_cls, assessment):
         result1 = generate_document(assessment, CRAGeneratedDocument.DocumentKind.VDP)
         hash1 = result1.value.content_hash
@@ -244,7 +244,7 @@ class TestRiskAssessment:
 
 @pytest.mark.django_db
 class TestRegenerateAll:
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_generates_all_document_kinds(self, mock_s3_cls, assessment):
         result = regenerate_all(assessment)
 
@@ -255,7 +255,7 @@ class TestRegenerateAll:
 
 @pytest.mark.django_db
 class TestRegenerateStale:
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_regenerates_only_stale_documents(self, mock_s3_cls, assessment):
         # Generate all
         regenerate_all(assessment)

--- a/sbomify/apps/compliance/tests/test_export_service.py
+++ b/sbomify/apps/compliance/tests/test_export_service.py
@@ -47,14 +47,14 @@ def assessment(sample_team_with_owner_member, sample_user, product):
 @pytest.fixture
 def assessment_with_docs(assessment):
     """Assessment with all documents generated."""
-    with patch("sbomify.apps.core.object_store.S3Client"):
+    with patch("sbomify.apps.core.object_store.StorageClient"):
         regenerate_all(assessment)
     return assessment
 
 
 @pytest.mark.django_db
 class TestBuildExportPackage:
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_creates_package_record(self, mock_get_content, mock_s3_cls, assessment_with_docs, sample_user):
         mock_get_content.return_value = b"mock document content"
@@ -70,7 +70,7 @@ class TestBuildExportPackage:
         assert package.manifest["product"]["name"] == "Export Test Product"
         assert package.manifest["manufacturer"]["name"] == "Acme Corp"
 
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_manifest_contains_file_entries(self, mock_get_content, mock_s3_cls, assessment_with_docs, sample_user):
         mock_get_content.return_value = b"mock document content"
@@ -88,7 +88,7 @@ class TestBuildExportPackage:
         # inconsistency between the DB manifest and the in-ZIP manifest.
         assert not any("metadata/manifest.json" in p for p in paths)
 
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_manifest_files_have_sha256(self, mock_get_content, mock_s3_cls, assessment_with_docs, sample_user):
         mock_get_content.return_value = b"mock document content"
@@ -99,7 +99,7 @@ class TestBuildExportPackage:
             assert "sha256" in file_entry
             assert len(file_entry["sha256"]) == 64
 
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_oscal_catalog_in_package(self, mock_get_content, mock_s3_cls, assessment_with_docs, sample_user):
         """OSCAL catalog JSON should be included in the package."""
@@ -113,7 +113,7 @@ class TestBuildExportPackage:
         catalog_entries = [f for f in files if "catalog.json" in f["path"]]
         assert len(catalog_entries) == 1
 
-    @patch("sbomify.apps.compliance.services.export_service.S3Client")
+    @patch("sbomify.apps.compliance.services.export_service.StorageClient")
     @patch("sbomify.apps.compliance.services.export_service._get_generated_doc_content")
     def test_product_category_in_manifest(self, mock_get_content, mock_s3_cls, assessment_with_docs, sample_user):
         mock_get_content.return_value = b"mock content"
@@ -129,10 +129,10 @@ class TestGetDownloadUrl:
         mock_package = MagicMock()
         mock_package.storage_key = "compliance/exports/test/abc.zip"
 
-        with patch("boto3.client") as mock_client_fn:
-            mock_s3 = MagicMock()
-            mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
-            mock_client_fn.return_value = mock_s3
+        with patch("sbomify.apps.compliance.services.export_service.StorageClient") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+            mock_cls.return_value = mock_instance
 
             result = get_download_url(mock_package)
 
@@ -143,8 +143,8 @@ class TestGetDownloadUrl:
         mock_package = MagicMock()
         mock_package.storage_key = "bad-key"
 
-        with patch("boto3.client") as mock_client_fn:
-            mock_client_fn.side_effect = Exception("S3 error")
+        with patch("sbomify.apps.compliance.services.export_service.StorageClient") as mock_cls:
+            mock_cls.side_effect = Exception("Storage error")
 
             result = get_download_url(mock_package)
 

--- a/sbomify/apps/compliance/tests/test_staleness.py
+++ b/sbomify/apps/compliance/tests/test_staleness.py
@@ -31,7 +31,7 @@ def assessment(sample_team_with_owner_member, sample_user, product):
 @pytest.fixture
 def assessment_with_docs(assessment):
     """Assessment with all 9 documents generated."""
-    with patch("sbomify.apps.core.object_store.S3Client"):
+    with patch("sbomify.apps.core.object_store.StorageClient"):
         regenerate_all(assessment)
     return assessment
 

--- a/sbomify/apps/compliance/views/vdp_public.py
+++ b/sbomify/apps/compliance/views/vdp_public.py
@@ -202,9 +202,9 @@ def _get_document_content(product: Any, document_kind: str) -> str | None:
 def _fetch_doc_from_s3(doc: CRAGeneratedDocument) -> str | None:
     """Fetch document content from S3 and return as string."""
     try:
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        s3 = S3Client("DOCUMENTS")
+        s3 = StorageClient("DOCUMENTS")
         data = s3.get_document_data(doc.storage_key)
         return data.decode("utf-8") if data else None
     except Exception:

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -19,7 +19,7 @@ from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_au
 from sbomify.apps.billing.config import is_billing_enabled
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.billing.stripe_cache import get_subscription_cancel_at_period_end, invalidate_subscription_cache
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.queries import optimize_component_queryset, optimize_product_queryset, optimize_project_queryset
 from sbomify.apps.core.utils import broadcast_to_workspace, build_entity_info_dict, verify_item_access
 from sbomify.apps.sboms.schemas import ComponentMetaData, ComponentMetaDataPatch, SupplierSchema
@@ -2110,7 +2110,7 @@ def delete_component(request: HttpRequest, component_id: str) -> Any:
     try:
         # Delete associated SBOMs from S3 storage
         sboms = component.sbom_set.all()
-        s3 = S3Client("SBOMS") if sboms.exists() else None
+        s3 = StorageClient("SBOMS") if sboms.exists() else None
 
         for sbom in sboms:
             if sbom.sbom_filename and s3:

--- a/sbomify/apps/core/apps.py
+++ b/sbomify/apps/core/apps.py
@@ -16,3 +16,22 @@ class CoreConfig(AppConfig):
         from sbomify.apps.core.posthog_service import shutdown
 
         atexit.register(shutdown)
+        self._validate_storage_credentials()
+
+    @staticmethod
+    def _validate_storage_credentials() -> None:
+        from django.conf import settings
+
+        from sbomify.apps.core.object_store import _VALID_BUCKET_TYPES
+
+        if getattr(settings, "STORAGE_BACKEND", "s3") != "s3":
+            return
+
+        for bucket_type in _VALID_BUCKET_TYPES:
+            access_key = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None
+            secret_key = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None
+            if (access_key is None) != (secret_key is None):
+                raise ValueError(
+                    f"AWS_{bucket_type}_ACCESS_KEY_ID and AWS_{bucket_type}_SECRET_ACCESS_KEY "
+                    f"must both be set or both be empty"
+                )

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -46,26 +46,18 @@ class S3ObjectStoreClient(ObjectStoreClient):
     def __init__(
         self,
         region: str,
-        endpoint_url: str,
+        endpoint_url: str | None = None,
         access_key: str | None = None,
         secret_key: str | None = None,
     ) -> None:
-        # When credentials are omitted, boto3 falls through to its default credential chain:
-        # env vars, IRSA tokens, EKS Pod Identity, EC2 instance metadata, etc.
-        self._resource: Any = boto3.resource(
-            "s3",
-            region_name=region,
-            endpoint_url=endpoint_url,
-            aws_access_key_id=access_key if access_key else None,
-            aws_secret_access_key=secret_key if secret_key else None,
-        )
-        self._client: Any = boto3.client(
-            "s3",
-            region_name=region,
-            endpoint_url=endpoint_url,
-            aws_access_key_id=access_key if access_key else None,
-            aws_secret_access_key=secret_key if secret_key else None,
-        )
+        self._boto3_kwargs: dict[str, Any] = {
+            "region_name": region,
+            "endpoint_url": endpoint_url,
+            "aws_access_key_id": access_key,
+            "aws_secret_access_key": secret_key,
+        }
+        self._resource: Any = boto3.resource("s3", **self._boto3_kwargs)
+        self.__client: Any | None = None
 
     def put_object(self, bucket_name: str, key: str, data: bytes) -> None:
         self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
@@ -83,6 +75,12 @@ class S3ObjectStoreClient(ObjectStoreClient):
     def download_file(self, bucket_name: str, key: str, file_path: str) -> None:
         self._resource.Bucket(bucket_name).download_file(key, file_path)
 
+    @property
+    def _client(self) -> Any:
+        if self.__client is None:
+            self.__client = boto3.client("s3", **self._boto3_kwargs)
+        return self.__client
+
     def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
         url: str = self._client.generate_presigned_url(
             "get_object",
@@ -92,21 +90,17 @@ class S3ObjectStoreClient(ObjectStoreClient):
         return url
 
 
-def _create_store(bucket_type: str) -> ObjectStoreClient:
+def _create_store(bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> ObjectStoreClient:
     """Create a storage backend based on STORAGE_BACKEND setting."""
-    backend = settings.STORAGE_BACKEND
-
-    if backend == "s3":
-        access_key: str = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "") or ""
-        secret_key: str = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "") or ""
+    if settings.STORAGE_BACKEND == "s3":
         return S3ObjectStoreClient(
             region=settings.AWS_REGION,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3 or None,
-            access_key=access_key or None,
-            secret_key=secret_key or None,
+            access_key=getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None,
+            secret_key=getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None,
         )
 
-    raise ValueError(f"Unsupported STORAGE_BACKEND: {backend!r}. Supported values: 's3'")
+    raise ValueError(f"Unsupported STORAGE_BACKEND: {settings.STORAGE_BACKEND!r}. Supported values: 's3'")
 
 
 class StorageClient:

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -91,6 +91,8 @@ class S3ObjectStoreClient(ObjectStoreClient):
         return self.__client
 
     def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
+        if expires_in <= 0:
+            raise ValueError(f"expires_in must be positive, got {expires_in}")
         url: str = self._client.generate_presigned_url(
             "get_object",
             Params={"Bucket": bucket_name, "Key": key},

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -1,12 +1,14 @@
 """
-S3 Compatible Storage
+Object Storage
 
-Utilities for working with S3 compatible storage services.
+Utilities for working with S3-compatible storage services.
+Supports optional credentials to enable cloud workload identity (IRSA, Pod Identity, ADC).
 """
 
 from __future__ import annotations
 
 import hashlib
+from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 import boto3
@@ -14,18 +16,117 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 
 
-class S3Client:
+class ObjectStoreClient(ABC):
+    """Base class for object storage backends."""
+
+    @abstractmethod
+    def put_object(self, bucket_name: str, key: str, data: bytes) -> None: ...
+
+    @abstractmethod
+    def get_object(self, bucket_name: str, key: str) -> bytes | None: ...
+
+    @abstractmethod
+    def delete_object(self, bucket_name: str, key: str) -> None: ...
+
+    @abstractmethod
+    def upload_file(self, bucket_name: str, file_path: str, key: str) -> None: ...
+
+    @abstractmethod
+    def download_file(self, bucket_name: str, key: str, file_path: str) -> None: ...
+
+    @abstractmethod
+    def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str: ...
+
+
+class S3ObjectStoreClient(ObjectStoreClient):
+    """S3-compatible storage backend using boto3. Works with AWS S3, Cloudflare R2, and Minio."""
+
+    def __init__(
+        self,
+        region: str,
+        endpoint_url: str,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+    ) -> None:
+        # When credentials are omitted, boto3 falls through to its default credential chain:
+        # env vars, IRSA tokens, EKS Pod Identity, EC2 instance metadata, etc.
+        self._resource: Any = boto3.resource(
+            "s3",
+            region_name=region,
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key if access_key else None,
+            aws_secret_access_key=secret_key if secret_key else None,
+        )
+        self._client: Any = boto3.client(
+            "s3",
+            region_name=region,
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key if access_key else None,
+            aws_secret_access_key=secret_key if secret_key else None,
+        )
+
+    def put_object(self, bucket_name: str, key: str, data: bytes) -> None:
+        try:
+            self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
+        except ClientError as e:
+            print(e)  # noqa F821
+            raise
+
+    def get_object(self, bucket_name: str, key: str) -> bytes | None:
+        try:
+            response = self._resource.Bucket(bucket_name).Object(key).get()
+            if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+                return response["Body"].read()  # type: ignore[no-any-return]
+            else:
+                return None
+        except ClientError as e:
+            print(e)  # noqa F821
+            raise
+
+    def delete_object(self, bucket_name: str, key: str) -> None:
+        try:
+            self._resource.Object(bucket_name, key).delete()
+        except ClientError as e:
+            print(e)  # noqa F821
+            raise
+
+    def upload_file(self, bucket_name: str, file_path: str, key: str) -> None:
+        try:
+            self._resource.Bucket(bucket_name).upload_file(file_path, key)
+        except ClientError as e:
+            print(e)  # noqa F821
+            raise
+
+    def download_file(self, bucket_name: str, key: str, file_path: str) -> None:
+        try:
+            self._resource.Bucket(bucket_name).download_file(key, file_path)
+        except ClientError as e:
+            print(e)  # noqa F821
+            raise
+
+    def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
+        url: str = self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket_name, "Key": key},
+            ExpiresIn=expires_in,
+        )
+        return url
+
+
+class StorageClient:
+    """Domain-level storage client. Delegates to an ObjectStoreClient backend."""
+
     def __init__(self, bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> None:
         self.bucket_type = bucket_type
-        access_key: str = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID")
-        secret_key: str = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY")
-        self.s3: Any = boto3.resource(
-            "s3",
-            region_name=settings.AWS_REGION,
+        access_key: str = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "") or ""
+        secret_key: str = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "") or ""
+        self._store = S3ObjectStoreClient(
+            region=settings.AWS_REGION,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3,
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
+            access_key=access_key or None,
+            secret_key=secret_key or None,
         )
+        self.s3: Any = self._store._resource
 
     def upload_data_as_file(self, bucket_name: str, object_name: str, data: bytes) -> None:
         try:
@@ -101,3 +202,6 @@ class S3Client:
         except ClientError as e:
             print(e)  # noqa F821
             raise
+
+    def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
+        return self._store.generate_presigned_url(bucket_name, key, expires_in)

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -93,8 +93,14 @@ class S3ObjectStoreClient(ObjectStoreClient):
         return url
 
 
+_VALID_BUCKET_TYPES = ("MEDIA", "SBOMS", "DOCUMENTS")
+
+
 def _create_store(bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> ObjectStoreClient:
     """Create a storage backend based on STORAGE_BACKEND setting."""
+    if bucket_type not in _VALID_BUCKET_TYPES:
+        raise ValueError(f"Invalid bucket_type: {bucket_type!r}. Must be one of {_VALID_BUCKET_TYPES}")
+
     if settings.STORAGE_BACKEND == "s3":
         return S3ObjectStoreClient(
             region=settings.AWS_REGION,

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -57,6 +57,12 @@ class S3ObjectStoreClient(ObjectStoreClient):
         self._resource: Any = boto3.resource("s3", **self._boto3_kwargs)
         self.__client: Any | None = None
 
+    def __repr__(self) -> str:
+        return (
+            f"S3ObjectStoreClient(region={self._boto3_kwargs['region_name']!r}, "
+            f"endpoint_url={self._boto3_kwargs['endpoint_url']!r})"
+        )
+
     def put_object(self, bucket_name: str, key: str, data: bytes) -> None:
         self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
 

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -8,12 +8,14 @@ Supports optional credentials to enable cloud workload identity (IRSA, Pod Ident
 from __future__ import annotations
 
 import hashlib
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 import boto3
-from botocore.exceptions import ClientError
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 class ObjectStoreClient(ABC):
@@ -66,43 +68,20 @@ class S3ObjectStoreClient(ObjectStoreClient):
         )
 
     def put_object(self, bucket_name: str, key: str, data: bytes) -> None:
-        try:
-            self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
 
     def get_object(self, bucket_name: str, key: str) -> bytes | None:
-        try:
-            response = self._resource.Bucket(bucket_name).Object(key).get()
-            if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
-                return response["Body"].read()  # type: ignore[no-any-return]
-            else:
-                return None
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        response = self._resource.Bucket(bucket_name).Object(key).get()
+        return response["Body"].read()  # type: ignore[no-any-return]
 
     def delete_object(self, bucket_name: str, key: str) -> None:
-        try:
-            self._resource.Object(bucket_name, key).delete()
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._resource.Object(bucket_name, key).delete()
 
     def upload_file(self, bucket_name: str, file_path: str, key: str) -> None:
-        try:
-            self._resource.Bucket(bucket_name).upload_file(file_path, key)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._resource.Bucket(bucket_name).upload_file(file_path, key)
 
     def download_file(self, bucket_name: str, key: str, file_path: str) -> None:
-        try:
-            self._resource.Bucket(bucket_name).download_file(key, file_path)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._resource.Bucket(bucket_name).download_file(key, file_path)
 
     def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
         url: str = self._client.generate_presigned_url(
@@ -113,27 +92,32 @@ class S3ObjectStoreClient(ObjectStoreClient):
         return url
 
 
-class StorageClient:
-    """Domain-level storage client. Delegates to an ObjectStoreClient backend."""
+def _create_store(bucket_type: str) -> ObjectStoreClient:
+    """Create a storage backend based on STORAGE_BACKEND setting."""
+    backend = settings.STORAGE_BACKEND
 
-    def __init__(self, bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> None:
-        self.bucket_type = bucket_type
+    if backend == "s3":
         access_key: str = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "") or ""
         secret_key: str = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "") or ""
-        self._store = S3ObjectStoreClient(
+        return S3ObjectStoreClient(
             region=settings.AWS_REGION,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3,
             access_key=access_key or None,
             secret_key=secret_key or None,
         )
-        self.s3: Any = self._store._resource
+
+    raise ValueError(f"Unsupported STORAGE_BACKEND: {backend!r}. Supported values: 's3'")
+
+
+class StorageClient:
+    """Domain-level storage client. Delegates to an ObjectStoreClient backend."""
+
+    def __init__(self, bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> None:
+        self.bucket_type = bucket_type
+        self._store: ObjectStoreClient = _create_store(bucket_type)
 
     def upload_data_as_file(self, bucket_name: str, object_name: str, data: bytes) -> None:
-        try:
-            self.s3.Bucket(bucket_name).put_object(Key=object_name, Body=data)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._store.put_object(bucket_name, object_name, data)
 
     def upload_media(self, object_name: str, data: bytes) -> None:
         if self.bucket_type != "MEDIA":
@@ -172,36 +156,16 @@ class StorageClient:
         return self.get_file_data(settings.AWS_DOCUMENTS_STORAGE_BUCKET_NAME, object_name)
 
     def upload_file(self, bucket_name: str, file_path: str, object_name: str) -> None:
-        try:
-            self.s3.Bucket(bucket_name).upload_file(file_path, object_name)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._store.upload_file(bucket_name, file_path, object_name)
 
     def download_file(self, bucket_name: str, object_name: str, file_path: str) -> None:
-        try:
-            self.s3.Bucket(bucket_name).download_file(object_name, file_path)
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._store.download_file(bucket_name, object_name, file_path)
 
     def get_file_data(self, bucket_name: str, file_path: str) -> bytes | None:
-        try:
-            response = self.s3.Bucket(bucket_name).Object(file_path).get()
-            if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
-                return response["Body"].read()  # type: ignore[no-any-return]
-            else:
-                return None
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        return self._store.get_object(bucket_name, file_path)
 
     def delete_object(self, bucket_name: str, object_name: str) -> None:
-        try:
-            self.s3.Object(bucket_name, object_name).delete()
-        except ClientError as e:
-            print(e)  # noqa F821
-            raise
+        self._store.delete_object(bucket_name, object_name)
 
     def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
         return self._store.generate_presigned_url(bucket_name, key, expires_in)

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 import boto3
+from botocore.exceptions import ClientError
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -63,8 +64,13 @@ class S3ObjectStoreClient(ObjectStoreClient):
         self._resource.Bucket(bucket_name).put_object(Key=key, Body=data)
 
     def get_object(self, bucket_name: str, key: str) -> bytes | None:
-        response = self._resource.Bucket(bucket_name).Object(key).get()
-        return response["Body"].read()  # type: ignore[no-any-return]
+        try:
+            response = self._resource.Bucket(bucket_name).Object(key).get()
+            return response["Body"].read()  # type: ignore[no-any-return]
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                return None
+            raise
 
     def delete_object(self, bucket_name: str, key: str) -> None:
         self._resource.Object(bucket_name, key).delete()

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -119,7 +119,7 @@ def _create_store(bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> Object
             )
 
         return S3ObjectStoreClient(
-            region=settings.AWS_REGION,
+            region=settings.AWS_REGION or None,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3 or None,
             access_key=access_key,
             secret_key=secret_key,

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -101,7 +101,7 @@ def _create_store(bucket_type: str) -> ObjectStoreClient:
         secret_key: str = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "") or ""
         return S3ObjectStoreClient(
             region=settings.AWS_REGION,
-            endpoint_url=settings.AWS_ENDPOINT_URL_S3,
+            endpoint_url=settings.AWS_ENDPOINT_URL_S3 or None,
             access_key=access_key or None,
             secret_key=secret_key or None,
         )

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -102,11 +102,18 @@ def _create_store(bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> Object
         raise ValueError(f"Invalid bucket_type: {bucket_type!r}. Must be one of {_VALID_BUCKET_TYPES}")
 
     if settings.STORAGE_BACKEND == "s3":
+        access_key = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None
+        secret_key = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None
+        if (access_key is None) != (secret_key is None):
+            raise ValueError(
+                f"AWS_{bucket_type}_ACCESS_KEY_ID and AWS_{bucket_type}_SECRET_ACCESS_KEY must both be set or both be empty"
+            )
+
         return S3ObjectStoreClient(
             region=settings.AWS_REGION,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3 or None,
-            access_key=getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None,
-            secret_key=getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None,
+            access_key=access_key,
+            secret_key=secret_key,
         )
 
     raise ValueError(f"Unsupported STORAGE_BACKEND: {settings.STORAGE_BACKEND!r}. Supported values: 's3'")

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -111,18 +111,11 @@ def _create_store(bucket_type: Literal["MEDIA", "SBOMS", "DOCUMENTS"]) -> Object
         raise ValueError(f"Invalid bucket_type: {bucket_type!r}. Must be one of {_VALID_BUCKET_TYPES}")
 
     if settings.STORAGE_BACKEND == "s3":
-        access_key = getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None
-        secret_key = getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None
-        if (access_key is None) != (secret_key is None):
-            raise ValueError(
-                f"AWS_{bucket_type}_ACCESS_KEY_ID and AWS_{bucket_type}_SECRET_ACCESS_KEY must both be set or both be empty"
-            )
-
         return S3ObjectStoreClient(
             region=settings.AWS_REGION or None,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3 or None,
-            access_key=access_key,
-            secret_key=secret_key,
+            access_key=getattr(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", None) or None,
+            secret_key=getattr(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", None) or None,
         )
 
     raise ValueError(f"Unsupported STORAGE_BACKEND: {settings.STORAGE_BACKEND!r}. Supported values: 's3'")

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -8,15 +8,12 @@ Supports optional credentials to enable cloud workload identity (IRSA, Pod Ident
 from __future__ import annotations
 
 import hashlib
-import logging
 from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
-
-logger = logging.getLogger(__name__)
 
 
 class ObjectStoreClient(ABC):

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -55,7 +55,7 @@ class S3ObjectStoreClient(ObjectStoreClient):
             "aws_secret_access_key": secret_key,
         }
         self._resource: Any = boto3.resource("s3", **self._boto3_kwargs)
-        self.__client: Any | None = None
+        self._client_instance: Any | None = None
 
     def __repr__(self) -> str:
         return (
@@ -86,9 +86,10 @@ class S3ObjectStoreClient(ObjectStoreClient):
 
     @property
     def _client(self) -> Any:
-        if self.__client is None:
-            self.__client = boto3.client("s3", **self._boto3_kwargs)
-        return self.__client
+        # Not thread-safe: assumes instances are not shared across threads (per-request lifecycle).
+        if self._client_instance is None:
+            self._client_instance = boto3.client("s3", **self._boto3_kwargs)
+        return self._client_instance
 
     def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
         if expires_in <= 0:

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -373,15 +373,18 @@ class TestStorageClient:
         self.mock_store.generate_presigned_url.assert_called_once_with("my-bucket", "path/to/key", 3600)
 
     @pytest.mark.parametrize(
-        "method,args",
+        "method,args,wrong_type,expected_match",
         [
-            ("upload_sbom", (b"data",)),
-            ("get_sbom_data", ("test",)),
+            ("upload_sbom", (b"data",), "MEDIA", "only for SBOMS bucket"),
+            ("get_sbom_data", ("test",), "MEDIA", "only for SBOMS bucket"),
+            ("upload_document", (b"data",), "SBOMS", "only for DOCUMENTS bucket"),
+            ("get_document_data", ("test",), "SBOMS", "only for DOCUMENTS bucket"),
+            ("upload_media", ("obj", b"data"), "SBOMS", "only for MEDIA bucket"),
         ],
     )
-    def test_bucket_type_validation(self, method: str, args: tuple):
-        client = StorageClient("MEDIA")
-        with pytest.raises(ValueError, match="only for SBOMS bucket"):
+    def test_bucket_type_validation(self, method: str, args: tuple, wrong_type: str, expected_match: str):
+        client = StorageClient(wrong_type)
+        with pytest.raises(ValueError, match=expected_match):
             getattr(client, method)(*args)
 
     def test_error_propagation(self):

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -63,6 +63,20 @@ class TestS3ObjectStoreClient:
         )
         mock_client.assert_not_called()
 
+    def test_repr_does_not_expose_secrets(self, mocker: MockerFixture):
+        mocker.patch("boto3.resource")
+        store = S3ObjectStoreClient(
+            region="us-east-1",
+            endpoint_url="http://localhost:9000",
+            access_key="AKIAIOSFODNN7EXAMPLE",
+            secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        )
+        r = repr(store)
+        assert "us-east-1" in r
+        assert "localhost:9000" in r
+        assert "AKIAIOSFODNN7EXAMPLE" not in r
+        assert "wJalrXUtnFEMI" not in r
+
     def test_init_with_empty_string_credentials(self, mocker: MockerFixture):
         """Empty strings should be passed as-is — normalization is the caller's responsibility."""
         mock_resource = mocker.patch("boto3.resource")

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -285,36 +285,6 @@ class TestStorageClient:
         with pytest.raises(ValueError, match="Invalid bucket_type"):
             StorageClient("INVALID")  # type: ignore[arg-type]
 
-    def test_mismatched_credentials_raises(self, mocker: MockerFixture):
-        """Only access key set without secret key should raise."""
-        mocker.stopall()
-        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
-        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
-        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
-        mocker.patch("boto3.resource")
-        with pytest.raises(ValueError, match="must both be set or both be empty"):
-            StorageClient("SBOMS")
-
-    def test_mismatched_credentials_secret_only_raises(self, mocker: MockerFixture):
-        """Only secret key set without access key should raise."""
-        mocker.stopall()
-        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
-        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
-        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
-        mocker.patch("boto3.resource")
-        with pytest.raises(ValueError, match="must both be set or both be empty"):
-            StorageClient("SBOMS")
-
-    def test_both_credentials_empty_is_valid(self, mocker: MockerFixture):
-        """Both credentials empty (IAM/IRSA) should work without error."""
-        mocker.stopall()
-        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
-        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
-        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
-        mocker.patch("boto3.resource")
-        client = StorageClient("SBOMS")
-        assert isinstance(client._store, S3ObjectStoreClient)
-
     def test_unsupported_backend_raises(self, mocker: MockerFixture):
         mocker.stopall()
         mocker.patch.object(settings, "STORAGE_BACKEND", "azure")

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -7,7 +7,6 @@ from pytest_mock.plugin import MockerFixture
 
 from sbomify.apps.core.object_store import ObjectStoreClient, S3ObjectStoreClient, StorageClient
 
-
 # ---------------------------------------------------------------------------
 # ObjectStoreClient (abstract base)
 # ---------------------------------------------------------------------------
@@ -169,22 +168,23 @@ class TestS3ObjectStoreClient:
 
 
 # ---------------------------------------------------------------------------
-# StorageClient (domain wrapper, delegates to S3ObjectStoreClient)
+# StorageClient (domain wrapper, delegates to ObjectStoreClient)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def mock_s3(mocker: MockerFixture):
-    """Mock boto3 S3 resource and return mock bucket/object references."""
-    mock_resource = mocker.patch("boto3.resource")
-    mocker.patch("boto3.client")
-    return mock_resource.return_value
-
-
 class TestStorageClient:
+    @pytest.fixture(autouse=True)
+    def _mock_store(self, mocker: MockerFixture):
+        """Replace _create_store so StorageClient gets a mock ObjectStoreClient."""
+        self.mock_store = mocker.MagicMock(spec=S3ObjectStoreClient)
+        mocker.patch("sbomify.apps.core.object_store._create_store", return_value=self.mock_store)
+
     def test_creates_s3_store_with_credentials(self, mocker: MockerFixture):
+        # Undo autouse mock to test real _create_store
+        mocker.stopall()
         mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
         mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
         mock_resource = mocker.patch("boto3.resource")
         mocker.patch("boto3.client")
 
@@ -202,8 +202,10 @@ class TestStorageClient:
 
     def test_credentials_optional_when_empty(self, mocker: MockerFixture):
         """Empty credential strings (from env defaults) should result in None passed to boto3."""
+        mocker.stopall()
         mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
         mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
         mock_resource = mocker.patch("boto3.resource")
         mocker.patch("boto3.client")
 
@@ -217,68 +219,73 @@ class TestStorageClient:
             aws_secret_access_key=None,
         )
 
+    def test_unsupported_backend_raises(self, mocker: MockerFixture):
+        mocker.stopall()
+        mocker.patch.object(settings, "STORAGE_BACKEND", "azure")
+        with pytest.raises(ValueError, match="Unsupported STORAGE_BACKEND"):
+            StorageClient("SBOMS")
+
     @pytest.mark.parametrize("bucket_type", ["MEDIA", "SBOMS", "DOCUMENTS"])
-    def test_client_initialization(self, bucket_type: str, mocker: MockerFixture):
-        mocker.patch.object(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "test-key")
-        mocker.patch.object(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "test-secret")
-        mock_resource = mocker.patch("boto3.resource")
-        mocker.patch("boto3.client")
-
+    def test_client_initialization(self, bucket_type: str):
         client = StorageClient(bucket_type)
-
         assert client.bucket_type == bucket_type
-        mock_resource.assert_called_once_with(
-            "s3",
-            region_name=settings.AWS_REGION,
-            endpoint_url=settings.AWS_ENDPOINT_URL_S3,
-            aws_access_key_id="test-key",
-            aws_secret_access_key="test-secret",
+        assert client._store is self.mock_store
+
+    def test_upload_data_as_file_delegates(self):
+        client = StorageClient("MEDIA")
+        client.upload_data_as_file("my-bucket", "key", b"data")
+        self.mock_store.put_object.assert_called_once_with("my-bucket", "key", b"data")
+
+    def test_upload_media_delegates(self):
+        client = StorageClient("MEDIA")
+        client.upload_media("test_object", b"test_data")
+        self.mock_store.put_object.assert_called_once_with(
+            settings.AWS_MEDIA_STORAGE_BUCKET_NAME, "test_object", b"test_data"
         )
 
-    def test_upload_media_success(self, mock_s3):
-        test_data = b"test_data"
-        client = StorageClient("MEDIA")
-        mock_bucket = mock_s3.Bucket.return_value
-
-        client.upload_media("test_object", test_data)
-
-        mock_bucket.put_object.assert_called_once_with(Key="test_object", Body=test_data)
-        assert mock_s3.Bucket.call_args[0][0] == settings.AWS_MEDIA_STORAGE_BUCKET_NAME
-
-    def test_upload_sbom_success(self, mock_s3):
-        test_data = b"test_data"
+    def test_upload_sbom_delegates(self):
         client = StorageClient("SBOMS")
-        mock_bucket = mock_s3.Bucket.return_value
-
-        object_name = client.upload_sbom(test_data)
-
+        object_name = client.upload_sbom(b"test_data")
         assert object_name.endswith(".json")
-        mock_bucket.put_object.assert_called_once()
-        assert mock_s3.Bucket.call_args[0][0] == settings.AWS_SBOMS_STORAGE_BUCKET_NAME
+        self.mock_store.put_object.assert_called_once()
+        call_args = self.mock_store.put_object.call_args
+        assert call_args[0][0] == settings.AWS_SBOMS_STORAGE_BUCKET_NAME
 
-    def test_get_sbom_data_success(self, mock_s3):
+    def test_get_sbom_data_delegates(self):
+        self.mock_store.get_object.return_value = b"test_data"
         client = StorageClient("SBOMS")
-        mock_object = mock_s3.Bucket.return_value.Object.return_value
-        mock_body = Mock()
-        mock_body.read.return_value = b"test_data"
-        mock_object.get.return_value = {
-            "Body": mock_body,
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-        }
-
         data = client.get_sbom_data("test_object")
-
         assert data == b"test_data"
-        mock_s3.Bucket.assert_called_with(settings.AWS_SBOMS_STORAGE_BUCKET_NAME)
+        self.mock_store.get_object.assert_called_once_with(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, "test_object")
 
-    def test_delete_object_success(self, mock_s3):
+    def test_get_file_data_delegates(self):
+        self.mock_store.get_object.return_value = b"file_bytes"
+        client = StorageClient("SBOMS")
+        data = client.get_file_data("my-bucket", "path/to/file")
+        assert data == b"file_bytes"
+        self.mock_store.get_object.assert_called_once_with("my-bucket", "path/to/file")
+
+    def test_delete_object_delegates(self):
         client = StorageClient("MEDIA")
-        mock_object = mock_s3.Object.return_value
-
         client.delete_object("test_bucket", "test_object")
+        self.mock_store.delete_object.assert_called_once_with("test_bucket", "test_object")
 
-        mock_object.delete.assert_called_once()
-        mock_s3.Object.assert_called_with("test_bucket", "test_object")
+    def test_upload_file_delegates(self):
+        client = StorageClient("MEDIA")
+        client.upload_file("my-bucket", "/tmp/file.txt", "key")
+        self.mock_store.upload_file.assert_called_once_with("my-bucket", "/tmp/file.txt", "key")
+
+    def test_download_file_delegates(self):
+        client = StorageClient("MEDIA")
+        client.download_file("my-bucket", "key", "/tmp/file.txt")
+        self.mock_store.download_file.assert_called_once_with("my-bucket", "key", "/tmp/file.txt")
+
+    def test_generate_presigned_url_delegates(self):
+        self.mock_store.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+        client = StorageClient("DOCUMENTS")
+        url = client.generate_presigned_url("my-bucket", "path/to/key", expires_in=3600)
+        assert url == "https://s3.example.com/presigned"
+        self.mock_store.generate_presigned_url.assert_called_once_with("my-bucket", "path/to/key", 3600)
 
     @pytest.mark.parametrize(
         "method,args",
@@ -287,38 +294,15 @@ class TestStorageClient:
             ("get_sbom_data", ("test",)),
         ],
     )
-    def test_bucket_type_validation(self, method: str, args: tuple, mock_s3):
+    def test_bucket_type_validation(self, method: str, args: tuple):
         client = StorageClient("MEDIA")
-        mock_bucket = mock_s3.Bucket.return_value
-
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="only for SBOMS bucket"):
             getattr(client, method)(*args)
 
-        assert "only for SBOMS bucket" in str(exc.value)
-        mock_bucket.put_object.assert_not_called()
-        mock_s3.Bucket.return_value.Object.return_value.get.assert_not_called()
-
-    def test_error_handling(self, mock_s3):
-        client = StorageClient("MEDIA")
-        mock_s3.Bucket.return_value.put_object.side_effect = ClientError(
+    def test_error_propagation(self):
+        self.mock_store.put_object.side_effect = ClientError(
             error_response={"Error": {"Code": 403}}, operation_name="PutObject"
         )
-
+        client = StorageClient("MEDIA")
         with pytest.raises(ClientError):
             client.upload_media("test", b"data")
-
-    def test_generate_presigned_url(self, mocker: MockerFixture):
-        mocker.patch("boto3.resource")
-        mock_client_fn = mocker.patch("boto3.client")
-        mock_client = mock_client_fn.return_value
-        mock_client.generate_presigned_url.return_value = "https://s3.example.com/presigned"
-
-        client = StorageClient("DOCUMENTS")
-        url = client.generate_presigned_url("my-bucket", "path/to/key", expires_in=3600)
-
-        assert url == "https://s3.example.com/presigned"
-        mock_client.generate_presigned_url.assert_called_once_with(
-            "get_object",
-            Params={"Bucket": "my-bucket", "Key": "path/to/key"},
-            ExpiresIn=3600,
-        )

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -148,6 +148,24 @@ class TestS3ObjectStoreClient:
         )
         assert url == "https://s3.example.com/presigned"
 
+    def test_get_object_returns_none_for_missing_key(self, s3_store):
+        store, mock_s3 = s3_store
+        mock_s3.Bucket.return_value.Object.return_value.get.side_effect = ClientError(
+            error_response={"Error": {"Code": "NoSuchKey"}},
+            operation_name="GetObject",
+        )
+        result = store.get_object("my-bucket", "missing/key")
+        assert result is None
+
+    def test_get_object_raises_on_other_errors(self, s3_store):
+        store, mock_s3 = s3_store
+        mock_s3.Bucket.return_value.Object.return_value.get.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied"}},
+            operation_name="GetObject",
+        )
+        with pytest.raises(ClientError):
+            store.get_object("my-bucket", "path/to/key")
+
     def test_error_propagation(self, s3_store):
         store, mock_s3 = s3_store
         mock_s3.Bucket.return_value.put_object.side_effect = ClientError(

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -5,58 +5,249 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from pytest_mock.plugin import MockerFixture
 
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import ObjectStoreClient, S3ObjectStoreClient, StorageClient
+
+
+# ---------------------------------------------------------------------------
+# ObjectStoreClient (abstract base)
+# ---------------------------------------------------------------------------
+
+
+class TestObjectStoreClient:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            ObjectStoreClient()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# S3ObjectStoreClient
+# ---------------------------------------------------------------------------
+
+
+class TestS3ObjectStoreClient:
+    def test_init_with_explicit_credentials(self, mocker: MockerFixture):
+        mock_resource = mocker.patch("boto3.resource")
+        mock_client = mocker.patch("boto3.client")
+
+        S3ObjectStoreClient(
+            region="us-east-1",
+            endpoint_url="http://localhost:9000",
+            access_key="my-key",
+            secret_key="my-secret",
+        )
+
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id="my-key",
+            aws_secret_access_key="my-secret",
+        )
+        mock_client.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id="my-key",
+            aws_secret_access_key="my-secret",
+        )
+
+    def test_init_without_credentials(self, mocker: MockerFixture):
+        mock_resource = mocker.patch("boto3.resource")
+        mock_client = mocker.patch("boto3.client")
+
+        S3ObjectStoreClient(
+            region="us-east-1",
+            endpoint_url="http://localhost:9000",
+        )
+
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
+        mock_client.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
+
+    def test_init_with_empty_string_credentials(self, mocker: MockerFixture):
+        """Empty strings (from os.environ.get(..., '')) should be treated as None (no credentials)."""
+        mock_resource = mocker.patch("boto3.resource")
+        mock_client = mocker.patch("boto3.client")
+
+        S3ObjectStoreClient(
+            region="us-east-1",
+            endpoint_url="http://localhost:9000",
+            access_key="",
+            secret_key="",
+        )
+
+        # Empty strings should be converted to None so boto3 uses default credential chain
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
+        mock_client.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
+
+    @pytest.fixture
+    def s3_store(self, mocker: MockerFixture):
+        mock_resource = mocker.patch("boto3.resource")
+        mocker.patch("boto3.client")
+        store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
+        return store, mock_resource.return_value
+
+    def test_put_object(self, s3_store):
+        store, mock_s3 = s3_store
+        store.put_object("my-bucket", "path/to/key", b"hello")
+        mock_s3.Bucket.return_value.put_object.assert_called_once_with(Key="path/to/key", Body=b"hello")
+
+    def test_get_object(self, s3_store):
+        store, mock_s3 = s3_store
+        mock_body = Mock()
+        mock_body.read.return_value = b"hello"
+        mock_s3.Bucket.return_value.Object.return_value.get.return_value = {
+            "Body": mock_body,
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        result = store.get_object("my-bucket", "path/to/key")
+        assert result == b"hello"
+
+    def test_delete_object(self, s3_store):
+        store, mock_s3 = s3_store
+        store.delete_object("my-bucket", "path/to/key")
+        mock_s3.Object.return_value.delete.assert_called_once()
+        mock_s3.Object.assert_called_with("my-bucket", "path/to/key")
+
+    def test_upload_file(self, s3_store):
+        store, mock_s3 = s3_store
+        store.upload_file("my-bucket", "/tmp/file.txt", "path/to/key")
+        mock_s3.Bucket.return_value.upload_file.assert_called_once_with("/tmp/file.txt", "path/to/key")
+
+    def test_download_file(self, s3_store):
+        store, mock_s3 = s3_store
+        store.download_file("my-bucket", "path/to/key", "/tmp/file.txt")
+        mock_s3.Bucket.return_value.download_file.assert_called_once_with("path/to/key", "/tmp/file.txt")
+
+    def test_generate_presigned_url(self, mocker: MockerFixture):
+        mocker.patch("boto3.resource")
+        mock_client_fn = mocker.patch("boto3.client")
+        mock_client = mock_client_fn.return_value
+        mock_client.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+        store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
+        url = store.generate_presigned_url("my-bucket", "path/to/key", expires_in=7200)
+
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "path/to/key"},
+            ExpiresIn=7200,
+        )
+        assert url == "https://s3.example.com/presigned"
+
+    def test_error_propagation(self, s3_store):
+        store, mock_s3 = s3_store
+        mock_s3.Bucket.return_value.put_object.side_effect = ClientError(
+            error_response={"Error": {"Code": "403"}},
+            operation_name="PutObject",
+        )
+        with pytest.raises(ClientError):
+            store.put_object("my-bucket", "key", b"data")
+
+
+# ---------------------------------------------------------------------------
+# StorageClient (domain wrapper, delegates to S3ObjectStoreClient)
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
 def mock_s3(mocker: MockerFixture):
-    """Mock boto3 S3 resource and return mock bucket/object references"""
+    """Mock boto3 S3 resource and return mock bucket/object references."""
     mock_resource = mocker.patch("boto3.resource")
-    mock_s3 = mock_resource.return_value
-    return mock_s3
+    mocker.patch("boto3.client")
+    return mock_resource.return_value
 
 
-class TestS3Client:
-    @pytest.mark.parametrize("bucket_type", ["MEDIA", "SBOMS"])
+class TestStorageClient:
+    def test_creates_s3_store_with_credentials(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
+        mock_resource = mocker.patch("boto3.resource")
+        mocker.patch("boto3.client")
+
+        client = StorageClient("SBOMS")
+
+        assert client.bucket_type == "SBOMS"
+        assert isinstance(client._store, S3ObjectStoreClient)
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name=settings.AWS_REGION,
+            endpoint_url=settings.AWS_ENDPOINT_URL_S3,
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+        )
+
+    def test_credentials_optional_when_empty(self, mocker: MockerFixture):
+        """Empty credential strings (from env defaults) should result in None passed to boto3."""
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        mock_resource = mocker.patch("boto3.resource")
+        mocker.patch("boto3.client")
+
+        StorageClient("SBOMS")
+
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name=settings.AWS_REGION,
+            endpoint_url=settings.AWS_ENDPOINT_URL_S3,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
+
+    @pytest.mark.parametrize("bucket_type", ["MEDIA", "SBOMS", "DOCUMENTS"])
     def test_client_initialization(self, bucket_type: str, mocker: MockerFixture):
-        """Test S3 client initialization with different bucket types"""
-        # Mock settings access
         mocker.patch.object(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "test-key")
         mocker.patch.object(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "test-secret")
-
-        # Mock boto3 and capture constructor args
         mock_resource = mocker.patch("boto3.resource")
+        mocker.patch("boto3.client")
 
-        client = S3Client(bucket_type)
+        client = StorageClient(bucket_type)
 
-        # Verify initialization parameters
         assert client.bucket_type == bucket_type
         mock_resource.assert_called_once_with(
             "s3",
             region_name=settings.AWS_REGION,
             endpoint_url=settings.AWS_ENDPOINT_URL_S3,
             aws_access_key_id="test-key",
-            aws_secret_access_key="test-secret"
+            aws_secret_access_key="test-secret",
         )
 
     def test_upload_media_success(self, mock_s3):
-        """Test media upload to correct bucket"""
         test_data = b"test_data"
-        client = S3Client("MEDIA")
+        client = StorageClient("MEDIA")
         mock_bucket = mock_s3.Bucket.return_value
 
         client.upload_media("test_object", test_data)
 
-        mock_bucket.put_object.assert_called_once_with(
-            Key="test_object",
-            Body=test_data
-        )
+        mock_bucket.put_object.assert_called_once_with(Key="test_object", Body=test_data)
         assert mock_s3.Bucket.call_args[0][0] == settings.AWS_MEDIA_STORAGE_BUCKET_NAME
 
     def test_upload_sbom_success(self, mock_s3):
-        """Test SBOM upload with generated filename"""
         test_data = b"test_data"
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
         mock_bucket = mock_s3.Bucket.return_value
 
         object_name = client.upload_sbom(test_data)
@@ -66,15 +257,13 @@ class TestS3Client:
         assert mock_s3.Bucket.call_args[0][0] == settings.AWS_SBOMS_STORAGE_BUCKET_NAME
 
     def test_get_sbom_data_success(self, mock_s3):
-        """Test retrieving SBOM data from correct bucket"""
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
         mock_object = mock_s3.Bucket.return_value.Object.return_value
-        # Create mock body with read() method using unittest.mock.Mock
         mock_body = Mock()
         mock_body.read.return_value = b"test_data"
         mock_object.get.return_value = {
             "Body": mock_body,
-            "ResponseMetadata": {"HTTPStatusCode": 200}
+            "ResponseMetadata": {"HTTPStatusCode": 200},
         }
 
         data = client.get_sbom_data("test_object")
@@ -83,8 +272,7 @@ class TestS3Client:
         mock_s3.Bucket.assert_called_with(settings.AWS_SBOMS_STORAGE_BUCKET_NAME)
 
     def test_delete_object_success(self, mock_s3):
-        """Test object deletion in correct bucket"""
-        client = S3Client("MEDIA")
+        client = StorageClient("MEDIA")
         mock_object = mock_s3.Object.return_value
 
         client.delete_object("test_bucket", "test_object")
@@ -92,34 +280,45 @@ class TestS3Client:
         mock_object.delete.assert_called_once()
         mock_s3.Object.assert_called_with("test_bucket", "test_object")
 
-    @pytest.mark.parametrize("method,args", [
-        # Test MEDIA client trying to call SBOMS-only methods
-        ("upload_sbom", (b"data",)),
-        ("get_sbom_data", ("test",)),
-    ])
+    @pytest.mark.parametrize(
+        "method,args",
+        [
+            ("upload_sbom", (b"data",)),
+            ("get_sbom_data", ("test",)),
+        ],
+    )
     def test_bucket_type_validation(self, method: str, args: tuple, mock_s3):
-        """Test methods validate bucket type before operation"""
-        client = S3Client("MEDIA")
-
-        # Setup mock for any S3 operations that might be called
+        client = StorageClient("MEDIA")
         mock_bucket = mock_s3.Bucket.return_value
 
         with pytest.raises(ValueError) as exc:
             getattr(client, method)(*args)
 
         assert "only for SBOMS bucket" in str(exc.value)
-
-        # Verify no S3 operations were called
         mock_bucket.put_object.assert_not_called()
         mock_s3.Bucket.return_value.Object.return_value.get.assert_not_called()
 
     def test_error_handling(self, mock_s3):
-        """Test ClientError propagation"""
-        client = S3Client("MEDIA")
+        client = StorageClient("MEDIA")
         mock_s3.Bucket.return_value.put_object.side_effect = ClientError(
-            error_response={"Error": {"Code": 403}},
-            operation_name="PutObject"
+            error_response={"Error": {"Code": 403}}, operation_name="PutObject"
         )
 
         with pytest.raises(ClientError):
             client.upload_media("test", b"data")
+
+    def test_generate_presigned_url(self, mocker: MockerFixture):
+        mocker.patch("boto3.resource")
+        mock_client_fn = mocker.patch("boto3.client")
+        mock_client = mock_client_fn.return_value
+        mock_client.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+        client = StorageClient("DOCUMENTS")
+        url = client.generate_presigned_url("my-bucket", "path/to/key", expires_in=3600)
+
+        assert url == "https://s3.example.com/presigned"
+        mock_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "my-bucket", "Key": "path/to/key"},
+            ExpiresIn=3600,
+        )

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -187,6 +187,17 @@ class TestS3ObjectStoreClient:
         with pytest.raises(ClientError):
             store.get_object("my-bucket", "path/to/key")
 
+    def test_generate_presigned_url_propagates_client_error(self, mocker: MockerFixture):
+        mocker.patch("boto3.resource")
+        mock_client_fn = mocker.patch("boto3.client")
+        mock_client_fn.return_value.generate_presigned_url.side_effect = ClientError(
+            error_response={"Error": {"Code": "ExpiredToken"}},
+            operation_name="GeneratePresignedUrl",
+        )
+        store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
+        with pytest.raises(ClientError):
+            store.generate_presigned_url("my-bucket", "key")
+
     def test_error_propagation(self, s3_store):
         store, mock_s3 = s3_store
         mock_s3.Bucket.return_value.put_object.side_effect = ClientError(
@@ -386,6 +397,14 @@ class TestStorageClient:
         client = StorageClient(wrong_type)
         with pytest.raises(ValueError, match=expected_match):
             getattr(client, method)(*args)
+
+    def test_generate_presigned_url_propagates_errors(self):
+        self.mock_store.generate_presigned_url.side_effect = ClientError(
+            error_response={"Error": {"Code": "NoSuchBucket"}}, operation_name="GeneratePresignedUrl"
+        )
+        client = StorageClient("SBOMS")
+        with pytest.raises(ClientError):
+            client.generate_presigned_url("missing-bucket", "key")
 
     def test_error_propagation(self):
         self.mock_store.put_object.side_effect = ClientError(

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -42,13 +42,8 @@ class TestS3ObjectStoreClient:
             aws_access_key_id="my-key",
             aws_secret_access_key="my-secret",
         )
-        mock_client.assert_called_once_with(
-            "s3",
-            region_name="us-east-1",
-            endpoint_url="http://localhost:9000",
-            aws_access_key_id="my-key",
-            aws_secret_access_key="my-secret",
-        )
+        # boto3.client is lazy — not called at construction time
+        mock_client.assert_not_called()
 
     def test_init_without_credentials(self, mocker: MockerFixture):
         mock_resource = mocker.patch("boto3.resource")
@@ -66,18 +61,12 @@ class TestS3ObjectStoreClient:
             aws_access_key_id=None,
             aws_secret_access_key=None,
         )
-        mock_client.assert_called_once_with(
-            "s3",
-            region_name="us-east-1",
-            endpoint_url="http://localhost:9000",
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-        )
+        mock_client.assert_not_called()
 
     def test_init_with_empty_string_credentials(self, mocker: MockerFixture):
-        """Empty strings (from os.environ.get(..., '')) should be treated as None (no credentials)."""
+        """Empty strings should be passed as-is — normalization is the caller's responsibility."""
         mock_resource = mocker.patch("boto3.resource")
-        mock_client = mocker.patch("boto3.client")
+        mocker.patch("boto3.client")
 
         S3ObjectStoreClient(
             region="us-east-1",
@@ -86,26 +75,17 @@ class TestS3ObjectStoreClient:
             secret_key="",
         )
 
-        # Empty strings should be converted to None so boto3 uses default credential chain
         mock_resource.assert_called_once_with(
             "s3",
             region_name="us-east-1",
             endpoint_url="http://localhost:9000",
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-        )
-        mock_client.assert_called_once_with(
-            "s3",
-            region_name="us-east-1",
-            endpoint_url="http://localhost:9000",
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
+            aws_access_key_id="",
+            aws_secret_access_key="",
         )
 
     @pytest.fixture
     def s3_store(self, mocker: MockerFixture):
         mock_resource = mocker.patch("boto3.resource")
-        mocker.patch("boto3.client")
         store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
         return store, mock_resource.return_value
 
@@ -148,8 +128,19 @@ class TestS3ObjectStoreClient:
         mock_client.generate_presigned_url.return_value = "https://s3.example.com/presigned"
 
         store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
+        # boto3.client is lazy — not created until first presigned URL call
+        mock_client_fn.assert_not_called()
+
         url = store.generate_presigned_url("my-bucket", "path/to/key", expires_in=7200)
 
+        # Now it should have been created
+        mock_client_fn.assert_called_once_with(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+        )
         mock_client.generate_presigned_url.assert_called_once_with(
             "get_object",
             Params={"Bucket": "my-bucket", "Key": "path/to/key"},
@@ -186,7 +177,6 @@ class TestStorageClient:
         mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
         mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
         mock_resource = mocker.patch("boto3.resource")
-        mocker.patch("boto3.client")
 
         client = StorageClient("SBOMS")
 
@@ -207,7 +197,6 @@ class TestStorageClient:
         mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
         mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
         mock_resource = mocker.patch("boto3.resource")
-        mocker.patch("boto3.client")
 
         StorageClient("SBOMS")
 

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -233,6 +233,36 @@ class TestStorageClient:
         with pytest.raises(ValueError, match="Invalid bucket_type"):
             StorageClient("INVALID")  # type: ignore[arg-type]
 
+    def test_mismatched_credentials_raises(self, mocker: MockerFixture):
+        """Only access key set without secret key should raise."""
+        mocker.stopall()
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch("boto3.resource")
+        with pytest.raises(ValueError, match="must both be set or both be empty"):
+            StorageClient("SBOMS")
+
+    def test_mismatched_credentials_secret_only_raises(self, mocker: MockerFixture):
+        """Only secret key set without access key should raise."""
+        mocker.stopall()
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch("boto3.resource")
+        with pytest.raises(ValueError, match="must both be set or both be empty"):
+            StorageClient("SBOMS")
+
+    def test_both_credentials_empty_is_valid(self, mocker: MockerFixture):
+        """Both credentials empty (IAM/IRSA) should work without error."""
+        mocker.stopall()
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch("boto3.resource")
+        client = StorageClient("SBOMS")
+        assert isinstance(client._store, S3ObjectStoreClient)
+
     def test_unsupported_backend_raises(self, mocker: MockerFixture):
         mocker.stopall()
         mocker.patch.object(settings, "STORAGE_BACKEND", "azure")

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -226,6 +226,13 @@ class TestStorageClient:
             aws_secret_access_key=None,
         )
 
+    def test_invalid_bucket_type_raises(self, mocker: MockerFixture):
+        mocker.stopall()
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch("boto3.resource")
+        with pytest.raises(ValueError, match="Invalid bucket_type"):
+            StorageClient("INVALID")  # type: ignore[arg-type]
+
     def test_unsupported_backend_raises(self, mocker: MockerFixture):
         mocker.stopall()
         mocker.patch.object(settings, "STORAGE_BACKEND", "azure")

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -162,6 +162,13 @@ class TestS3ObjectStoreClient:
         )
         assert url == "https://s3.example.com/presigned"
 
+    @pytest.mark.parametrize("bad_value", [0, -1, -3600])
+    def test_generate_presigned_url_rejects_non_positive_expiry(self, mocker: MockerFixture, bad_value: int):
+        mocker.patch("boto3.resource")
+        store = S3ObjectStoreClient(region="us-east-1", endpoint_url="http://localhost:9000")
+        with pytest.raises(ValueError, match="expires_in must be positive"):
+            store.generate_presigned_url("my-bucket", "key", expires_in=bad_value)
+
     def test_get_object_returns_none_for_missing_key(self, s3_store):
         store, mock_s3 = s3_store
         mock_s3.Bucket.return_value.Object.return_value.get.side_effect = ClientError(

--- a/sbomify/apps/core/tests/integration/test_object_store.py
+++ b/sbomify/apps/core/tests/integration/test_object_store.py
@@ -247,6 +247,26 @@ class TestStorageClient:
             aws_secret_access_key=None,
         )
 
+    def test_empty_endpoint_url_normalized_to_none(self, mocker: MockerFixture):
+        """Empty AWS_ENDPOINT_URL_S3 (production default) should be normalized to None for boto3."""
+        mocker.stopall()
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
+        mocker.patch.object(settings, "AWS_ENDPOINT_URL_S3", "")
+        mocker.patch.object(settings, "AWS_REGION", "")
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mock_resource = mocker.patch("boto3.resource")
+
+        StorageClient("SBOMS")
+
+        mock_resource.assert_called_once_with(
+            "s3",
+            region_name=None,
+            endpoint_url=None,
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+        )
+
     def test_invalid_bucket_type_raises(self, mocker: MockerFixture):
         mocker.stopall()
         mocker.patch.object(settings, "STORAGE_BACKEND", "s3")

--- a/sbomify/apps/core/tests/s3_fixtures.py
+++ b/sbomify/apps/core/tests/s3_fixtures.py
@@ -15,8 +15,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 
-class MockS3Client:
-    """A mock S3Client that mimics the real S3Client interface with type safety."""
+class MockStorageClient:
+    """A mock StorageClient that mimics the real StorageClient interface with type safety."""
 
     def __init__(self, bucket_type: str = "SBOMS") -> None:
         self.bucket_type = bucket_type
@@ -87,41 +87,41 @@ class MockS3Client:
 
 
 @pytest.fixture
-def mock_s3_client() -> Generator[MockS3Client, None, None]:
-    """Provide a mock S3Client instance for testing."""
-    yield MockS3Client()
+def mock_s3_client() -> Generator[MockStorageClient, None, None]:
+    """Provide a mock StorageClient instance for testing."""
+    yield MockStorageClient()
 
 
 @pytest.fixture
-def s3_mock(mocker: MockerFixture) -> Generator[MockS3Client, None, None]:
+def s3_mock(mocker: MockerFixture) -> Generator[MockStorageClient, None, None]:
     """
-    Mock the core.object_store.S3Client class completely.
+    Mock the core.object_store.StorageClient class completely.
 
-    This fixture replaces the S3Client class with our MockS3Client
+    This fixture replaces the StorageClient class with our MockStorageClient
     and returns the mock instance for test configuration.
     """
-    mock_client = MockS3Client()
-    mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+    mock_client = MockStorageClient()
+    mocker.patch("sbomify.apps.core.object_store.StorageClient", return_value=mock_client)
     yield mock_client
 
 
 @pytest.fixture
-def s3_documents_mock(mocker: MockerFixture) -> Generator[MockS3Client, None, None]:
-    """Mock S3Client specifically configured for documents operations."""
-    mock_client = MockS3Client(bucket_type="DOCUMENTS")
+def s3_documents_mock(mocker: MockerFixture) -> Generator[MockStorageClient, None, None]:
+    """Mock StorageClient specifically configured for documents operations."""
+    mock_client = MockStorageClient(bucket_type="DOCUMENTS")
     # Pre-populate with common test document data
     mock_client.uploaded_files["test_document.pdf"] = b"test document content"
     mock_client.uploaded_files["public_doc.pdf"] = b"public document content"
     mock_client.uploaded_files["private_doc.pdf"] = b"private document content"
 
-    mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+    mocker.patch("sbomify.apps.core.object_store.StorageClient", return_value=mock_client)
     yield mock_client
 
 
 @pytest.fixture
-def s3_sboms_mock(mocker: MockerFixture) -> Generator[MockS3Client, None, None]:
-    """Mock S3Client specifically configured for SBOM operations."""
-    mock_client = MockS3Client(bucket_type="SBOMS")
+def s3_sboms_mock(mocker: MockerFixture) -> Generator[MockStorageClient, None, None]:
+    """Mock StorageClient specifically configured for SBOM operations."""
+    mock_client = MockStorageClient(bucket_type="SBOMS")
 
     # Pre-populate with common test SBOM data
     sample_sbom = {
@@ -136,17 +136,17 @@ def s3_sboms_mock(mocker: MockerFixture) -> Generator[MockS3Client, None, None]:
     legacy_sbom["specVersion"] = "1.5"
     mock_client.uploaded_files["legacy_sbom.json"] = json.dumps(legacy_sbom).encode()
 
-    mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+    mocker.patch("sbomify.apps.core.object_store.StorageClient", return_value=mock_client)
     yield mock_client
 
 
 @pytest.fixture
-def s3_error_mock(mocker: MockerFixture) -> Generator[MockS3Client, None, None]:
-    """Mock S3Client that raises errors for testing error handling."""
-    mock_client = MockS3Client()
+def s3_error_mock(mocker: MockerFixture) -> Generator[MockStorageClient, None, None]:
+    """Mock StorageClient that raises errors for testing error handling."""
+    mock_client = MockStorageClient()
     mock_client.configure_error(should_raise=True, message="S3 service unavailable")
 
-    mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+    mocker.patch("sbomify.apps.core.object_store.StorageClient", return_value=mock_client)
     yield mock_client
 
 
@@ -154,18 +154,18 @@ def create_s3_method_mock(
     mocker: MockerFixture, method_name: str, return_value: Any = None, side_effect: Exception | None = None
 ) -> Mock:
     """
-    Create a mock for a specific S3Client method.
+    Create a mock for a specific StorageClient method.
 
     Args:
         mocker: pytest-mock fixture
-        method_name: Name of the S3Client method to mock (e.g., 'get_sbom_data')
+        method_name: Name of the StorageClient method to mock (e.g., 'get_sbom_data')
         return_value: Value to return from the method
         side_effect: Exception to raise when method is called
 
     Returns:
         The mock object for further configuration
     """
-    mock_path = f"sbomify.apps.core.object_store.S3Client.{method_name}"
+    mock_path = f"sbomify.apps.core.object_store.StorageClient.{method_name}"
 
     if side_effect:
         return mocker.patch(mock_path, side_effect=side_effect)
@@ -175,16 +175,16 @@ def create_s3_method_mock(
 
 def create_documents_api_mock(mocker: MockerFixture, scenario: str = "success") -> MagicMock:
     """
-    Create a mock specifically for documents.apis.S3Client.
+    Create a mock specifically for documents.apis.StorageClient.
 
     Args:
         mocker: pytest-mock fixture
         scenario: Test scenario - 'success', 'upload_error', 'download_error', 'not_found'
 
     Returns:
-        Mock S3Client instance configured for the scenario
+        Mock StorageClient instance configured for the scenario
     """
-    mock_s3_client = mocker.patch("sbomify.apps.documents.apis.S3Client")
+    mock_s3_client = mocker.patch("sbomify.apps.documents.apis.StorageClient")
     mock_instance = MagicMock()
     mock_s3_client.return_value = mock_instance
 
@@ -205,16 +205,16 @@ def create_documents_api_mock(mocker: MockerFixture, scenario: str = "success") 
 
 def create_documents_views_mock(mocker: MockerFixture, scenario: str = "success") -> MagicMock:
     """
-    Create a mock specifically for documents.views.S3Client.
+    Create a mock specifically for documents.views.StorageClient.
 
     Args:
         mocker: pytest-mock fixture
         scenario: Test scenario - 'success', 'upload_error', 'download_error', 'not_found'
 
     Returns:
-        Mock S3Client instance configured for the scenario
+        Mock StorageClient instance configured for the scenario
     """
-    mock_s3_client = mocker.patch("sbomify.apps.documents.views.document_download.S3Client")
+    mock_s3_client = mocker.patch("sbomify.apps.documents.views.document_download.StorageClient")
     mock_instance = MagicMock()
     mock_s3_client.return_value = mock_instance
 
@@ -234,5 +234,5 @@ def create_documents_views_mock(mocker: MockerFixture, scenario: str = "success"
 
 
 # Type aliases for better type hints
-S3MockFactory = Callable[[str], MockS3Client]
-S3MethodMock = Callable[[str, Any, Exception | None], Mock]
+StorageMockFactory = Callable[[str], MockStorageClient]
+StorageMethodMock = Callable[[str, Any, Exception | None], Mock]

--- a/sbomify/apps/core/tests/s3_fixtures.py
+++ b/sbomify/apps/core/tests/s3_fixtures.py
@@ -80,6 +80,12 @@ class MockStorageClient:
             raise Exception(self.error_message)
         self.uploaded_files.pop(object_name, None)
 
+    def generate_presigned_url(self, bucket_name: str, key: str, expires_in: int = 3600) -> str:
+        """Mock generate_presigned_url method."""
+        if self.should_raise_error:
+            raise Exception(self.error_message)
+        return f"https://mock-storage.example.com/{bucket_name}/{key}?expires={expires_in}"
+
     def configure_error(self, should_raise: bool = True, message: str = "S3 operation failed") -> None:
         """Configure the mock to raise errors."""
         self.should_raise_error = should_raise

--- a/sbomify/apps/core/tests/test_apps.py
+++ b/sbomify/apps/core/tests/test_apps.py
@@ -1,0 +1,41 @@
+import pytest
+from django.conf import settings
+from pytest_mock import MockerFixture
+
+from sbomify.apps.core.apps import CoreConfig
+
+
+class TestStorageCredentialValidation:
+    def test_mismatched_credentials_access_key_only(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "test-key")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        with pytest.raises(ValueError, match="must both be set or both be empty"):
+            CoreConfig._validate_storage_credentials()
+
+    def test_mismatched_credentials_secret_key_only(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "test-secret")
+        with pytest.raises(ValueError, match="must both be set or both be empty"):
+            CoreConfig._validate_storage_credentials()
+
+    def test_both_credentials_empty_is_valid(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        for bucket_type in ("MEDIA", "SBOMS", "DOCUMENTS"):
+            mocker.patch.object(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "")
+            mocker.patch.object(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "")
+        CoreConfig._validate_storage_credentials()  # should not raise
+
+    def test_both_credentials_set_is_valid(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "STORAGE_BACKEND", "s3")
+        for bucket_type in ("MEDIA", "SBOMS", "DOCUMENTS"):
+            mocker.patch.object(settings, f"AWS_{bucket_type}_ACCESS_KEY_ID", "key")
+            mocker.patch.object(settings, f"AWS_{bucket_type}_SECRET_ACCESS_KEY", "secret")
+        CoreConfig._validate_storage_credentials()  # should not raise
+
+    def test_skipped_for_non_s3_backend(self, mocker: MockerFixture):
+        mocker.patch.object(settings, "STORAGE_BACKEND", "gcs")
+        mocker.patch.object(settings, "AWS_SBOMS_ACCESS_KEY_ID", "key-only")
+        mocker.patch.object(settings, "AWS_SBOMS_SECRET_ACCESS_KEY", "")
+        CoreConfig._validate_storage_credentials()  # should not raise

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -655,7 +655,7 @@ def test_delete_component_success(
     """Test successful component deletion."""
     # Mock S3 operations
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.delete_object")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.delete_object")
 
     client = Client()
     url = reverse("api-1:delete_component", kwargs={"component_id": sample_component.id})

--- a/sbomify/apps/core/tests/test_s3_fixtures_examples.py
+++ b/sbomify/apps/core/tests/test_s3_fixtures_examples.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from sbomify.apps.core.tests.s3_fixtures import (
-    MockS3Client,
+    MockStorageClient,
     create_documents_api_mock,
     create_s3_method_mock,
 )
@@ -19,12 +19,12 @@ from sbomify.apps.core.tests.s3_fixtures import (
 class TestS3FixturesUsage:
     """Example tests showing different ways to use S3 fixtures."""
 
-    def test_basic_s3_mock_usage(self, s3_mock: MockS3Client) -> None:
+    def test_basic_s3_mock_usage(self, s3_mock: MockStorageClient) -> None:
         """Example: Basic usage of the s3_mock fixture."""
-        # The S3Client is already mocked at the class level
-        from sbomify.apps.core.object_store import S3Client
+        # The StorageClient is already mocked at the class level
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         # Upload some data
         filename = client.upload_sbom(b'{"bomFormat": "CycloneDX"}')
@@ -37,11 +37,11 @@ class TestS3FixturesUsage:
         retrieved = client.get_sbom_data(filename)
         assert retrieved == b'{"bomFormat": "CycloneDX"}'
 
-    def test_documents_specific_mock(self, s3_documents_mock: MockS3Client) -> None:
+    def test_documents_specific_mock(self, s3_documents_mock: MockStorageClient) -> None:
         """Example: Using the documents-specific mock with pre-populated data."""
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("DOCUMENTS")
+        client = StorageClient("DOCUMENTS")
 
         # The mock comes pre-populated with test documents
         assert client.get_document_data("test_document.pdf") == b"test document content"
@@ -51,11 +51,11 @@ class TestS3FixturesUsage:
         filename = client.upload_document(b"new document content")
         assert client.get_document_data(filename) == b"new document content"
 
-    def test_sboms_specific_mock(self, s3_sboms_mock: MockS3Client) -> None:
+    def test_sboms_specific_mock(self, s3_sboms_mock: MockStorageClient) -> None:
         """Example: Using the SBOM-specific mock with pre-populated data."""
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         # The mock comes pre-populated with test SBOMs
         sbom_data = client.get_sbom_data("test_sbom.json")
@@ -70,11 +70,11 @@ class TestS3FixturesUsage:
         legacy_parsed = json.loads(legacy_data.decode())
         assert legacy_parsed["specVersion"] == "1.5"
 
-    def test_error_scenarios(self, s3_error_mock: MockS3Client) -> None:
+    def test_error_scenarios(self, s3_error_mock: MockStorageClient) -> None:
         """Example: Testing error scenarios."""
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         # All operations should raise exceptions
         with pytest.raises(Exception, match="S3 service unavailable"):
@@ -83,11 +83,11 @@ class TestS3FixturesUsage:
         with pytest.raises(Exception, match="S3 service unavailable"):
             client.get_sbom_data("test.json")
 
-    def test_configurable_mock_behavior(self, s3_mock: MockS3Client) -> None:
+    def test_configurable_mock_behavior(self, s3_mock: MockStorageClient) -> None:
         """Example: Configuring mock behavior during test."""
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         # Initially works fine
         filename = client.upload_sbom(b'{"test": "data"}')
@@ -104,13 +104,13 @@ class TestS3FixturesUsage:
         assert client.get_sbom_data(filename) == b'{"test": "data"}'
 
     def test_method_specific_mocking(self, mocker: MockerFixture) -> None:
-        """Example: Mocking only specific S3Client methods."""
+        """Example: Mocking only specific StorageClient methods."""
         # Mock only the get_sbom_data method
         mock_get = create_s3_method_mock(mocker, "get_sbom_data", return_value=b'{"mocked": "data"}')
 
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         result = client.get_sbom_data("any_filename")
         assert result == b'{"mocked": "data"}'
@@ -120,9 +120,9 @@ class TestS3FixturesUsage:
         """Example: Mocking method to raise specific errors."""
         mock_upload = create_s3_method_mock(mocker, "upload_sbom", side_effect=Exception("Upload failed"))
 
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
-        client = S3Client("SBOMS")
+        client = StorageClient("SBOMS")
 
         with pytest.raises(Exception, match="Upload failed"):
             client.upload_sbom(b'{"test": "data"}')
@@ -146,13 +146,13 @@ class TestS3FixturesUsage:
         # In real tests, this would be called by the API endpoint being tested
 
 
-class TestMockS3ClientDirectly:
-    """Test the MockS3Client class directly to ensure it works correctly."""
+class TestMockStorageClientDirectly:
+    """Test the MockStorageClient class directly to ensure it works correctly."""
 
     def test_mock_client_bucket_validation(self) -> None:
-        """Test that MockS3Client validates bucket types correctly."""
-        sbom_client = MockS3Client("SBOMS")
-        doc_client = MockS3Client("DOCUMENTS")
+        """Test that MockStorageClient validates bucket types correctly."""
+        sbom_client = MockStorageClient("SBOMS")
+        doc_client = MockStorageClient("DOCUMENTS")
 
         # SBOM client can't do document operations
         with pytest.raises(ValueError, match="only for DOCUMENTS bucket"):
@@ -163,8 +163,8 @@ class TestMockS3ClientDirectly:
             doc_client.upload_sbom(b"test")
 
     def test_mock_client_file_storage(self) -> None:
-        """Test that MockS3Client properly stores and retrieves files."""
-        client = MockS3Client("SBOMS")
+        """Test that MockStorageClient properly stores and retrieves files."""
+        client = MockStorageClient("SBOMS")
 
         # Upload and retrieve
         filename = client.upload_sbom(b'{"test": "data"}')
@@ -176,8 +176,8 @@ class TestMockS3ClientDirectly:
         assert client.uploaded_files[filename] == b'{"test": "data"}'
 
     def test_mock_client_deletion(self) -> None:
-        """Test that MockS3Client handles file deletion."""
-        client = MockS3Client("SBOMS")
+        """Test that MockStorageClient handles file deletion."""
+        client = MockStorageClient("SBOMS")
 
         # Upload a file
         filename = client.upload_sbom(b'{"test": "data"}')
@@ -191,8 +191,8 @@ class TestMockS3ClientDirectly:
         assert client.get_sbom_data(filename) is None
 
     def test_mock_client_error_configuration(self) -> None:
-        """Test MockS3Client error configuration."""
-        client = MockS3Client("SBOMS")
+        """Test MockStorageClient error configuration."""
+        client = MockStorageClient("SBOMS")
 
         # Configure to raise errors
         client.configure_error(True, "Test error")

--- a/sbomify/apps/documents/access_apis.py
+++ b/sbomify/apps/documents/access_apis.py
@@ -17,7 +17,7 @@ from ninja import Router
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.core.url_utils import get_base_url
 from sbomify.apps.core.utils import broadcast_to_workspace, get_client_ip
@@ -347,7 +347,7 @@ def get_nda_for_signing(request: HttpRequest, team_key: str, request_id: str) ->
 
         # Return NDA document for download
         try:
-            s3 = S3Client("DOCUMENTS")
+            s3 = StorageClient("DOCUMENTS")
             document_data = s3.get_document_data(company_nda.document_filename)
 
             if document_data:
@@ -400,7 +400,7 @@ def sign_nda(request: HttpRequest, team_key: str, request_id: str, payload: NDAS
 
         # Get NDA document content and calculate hash
         try:
-            s3 = S3Client("DOCUMENTS")
+            s3 = StorageClient("DOCUMENTS")
             document_data = s3.get_document_data(company_nda.document_filename)
             if not document_data:
                 return 404, {"detail": "NDA document not found in storage"}

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -9,7 +9,7 @@ from ninja import File, Query, Router, UploadedFile
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.schemas import ErrorResponse
 from sbomify.apps.core.utils import broadcast_to_workspace, get_by_uuid_or_pk, verify_item_access
 from sbomify.apps.sboms.models import Component
@@ -112,7 +112,7 @@ def create_document(
         sha256_hash = hashlib.sha256(content).hexdigest()
 
         # Upload to S3 using dedicated DOCUMENTS bucket (fallback to SBOMS if not configured)
-        s3 = S3Client("DOCUMENTS")
+        s3 = StorageClient("DOCUMENTS")
         filename = s3.upload_document(content)
 
         document_dict = {
@@ -208,7 +208,7 @@ def download_document(request: HttpRequest, document_id: str) -> Any:
 
     if access_result.has_access:
         try:
-            s3 = S3Client("DOCUMENTS")
+            s3 = StorageClient("DOCUMENTS")
             document_data = s3.get_document_data(document.document_filename)
 
             if document_data:
@@ -310,7 +310,7 @@ def download_document_signed(request: HttpRequest, document_id: str, token: str 
         return 404, {"detail": "Document file not found"}
 
     try:
-        s3 = S3Client("DOCUMENTS")
+        s3 = StorageClient("DOCUMENTS")
         document_data = s3.get_document_data(document.document_filename)
 
         if document_data:

--- a/sbomify/apps/documents/tests/test_access_apis.py
+++ b/sbomify/apps/documents/tests/test_access_apis.py
@@ -293,7 +293,7 @@ class TestRevokeAccessRequestAPI:
 class TestSignNDAAPI:
     """Test sign NDA API."""
 
-    @patch("sbomify.apps.documents.access_apis.S3Client")
+    @patch("sbomify.apps.documents.access_apis.StorageClient")
     def test_sign_nda_with_valid_hash(
         self,
         mock_s3_client,
@@ -337,7 +337,7 @@ class TestSignNDAAPI:
         assert signature is not None
         assert signature.nda_document == company_nda_document
 
-    @patch("sbomify.apps.documents.access_apis.S3Client")
+    @patch("sbomify.apps.documents.access_apis.StorageClient")
     def test_sign_nda_with_invalid_hash(
         self,
         mock_s3_client,
@@ -373,7 +373,7 @@ class TestSignNDAAPI:
 
         assert response.status_code == 400
 
-    @patch("sbomify.apps.documents.access_apis.S3Client")
+    @patch("sbomify.apps.documents.access_apis.StorageClient")
     def test_sign_nda_captures_correct_ip_with_proxy(
         self,
         mock_s3_client,
@@ -417,7 +417,7 @@ class TestSignNDAAPI:
         assert signature is not None
         assert signature.ip_address == "203.0.113.42"
 
-    @patch("sbomify.apps.documents.access_apis.S3Client")
+    @patch("sbomify.apps.documents.access_apis.StorageClient")
     def test_sign_nda_falls_back_to_remote_addr_without_proxy(
         self,
         mock_s3_client,

--- a/sbomify/apps/documents/tests/test_access_requests.py
+++ b/sbomify/apps/documents/tests/test_access_requests.py
@@ -196,7 +196,7 @@ class TestNDASigning:
         response = client.get(url)
         assert response.status_code in [302, 401, 403]
 
-    @patch("sbomify.apps.documents.views.access_requests.S3Client")
+    @patch("sbomify.apps.documents.views.access_requests.StorageClient")
     def test_sign_nda_with_valid_hash(
         self, mock_s3_client, authenticated_web_client, team_with_business_plan, 
         company_nda_document, pending_access_request, guest_user
@@ -231,7 +231,7 @@ class TestNDASigning:
         assert signature.nda_document == company_nda_document
         assert signature.nda_content_hash == company_nda_document.content_hash
 
-    @patch("sbomify.apps.documents.views.access_requests.S3Client")
+    @patch("sbomify.apps.documents.views.access_requests.StorageClient")
     def test_sign_nda_with_invalid_hash(
         self, mock_s3_client, authenticated_web_client, team_with_business_plan,
         company_nda_document, pending_access_request, guest_user
@@ -264,7 +264,7 @@ class TestNDASigning:
         # Verify signature was NOT created
         assert not NDASignature.objects.filter(access_request=pending_access_request).exists()
 
-    @patch("sbomify.apps.documents.views.access_requests.S3Client")
+    @patch("sbomify.apps.documents.views.access_requests.StorageClient")
     def test_sign_nda_captures_correct_ip_with_proxy(
         self, mock_s3_client, authenticated_web_client, team_with_business_plan,
         company_nda_document, pending_access_request, guest_user
@@ -299,7 +299,7 @@ class TestNDASigning:
         assert signature is not None
         assert signature.ip_address == "203.0.113.42"
 
-    @patch("sbomify.apps.documents.views.access_requests.S3Client")
+    @patch("sbomify.apps.documents.views.access_requests.StorageClient")
     def test_sign_nda_falls_back_to_remote_addr_without_proxy(
         self, mock_s3_client, authenticated_web_client, team_with_business_plan,
         company_nda_document, pending_access_request, guest_user
@@ -921,7 +921,7 @@ class TestGatedComponentAccess:
         response = client.get(url)
         assert response.status_code == 200
 
-    @patch("sbomify.apps.documents.views.document_download.S3Client")
+    @patch("sbomify.apps.documents.views.document_download.StorageClient")
     def test_gated_component_download_requires_access(
         self, mock_s3_client, client, gated_component, team_with_business_plan, guest_user
     ):
@@ -975,7 +975,7 @@ class TestGatedComponentAccess:
 class TestNDADocumentVersioning:
     """Test NDA document versioning functionality."""
 
-    @patch("sbomify.apps.core.object_store.S3Client")
+    @patch("sbomify.apps.core.object_store.StorageClient")
     def test_nda_versioning_creates_new_version(
         self, mock_s3_client, authenticated_web_client, team_with_business_plan, company_nda_document, sample_user
     ):

--- a/sbomify/apps/documents/views/access_requests.py
+++ b/sbomify/apps/documents/views/access_requests.py
@@ -22,7 +22,7 @@ from django.views.decorators.cache import never_cache
 
 from sbomify.apps.core.errors import error_response
 from sbomify.apps.core.models import User
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.url_utils import get_base_url
 from sbomify.apps.core.utils import get_client_ip
 from sbomify.apps.documents.access_models import AccessRequest, NDASignature
@@ -544,7 +544,7 @@ class NDASigningView(View):
 
         try:
             # Get NDA document content and calculate hash
-            s3 = S3Client("DOCUMENTS")
+            s3 = StorageClient("DOCUMENTS")
             document_data = s3.get_document_data(company_nda.document_filename)
             if not document_data:
                 messages.error(request, "NDA document not found in storage")

--- a/sbomify/apps/documents/views/document_download.py
+++ b/sbomify/apps/documents/views/document_download.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpRe
 from django.views import View
 
 from sbomify.apps.core.errors import error_response
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.services.access_control import check_component_access
 from sbomify.apps.documents.models import Document
 
@@ -24,7 +24,7 @@ class DocumentDownloadView(View):
 
         if access_result.has_access:
             try:
-                s3 = S3Client("DOCUMENTS")
+                s3 = StorageClient("DOCUMENTS")
                 document_data = s3.get_document_data(document.document_filename)
 
                 if document_data:

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
 from sbomify.apps.core.apis import get_component_metadata, patch_component_metadata
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.purl import extract_purl_qualifiers
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.core.services.access_control import check_component_access
@@ -397,7 +397,7 @@ def sbom_upload_cyclonedx(
                 "error_code": ErrorCode.DUPLICATE_ARTIFACT,
             }
 
-        s3 = S3Client("SBOMS")
+        s3 = StorageClient("SBOMS")
         filename = s3.upload_sbom(request.body)
 
         sbom_dict["format"] = sbom_format
@@ -509,7 +509,7 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str) -> tuple[int, dict
                 "error_code": ErrorCode.DUPLICATE_ARTIFACT,
             }
 
-        s3 = S3Client("SBOMS")
+        s3 = StorageClient("SBOMS")
         filename = s3.upload_sbom(request.body)
 
         sbom_dict["version"] = sbom_version
@@ -705,7 +705,7 @@ def download_sbom(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, An
         return 404, {"detail": "SBOM file not found"}
 
     try:
-        s3 = S3Client("SBOMS")
+        s3 = StorageClient("SBOMS")
         sbom_data = s3.get_sbom_data(sbom.sbom_filename)
 
         if sbom_data:
@@ -795,7 +795,7 @@ def download_sbom_signed(
         return 404, {"detail": "SBOM file not found"}
 
     try:
-        s3 = S3Client("SBOMS")
+        s3 = StorageClient("SBOMS")
         sbom_data = s3.get_sbom_data(sbom.sbom_filename)
 
         if sbom_data:
@@ -905,7 +905,7 @@ def sbom_upload_file(
                     "error_code": ErrorCode.DUPLICATE_ARTIFACT,
                 }
 
-            s3 = S3Client("SBOMS")
+            s3 = StorageClient("SBOMS")
             filename = s3.upload_sbom(file_content)
 
             sbom_dict["version"] = sbom_version
@@ -973,7 +973,7 @@ def sbom_upload_file(
                     "error_code": ErrorCode.DUPLICATE_ARTIFACT,
                 }
 
-            s3 = S3Client("SBOMS")
+            s3 = StorageClient("SBOMS")
             filename = s3.upload_sbom(file_content)
 
             sbom_dict["format"] = sbom_format

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -160,13 +160,13 @@ class BaseSBOMBuilder(ABC):
         Returns:
             Tuple of (Path to downloaded file, SBOM ID) or None
         """
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
         if not sbom.sbom_filename:
             return None
 
         try:
-            s3_client = S3Client("SBOMS")
+            s3_client = StorageClient("SBOMS")
             sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
             download_path = self.target_folder / sbom.sbom_filename
             download_path.write_bytes(sbom_data)

--- a/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
+++ b/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandParser
 from django.db import transaction
 from django.http import HttpRequest
 
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.sboms.apis import sbom_upload_cyclonedx, sbom_upload_spdx
 from sbomify.apps.sboms.models import SBOM, Component, Product, ProductProject, Project, ProjectComponent
 from sbomify.apps.teams.models import Team
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self.s3 = S3Client(bucket_type="SBOMS")
+        self.s3 = StorageClient(bucket_type="SBOMS")
         self.sbom_bucket: str = settings.AWS_SBOMS_STORAGE_BUCKET_NAME
 
     def add_arguments(self, parser: CommandParser) -> None:

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest
 
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace, verify_item_access
 from sbomify.apps.sboms.models import SBOM
@@ -31,7 +31,7 @@ def delete_sbom_record(request: HttpRequest, sbom_id: str) -> ServiceResult[None
 
     if sbom.sbom_filename:
         try:
-            s3 = S3Client("SBOMS")
+            s3 = StorageClient("SBOMS")
             s3.delete_object(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, sbom.sbom_filename)
         except Exception as exc:
             log.warning(f"Failed to delete SBOM file {sbom.sbom_filename} from S3: {exc}")

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -85,7 +85,7 @@ def test_sbom_upload_api_spdx(
     mocker: MockerFixture,  # noqa: F811
 ):
     mocker.patch("boto3.resource")
-    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
     SBOM.objects.all().delete()
 
     test_file_path = pathlib.Path(__file__).parent.resolve() / "test_data/sbomify_trivy.spdx.json"
@@ -121,7 +121,7 @@ def test_sbom_upload_api_cyclonedx(
     mocker: MockerFixture,  # noqa: F811
 ):
     mocker.patch("boto3.resource")
-    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -162,7 +162,7 @@ def test_sbom_upload_api_cyclonedx_1_6_with_manufacturer(
 ):
     """Test that CycloneDX 1.6 SBOMs with manufacturer field are accepted."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -213,7 +213,7 @@ def test_sbom_upload_api_cyclonedx_1_5(
 ):
     """Test that CycloneDX 1.5 SBOMs are still accepted."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -252,7 +252,7 @@ def test_sbom_upload_api_cyclonedx_unsupported_version(
 ):
     """Test that unsupported CycloneDX versions are rejected."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -283,7 +283,7 @@ def test_sbom_upload_api_cyclonedx_invalid_json(
 ):
     """Test that invalid JSON is rejected."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -309,7 +309,7 @@ def test_cyclonedx_1_6_manufacturer_field(
 ):
     """Test CycloneDX 1.6 specific feature: 'manufacturer' field (vs 1.5's 'manufacture')."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -346,7 +346,7 @@ def test_cyclonedx_1_5_manufacture_field(
 ):
     """Test CycloneDX 1.5 specific feature: 'manufacture' field (typo, fixed in 1.6)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -383,7 +383,7 @@ def test_cyclonedx_1_6_declarations_field(
 ):
     """Test CycloneDX 1.6 new feature: declarations field for conformance/attestations."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -428,7 +428,7 @@ def test_cyclonedx_1_7_citations_field(
 ):
     """Test CycloneDX 1.7 new feature: citations for data attribution tracking."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -473,7 +473,7 @@ def test_cyclonedx_1_7_distribution_constraints(
 ):
     """Test CycloneDX 1.7 new feature: distributionConstraints with TLP classification."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -512,7 +512,7 @@ def test_cyclonedx_1_7_patents_in_definitions(
 ):
     """Test CycloneDX 1.7 enhancement: patents field added to definitions (not in 1.6)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -551,7 +551,7 @@ def test_cyclonedx_1_6_rejects_citations_field(
 ):
     """Test that CycloneDX 1.6 rejects 'citations' field (only in 1.7+)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -595,7 +595,7 @@ def test_cyclonedx_1_6_definitions_rejects_patents(
 ):
     """Test that CycloneDX 1.6 definitions field rejects 'patents' (added in 1.7)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -636,7 +636,7 @@ def test_cyclonedx_1_6_rejects_distribution_constraints(
 ):
     """Test that CycloneDX 1.6 rejects 'distributionConstraints' field (only in 1.7+)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -674,7 +674,7 @@ def test_cyclonedx_1_5_rejects_declarations_field(
 ):
     """Test that CycloneDX 1.5 rejects 'declarations' field (only in 1.6+)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -714,7 +714,7 @@ def test_spdx_2_2_with_document_describes(
 ):
     """Test SPDX 2.2 with documentDescribes field (deprecated in 2.3, use relationships instead)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -764,7 +764,7 @@ def test_spdx_2_3_with_relationships(
 ):
     """Test SPDX 2.3 using relationships (preferred over deprecated documentDescribes)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -820,7 +820,7 @@ def test_spdx_2_3_enhanced_external_ref_types(
 ):
     """Test SPDX 2.3 enhanced external reference types (PERSISTENT_ID, PACKAGE_MANAGER)."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -875,7 +875,7 @@ def test_spdx_unsupported_version(
 ):
     """Test that unsupported SPDX versions are rejected."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -913,7 +913,7 @@ def test_spdx_invalid_version_format(
 ):
     """Test that invalid SPDX version format is rejected."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -950,7 +950,7 @@ def test_spdx3_upload_api(
 ):
     """Test uploading an SPDX 3.0 SBOM via the API endpoint."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -984,7 +984,7 @@ def test_spdx3_upload_file(
 ):
     """Test uploading an SPDX 3.0 SBOM via the file upload endpoint."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -1027,7 +1027,7 @@ def test_spdx3_version_extraction(
 ):
     """Test that SPDX 3.0 correctly extracts package version from software_packageVersion."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -1058,7 +1058,7 @@ def test_spdx3_patch_version_accepted(
 ):
     """Test that SPDX 3.0.x patch versions (e.g. SPDX-3.0.1) are accepted."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -1091,7 +1091,7 @@ def test_spdx3_no_packages_error(
 ):
     """Test that SPDX 3.0 SBOM with no packages returns an error."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -1145,7 +1145,7 @@ def test_spdx3_duplicate_check(
 ):
     """Test that duplicate SPDX 3.0 SBOM uploads are rejected."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -1185,7 +1185,7 @@ def test_spdx3_legacy_format_accepted(
 ):
     """Test that legacy SPDX 3.0 format (spdxVersion/elements) is still accepted."""
     mocker.patch("boto3.resource")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
     SBOM.objects.all().delete()
 
@@ -2682,7 +2682,7 @@ def test_sbom_upload_file_cyclonedx(
     mocker: MockerFixture,  # noqa: F811
 ):
     mocker.patch("boto3.resource")
-    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
     SBOM.objects.all().delete()
 
     test_file_path = pathlib.Path(__file__).parent.resolve() / "test_data/sbomify_trivy.cdx.json"
@@ -2715,7 +2715,7 @@ def test_sbom_upload_file_spdx(
     mocker: MockerFixture,  # noqa: F811
 ):
     mocker.patch("boto3.resource")
-    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    patched_upload_data_as_file = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
     SBOM.objects.all().delete()
 
     test_file_path = pathlib.Path(__file__).parent.resolve() / "test_data/sbomify_trivy.spdx.json"
@@ -2817,7 +2817,7 @@ def test_delete_sbom_api(
 ):
     """Test SBOM deletion via API endpoint."""
     mocker.patch("boto3.resource")
-    mock_delete_object = mocker.patch("sbomify.apps.core.object_store.S3Client.delete_object")
+    mock_delete_object = mocker.patch("sbomify.apps.core.object_store.StorageClient.delete_object")
 
     client = Client()
 
@@ -3275,7 +3275,7 @@ def test_download_sbom_public_success(
     )
 
     # Mock S3 client
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.return_value = b'{"name": "public sbom content"}'
 
     response = client.get(reverse("api-1:download_sbom", kwargs={"sbom_id": public_sbom.id}))
@@ -3310,7 +3310,7 @@ def test_download_sbom_public_by_uuid(
         format_version="1.6",
     )
 
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.return_value = b'{"name": "public sbom content"}'
 
     response = client.get(reverse("api-1:download_sbom", kwargs={"sbom_id": str(public_sbom.uuid)}))
@@ -3330,7 +3330,7 @@ def test_download_sbom_private_success(
 ):
     """Test successful private SBOM download with authentication."""
     # Mock S3 client
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.return_value = b'{"name": "private sbom content"}'
 
     # Set up session with team access
@@ -3420,7 +3420,7 @@ def test_download_sbom_s3_file_not_found(
 ):
     """Test download when S3 file doesn't exist."""
     # Mock S3 client to return None (file not found)
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.return_value = None
 
     # Set up session with team access
@@ -3442,7 +3442,7 @@ def test_download_sbom_s3_error(
 ):
     """Test download handling when S3 raises an error."""
     # Mock S3 client to raise an exception
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.side_effect = Exception("S3 download failed")
 
     # Set up session with team access
@@ -3464,7 +3464,7 @@ def test_download_sbom_with_fallback_filename(
 ):
     """Test download with SBOM that has no name (fallback to sbom UUID)."""
     # Mock S3 client
-    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.S3Client.get_sbom_data")
+    mock_get_sbom_data = mocker.patch("sbomify.apps.core.object_store.StorageClient.get_sbom_data")
     mock_get_sbom_data.return_value = b'{"name": "test sbom content"}'
 
     # Create SBOM with empty name

--- a/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
+++ b/sbomify/apps/sboms/tests/test_sbom_uniqueness.py
@@ -35,7 +35,7 @@ class TestSBOMUniquenessConstraintCycloneDX:
     ) -> None:
         """Test that uploading a duplicate CycloneDX SBOM returns 409 Conflict."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -85,7 +85,7 @@ class TestSBOMUniquenessConstraintCycloneDX:
     ) -> None:
         """Test that uploading CycloneDX SBOM with different version succeeds."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -151,7 +151,7 @@ class TestSBOMUniquenessConstraintCycloneDX:
     ) -> None:
         """Test that uploading duplicate SBOMs with empty versions returns 409."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -203,7 +203,7 @@ class TestSBOMUniquenessConstraintSPDX:
     ) -> None:
         """Test that uploading a duplicate SPDX SBOM returns 409 Conflict."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -263,7 +263,7 @@ class TestSBOMUniquenessConstraintSPDX:
     ) -> None:
         """Test that uploading SPDX SBOM with different version succeeds."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -319,7 +319,7 @@ class TestSBOMUniquenessConstraintSPDX:
         Two SBOMs with no versionInfo should still be considered duplicates.
         """
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -386,7 +386,7 @@ class TestSBOMUniquenessConstraintCrossFormat:
     ) -> None:
         """Test that uploading SBOM with same version but different format succeeds."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -452,7 +452,7 @@ class TestSBOMUniquenessConstraintCrossFormat:
     ) -> None:
         """Test that same version can be uploaded to different components."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -516,7 +516,7 @@ class TestSBOMUniquenessConstraintFileUpload:
     ) -> None:
         """Test that file upload of duplicate CycloneDX SBOM returns 409 Conflict."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -561,7 +561,7 @@ class TestSBOMUniquenessConstraintFileUpload:
     ) -> None:
         """Test that file upload of duplicate SPDX SBOM returns 409 Conflict."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -625,7 +625,7 @@ class TestSBOMUniquenessConstraintFileUploadQualifiers:
     ) -> None:
         """File upload of CycloneDX SBOMs with different qualifiers should both succeed."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -670,7 +670,7 @@ class TestSBOMUniquenessConstraintFileUploadQualifiers:
     ) -> None:
         """File upload of duplicate CycloneDX SBOMs with same qualifiers should return 409."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -714,7 +714,7 @@ class TestSBOMUniquenessConstraintErrorHandling:
     ) -> None:
         """Test that the 409 error message contains version and format details."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -760,7 +760,7 @@ class TestSBOMUniquenessConstraintErrorHandling:
     ) -> None:
         """Test that duplicate uploads do not upload files to S3."""
         mocker.patch("boto3.resource")
-        mock_upload = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mock_upload = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -807,7 +807,7 @@ class TestSBOMQualifierDedup:
     ) -> None:
         """Two CycloneDX SBOMs with same version but different PURL qualifiers should both be accepted."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -875,7 +875,7 @@ class TestSBOMQualifierDedup:
     ) -> None:
         """Two CycloneDX SBOMs with same version and same qualifiers should return 409."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -922,7 +922,7 @@ class TestSBOMQualifierDedup:
     ) -> None:
         """CycloneDX SBOM without a PURL should store empty qualifiers."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 
@@ -957,7 +957,7 @@ class TestSBOMQualifierDedup:
     ) -> None:
         """Two SPDX SBOMs with same version but different PURL qualifiers should both be accepted."""
         mocker.patch("boto3.resource")
-        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_data_as_file")
 
         SBOM.objects.all().delete()
 

--- a/sbomify/apps/sboms/tests/test_signed_urls.py
+++ b/sbomify/apps/sboms/tests/test_signed_urls.py
@@ -194,7 +194,7 @@ class TestSignedURLs:
         token = make_download_token(self.private_sbom.id, str(self.user.id))
 
         # Mock S3 client using the proper sboms API mock
-        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.sboms.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_sbom_data.return_value = b'{"test": "data"}'
             mock_s3_client.return_value = mock_s3_instance
@@ -212,7 +212,7 @@ class TestSignedURLs:
         token = make_document_download_token(self.private_document.id, str(self.user.id))
 
         # Mock S3 client using the proper documents API mock
-        with patch("sbomify.apps.documents.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.documents.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_document_data.return_value = b"test document content"
             mock_s3_client.return_value = mock_s3_instance
@@ -275,7 +275,7 @@ class TestSignedURLs:
         token = make_download_token(self.public_sbom.id, str(self.user.id))
 
         # Mock S3 client using the proper sboms API mock
-        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.sboms.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_sbom_data.return_value = b'{"test": "data"}'
             mock_s3_client.return_value = mock_s3_instance
@@ -291,7 +291,7 @@ class TestSignedURLs:
         token = make_document_download_token(self.public_document.id, str(self.user.id))
 
         # Mock S3 client using the proper documents API mock
-        with patch("sbomify.apps.documents.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.documents.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_document_data.return_value = b"test document content"
             mock_s3_client.return_value = mock_s3_instance
@@ -393,7 +393,7 @@ class TestSignedURLIntegration:
     def test_project_sbom_contains_signed_urls(self):
         """Test that project SBOMs contain signed URLs for private components."""
         # Mock S3 client to return sample SBOM data
-        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.sboms.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_sbom_data.return_value = b"""{
                 "bomFormat": "CycloneDX",
@@ -423,7 +423,7 @@ class TestSignedURLIntegration:
     def test_product_sbom_contains_signed_urls(self):
         """Test that product SBOMs contain signed URLs for private components."""
         # Mock S3 client to return sample SBOM data
-        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+        with patch("sbomify.apps.sboms.apis.StorageClient") as mock_s3_client:
             mock_s3_instance = MagicMock()
             mock_s3_instance.get_sbom_data.return_value = b"""{
                 "bomFormat": "CycloneDX",

--- a/sbomify/apps/sboms/tests/test_utils.py
+++ b/sbomify/apps/sboms/tests/test_utils.py
@@ -110,8 +110,8 @@ def mock_s3_client(mocker):
         }
     ).encode()
 
-    # Mock the S3Client class to return our mock instance
-    mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+    # Mock the StorageClient class to return our mock instance
+    mocker.patch("sbomify.apps.core.object_store.StorageClient", return_value=mock_client)
     return mock_client
 
 
@@ -364,7 +364,7 @@ def test_project_sbom_file_generation_with_components(sample_project, tmp_path):
     ProjectComponent.objects.create(project=sample_project, component=component2)
 
     # Mock S3 client to return different mock SBOM data for each component
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
 
         def mock_get_sbom_data(filename):
@@ -493,7 +493,7 @@ def test_project_sbom_builder_serialization(sample_project, tmp_path):  # noqa: 
     ProjectComponent.objects.create(project=sample_project, component=component)
 
     # Mock S3 client
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.return_value = json.dumps(
             {
@@ -592,7 +592,7 @@ def test_mixed_cyclonedx_versions_serialization(sample_project, tmp_path):  # no
     ProjectComponent.objects.create(project=sample_project, component=component2)
 
     # Mock S3 client
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
 
         def mock_get_sbom_data(filename):
@@ -725,7 +725,7 @@ def test_product_sbom_file_generation(tmp_path):
     ProjectComponent.objects.create(project=project, component=component2)
 
     # Mock S3 client
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
 
         def mock_get_sbom_data(filename):
@@ -808,7 +808,7 @@ def test_sbom_vendor_and_remote_file_references(tmp_path):
     ProjectComponent.objects.create(project=project, component=component)
 
     # Mock S3 client
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.return_value = json.dumps(
             {
@@ -951,7 +951,7 @@ def test_network_failure_during_s3_operations(sample_project, tmp_path):  # noqa
     ProjectComponent.objects.create(project=sample_project, component=component)
 
     # Mock S3 client to simulate network failure
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.side_effect = Exception("Network connection failed")
 
@@ -1000,7 +1000,7 @@ def test_malformed_sbom_file_handling(sample_project, tmp_path):  # noqa: F811
     ProjectComponent.objects.create(project=sample_project, component=component)
 
     # Mock S3 client to return malformed JSON
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.return_value = b"{ invalid json content"
 
@@ -1049,7 +1049,7 @@ def test_invalid_sbom_format_handling(sample_project, tmp_path):  # noqa: F811
     ProjectComponent.objects.create(project=sample_project, component=component)
 
     # Mock S3 client to return SBOM with invalid format
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.return_value = json.dumps(
             {
@@ -1339,7 +1339,7 @@ def test_sbom_serialization_uses_schema_alias(tmp_path):
     )
     ProjectComponent.objects.create(project=project, component=component)
 
-    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+    with patch("sbomify.apps.core.object_store.StorageClient") as mock_s3:
         mock_s3_instance = mock_s3.return_value
         mock_s3_instance.get_sbom_data.return_value = json.dumps(
             {

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -17,7 +17,7 @@ from django.utils import timezone
 
 from sbomify.apps.core.models import Component, Product, Project
 
-# S3Client import moved to function level to support test mocking
+# StorageClient import moved to function level to support test mocking
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.sboms.sbom_format_schemas import cyclonedx_1_6 as cdx16
 from sbomify.apps.teams.models import ContactProfile, Member, Team
@@ -108,9 +108,9 @@ def get_sbom_data(sbom_id: str) -> tuple[SBOM, dict[str, Any]]:
         raise SBOMDataError(f"SBOM ID: {sbom_id} has no sbom_filename")
 
     # 2) Download SBOM data from S3
-    from sbomify.apps.core.object_store import S3Client
+    from sbomify.apps.core.object_store import StorageClient
 
-    s3_client = S3Client(bucket_type="SBOMS")
+    s3_client = StorageClient(bucket_type="SBOMS")
     sbom_bytes = s3_client.get_sbom_data(sbom_instance.sbom_filename)
 
     if not sbom_bytes:
@@ -181,9 +181,9 @@ def get_sbom_data_bytes(sbom_id: str) -> tuple[SBOM, bytes]:
         raise SBOMDataError(f"SBOM ID: {sbom_id} has no sbom_filename")
 
     # 2) Download SBOM data from S3
-    from sbomify.apps.core.object_store import S3Client
+    from sbomify.apps.core.object_store import StorageClient
 
-    s3_client = S3Client(bucket_type="SBOMS")
+    s3_client = StorageClient(bucket_type="SBOMS")
     sbom_bytes = s3_client.get_sbom_data(sbom_instance.sbom_filename)
 
     if not sbom_bytes:
@@ -801,7 +801,7 @@ class ProjectSBOMBuilder:
         Returns:
             Tuple of (Path to the downloaded SBOM file, SBOM ID), or None if no SBOM found
         """
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
         # Use the prefetched SBOMs to avoid additional queries
         sboms = list(component.sbom_set.all())
@@ -816,7 +816,7 @@ class ProjectSBOMBuilder:
         sbom = sboms[0]
 
         # Download SBOM data from S3
-        s3_client = S3Client("SBOMS")
+        s3_client = StorageClient("SBOMS")
         try:
             sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
             download_path = self.target_folder / sbom.sbom_filename
@@ -1019,7 +1019,7 @@ class ProductSBOMBuilder:
         Returns:
             Tuple of (Path to the downloaded SBOM file, SBOM ID), or None if no SBOM found
         """
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
         # Use the prefetched SBOMs to avoid additional queries
         sboms = list(component.sbom_set.all())
@@ -1034,7 +1034,7 @@ class ProductSBOMBuilder:
         sbom = sboms[0]
 
         # Download SBOM data from S3
-        s3_client = S3Client("SBOMS")
+        s3_client = StorageClient("SBOMS")
         try:
             sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
             download_path = self.target_folder / sbom.sbom_filename
@@ -1271,7 +1271,7 @@ class ReleaseSBOMBuilder:
         Returns:
             Tuple of (Path to the downloaded SBOM file, SBOM ID), or None if not found
         """
-        from sbomify.apps.core.object_store import S3Client
+        from sbomify.apps.core.object_store import StorageClient
 
         if not sbom.sbom_filename:
             return None
@@ -1279,7 +1279,7 @@ class ReleaseSBOMBuilder:
         download_path = None
         try:
             # Download SBOM data from S3
-            s3_client = S3Client("SBOMS")
+            s3_client = StorageClient("SBOMS")
             sbom_data = s3_client.get_sbom_data(sbom.sbom_filename)
             download_path = self.target_folder / sbom.sbom_filename
             download_path.write_bytes(sbom_data)

--- a/sbomify/apps/sboms/views/sbom_download.py
+++ b/sbomify/apps/sboms/views/sbom_download.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpR
 from django.views import View
 
 from sbomify.apps.core.errors import error_response
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.services.access_control import check_component_access
 from sbomify.apps.sboms.models import SBOM
 
@@ -82,7 +82,7 @@ class SbomDownloadView(View):
             return error_response(request, HttpResponseBadRequest("SBOM file not found"))
 
         try:
-            s3 = S3Client("SBOMS")
+            s3 = StorageClient("SBOMS")
             sbom_data = s3.get_sbom_data(sbom.sbom_filename)
 
             if not sbom_data:

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
 from sbomify.apps.core.models import User
-from sbomify.apps.core.object_store import S3Client
+from sbomify.apps.core.object_store import StorageClient
 from sbomify.apps.core.schemas import ErrorResponse
 from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.teams.models import ContactEntity, ContactProfile, ContactProfileContact, Member, Team
@@ -185,7 +185,7 @@ def update_team_branding_field(
     current_branding = BrandingInfo(**branding_data)
     update_data = current_branding.model_dump()
 
-    s3_client = S3Client("MEDIA")
+    s3_client = StorageClient("MEDIA")
 
     # Handle file deletions
     if field in ["icon", "logo"] and data.value is None and update_data.get(field):
@@ -222,7 +222,7 @@ def upload_to_s3(
     filename: str,
     file: Any,
 ) -> None:
-    s3_client = S3Client("MEDIA")
+    s3_client = StorageClient("MEDIA")
     file.seek(0)
     s3_client.upload_media(filename, file.read())
 
@@ -230,7 +230,7 @@ def upload_to_s3(
 def delete_from_s3(
     filename: str,
 ) -> None:
-    s3_client = S3Client("MEDIA")
+    s3_client = StorageClient("MEDIA")
     s3_client.delete_object(settings.AWS_MEDIA_STORAGE_BUCKET_NAME, filename)
 
 
@@ -332,7 +332,7 @@ def upload_branding_file(
     branding_data = _normalize_branding_payload(team.branding_info)
     current_branding = BrandingInfo(**branding_data)
     update_data = current_branding.model_dump()
-    s3_client = S3Client("MEDIA")
+    s3_client = StorageClient("MEDIA")
 
     # Generate new filename first
     uploaded = request.FILES["file"]

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -1088,8 +1088,8 @@ def test_team_branding_api(sample_team_with_owner_member: Member, mocker):  # no
     base_uri = f"/api/v1/workspaces/{team_key}/branding"
 
     # Mock S3 client methods
-    mock_upload = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_media")
-    mock_delete = mocker.patch("sbomify.apps.core.object_store.S3Client.delete_object")
+    mock_upload = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_media")
+    mock_delete = mocker.patch("sbomify.apps.core.object_store.StorageClient.delete_object")
 
     # Set up mock to store the filename that was used
     def upload_side_effect(filename, data):
@@ -1184,8 +1184,8 @@ def test_team_branding_atomic_upload(sample_team_with_owner_member: Member, mock
     base_uri = f"/api/v1/workspaces/{team_key}/branding"
 
     # Mock S3 client methods
-    mock_upload = mocker.patch("sbomify.apps.core.object_store.S3Client.upload_media")
-    mock_delete = mocker.patch("sbomify.apps.core.object_store.S3Client.delete_object")
+    mock_upload = mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_media")
+    mock_delete = mocker.patch("sbomify.apps.core.object_store.StorageClient.delete_object")
 
     uploaded_files = []
     deleted_files = []
@@ -1376,8 +1376,8 @@ def test_team_branding_api_preserves_company_nda_document_id(sample_team_with_ow
 
     # Test file upload - should preserve company_nda_document_id
     # Mock S3 client to avoid actual uploads
-    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_media")
-    mocker.patch("sbomify.apps.core.object_store.S3Client.delete_object")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.upload_media")
+    mocker.patch("sbomify.apps.core.object_store.StorageClient.delete_object")
 
     with open("test_icon.png", "wb") as f:
         f.write(b"fake png content")

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -494,7 +494,7 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             import hashlib
             from decimal import Decimal, InvalidOperation
 
-            from sbomify.apps.core.object_store import S3Client
+            from sbomify.apps.core.object_store import StorageClient
             from sbomify.apps.documents.models import Document
 
             # Read file content
@@ -505,7 +505,7 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             content_hash = hashlib.sha256(file_content).hexdigest()
 
             # Upload to S3
-            s3 = S3Client("DOCUMENTS")
+            s3 = StorageClient("DOCUMENTS")
             filename = s3.upload_document(file_content)
 
             # Get or create company-wide component

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -651,7 +651,10 @@ JWT_ISSUER = os.environ.get("JWT_ISSUER", "sbomify")
 JWT_ALGORITHM = os.environ.get("JWT_ALGORITHM", "HS256")
 JWT_AUDIENCE = os.environ.get("JWT_AUDIENCE", "sbomify")
 
-# Localstack and AWS/S3 related settings
+# Object storage settings
+STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "s3")
+
+# AWS/S3 related settings
 AWS_REGION = os.environ.get("AWS_REGION", "")
 AWS_ENDPOINT_URL_S3 = os.environ.get("AWS_ENDPOINT_URL_S3", "")
 

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -92,6 +92,9 @@ SIGNED_URL_SALT = "test-signed-url-salt-unique-per-installation"
 
 SECRET_KEY = "django-insecure-test-key-do-not-use-in-production"  # nosec B105 - This is a test-only key
 
+# Object storage settings
+STORAGE_BACKEND = "s3"
+
 # Mock AWS settings for testing
 AWS_REGION = "test-region"
 AWS_ENDPOINT_URL_S3 = "http://test-s3.localhost"


### PR DESCRIPTION
Initial implementation of https://github.com/sbomify/sbomify/pull/843 centralize S3 and prepare abstractions to support multiple Object storage backends.

Trying to find a good level of abstraction and number of changes todo at the same time. In multiple places there are still notes about AWS for bucket names for example. I'm thinking this can be changed when implementing GCS support. 

The intersting files to look at 

```
┌──────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────┐
  │                           File                           │                            Why it's interesting                            │
  ├──────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ sbomify/apps/core/object_store.py                        │ The core of the PR — ABC, S3 implementation, factory, domain wrapper       │
  ├──────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ sbomify/apps/core/tests/integration/test_object_store.py │ New/rewritten tests for the abstraction layer                              │
  ├──────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ sbomify/apps/core/tests/s3_fixtures.py                   │ Test fixture changes to support the new architecture                       │
  ├──────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ sbomify/apps/compliance/services/export_service.py       │ Presigned URL consolidation — removed direct boto3 usage in business logic │
  ├──────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ sbomify/settings.py / sbomify/test_settings.py           │ New STORAGE_BACKEND setting                                                │
  └──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────┘
``` 
## Summary

- Introduces `ObjectStoreClient` abstract base class and `S3ObjectStoreClient` implementation to decouple storage operations from domain logic (ADR-0007 Phase 1)
- Makes S3 credentials optional — when empty, boto3 falls through to its default credential chain, enabling AWS workload identity (IRSA/Pod Identity) without code changes
- Renames `S3Client` → `StorageClient` across all 30 caller and test files to reflect its backend-agnostic role
- Consolidates the ad-hoc `boto3.client()` presigned URL generation in `export_service.py` into `StorageClient.generate_presigned_url()`
- Adds `STORAGE_BACKEND` setting (default: `s3`) for future GCS support

## Test plan

- [x] 24 new unit tests for `ObjectStoreClient`, `S3ObjectStoreClient`, and `StorageClient` (all pass)
- [x] All existing storage-related tests pass with the rename (257+ tests)
- [x] Presigned URL tests updated and passing
- [x] `ruff check`, `ruff format`, `mypy` clean

Ref: #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)