### PR TITLE
fix: pass pre-built Redis client to Dramatiq for TLS support

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -18,6 +18,7 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import dj_database_url
+import redis
 import sentry_sdk
 from django.contrib import messages
 from dotenv import find_dotenv, load_dotenv
@@ -437,9 +438,13 @@ CHANNEL_LAYERS = {
     },
 }
 
-_dramatiq_broker_options: dict[str, Any] = {"url": REDIS_WORKER_URL}
+_dramatiq_broker_options: dict[str, Any] = {}
 if REDIS_CA_CERTS:
-    _dramatiq_broker_options["ssl_ca_certs"] = REDIS_CA_CERTS
+    # Pass a pre-built client because Dramatiq's RedisBroker creates a
+    # ConnectionPool.from_url() that drops ssl_ca_certs kwargs.
+    _dramatiq_broker_options["client"] = redis.Redis.from_url(REDIS_WORKER_URL, ssl_ca_certs=REDIS_CA_CERTS)
+else:
+    _dramatiq_broker_options["url"] = REDIS_WORKER_URL
 DRAMATIQ_BROKER = {
     "BROKER": "dramatiq.brokers.redis.RedisBroker",
     "OPTIONS": _dramatiq_broker_options,
@@ -451,9 +456,11 @@ DRAMATIQ_BROKER = {
     ],
 }
 
-_dramatiq_backend_options: dict[str, Any] = {"url": REDIS_WORKER_URL}
+_dramatiq_backend_options: dict[str, Any] = {}
 if REDIS_CA_CERTS:
-    _dramatiq_backend_options["ssl_ca_certs"] = REDIS_CA_CERTS
+    _dramatiq_backend_options["client"] = redis.Redis.from_url(REDIS_WORKER_URL, ssl_ca_certs=REDIS_CA_CERTS)
+else:
+    _dramatiq_backend_options["url"] = REDIS_WORKER_URL
 DRAMATIQ_RESULT_BACKEND = {
     "BACKEND": "dramatiq.results.backends.redis.RedisBackend",
     "BACKEND_OPTIONS": _dramatiq_backend_options,


### PR DESCRIPTION
## Summary
- Dramatiq's `RedisBroker` uses `ConnectionPool.from_url()` which silently drops `ssl_ca_certs` kwargs, breaking TLS with custom CA certificates
- Work around this by passing a pre-built `redis.Redis` client (via the `client` option) when `REDIS_CA_CERTS` is configured
- When no CA certs are set, the existing `url`-based configuration is preserved

## Test plan
- [ ] Verify Dramatiq workers connect successfully to Redis with TLS + custom CA certs
- [ ] Verify Dramatiq works without TLS (no `REDIS_CA_CERTS` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)