### PR TITLE
fix: sanitize non-ASCII characters in CRA catalog for SQL_ASCII databases

### DIFF
--- a/sbomify/apps/compliance/services/oscal_service.py
+++ b/sbomify/apps/compliance/services/oscal_service.py
@@ -52,6 +52,52 @@ def load_cra_catalog() -> Catalog:
     return Catalog(**raw["catalog"])
 
 
+_UNICODE_REPLACEMENTS = {
+    "\u2014": "--",  # em-dash
+    "\u2013": "-",  # en-dash
+    "\u00a7": "S.",  # section sign §
+    "\u2018": "'",  # left single quote
+    "\u2019": "'",  # right single quote
+    "\u201c": '"',  # left double quote
+    "\u201d": '"',  # right double quote
+    "\u2026": "...",  # ellipsis
+}
+
+
+def _sanitize_non_ascii(obj: Any) -> Any:
+    """Replace non-ASCII characters in strings with ASCII equivalents.
+
+    Mutates dicts/lists in place. PostgreSQL with SQL_ASCII encoding cannot
+    store Unicode escapes in JSON columns.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, str):
+                for char, replacement in _UNICODE_REPLACEMENTS.items():
+                    value = value.replace(char, replacement)
+                obj[key] = value
+            else:
+                _sanitize_non_ascii(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, str):
+                for char, replacement in _UNICODE_REPLACEMENTS.items():
+                    item = item.replace(char, replacement)
+                obj[i] = item
+            else:
+                _sanitize_non_ascii(item)
+    return obj
+
+
+def _sanitize_str(value: str | None) -> str:
+    """Replace non-ASCII characters in a single string."""
+    if not value:
+        return value or ""
+    for char, replacement in _UNICODE_REPLACEMENTS.items():
+        value = value.replace(char, replacement)
+    return value
+
+
 def import_catalog_to_db(trestle_catalog: Catalog, name: str, version: str) -> OSCALCatalog:
     """Create an ``OSCALCatalog`` record and materialize ``OSCALControl`` rows.
 
@@ -62,6 +108,10 @@ def import_catalog_to_db(trestle_catalog: Catalog, name: str, version: str) -> O
 
     with transaction.atomic():
         catalog_json = json.loads(trestle_catalog.oscal_serialize_json())
+        # Sanitize non-ASCII characters that SQL_ASCII PostgreSQL databases
+        # cannot store. PG rejects Unicode escapes in JSON columns when the
+        # encoding is SQL_ASCII.
+        _sanitize_non_ascii(catalog_json)
         db_catalog = OSCALCatalog.objects.create(
             name=name,
             version=version,
@@ -73,7 +123,7 @@ def import_catalog_to_db(trestle_catalog: Catalog, name: str, version: str) -> O
         controls_to_create: list[OSCALControl] = []
         for group in trestle_catalog.groups or []:
             group_id = group.id or ""
-            group_title = group.title
+            group_title = _sanitize_str(group.title)
             for control in group.controls or []:
                 # Extract the prose from the statement part as the description
                 description = ""
@@ -87,8 +137,8 @@ def import_catalog_to_db(trestle_catalog: Catalog, name: str, version: str) -> O
                         control_id=control.id,
                         group_id=group_id,
                         group_title=group_title,
-                        title=control.title,
-                        description=description,
+                        title=_sanitize_str(control.title),
+                        description=_sanitize_str(description),
                         sort_order=sort_order,
                     )
                 )

--- a/sbomify/apps/compliance/services/oscal_service.py
+++ b/sbomify/apps/compliance/services/oscal_service.py
@@ -52,6 +52,10 @@ def load_cra_catalog() -> Catalog:
     return Catalog(**raw["catalog"])
 
 
+# Best-effort replacements for common Unicode characters.
+# Any non-ASCII character NOT in this map is transliterated via
+# unicodedata.normalize (NFKD) or dropped, so unknown chars are
+# handled gracefully instead of crashing.
 _UNICODE_REPLACEMENTS = {
     "\u2014": "--",  # em-dash
     "\u2013": "-",  # en-dash
@@ -61,11 +65,34 @@ _UNICODE_REPLACEMENTS = {
     "\u201c": '"',  # left double quote
     "\u201d": '"',  # right double quote
     "\u2026": "...",  # ellipsis
+    "\u00ab": "<<",  # left guillemet «
+    "\u00bb": ">>",  # right guillemet »
+    "\u00b0": "deg",  # degree sign °
+    "\u00b7": "*",  # middle dot ·
+    "\u2022": "*",  # bullet •
+    "\u00a9": "(c)",  # copyright ©
+    "\u00ae": "(R)",  # registered ®
+    "\u2122": "(TM)",  # trademark ™
 }
 
 
+def _to_ascii(s: str) -> str:
+    """Convert a string to ASCII, replacing non-ASCII chars gracefully.
+
+    1. Apply known replacements for common Unicode characters.
+    2. NFKD-normalize to decompose accented chars (e.g. é → e + combining accent).
+    3. Encode to ASCII with 'ignore' to drop any remaining non-ASCII bytes.
+    """
+    import unicodedata
+
+    for char, replacement in _UNICODE_REPLACEMENTS.items():
+        s = s.replace(char, replacement)
+    s = unicodedata.normalize("NFKD", s)
+    return s.encode("ascii", "ignore").decode("ascii")
+
+
 def _sanitize_non_ascii(obj: Any) -> Any:
-    """Replace non-ASCII characters in strings with ASCII equivalents.
+    """Recursively replace non-ASCII characters in all strings.
 
     Mutates dicts/lists in place. PostgreSQL with SQL_ASCII encoding cannot
     store Unicode escapes in JSON columns.
@@ -73,17 +100,13 @@ def _sanitize_non_ascii(obj: Any) -> Any:
     if isinstance(obj, dict):
         for key, value in obj.items():
             if isinstance(value, str):
-                for char, replacement in _UNICODE_REPLACEMENTS.items():
-                    value = value.replace(char, replacement)
-                obj[key] = value
+                obj[key] = _to_ascii(value)
             else:
                 _sanitize_non_ascii(value)
     elif isinstance(obj, list):
         for i, item in enumerate(obj):
             if isinstance(item, str):
-                for char, replacement in _UNICODE_REPLACEMENTS.items():
-                    item = item.replace(char, replacement)
-                obj[i] = item
+                obj[i] = _to_ascii(item)
             else:
                 _sanitize_non_ascii(item)
     return obj
@@ -93,9 +116,7 @@ def _sanitize_str(value: str | None) -> str:
     """Replace non-ASCII characters in a single string."""
     if not value:
         return value or ""
-    for char, replacement in _UNICODE_REPLACEMENTS.items():
-        value = value.replace(char, replacement)
-    return value
+    return _to_ascii(value)
 
 
 def import_catalog_to_db(trestle_catalog: Catalog, name: str, version: str) -> OSCALCatalog:


### PR DESCRIPTION
## Summary
Fix 500 error on CRA wizard in production caused by Unicode characters in the OSCAL catalog JSON.

## Problem
The production PostgreSQL database uses `SQL_ASCII` encoding. When the CRA wizard first runs, it loads `cra-annex-i-catalog.json` which contains Unicode characters (em-dash `\u2014`, section sign `\u00a7`, etc.) and tries to insert them into a `JSONField`. PostgreSQL rejects the `\uXXXX` escapes with:

```
UntranslatableCharacter: unsupported Unicode escape sequence
DETAIL: Unicode escape value could not be translated to the server's encoding SQL_ASCII.
```

## Fix
- Add `_UNICODE_REPLACEMENTS` mapping for known non-ASCII chars → ASCII equivalents
- `_sanitize_non_ascii()` recursively walks the catalog JSON dict/list and replaces them
- `_sanitize_str()` does the same for individual text fields (control titles, descriptions)
- Applied before `OSCALCatalog.objects.create()` and `OSCALControl` bulk_create

## Test plan
- [ ] CRA wizard no longer 500s on prod
- [ ] Catalog and controls are created with readable ASCII text
- [ ] Existing UTF8 databases are unaffected (replacements are harmless)