### PR TITLE
fix(plugins): BSI creator check + FDA CLE lifecycle fallback

### DIFF
--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1180,19 +1180,21 @@ class BSICompliancePlugin(AssessmentPlugin):
                         return u
             elif isinstance(url, str) and _is_valid_url(url):
                 return url
-            for contact in source.get("contact", []):
+            contacts = source.get("contact") or []
+            for contact in contacts if isinstance(contacts, list) else []:
                 if not isinstance(contact, dict):
                     continue
-                email: str = contact.get("email", "")
-                if _is_valid_email(email):
+                email: str = contact.get("email") or ""
+                if isinstance(email, str) and _is_valid_email(email):
                     return email
 
         # Check authors
-        for author in metadata.get("authors", []):
+        authors = metadata.get("authors") or []
+        for author in authors if isinstance(authors, list) else []:
             if not isinstance(author, dict):
                 continue
-            email = author.get("email", "")
-            if _is_valid_email(email):
+            email = author.get("email") or ""
+            if isinstance(email, str) and _is_valid_email(email):
                 return email
 
         return None

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1162,17 +1162,32 @@ class BSICompliancePlugin(AssessmentPlugin):
     # === Helper methods ===
 
     def _get_cyclonedx_sbom_creator(self, metadata: dict[str, Any]) -> str | None:
-        """Extract SBOM creator email or URL from CycloneDX metadata."""
-        manufacturer = metadata.get("manufacturer", {})
+        """Extract SBOM creator email or URL from CycloneDX metadata.
 
-        # Check for URL
-        url: str = manufacturer.get("url", "")
-        if _is_valid_url(url):
-            return url
+        Checks manufacturer, supplier, and authors — the augmentation may
+        populate any of these depending on the data source.
+        """
+        # Check manufacturer (primary BSI expectation)
+        for source_key in ("manufacturer", "supplier"):
+            source = metadata.get(source_key, {})
+            if not source:
+                continue
+            url = source.get("url", "")
+            # url can be a string or list
+            if isinstance(url, list):
+                for u in url:
+                    if _is_valid_url(u):
+                        return u
+            elif _is_valid_url(url):
+                return url
+            for contact in source.get("contact", []):
+                email: str = contact.get("email", "")
+                if _is_valid_email(email):
+                    return email
 
-        # Check for email in contacts
-        for contact in manufacturer.get("contact", []):
-            email: str = contact.get("email", "")
+        # Check authors
+        for author in metadata.get("authors", []):
+            email = author.get("email", "")
             if _is_valid_email(email):
                 return email
 

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1176,17 +1176,21 @@ class BSICompliancePlugin(AssessmentPlugin):
             # url can be a string or list
             if isinstance(url, list):
                 for u in url:
-                    if _is_valid_url(u):
-                        return str(u)
-            elif _is_valid_url(url):
-                return str(url)
+                    if isinstance(u, str) and _is_valid_url(u):
+                        return u
+            elif isinstance(url, str) and _is_valid_url(url):
+                return url
             for contact in source.get("contact", []):
+                if not isinstance(contact, dict):
+                    continue
                 email: str = contact.get("email", "")
                 if _is_valid_email(email):
                     return email
 
         # Check authors
         for author in metadata.get("authors", []):
+            if not isinstance(author, dict):
+                continue
             email = author.get("email", "")
             if _is_valid_email(email):
                 return email

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1177,9 +1177,9 @@ class BSICompliancePlugin(AssessmentPlugin):
             if isinstance(url, list):
                 for u in url:
                     if _is_valid_url(u):
-                        return u
+                        return str(u)
             elif _is_valid_url(url):
-                return url
+                return str(url)
             for contact in source.get("contact", []):
                 email: str = contact.get("email", "")
                 if _is_valid_email(email):

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -730,6 +730,12 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         support_status_failures: list[str] = []
         end_of_support_failures: list[str] = []
 
+        # Hoist metadata-level lifecycle check out of the per-component loop.
+        # Having an end-of-support date implies active support (until that date),
+        # satisfying the FDA "support level" requirement as a fallback when
+        # per-component cdx:cle:supportStatus is absent.
+        metadata_has_eos = self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")
+
         # Check each component for required elements
         for i, component in enumerate(components):
             component_name = component.get("name", f"Component {i + 1}")
@@ -760,21 +766,15 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
 
             # === FDA CLE Elements ===
 
-            # 8. Support status (from component or metadata properties)
-            # Check per-component cdx:cle:supportStatus first. Fall back to
-            # metadata-level cdx:lifecycle:milestone:endOfSupport — having an
-            # end-of-support date implies the software is actively supported
-            # (until that date), satisfying the "support level" requirement.
-            has_support_status = self._cyclonedx_has_cle_property(
-                component, "cdx:cle:supportStatus"
-            ) or self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")
+            # 8. Support status
+            has_support_status = (
+                self._cyclonedx_has_cle_property(component, "cdx:cle:supportStatus") or metadata_has_eos
+            )
             if not has_support_status:
                 support_status_failures.append(component_name)
 
             # 9. End of support date
-            has_end_of_support = self._cyclonedx_has_cle_property(
-                component, "cdx:cle:endOfSupport"
-            ) or self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")
+            has_end_of_support = self._cyclonedx_has_cle_property(component, "cdx:cle:endOfSupport") or metadata_has_eos
             if not has_end_of_support:
                 end_of_support_failures.append(component_name)
 
@@ -900,8 +900,12 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         as a fallback when per-component cdx:cle:* properties are absent.
         """
         for prop in metadata.get("properties", []):
-            if prop.get("name") == property_name and prop.get("value", "").strip():
-                return True
+            if not isinstance(prop, dict):
+                continue
+            if prop.get("name") == property_name:
+                value = prop.get("value", "")
+                if isinstance(value, str) and value.strip():
+                    return True
         return False
 
     def _cyclonedx_has_cle_property(self, component: dict[str, Any], property_name: str) -> bool:

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -760,13 +760,19 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
 
             # === FDA CLE Elements ===
 
-            # 8. Support status (from properties cdx:cle:supportStatus)
-            has_support_status = self._cyclonedx_has_cle_property(component, "cdx:cle:supportStatus")
+            # 8. Support status (from component or metadata properties)
+            # Check both cdx:cle:* (per-component) and cdx:lifecycle:milestone:*
+            # (metadata-level, written by sbomify-action augmentation)
+            has_support_status = self._cyclonedx_has_cle_property(
+                component, "cdx:cle:supportStatus"
+            ) or self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")
             if not has_support_status:
                 support_status_failures.append(component_name)
 
-            # 9. End of support date (from properties cdx:cle:endOfSupport)
-            has_end_of_support = self._cyclonedx_has_cle_property(component, "cdx:cle:endOfSupport")
+            # 9. End of support date
+            has_end_of_support = self._cyclonedx_has_cle_property(
+                component, "cdx:cle:endOfSupport"
+            ) or self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")
             if not has_end_of_support:
                 end_of_support_failures.append(component_name)
 
@@ -883,6 +889,18 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         )
 
         return findings
+
+    def _cyclonedx_has_lifecycle_property(self, metadata: dict[str, Any], property_name: str) -> bool:
+        """Check if CycloneDX metadata has a lifecycle milestone property.
+
+        The sbomify-action augmentation writes support dates as metadata-level
+        properties using the cdx:lifecycle:milestone:* taxonomy. This serves
+        as a fallback when per-component cdx:cle:* properties are absent.
+        """
+        for prop in metadata.get("properties", []):
+            if prop.get("name") == property_name and prop.get("value", "").strip():
+                return True
+        return False
 
     def _cyclonedx_has_cle_property(self, component: dict[str, Any], property_name: str) -> bool:
         """Check if a CycloneDX component has a specific CLE property.

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -761,8 +761,10 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
             # === FDA CLE Elements ===
 
             # 8. Support status (from component or metadata properties)
-            # Check both cdx:cle:* (per-component) and cdx:lifecycle:milestone:*
-            # (metadata-level, written by sbomify-action augmentation)
+            # Check per-component cdx:cle:supportStatus first. Fall back to
+            # metadata-level cdx:lifecycle:milestone:endOfSupport — having an
+            # end-of-support date implies the software is actively supported
+            # (until that date), satisfying the "support level" requirement.
             has_support_status = self._cyclonedx_has_cle_property(
                 component, "cdx:cle:supportStatus"
             ) or self._cyclonedx_has_lifecycle_property(metadata, "cdx:lifecycle:milestone:endOfSupport")

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -899,7 +899,8 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         properties using the cdx:lifecycle:milestone:* taxonomy. This serves
         as a fallback when per-component cdx:cle:* properties are absent.
         """
-        for prop in metadata.get("properties", []):
+        properties = metadata.get("properties") or []
+        for prop in properties if isinstance(properties, list) else []:
             if not isinstance(prop, dict):
                 continue
             if prop.get("name") == property_name:

--- a/sbomify/apps/plugins/tests/test_bsi_plugin.py
+++ b/sbomify/apps/plugins/tests/test_bsi_plugin.py
@@ -357,6 +357,43 @@ class TestSBOMLevelValidation:
         assert finding is not None
         assert finding.status == "fail"
 
+    def test_sbom_creator_from_authors_email_passes(self):
+        """SBOM creator found via metadata.authors[].email should pass."""
+        sbom = create_base_cyclonedx_sbom()
+        sbom["metadata"]["manufacturer"] = {"name": "No Contact"}
+        sbom["metadata"]["authors"] = [{"name": "Dev", "email": "dev@example.com"}]
+        result = assess_sbom(sbom)
+
+        finding = get_finding(result, "bsi-tr03183:sbom-creator")
+        assert finding is not None
+        assert finding.status == "pass"
+
+    def test_sbom_creator_from_supplier_url_passes(self):
+        """SBOM creator found via metadata.supplier.url should pass."""
+        sbom = create_base_cyclonedx_sbom()
+        sbom["metadata"]["manufacturer"] = {"name": "No Contact"}
+        sbom["metadata"]["supplier"] = {
+            "name": "Supplier Corp",
+            "url": ["https://supplier.example.com"],
+        }
+        result = assess_sbom(sbom)
+
+        finding = get_finding(result, "bsi-tr03183:sbom-creator")
+        assert finding is not None
+        assert finding.status == "pass"
+
+    def test_sbom_creator_no_email_no_url_anywhere_fails(self):
+        """No email or URL in manufacturer, supplier, or authors should fail."""
+        sbom = create_base_cyclonedx_sbom()
+        sbom["metadata"]["manufacturer"] = {"name": "No Contact"}
+        sbom["metadata"]["supplier"] = {"name": "No URL"}
+        sbom["metadata"]["authors"] = [{"name": "No Email"}]
+        result = assess_sbom(sbom)
+
+        finding = get_finding(result, "bsi-tr03183:sbom-creator")
+        assert finding is not None
+        assert finding.status == "fail"
+
     def test_timestamp_valid_passes(self):
         """Valid ISO-8601 timestamp should pass."""
         sbom = create_base_cyclonedx_sbom()

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -367,6 +367,7 @@ class TestCycloneDXLifecycleFallback:
 
         # Both CLE checks should pass via metadata fallback
         cle_findings = [f for f in result.findings if "cle:" in f.id]
+        assert len(cle_findings) == 2, f"Expected 2 CLE findings, got {len(cle_findings)}"
         assert all(f.status == "pass" for f in cle_findings), (
             f"CLE findings should pass with metadata lifecycle: {[(f.id, f.status) for f in cle_findings]}"
         )
@@ -393,6 +394,7 @@ class TestCycloneDXLifecycleFallback:
         result = self._assess_sbom(sbom_data)
 
         cle_findings = [f for f in result.findings if "cle:" in f.id]
+        assert len(cle_findings) == 2, f"Expected 2 CLE findings, got {len(cle_findings)}"
         assert all(f.status == "fail" for f in cle_findings)
 
 

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -331,6 +331,71 @@ class TestCycloneDXValidation:
             return plugin.assess("test-sbom-id", Path(f.name))
 
 
+class TestCycloneDXLifecycleFallback:
+    """Tests for metadata-level lifecycle property fallback."""
+
+    def _assess_sbom(self, sbom_data: dict) -> AssessmentResult:
+        plugin = FDAMedicalDevicePlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            return plugin.assess("test-sbom-id", Path(f.name))
+
+    def test_metadata_lifecycle_satisfies_cle_support_status(self) -> None:
+        """Metadata-level cdx:lifecycle:milestone:endOfSupport should satisfy support status."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example",
+                    "version": "1.0.0",
+                    "publisher": "Corp",
+                    "purl": "pkg:pypi/example@1.0.0",
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+                "properties": [
+                    {"name": "cdx:lifecycle:milestone:endOfSupport", "value": "2027-12-31"},
+                ],
+            },
+        }
+        result = self._assess_sbom(sbom_data)
+
+        # Both CLE checks should pass via metadata fallback
+        cle_findings = [f for f in result.findings if "cle:" in f.id]
+        assert all(f.status == "pass" for f in cle_findings), (
+            f"CLE findings should pass with metadata lifecycle: {[(f.id, f.status) for f in cle_findings]}"
+        )
+
+    def test_no_lifecycle_anywhere_fails_cle(self) -> None:
+        """Without any lifecycle data, CLE checks should fail."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "example",
+                    "version": "1.0.0",
+                    "publisher": "Corp",
+                    "purl": "pkg:pypi/example@1.0.0",
+                }
+            ],
+            "dependencies": [{"ref": "pkg:pypi/example@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2023-01-01T00:00:00Z",
+            },
+        }
+        result = self._assess_sbom(sbom_data)
+
+        cle_findings = [f for f in result.findings if "cle:" in f.id]
+        assert all(f.status == "fail" for f in cle_findings)
+
+
 class TestSPDXValidation:
     """Tests for SPDX SBOM validation."""
 


### PR DESCRIPTION
## Summary

Fixes 3 compliance plugin failures that occur when SBOMs are augmented via sbomify-action with `sbomify.json`.

### BSI TR-03183-2: sbom-creator (1 fail → pass)

`_get_cyclonedx_sbom_creator` only checked `metadata.manufacturer` for email/URL. The sbomify-action augmentation writes to `metadata.authors` (with email) and `metadata.supplier` (with URL). Now checks all three sources.

### FDA Medical Device: CLE support-status + end-of-support (2 fails → pass)

`_cyclonedx_has_cle_property` only checked per-component `cdx:cle:*` properties. The sbomify-action writes `support_period_end` from `sbomify.json` as `cdx:lifecycle:milestone:endOfSupport` on `metadata.properties`. Added `_cyclonedx_has_lifecycle_property` fallback to check metadata-level lifecycle properties.

## Test plan

- [x] 15 compliance plugin tests pass
- [x] Pre-commit hooks pass (ruff, bandit)