### PR TITLE
fix(plugins): skip file-type components in PURL check

### DIFF
--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -763,7 +763,7 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
             # 4. Unique identifiers (PURL, CPE, SWID)
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
             # Skip type=file components (e.g., lockfiles) — not software packages.
-            if component.get("type") != "file":
+            if str(component.get("type", "")).lower() != "file":
                 has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
                 if not has_unique_id:
                     unique_id_failures.append(component_name)

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -296,21 +296,23 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
                 version_failures.append(package_name)
 
             # 4. Unique identifiers (PURL, CPE, SWID via externalRefs)
-            # Only accept externalRefs with valid identifier types
-            # Note: checksums are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
-            purl = package.get("purl")
-            external_refs = package.get("externalRefs")
-            if not isinstance(external_refs, list):
-                external_refs = []
-            has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
-                isinstance(ref, dict)
-                and isinstance(ref.get("referenceType"), str)
-                and ref["referenceType"] in valid_identifier_types
-                for ref in external_refs
-            )
-            if not has_unique_id:
-                unique_id_failures.append(package_name)
+            # Skip file-type packages (e.g., lockfiles) — not software packages.
+            spdx_id = str(package.get("SPDXID") or "")
+            is_file_entry = "-File-" in spdx_id
+            if not is_file_entry:
+                valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
+                purl = package.get("purl")
+                external_refs = package.get("externalRefs")
+                if not isinstance(external_refs, list):
+                    external_refs = []
+                has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
+                    isinstance(ref, dict)
+                    and isinstance(ref.get("referenceType"), str)
+                    and ref["referenceType"] in valid_identifier_types
+                    for ref in external_refs
+                )
+                if not has_unique_id:
+                    unique_id_failures.append(package_name)
 
             # === FDA CLE Elements ===
 
@@ -760,9 +762,11 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
 
             # 4. Unique identifiers (PURL, CPE, SWID)
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
-            if not has_unique_id:
-                unique_id_failures.append(component_name)
+            # Skip type=file components (e.g., lockfiles) — not software packages.
+            if component.get("type") != "file":
+                has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
+                if not has_unique_id:
+                    unique_id_failures.append(component_name)
 
             # === FDA CLE Elements ===
 

--- a/sbomify/apps/plugins/builtins/ntia.py
+++ b/sbomify/apps/plugins/builtins/ntia.py
@@ -262,17 +262,21 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
 
             # 4. Unique identifiers (PURL, CPE, SWID via externalRefs)
             # Only accept externalRefs with valid identifier types
-            # Note: checksums are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
-            purl = package.get("purl")
-            has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
-                isinstance(ref, dict)
-                and isinstance(ref.get("referenceType"), str)
-                and ref["referenceType"] in valid_identifier_types
-                for ref in (_as_list(package.get("externalRefs")))
-            )
-            if not has_unique_id:
-                unique_id_failures.append(package_name)
+            # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
+            # Skip file-type packages (e.g., lockfiles) — not software packages.
+            spdx_id = str(package.get("SPDXID") or "")
+            is_file_entry = "-File-" in spdx_id
+            if not is_file_entry:
+                valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
+                purl = package.get("purl")
+                has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
+                    isinstance(ref, dict)
+                    and isinstance(ref.get("referenceType"), str)
+                    and ref["referenceType"] in valid_identifier_types
+                    for ref in (_as_list(package.get("externalRefs")))
+                )
+                if not has_unique_id:
+                    unique_id_failures.append(package_name)
 
         # Create findings for per-package elements
         findings.append(
@@ -524,9 +528,12 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
 
             # 4. Unique identifiers (PURL, CPE, SWID)
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
-            if not has_unique_id:
-                unique_id_failures.append(component_name)
+            # Skip type=file components (e.g., lockfiles) — they're input metadata,
+            # not software packages, and don't have package identifiers.
+            if component.get("type") != "file":
+                has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
+                if not has_unique_id:
+                    unique_id_failures.append(component_name)
 
         # Create findings for per-component elements
         findings.append(

--- a/sbomify/apps/plugins/builtins/ntia.py
+++ b/sbomify/apps/plugins/builtins/ntia.py
@@ -530,7 +530,7 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
             # Skip type=file components (e.g., lockfiles) — they're input metadata,
             # not software packages, and don't have package identifiers.
-            if component.get("type") != "file":
+            if str(component.get("type", "")).lower() != "file":
                 has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
                 if not has_unique_id:
                     unique_id_failures.append(component_name)

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -1048,3 +1048,95 @@ class TestSPDX3Validation:
             json.dump(sbom_data, f)
             f.flush()
             return plugin.assess("test-sbom-id", Path(f.name))
+
+
+class TestFileTypeComponentSkipped:
+    """File-type components should be skipped in unique-identifier checks."""
+
+    def _assess_sbom(self, sbom_data: dict) -> "AssessmentResult":
+        plugin = FDAMedicalDevicePlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            return plugin.assess("test-sbom-id", Path(f.name))
+
+    def test_cyclonedx_file_type_skipped(self) -> None:
+        """CycloneDX type=file should not fail unique-identifiers."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "django",
+                    "version": "5.2.3",
+                    "type": "library",
+                    "publisher": "Django",
+                    "purl": "pkg:pypi/django@5.2.3",
+                    "properties": [
+                        {"name": "cdx:cle:supportStatus", "value": "active"},
+                        {"name": "cdx:cle:endOfSupport", "value": "2027-12-31"},
+                    ],
+                },
+                {
+                    "name": "uv.lock",
+                    "type": "file",
+                },
+            ],
+            "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+        }
+        result = self._assess_sbom(sbom_data)
+
+        uid_finding = next((f for f in result.findings if f.id == "fda-2025:ntia:unique-identifiers"), None)
+        assert uid_finding is not None
+        assert uid_finding.status == "pass", f"type=file should be skipped: {uid_finding.description}"
+
+    def test_spdx_file_entry_skipped(self) -> None:
+        """SPDX -File- packages should not fail unique-identifiers."""
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2026-01-01T00:00:00Z",
+                "creators": ["Tool: test"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/django@5.2.3",
+                        }
+                    ],
+                },
+                {
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                },
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                }
+            ],
+        }
+        result = self._assess_sbom(sbom_data)
+
+        uid_finding = next((f for f in result.findings if f.id == "fda-2025:ntia:unique-identifiers"), None)
+        assert uid_finding is not None
+        assert uid_finding.status == "pass", f"File entry should be skipped: {uid_finding.description}"

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -397,3 +397,106 @@ class TestNTIAPluginAPIIntegration(TestCase):
 
         assert response.overall_status == "has_failures"
         assert response.failing_count == 1
+
+
+class TestFileTypeComponentSkipped:
+    """File-type components should be skipped in unique-identifier checks."""
+
+    def test_cyclonedx_file_type_skipped_in_purl_check(self):
+        """CycloneDX type=file components should not fail unique-identifiers."""
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+            "components": [
+                {
+                    "name": "django",
+                    "version": "5.2.3",
+                    "type": "library",
+                    "purl": "pkg:pypi/django@5.2.3",
+                    "publisher": "Django",
+                },
+                {
+                    "name": "uv.lock",
+                    "type": "file",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123"}],
+                },
+            ],
+            "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        uid_finding = next((f for f in result.findings if f.id == "ntia-2021:unique-identifiers"), None)
+        assert uid_finding is not None
+        assert uid_finding.status == "pass", f"uv.lock (type=file) should be skipped: {uid_finding.description}"
+
+    def test_spdx_file_entry_skipped_in_purl_check(self):
+        """SPDX packages with -File- in SPDXID should not fail unique-identifiers."""
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2026-01-01T00:00:00Z",
+                "creators": ["Tool: test"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/django@5.2.3",
+                        }
+                    ],
+                },
+                {
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                },
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                }
+            ],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".spdx.json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        uid_finding = next((f for f in result.findings if f.id == "ntia-2021:unique-identifiers"), None)
+        assert uid_finding is not None
+        assert uid_finding.status == "pass", f"uv.lock (File entry) should be skipped: {uid_finding.description}"


### PR DESCRIPTION
## Summary

NTIA and FDA plugins fail unique-identifiers check on file-type components (e.g., `uv.lock` added by `cyclonedx-py` as `type: file`). These are input metadata, not software packages — they don't have PURLs and shouldn't be checked.

### Fix

- **CycloneDX**: Skip components with `type: file` in the PURL check
- **SPDX 2.x**: Skip packages with `-File-` in SPDXID (e.g., `SPDXRef-DocumentRoot-File-uv.lock`)

### Result

- NTIA: 1 fail → 0 fail (SPDX)
- FDA: unique-identifiers fail → pass (SPDX)

## Test plan

- [x] 52 NTIA + FDA plugin tests pass