### PR TITLE
fix(dt): PATCH for tag updates + race-safe release check

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -125,24 +125,32 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 f"Team {team.key} does not have Dependency Track enabled as vulnerability provider."
             )
 
-        # Resolve the current release set for tag context.
-        # DT scanning implicitly requires product membership: an SBOM whose
-        # component has no product (via Project→Product) will have no
-        # ReleaseArtifact rows and will be skipped with a user-facing note.
-        # In practice, the upload signal auto-creates the 'latest'
-        # ReleaseArtifact for any SBOM whose component is in a product.
-        current_release_names = self._resolve_release_context(sbom_id, team_id=team.id)
-        if not current_release_names:
+        # Guard: DT scanning requires product membership. Check via the
+        # Project→Product link (stable at SBOM creation time) rather than
+        # ReleaseArtifact (subject to race — sbomify-action creates the SBOM
+        # and release association in separate API calls, so the ReleaseArtifact
+        # may not exist yet when the upload-triggered scan fires).
+        from sbomify.apps.core.models import Project
+
+        has_product = Project.objects.filter(
+            components=sbom.component,
+            products__isnull=False,
+        ).exists()
+        if not has_product:
             return self._create_skipped_result(
-                finding_id="dependency-track:no-release",
-                title="Skipped — SBOM has no release association",
+                finding_id="dependency-track:no-product",
+                title="Skipped — component has no product membership",
                 description=(
-                    "Dependency Track needs at least one release association so the DT "
-                    "project's tag list is meaningful. This SBOM isn't currently linked "
-                    "to any release via ReleaseArtifact (typically because its component "
-                    "has no product membership), so it was skipped."
+                    "Dependency Track scanning requires the component to be linked "
+                    "to a product (via a project). This component has no product "
+                    "membership, so no release context exists for DT tags."
                 ),
             )
+
+        # Resolve release names for DT project tags. May be empty if the
+        # ReleaseArtifact hasn't been committed yet (race with sbomify-action).
+        # Empty is fine — tags will be set at run completion by sync_release_tags.
+        current_release_names = self._resolve_release_context(sbom_id, team_id=team.id)
 
         # Select dt_server FIRST so the team's configured dt_server_id (or
         # plan-based pool selection) is honored.

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -136,11 +136,12 @@ class DependencyTrackPlugin(AssessmentPlugin):
             components=sbom.component,
             team=team,
             products__isnull=False,
+            products__team=team,
         ).exists()
         if not has_product:
             return self._create_skipped_result(
-                finding_id="dependency-track:no-release",
-                title="Skipped — SBOM has no release association",
+                finding_id="dependency-track:no-product",
+                title="Skipped — component has no product membership",
                 description=(
                     "Dependency Track scanning requires the component to be linked "
                     "to a product (via a project in the same team). This component "

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -134,16 +134,18 @@ class DependencyTrackPlugin(AssessmentPlugin):
 
         has_product = Project.objects.filter(
             components=sbom.component,
+            team=team,
             products__isnull=False,
         ).exists()
         if not has_product:
             return self._create_skipped_result(
-                finding_id="dependency-track:no-product",
-                title="Skipped — component has no product membership",
+                finding_id="dependency-track:no-release",
+                title="Skipped — SBOM has no release association",
                 description=(
                     "Dependency Track scanning requires the component to be linked "
-                    "to a product (via a project). This component has no product "
-                    "membership, so no release context exists for DT tags."
+                    "to a product (via a project in the same team). This component "
+                    "has no product membership, so no release context exists for "
+                    "DT project tags."
                 ),
             )
 

--- a/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
+++ b/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
@@ -11,6 +11,8 @@ the existing run's M2M and call sync hooks on continuous plugins — no rescan.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from sbomify.apps.plugins.sdk.enums import AssessmentCategory, RunReason
@@ -98,6 +100,40 @@ class TestDependencyTrackSkippedFinding:
         assert "product" in finding.description.lower()
         assert result.summary.error_count == 0
         assert result.summary.warning_count == 1
+
+    def test_proceeds_when_product_exists_but_no_release_artifact(self, sample_team_with_owner_member, tmp_path):
+        """Race case: component has product membership but ReleaseArtifact
+        hasn't been committed yet (sbomify-action 2-step upload). Scan must
+        proceed with empty tags, NOT return a skipped result."""
+        from sbomify.apps.core.models import Component, Product, Project
+        from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
+        from sbomify.apps.sboms.models import SBOM
+
+        team = sample_team_with_owner_member.team
+        component = Component.objects.create(name="race-test", team=team)
+        product = Product.objects.create(name="p", team=team)
+        project = Project.objects.create(name="proj", team=team)
+        project.products.add(product)
+        project.components.add(component)
+
+        sbom = SBOM.objects.create(name="race-sbom", component=component, format="cyclonedx")
+        # No ReleaseArtifact created — simulates the race window
+
+        sbom_path = tmp_path / "sbom.json"
+        sbom_path.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+        plugin = DependencyTrackPlugin()
+        with (
+            patch.object(plugin, "_team_has_dt_enabled", return_value=True),
+            patch.object(plugin, "_select_dt_server", side_effect=RuntimeError("no server")),
+        ):
+            result = plugin.assess(sbom_id=sbom.id, sbom_path=sbom_path)
+
+        # Should NOT be skipped — the product membership check passes.
+        # It will fail with "no server" from our mock, which proves it
+        # passed the product-membership guard and reached server selection.
+        assert result.metadata.get("skipped") is not True
+        assert any("no server" in (f.description or "").lower() for f in result.findings)
 
     def test_skipped_result_metadata_flag_is_explicit(self):
         """API consumers must be able to detect the skipped state via metadata."""

--- a/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
+++ b/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
@@ -71,8 +71,6 @@ class TestDependencyTrackSkippedFinding:
     """
 
     def test_no_release_returns_warning_not_error(self, tmp_path, sample_team_with_owner_member):
-        from unittest.mock import patch
-
         from sbomify.apps.core.models import Component
         from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
         from sbomify.apps.sboms.models import SBOM
@@ -96,7 +94,7 @@ class TestDependencyTrackSkippedFinding:
         assert len(result.findings) == 1
         finding = result.findings[0]
         assert finding.status == "warning"
-        assert finding.id == "dependency-track:no-release"
+        assert finding.id == "dependency-track:no-product"
         assert "product" in finding.description.lower()
         assert result.summary.error_count == 0
         assert result.summary.warning_count == 1

--- a/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
+++ b/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
@@ -95,7 +95,7 @@ class TestDependencyTrackSkippedFinding:
         finding = result.findings[0]
         assert finding.status == "warning"
         assert finding.id == "dependency-track:no-release"
-        assert "releaseartifact" in finding.description.lower()
+        assert "product" in finding.description.lower()
         assert result.summary.error_count == 0
         assert result.summary.warning_count == 1
 

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -226,11 +226,15 @@ class DependencyTrackClient:
             project_uuid: UUID of the DT project version to update.
             tag_names: Canonical list of tag strings. Duplicates are deduped.
         """
-        current_project = self.get_project(project_uuid)
-        # DT expects tag objects with a "name" key; dedupe + sort for stable writes
+        # DT expects tag objects with a "name" key; dedupe + sort for stable writes.
+        # Use PATCH (partial update) instead of GET-then-POST to avoid sending
+        # read-only fields back that DT may reject (metrics, lastBomImport, etc.).
         unique_names = sorted(set(tag_names))
-        current_project["tags"] = [{"name": name} for name in unique_names]
-        return self._make_request("POST", "/v1/project", data=current_project)
+        patch_data = {
+            "uuid": project_uuid,
+            "tags": [{"name": name} for name in unique_names],
+        }
+        return self._make_request("PATCH", f"/v1/project/{project_uuid}", data=patch_data)
 
     def upload_sbom(self, project_uuid: str, sbom_data: bytes, auto_create: bool = True) -> dict[str, Any]:
         """Upload an SBOM to a project.

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -206,7 +206,7 @@ class DependencyTrackClient:
         return self._make_request("POST", "/v1/project", data=current_project)
 
     def set_project_tags(self, project_uuid: str, tag_names: list[str]) -> dict[str, Any]:
-        """Replace the full tag list on a DT project version.
+        """Replace the full tag list on a DT project.
 
         Uses ``PATCH /v1/project/{uuid}`` to set only the ``tags`` field
         without touching other project properties. DT tags have shape
@@ -215,7 +215,7 @@ class DependencyTrackClient:
         DT side stays in sync with the source of truth.
 
         Args:
-            project_uuid: UUID of the DT project version to update.
+            project_uuid: UUID of the DT project to update.
             tag_names: Canonical list of tag strings. Duplicates are deduped.
         """
         # DT expects tag objects with a "name" key; dedupe + sort for stable writes.

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -208,19 +208,11 @@ class DependencyTrackClient:
     def set_project_tags(self, project_uuid: str, tag_names: list[str]) -> dict[str, Any]:
         """Replace the full tag list on a DT project version.
 
-        DT tags have shape ``{"name": "<tag-string>"}``. This method overwrites
-        whatever tags the project currently has with the canonical set provided
-        — designed to be called with the full, idempotent release-name list from
-        ``AssessmentRun.releases`` so the DT side stays in sync with the source
-        of truth even if tags drift (e.g., manual edits in DT UI, race between
-        attach and scan-completion, partial prior write).
-
-        Note: uses a GET-then-POST (read-modify-write) pattern because DT's
-        API has no PATCH-tags-only endpoint. Two concurrent calls could clobber
-        each other's non-tag fields in theory, but in practice sbomify is the
-        sole writer and the ``tags`` field is the only one modified. Convergence
-        is guaranteed because the Q2=B design always re-reads the full canonical
-        set from the M2M.
+        Uses ``PATCH /v1/project/{uuid}`` to set only the ``tags`` field
+        without touching other project properties. DT tags have shape
+        ``{"name": "<tag-string>"}``. Designed to be called with the full,
+        idempotent release-name list from ``AssessmentRun.releases`` so the
+        DT side stays in sync with the source of truth.
 
         Args:
             project_uuid: UUID of the DT project version to update.

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -311,3 +311,36 @@ class TestDependencyTrackClient:
         mock_make_paginated_request.assert_called_once_with(
             f"/v1/finding/project/{project_uuid}", {"suppressed": "false"}, None, None
         )
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
+    def test_set_project_tags_sends_patch(self, mock_make_request):
+        """set_project_tags uses PATCH with uuid + tags only."""
+        project_uuid = str(uuid.uuid4())
+        mock_make_request.return_value = {"uuid": project_uuid, "tags": [{"name": "v1"}]}
+
+        client = DependencyTrackClient("https://dt.example.com", "test-key")
+        client.set_project_tags(project_uuid, ["v2", "v1", "v2"])
+
+        mock_make_request.assert_called_once_with(
+            "PATCH",
+            f"/v1/project/{project_uuid}",
+            data={
+                "uuid": project_uuid,
+                "tags": [{"name": "v1"}, {"name": "v2"}],  # deduped + sorted
+            },
+        )
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
+    def test_set_project_tags_empty_list(self, mock_make_request):
+        """set_project_tags with empty list sends empty tags array."""
+        project_uuid = str(uuid.uuid4())
+        mock_make_request.return_value = {"uuid": project_uuid, "tags": []}
+
+        client = DependencyTrackClient("https://dt.example.com", "test-key")
+        client.set_project_tags(project_uuid, [])
+
+        mock_make_request.assert_called_once_with(
+            "PATCH",
+            f"/v1/project/{project_uuid}",
+            data={"uuid": project_uuid, "tags": []},
+        )


### PR DESCRIPTION
## Summary

Two DT plugin fixes discovered on staging after #881 merged.

### Fix 1: Use PATCH for tag updates instead of GET-then-POST

`set_project_tags` was doing `GET /v1/project/{uuid}` then `POST /v1/project` with the full body. DT's POST rejects read-only fields returned by GET (metrics, lastBomImport, etc.), causing `sync_release_tags` to fail on real DT servers.

**Fix**: Use `PATCH /v1/project/{uuid}` with only `uuid` + `tags`.

### Fix 2: Race-safe release check for sbomify-action two-step uploads

The sbomify-action creates the SBOM and the release association in **separate API calls**. The DT scan fires on SBOM upload (via `on_commit`), but at that point the `ReleaseArtifact` doesn't exist yet. The plugin checked `ReleaseArtifact` for release context and returned "Skipped — SBOM has no release association."

**Fix**: Check product membership (via `Project→Product` link, stable at SBOM creation time) instead of `ReleaseArtifact` (subject to race). SBOMs with product membership proceed — tags will be empty initially but set correctly at run completion by `sync_release_tags`. SBOMs without product membership are still skipped.

## Test plan

- [x] 15 scan-once tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit)