### PR TITLE
fix(dt): POST with stripped fields + aliases serialization crash

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -611,7 +611,18 @@ class DependencyTrackPlugin(AssessmentPlugin):
             if isinstance(raw_refs, list) and raw_refs:
                 references = [str(ref.get("url", "")) if isinstance(ref, dict) else str(ref) for ref in raw_refs if ref]
 
-            aliases = vuln_data.get("aliases", []) or None
+            # DT returns aliases as [{"cveId": "CVE-...", "ghsaId": "GHSA-..."}]
+            # but FindingSchema.aliases expects list[str]. Extract all ID values.
+            raw_aliases = vuln_data.get("aliases", []) or []
+            aliases: list[str] | None = None
+            if isinstance(raw_aliases, list) and raw_aliases:
+                flat: list[str] = []
+                for alias in raw_aliases:
+                    if isinstance(alias, dict):
+                        flat.extend(str(v) for v in alias.values() if v)
+                    elif isinstance(alias, str):
+                        flat.append(alias)
+                aliases = flat if flat else None
 
             findings.append(
                 Finding(

--- a/sbomify/apps/plugins/schemas.py
+++ b/sbomify/apps/plugins/schemas.py
@@ -30,6 +30,8 @@ class FindingSchema(BaseModel):
         """
         if not v:
             return None
+        if not isinstance(v, list):
+            return [str(v)] if isinstance(v, str) else None
         flat: list[str] = []
         for item in v:
             if isinstance(item, dict):

--- a/sbomify/apps/plugins/schemas.py
+++ b/sbomify/apps/plugins/schemas.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class FindingSchema(BaseModel):
@@ -20,6 +20,23 @@ class FindingSchema(BaseModel):
     aliases: list[str] | None = None
     remediation: str | None = None
     metadata: dict[str, Any] | None = None
+
+    @field_validator("aliases", mode="before")
+    @classmethod
+    def flatten_alias_dicts(cls, v: Any) -> list[str] | None:
+        """DT stores aliases as [{"cveId": "...", "ghsaId": "..."}] dicts.
+
+        Flatten to list[str] so existing stored results don't crash Pydantic.
+        """
+        if not v:
+            return None
+        flat: list[str] = []
+        for item in v:
+            if isinstance(item, dict):
+                flat.extend(str(val) for val in item.values() if val)
+            elif isinstance(item, str):
+                flat.append(item)
+        return flat if flat else None
 
 
 class AssessmentSummarySchema(BaseModel):

--- a/sbomify/apps/plugins/tests/test_sdk.py
+++ b/sbomify/apps/plugins/tests/test_sdk.py
@@ -353,3 +353,59 @@ class TestAssessmentPlugin:
         plugin = SimplePlugin()
 
         assert plugin.config == {}
+
+
+class TestFindingSchemaAliasesValidator:
+    """FindingSchema.aliases must handle both list[str] and DT-style list[dict]."""
+
+    def test_string_aliases_pass_through(self):
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(id="test", title="t", description="d", aliases=["CVE-2025-1234", "GHSA-xxxx"])
+        assert f.aliases == ["CVE-2025-1234", "GHSA-xxxx"]
+
+    def test_dict_aliases_flattened_to_strings(self):
+        """DT returns [{"cveId": "CVE-...", "ghsaId": "GHSA-..."}]."""
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(
+            id="test",
+            title="t",
+            description="d",
+            aliases=[{"cveId": "CVE-2025-13465", "ghsaId": "GHSA-xxjr-mmjv-4gpg"}],
+        )
+        assert f.aliases == ["CVE-2025-13465", "GHSA-xxjr-mmjv-4gpg"]
+
+    def test_mixed_aliases(self):
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(
+            id="test",
+            title="t",
+            description="d",
+            aliases=["CVE-plain", {"cveId": "CVE-dict", "ghsaId": "GHSA-dict"}],
+        )
+        assert f.aliases == ["CVE-plain", "CVE-dict", "GHSA-dict"]
+
+    def test_empty_aliases_returns_none(self):
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(id="test", title="t", description="d", aliases=[])
+        assert f.aliases is None
+
+    def test_none_aliases_stays_none(self):
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(id="test", title="t", description="d", aliases=None)
+        assert f.aliases is None
+
+    def test_dict_with_null_values_skipped(self):
+        from sbomify.apps.plugins.schemas import FindingSchema
+
+        f = FindingSchema(
+            id="test",
+            title="t",
+            description="d",
+            aliases=[{"cveId": "CVE-2025-1", "ghsaId": None}],
+        )
+        assert f.aliases == ["CVE-2025-1"]

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -195,6 +195,8 @@ class DependencyTrackClient:
     ) -> dict[str, Any]:
         """Update an existing project."""
         current_project = self.get_project(project_uuid)
+        for field in self._DT_READ_ONLY_FIELDS:
+            current_project.pop(field, None)
 
         if name is not None:
             current_project["name"] = name

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -205,28 +205,39 @@ class DependencyTrackClient:
 
         return self._make_request("POST", "/v1/project", data=current_project)
 
+    # Fields returned by GET /v1/project that DT rejects on POST (read-only
+    # computed fields). Stripped before sending the project back for update.
+    _DT_READ_ONLY_FIELDS = frozenset(
+        {
+            "metrics",
+            "lastBomImport",
+            "lastBomImportFormat",
+            "lastInheritedRiskScore",
+            "lastVulnerabilityAnalysis",
+            "active",
+            "isLatest",
+        }
+    )
+
     def set_project_tags(self, project_uuid: str, tag_names: list[str]) -> dict[str, Any]:
         """Replace the full tag list on a DT project.
 
-        Uses ``PATCH /v1/project/{uuid}`` to set only the ``tags`` field
-        without touching other project properties. DT tags have shape
-        ``{"name": "<tag-string>"}``. Designed to be called with the full,
-        idempotent release-name list from ``AssessmentRun.releases`` so the
-        DT side stays in sync with the source of truth.
+        Uses GET-then-POST with read-only fields stripped. DT's POST
+        ``/v1/project`` is the standard update endpoint (DT 4.x does not
+        support PATCH). DT tags have shape ``{"name": "<tag-string>"}``.
 
         Args:
             project_uuid: UUID of the DT project to update.
             tag_names: Canonical list of tag strings. Duplicates are deduped.
         """
-        # DT expects tag objects with a "name" key; dedupe + sort for stable writes.
-        # Use PATCH (partial update) instead of GET-then-POST to avoid sending
-        # read-only fields back that DT may reject (metrics, lastBomImport, etc.).
+        current_project = self.get_project(project_uuid)
+        # Strip read-only computed fields that DT rejects on POST
+        for field in self._DT_READ_ONLY_FIELDS:
+            current_project.pop(field, None)
+        # DT expects tag objects with a "name" key; dedupe + sort for stable writes
         unique_names = sorted(set(tag_names))
-        patch_data = {
-            "uuid": project_uuid,
-            "tags": [{"name": name} for name in unique_names],
-        }
-        return self._make_request("PATCH", f"/v1/project/{project_uuid}", data=patch_data)
+        current_project["tags"] = [{"name": name} for name in unique_names]
+        return self._make_request("POST", "/v1/project", data=current_project)
 
     def upload_sbom(self, project_uuid: str, sbom_data: bytes, auto_create: bool = True) -> dict[str, Any]:
         """Upload an SBOM to a project.

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -313,34 +313,49 @@ class TestDependencyTrackClient:
         )
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_set_project_tags_sends_patch(self, mock_make_request):
-        """set_project_tags uses PATCH with uuid + tags only."""
+    def test_set_project_tags_strips_readonly_and_posts(self, mock_make_request):
+        """set_project_tags does GET then POST with read-only fields stripped."""
         project_uuid = str(uuid.uuid4())
-        mock_make_request.return_value = {"uuid": project_uuid, "tags": [{"name": "v1"}]}
+        # First call is GET (get_project), second is POST
+        mock_make_request.side_effect = [
+            {
+                "uuid": project_uuid,
+                "name": "test-project",
+                "version": "1.0",
+                "tags": [],
+                "metrics": {"critical": 5},  # read-only, must be stripped
+                "lastBomImport": 123456,  # read-only, must be stripped
+                "lastInheritedRiskScore": 42.0,  # read-only, must be stripped
+            },
+            {"uuid": project_uuid, "tags": [{"name": "v1"}, {"name": "v2"}]},
+        ]
 
         client = DependencyTrackClient("https://dt.example.com", "test-key")
         client.set_project_tags(project_uuid, ["v2", "v1", "v2"])
 
-        mock_make_request.assert_called_once_with(
-            "PATCH",
-            f"/v1/project/{project_uuid}",
-            data={
-                "uuid": project_uuid,
-                "tags": [{"name": "v1"}, {"name": "v2"}],  # deduped + sorted
-            },
-        )
+        # Second call is the POST with stripped body
+        post_call = mock_make_request.call_args_list[1]
+        assert post_call[0][0] == "POST"
+        assert post_call[0][1] == "/v1/project"
+        post_data = post_call[1]["data"]
+        assert post_data["tags"] == [{"name": "v1"}, {"name": "v2"}]
+        assert "metrics" not in post_data
+        assert "lastBomImport" not in post_data
+        assert "lastInheritedRiskScore" not in post_data
+        assert post_data["name"] == "test-project"  # non-readonly preserved
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_set_project_tags_empty_list(self, mock_make_request):
         """set_project_tags with empty list sends empty tags array."""
         project_uuid = str(uuid.uuid4())
-        mock_make_request.return_value = {"uuid": project_uuid, "tags": []}
+        mock_make_request.side_effect = [
+            {"uuid": project_uuid, "name": "p", "version": "1.0", "tags": [{"name": "old"}]},
+            {"uuid": project_uuid, "tags": []},
+        ]
 
         client = DependencyTrackClient("https://dt.example.com", "test-key")
         client.set_project_tags(project_uuid, [])
 
-        mock_make_request.assert_called_once_with(
-            "PATCH",
-            f"/v1/project/{project_uuid}",
-            data={"uuid": project_uuid, "tags": []},
-        )
+        post_call = mock_make_request.call_args_list[1]
+        assert post_call[0][0] == "POST"
+        assert post_call[1]["data"]["tags"] == []


### PR DESCRIPTION
## Summary

Fixes two DT integration bugs discovered on staging that caused the **Assessment Results section to completely disappear** from the SBOM detail page.

### Root cause

DT returns vulnerability aliases as `[{"cveId": "CVE-...", "ghsaId": "GHSA-..."}]` (dict objects), but `FindingSchema.aliases` expects `list[str]`. When Pydantic validated the DT findings during `get_sbom_assessments`, it threw a `ValidationError`. The view's bare `except Exception` silently caught it and set `assessment_runs = None`, hiding the entire Assessment Results section.

### Fixes

1. **`FindingSchema` aliases validator** — Pydantic `field_validator` that flattens dict aliases to strings. Handles both new scans and existing stored results.

2. **`_convert_dt_findings` aliases extraction** — Now extracts string values from DT's alias dict format at scan time (defense-in-depth).

3. **`set_project_tags` POST with stripped fields** — DT 4.x does not support PATCH. Reverted to GET-then-POST but strips read-only computed fields (metrics, lastBomImport, etc.) that DT rejects.

## Test plan

- [x] 6 new aliases validator tests (string, dict, mixed, empty, None, null values)
- [x] 2 set_project_tags tests (strips readonly + empty list)
- [x] 630 plugin tests pass
- [x] Verified on local UI: Assessment Results section renders with all 7 plugins including DT with real vulnerabilities