### PR TITLE
feat(dashboard): improve zero state with clickable tree diagram (#776)

### DIFF
--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -1,4 +1,5 @@
-<div x-data="sbomUpload('{{ component_id }}', {{ component.sbom_count|default:0 }} > 0)"
+<div id="upload-sbom"
+     x-data="sbomUpload('{{ component_id }}', {{ component.sbom_count|default:0 }} > 0)"
      x-init="$watch('expanded', val => localStorage.setItem('sbom-upload-expanded', val ? 'true' : 'false'))">
     <div class="tw-card" :class="{ 'opacity-75': !expanded }">
         <button type="button"

--- a/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
+++ b/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
@@ -261,14 +261,68 @@
             </div>
         {% endif %}
     {% else %}
-        {# Empty State #}
-        <div class="flex flex-col items-center justify-center py-12">
-            <div class="w-20 h-20 rounded-full bg-success/10 flex items-center justify-center mb-4">
-                <i class="fas fa-shield-check text-3xl text-success"></i>
+        {% if hierarchy %}
+            {# Zero State: Workspace Hierarchy Tree #}
+            <div class="flex flex-col items-center py-8">
+                <div class="w-14 h-14 rounded-2xl bg-primary/10 flex items-center justify-center mb-3">
+                    <i class="fas fa-sitemap text-xl text-primary" aria-hidden="true"></i>
+                </div>
+                <h5 class="text-lg font-semibold text-text mb-1">Your workspace hierarchy</h5>
+                <p class="text-text-muted text-sm mb-6">Upload your first SBOM to start tracking vulnerabilities</p>
+                {# Tree Diagram #}
+                <div class="w-full max-w-lg">
+                    {% for product in hierarchy %}
+                        {# Product Node #}
+                        <div class="flex flex-col items-center">
+                            <a href="{% url 'core:product_details' product_id=product.id %}"
+                               class="inline-flex items-center gap-2 px-4 py-2.5 bg-primary text-white rounded-xl text-sm font-semibold hover:bg-primary-dark transition-colors no-underline">
+                                <i class="fas fa-cube" aria-hidden="true"></i>
+                                {{ product.name }}
+                            </a>
+                            {% for project in product.projects %}
+                                {# Connector Line #}
+                                <div class="w-px h-5 bg-border"></div>
+                                {# Project Node #}
+                                <a href="{% url 'core:project_details' project_id=project.id %}"
+                                   class="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 text-primary rounded-lg text-sm font-medium hover:bg-primary/20 transition-colors no-underline">
+                                    <i class="fas fa-folder" aria-hidden="true"></i>
+                                    {{ project.name }}
+                                </a>
+                                {% for component in project.components %}
+                                    {# Connector Line #}
+                                    <div class="w-px h-5 bg-border"></div>
+                                    {# Component Node (dashed border — needs SBOM) #}
+                                    <a href="{% url 'core:component_details' component_id=component.id %}"
+                                       class="inline-flex items-center gap-2 px-4 py-2 border-2 border-dashed border-success rounded-lg text-sm font-medium text-success hover:bg-success/5 transition-colors no-underline">
+                                        <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                                        {{ component.name }}
+                                        <span class="text-xs text-text-muted ml-1">← upload SBOM</span>
+                                    </a>
+                                {% endfor %}
+                            {% endfor %}
+                        </div>
+                        {% if not forloop.last %}<div class="my-6 border-t border-border"></div>{% endif %}
+                    {% endfor %}
+                </div>
+                {# CTA Button #}
+                {% if hierarchy and hierarchy.0.projects and hierarchy.0.projects.0.components %}
+                    <a href="{% url 'core:component_details' component_id=hierarchy.0.projects.0.components.0.id %}"
+                       class="tw-btn-primary mt-6 no-underline">
+                        <i class="fas fa-upload mr-2" aria-hidden="true"></i>
+                        Upload your first SBOM
+                    </a>
+                {% endif %}
             </div>
-            <h5 class="text-lg font-semibold text-text mb-2">No Vulnerability Data</h5>
-            <p class="text-text-muted text-center">No vulnerability scan results found for the selected time period.</p>
-            <p class="text-xs text-text-muted mt-2">Vulnerability scans are performed automatically on a weekly schedule.</p>
-        </div>
+        {% else %}
+            {# Has SBOMs but no vulnerability data yet #}
+            <div class="flex flex-col items-center justify-center py-12">
+                <div class="w-20 h-20 rounded-full bg-success/10 flex items-center justify-center mb-4">
+                    <i class="fas fa-shield-check text-3xl text-success"></i>
+                </div>
+                <h5 class="text-lg font-semibold text-text mb-2">No Vulnerability Data</h5>
+                <p class="text-text-muted text-center">No vulnerability scan results found for the selected time period.</p>
+                <p class="text-xs text-text-muted mt-2">Vulnerability scans are performed automatically on a weekly schedule.</p>
+            </div>
+        {% endif %}
     {% endif %}
 </div>

--- a/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
+++ b/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
@@ -306,7 +306,7 @@
                 </div>
                 {# CTA Button — links to first component across entire hierarchy #}
                 {% if first_component_id %}
-                    <a href="{% url 'core:component_details' component_id=first_component_id %}"
+                    <a href="{% url 'core:component_details' component_id=first_component_id %}#upload-sbom"
                        class="tw-btn-primary mt-6 no-underline">
                         <i class="fas fa-upload mr-2" aria-hidden="true"></i>
                         Upload your first SBOM

--- a/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
+++ b/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/components/vulnerability_trends.html.j2
@@ -304,9 +304,9 @@
                         {% if not forloop.last %}<div class="my-6 border-t border-border"></div>{% endif %}
                     {% endfor %}
                 </div>
-                {# CTA Button #}
-                {% if hierarchy and hierarchy.0.projects and hierarchy.0.projects.0.components %}
-                    <a href="{% url 'core:component_details' component_id=hierarchy.0.projects.0.components.0.id %}"
+                {# CTA Button — links to first component across entire hierarchy #}
+                {% if first_component_id %}
+                    <a href="{% url 'core:component_details' component_id=first_component_id %}"
                        class="tw-btn-primary mt-6 no-underline">
                         <i class="fas fa-upload mr-2" aria-hidden="true"></i>
                         Upload your first SBOM

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -69,7 +69,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         if not trends_data["has_data"] and not component_id:
             from sbomify.apps.sboms.models import SBOM
 
-            has_sboms = SBOM.objects.filter(component__team=team).exists()
+            has_sboms = SBOM.objects.filter(component__team=team, bom_type=SBOM.BomType.SBOM).exists()
             if not has_sboms:
                 hierarchy, first_component_id = self._build_workspace_hierarchy(team)
 

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils import timezone
@@ -64,12 +65,13 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
 
         # Zero-state: if no vulnerability data AND no SBOMs, show the hierarchy tree
         hierarchy = None
+        first_component_id = None
         if not trends_data["has_data"] and not component_id:
             from sbomify.apps.sboms.models import SBOM
 
             has_sboms = SBOM.objects.filter(component__team=team).exists()
             if not has_sboms:
-                hierarchy = self._build_workspace_hierarchy(team)
+                hierarchy, first_component_id = self._build_workspace_hierarchy(team)
 
         context = {
             "team_key": team_key,
@@ -81,6 +83,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "products": products,
             "days_options": [7, 30, 90, 180, 365],
             "hierarchy": hierarchy,
+            "first_component_id": first_component_id,
             **trends_data,
         }
 
@@ -241,42 +244,33 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "recent_scans": formatted_scans,
         }
 
-    def _build_workspace_hierarchy(self, team: Team) -> list[dict[str, Any]]:
-        """Build product -> project -> component hierarchy for the zero-state tree.
+    def _build_workspace_hierarchy(self, team: Team) -> tuple[list[dict[str, Any]], str | None]:
+        """Build product → project → component hierarchy for the zero-state tree.
 
-        Returns a nested list of products, each with their projects and components.
+        Uses prefetch_related to load the full tree in 3 queries (products,
+        projects, components) instead of N+1 per nesting level.
         """
-        from sbomify.apps.sboms.models import ProductProject, ProjectComponent
+        from sbomify.apps.sboms.models import Project
 
-        products = list(Product.objects.filter(team=team).order_by("name"))
+        products = (
+            Product.objects.filter(team=team)
+            .prefetch_related(
+                Prefetch("projects", queryset=Project.objects.prefetch_related("components").order_by("name")),
+            )
+            .order_by("name")
+        )
 
         hierarchy = []
+        first_component_id = None
         for product in products:
-            product_projects = ProductProject.objects.filter(product=product).select_related("project")
             projects_list = []
-            for pp in product_projects:
-                project = pp.project
-                project_components = ProjectComponent.objects.filter(project=project).select_related("component")
-                components_list = [
-                    {
-                        "id": pc.component.id,
-                        "name": pc.component.name,
-                    }
-                    for pc in project_components
-                ]
-                projects_list.append(
-                    {
-                        "id": project.id,
-                        "name": project.name,
-                        "components": components_list,
-                    }
-                )
-            hierarchy.append(
-                {
-                    "id": product.id,
-                    "name": product.name,
-                    "projects": projects_list,
-                }
-            )
+            for project in product.projects.all():
+                components_list = []
+                for component in project.components.all():
+                    components_list.append({"id": component.id, "name": component.name})
+                    if first_component_id is None:
+                        first_component_id = component.id
+                projects_list.append({"id": project.id, "name": project.name, "components": components_list})
+            hierarchy.append({"id": product.id, "name": product.name, "projects": projects_list})
 
-        return hierarchy
+        return hierarchy, first_component_id

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -62,6 +62,15 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
 
         trends_data = self._get_trends_data(team, selected_days, component_id, selected_product_id)
 
+        # Zero-state: if no vulnerability data AND no SBOMs, show the hierarchy tree
+        hierarchy = None
+        if not trends_data["has_data"] and not component_id:
+            from sbomify.apps.sboms.models import SBOM
+
+            has_sboms = SBOM.objects.filter(component__team=team).exists()
+            if not has_sboms:
+                hierarchy = self._build_workspace_hierarchy(team)
+
         context = {
             "team_key": team_key,
             "component_id": component_id,
@@ -71,6 +80,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "selected_product_id": selected_product_id,
             "products": products,
             "days_options": [7, 30, 90, 180, 365],
+            "hierarchy": hierarchy,
             **trends_data,
         }
 
@@ -230,3 +240,43 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "has_data": summary["total"] > 0,
             "recent_scans": formatted_scans,
         }
+
+    def _build_workspace_hierarchy(self, team: Team) -> list[dict[str, Any]]:
+        """Build product -> project -> component hierarchy for the zero-state tree.
+
+        Returns a nested list of products, each with their projects and components.
+        """
+        from sbomify.apps.sboms.models import ProductProject, ProjectComponent
+
+        products = list(Product.objects.filter(team=team).order_by("name"))
+
+        hierarchy = []
+        for product in products:
+            product_projects = ProductProject.objects.filter(product=product).select_related("project")
+            projects_list = []
+            for pp in product_projects:
+                project = pp.project
+                project_components = ProjectComponent.objects.filter(project=project).select_related("component")
+                components_list = [
+                    {
+                        "id": pc.component.id,
+                        "name": pc.component.name,
+                    }
+                    for pc in project_components
+                ]
+                projects_list.append(
+                    {
+                        "id": project.id,
+                        "name": project.name,
+                        "components": components_list,
+                    }
+                )
+            hierarchy.append(
+                {
+                    "id": product.id,
+                    "name": product.name,
+                    "projects": projects_list,
+                }
+            )
+
+        return hierarchy


### PR DESCRIPTION
## Summary
Replace the dashboard's "No Vulnerability Data" empty state with a clickable tree diagram showing the workspace's product → project → component hierarchy.

Closes #776

## When does the tree show?
When **both** conditions are true:
- Zero SBOMs in the workspace
- Zero vulnerability scan results

Once either exists, the normal view takes over:
- SBOMs exist but no scans → "No Vulnerability Data" message (scans will run)
- Vulnerability data exists → normal trends chart

## Tree features
- Vertical top-down layout: Product → Project → Component
- All nodes are clickable (link to detail pages)
- Component nodes have dashed green border with "← upload SBOM" hint
- CTA button: "Upload your first SBOM" linking to the first component
- Shows full hierarchy (all products/projects/components)


## Test plan
- [x] Tree shows on workspace with 0 SBOMs + 0 vulnerability data
- [x] Each node links to correct detail page
- [x] CTA button links to first component
- [x] Workspace with SBOMs shows normal vulnerability trends
- [x] Workspace with vulnerability data shows normal chart

<img width="940" height="567" alt="Screenshot 2026-04-02 at 8 06 12 PM" src="https://github.com/user-attachments/assets/f58c3c8a-df58-42e6-9904-88b3da29b933" />