### PR TITLE
fix(osv): remove 'source' subcommand — all SBOM scans returning 0 vulns

### DIFF
--- a/sbomify/apps/plugins/builtins/osv.py
+++ b/sbomify/apps/plugins/builtins/osv.py
@@ -291,7 +291,6 @@ class OSVPlugin(AssessmentPlugin):
         scan_command = [
             scanner_path,
             "scan",
-            "source",
             "--sbom",
             str(absolute_path),
             "--format",


### PR DESCRIPTION
## Summary

**Critical bug**: The OSV plugin was running `osv-scanner scan source --sbom <path>`. The `source` subcommand scans directories for lockfiles and ignores the `--sbom` flag entirely, causing **all SBOM vulnerability scans to silently return 0 vulnerabilities**.

### Root cause

`source` was added as a subcommand between `scan` and `--sbom`:
```
osv-scanner scan source --sbom /tmp/sbom.cdx.json  # ❌ scans dirs, ignores SBOM
osv-scanner scan --sbom /tmp/sbom.cdx.json          # ✅ scans the SBOM
```

### Impact

Every OSV scan on staging and production has been returning 0 vulnerabilities. A Lithium SBOM with 30 known vulns (2 critical, 9 high) was showing as clean.

### Fix

Remove `source` from the command. One line deletion.

## Test plan

- [x] Verified `osv-scanner scan --sbom` finds 30 vulns on Lithium staging SBOM
- [x] Verified `osv-scanner scan source --sbom` finds 0 (the bug)