### PR TITLE
chore: upgrade setup-uv to v8.0.0 (immutable release)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/uv.lock"
@@ -140,7 +140,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/uv.lock"
@@ -224,7 +224,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/uv.lock"

--- a/.github/workflows/screencasts.yml
+++ b/.github/workflows/screencasts.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/uv.lock"


### PR DESCRIPTION
## Summary
- Upgrade `astral-sh/setup-uv` from v7.6.0 to v8.0.0 across all CI workflows
- v8.0.0 is the first **immutable release**, enhancing supply chain security
- Pinned to exact commit hash `cec208311dfd045dd5311c1add060b2062131d57`

## Files changed
- `.github/workflows/ci-cd.yml` (3 occurrences)
- `.github/workflows/screencasts.yml` (1 occurrence)

## Test plan
- [ ] CI pipeline runs successfully with the new setup-uv version
- [x] uv caching still works (`enable-cache: true`)