### PR TITLE
fix(osv): strip deprecation warning from stdout before JSON parsing

### DIFF
--- a/sbomify/apps/plugins/builtins/osv.py
+++ b/sbomify/apps/plugins/builtins/osv.py
@@ -291,7 +291,8 @@ class OSVPlugin(AssessmentPlugin):
         scan_command = [
             scanner_path,
             "scan",
-            "--sbom",
+            "source",
+            "--lockfile",
             str(absolute_path),
             "--format",
             "json",

--- a/sbomify/apps/plugins/tests/test_osv_plugin.py
+++ b/sbomify/apps/plugins/tests/test_osv_plugin.py
@@ -392,7 +392,7 @@ class TestOSVPluginAssess:
             # Verify the command used a .spdx.json file
             call_args = mock_run.call_args
             cmd = call_args[0][0]
-            sbom_arg = cmd[cmd.index("--sbom") + 1]
+            sbom_arg = cmd[cmd.index("--lockfile") + 1]
             assert sbom_arg.endswith(".spdx.json")
 
     def test_metadata_includes_format(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #891. Two changes to the osv-scanner invocation:

1. **Use `scan source --lockfile` instead of `scan --sbom`** — The `--sbom` flag is deprecated in osv-scanner v2.x and prints a warning to stdout that broke JSON parsing (all scans returned 0 vulns). The correct v2 syntax is `scan source --lockfile <path>` which auto-detects SBOM format from the filename suffix (`.cdx.json` / `.spdx.json`).

   Note: `scan source --lockfile` is NOT the same as the `scan source --sbom` bug in #891. The `--lockfile` / `-L` flag handles both lockfiles AND SBOMs (osv-scanner auto-detects the format). The `--sbom` flag was a separate deprecated alias.

2. **Removed the JSON warning strip** — No longer needed since `--lockfile` doesn't produce the deprecation warning.

### Verified

- 37 vulnerabilities detected on Lithium staging SBOM (was 0 before #891 + this fix)
- 0 vulnerabilities after dependency upgrades