### PR TITLE
fix: persist Caddy TLS certificates with named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       - "${BIND_IP:-127.0.0.1}:${HTTPS_PORT:-8443}:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
     environment:
       LOG_LEVEL: ${CADDY_LOG_LEVEL:-INFO}
       CADDY_ADMIN: ${CADDY_ADMIN:-off}
@@ -184,3 +185,4 @@ volumes:
   sbomify_postgres_data:
   sbomify_redis_data:
   ca_certs:
+  caddy_data:


### PR DESCRIPTION
## Summary
- Add `caddy_data` named volume to persist Caddy's `/data` directory across container restarts
- Prevents unnecessary ACME certificate re-issuance and potential Let's Encrypt rate-limit hits

## Test plan
- [ ] Verify `docker compose up` starts Caddy with the new volume
- [ ] Confirm certificates persist after `docker compose restart sbomify-caddy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)