### PR TITLE
fix: update screencast scripts for current UI state

### DIFF
--- a/bin/record_screencasts.sh
+++ b/bin/record_screencasts.sh
@@ -40,7 +40,15 @@ ensure_services() {
     compose up -d --build
     SERVICES_STARTED=true
     echo "Waiting for services to be healthy..."
-    compose exec tests bash -c "until pg_isready -h 172.25.0.10 -U sbomify_test -q 2>/dev/null; do sleep 1; done"
+    compose exec tests python -c "
+import socket, time
+while True:
+    try:
+        s = socket.create_connection(('172.25.0.10', 5432), timeout=2)
+        s.close(); break
+    except OSError:
+        time.sleep(1)
+"
 }
 
 ensure_ffmpeg() {

--- a/screencasts/conftest.py
+++ b/screencasts/conftest.py
@@ -177,6 +177,14 @@ def navigate_to_releases(page: Page) -> None:
     pace(page, 1200)
 
 
+def navigate_to_plugins(page: Page) -> None:
+    """Click the sidebar Plugins link and wait for the page to load."""
+    plugins_link = page.get_by_role("link", name="Plugins")
+    hover_and_click(page, plugins_link)
+    page.wait_for_load_state("networkidle")
+    pace(page, 1200)
+
+
 def navigate_to_trust_center_tab(page: Page) -> None:
     """Navigate to Settings, then click the Trust Center tab."""
     navigate_to_settings(page)

--- a/screencasts/document_upload.py
+++ b/screencasts/document_upload.py
@@ -48,7 +48,7 @@ def _upload_document(page: Page, pdf_path: str) -> None:
     pace(page, 600)
 
     # Select Compliance Subcategory: SOC 2
-    subcat_select = page.locator("select[name='compliance_subcategory']")
+    subcat_select = page.locator("#document-subcategory-compliance")
     subcat_select.wait_for(state="visible", timeout=5_000)
     subcat_select.scroll_into_view_if_needed()
     pace(page, 300)

--- a/screencasts/vulnerability_scanning.py
+++ b/screencasts/vulnerability_scanning.py
@@ -1,6 +1,6 @@
 """Record the vulnerability scanning enablement screencast.
 
-Drives: Dashboard → Settings → Plugins tab → enable OSV (free) → save settings.
+Drives: Dashboard → Plugins page → enable OSV (free) → save settings.
 """
 
 import pytest
@@ -9,7 +9,7 @@ from playwright.sync_api import Page
 from conftest import (
     dismiss_toasts,
     hover_and_click,
-    navigate_to_settings,
+    navigate_to_plugins,
     pace,
     start_on_dashboard,
 )
@@ -21,20 +21,11 @@ def vulnerability_scanning(recording_page: Page) -> None:
 
     start_on_dashboard(page)
 
-    # ── 1. Navigate to Settings → Plugins tab ─────────────────────────────
-    navigate_to_settings(page)
-
-    plugins_tab = page.locator("a[data-tab='plugins']")
-    hover_and_click(page, plugins_tab)
-    pace(page, 800)
-
-    # Wait for the plugins tab pane to be visible
-    plugins_pane = page.locator("#plugins")
-    plugins_pane.wait_for(state="visible", timeout=10_000)
+    # ── 1. Navigate to Plugins page ──────────────────────────────────────
+    navigate_to_plugins(page)
 
     # Wait for the HTMX-loaded plugin settings to appear
-    page.wait_for_load_state("networkidle")
-    plugins_pane.locator("#plugin-settings-form").wait_for(state="visible", timeout=15_000)
+    page.locator("#plugin-settings-form").wait_for(state="visible", timeout=15_000)
     pace(page, 1500)
 
     # ── 2. Enable OSV vulnerability scanner (available to all plans) ──────


### PR DESCRIPTION
## Summary
- **vulnerability_scanning.py**: Plugins moved from Settings tab to standalone sidebar page — updated navigation to use sidebar link
- **document_upload.py**: Hardened subcategory selector to use Alpine-generated element ID (`#document-subcategory-compliance`) instead of dynamically-bound `:name` attribute
- **conftest.py**: Added `navigate_to_plugins()` helper matching existing navigation helper pattern
- **record_screencasts.sh**: Replaced `pg_isready` DB wait with Python socket check since `postgresql-client` is not in the tests container build target

## Test plan
- [x] All 9 screencasts re-recorded successfully (account_deletion, document_upload, product_creation, profile_editing, release_creation, tea_enabling, trust_center_setup, vulnerability_scanning, workspace_deletion)
- [x] Linting passes (`ruff check`, `ruff format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)