### PR TITLE
fix: suppress CancelledError log noise from asyncio/asgiref

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -502,6 +502,12 @@ LOGGING = {
             "stream": "ext://sys.stdout",
             "formatter": "default",
         },
+        "console_asyncio": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "default",
+            "filters": ["suppress_cancelled_error"],
+        },
     },
     "root": {
         "handlers": ["console"],
@@ -544,9 +550,8 @@ LOGGING = {
             "propagate": False,
         },
         "asyncio": {
-            "handlers": ["console"],
+            "handlers": ["console_asyncio"],
             "level": "WARNING",
-            "filters": ["suppress_cancelled_error"],
             "propagate": False,
         },
         # "teams": {

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -487,13 +487,13 @@ LOGGING = {
         "default": {"format": "%(asctime)s:%(name)s:%(levelname)s:%(message)s"},
     },
     "filters": {
-        # Suppress "CancelledError exception in shielded future" from asgiref.
-        # This is expected ASGI behavior when clients disconnect mid-request
-        # (e.g., browser navigating away during a slow Keycloak OIDC redirect).
+        # Suppress "CancelledError exception in shielded future" from the asyncio
+        # logger. This is logged by asgiref's SyncToAsync when a client disconnects
+        # mid-request under ASGI (e.g., navigating away during a slow OIDC redirect).
         # Already suppressed in Sentry via ignore_errors; this silences the log.
         "suppress_cancelled_error": {
             "()": "django.utils.log.CallbackFilter",
-            "callback": lambda record: "CancelledError" not in record.getMessage(),
+            "callback": lambda record: "CancelledError exception in shielded future" not in record.getMessage(),
         },
     },
     "handlers": {

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -486,6 +486,16 @@ LOGGING = {
     "formatters": {
         "default": {"format": "%(asctime)s:%(name)s:%(levelname)s:%(message)s"},
     },
+    "filters": {
+        # Suppress "CancelledError exception in shielded future" from asgiref.
+        # This is expected ASGI behavior when clients disconnect mid-request
+        # (e.g., browser navigating away during a slow Keycloak OIDC redirect).
+        # Already suppressed in Sentry via ignore_errors; this silences the log.
+        "suppress_cancelled_error": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": lambda record: "CancelledError" not in record.getMessage(),
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
@@ -531,6 +541,12 @@ LOGGING = {
         "allauth.socialaccount": {
             "handlers": ["console"],
             "level": "DEBUG",
+            "propagate": False,
+        },
+        "asyncio": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "filters": ["suppress_cancelled_error"],
             "propagate": False,
         },
         # "teams": {


### PR DESCRIPTION
## Summary
Suppress the noisy `asyncio:ERROR:CancelledError exception in shielded future` log entries that appear when clients disconnect mid-request under ASGI.

## Problem
When a client disconnects before the response completes (e.g., navigating away during a slow Keycloak OIDC redirect), `asgiref`'s `SyncToAsync` logs:

```
asyncio:ERROR:CancelledError exception in shielded future
future: <Future finished exception=CancelledError()>
Traceback (most recent call last):
  ...
asyncio.exceptions.CancelledError
```

This is expected ASGI behavior, not a bug. It's already suppressed in Sentry via `ignore_errors=[asyncio.CancelledError]` (PR #837), but the log output is still noisy.

## Fix
- Add a `CallbackFilter` to Django's `LOGGING` config that drops log records containing "CancelledError"
- Configure the `asyncio` logger with this filter at `WARNING` level
- Uses Django's built-in `django.utils.log.CallbackFilter` — no custom code needed

## Reference
- [asgiref#247: sync_to_async cannot be used after CancelledError](https://github.com/django/asgiref/issues/247)
- [Django ASGI docs: CancelledError on client disconnect](https://docs.djangoproject.com/en/6.0/topics/async/)

## Test plan
- [ ] Deploy to staging and verify no more `CancelledError` log spam
- [ ] Verify other asyncio warnings still appear (filter only suppresses CancelledError)