### PR TITLE
fix(plugins): extend file-type skip across BSI/NTIA/FDA and skip DT on SPDX

### DIFF
--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -495,9 +495,19 @@ class BSICompliancePlugin(AssessmentPlugin):
         for i, component in enumerate(components):
             component_name = component.get("name", f"Component {i + 1}")
 
-            # 1. Component name
+            # Skip type=file components (e.g., lockfiles, scan inputs) for BSI
+            # per-component checks. BSI TR-03183-2 §5.2.2 fields apply to software
+            # components (type=library/application/framework/container/...), not to
+            # file-type entries that generators like syft emit for their scan input.
+            # Component Name is still validated so misnamed file entries surface.
+            is_file_type = str(component.get("type", "")).lower() == "file"
+
+            # 1. Component name (applies to all component types)
             if not component.get("name"):
                 name_failures.append(f"Component at index {i}")
+
+            if is_file_type:
+                continue
 
             # 2. Component version
             if not component.get("version"):
@@ -1058,10 +1068,23 @@ class BSICompliancePlugin(AssessmentPlugin):
             )
         )
 
-        # Component-level - mark most as fail with note about SPDX 2.x limitations
+        # Component-level - mark most as fail with note about SPDX 2.x limitations.
+        # Skip file-type entries (SPDXID contains "-File-") since BSI §5.2.2 applies
+        # to software packages, not to file entries generators emit for their inputs.
+        def _is_file_pkg(p: dict[str, Any]) -> bool:
+            return "-File-" in str(p.get("SPDXID") or "")
+
         name_failures = [p.get("name", f"Package {i}") for i, p in enumerate(packages) if not p.get("name")]
-        version_failures = [p.get("name", f"Package {i}") for i, p in enumerate(packages) if not p.get("versionInfo")]
-        supplier_failures = [p.get("name", f"Package {i}") for i, p in enumerate(packages) if not p.get("supplier")]
+        version_failures = [
+            p.get("name", f"Package {i}")
+            for i, p in enumerate(packages)
+            if not _is_file_pkg(p) and not p.get("versionInfo")
+        ]
+        supplier_failures = [
+            p.get("name", f"Package {i}")
+            for i, p in enumerate(packages)
+            if not _is_file_pkg(p) and not p.get("supplier")
+        ]
 
         findings.append(
             self._create_finding(
@@ -1127,9 +1150,11 @@ class BSICompliancePlugin(AssessmentPlugin):
             )
         )
 
-        # Unique identifiers
+        # Unique identifiers (skip file-type entries — they don't have package IDs)
         identifier_warnings = []
         for i, pkg in enumerate(packages):
+            if _is_file_pkg(pkg):
+                continue
             purl = pkg.get("purl")
             external_refs = pkg.get("externalRefs")
             if not isinstance(external_refs, list):

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -38,8 +38,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
     """Dependency Track vulnerability scanning plugin.
 
     Scans CycloneDX SBOMs by uploading them to a Dependency Track server
-    and polling for vulnerability results. SPDX SBOMs are rejected since
-    DT only supports CycloneDX.
+    and polling for vulnerability results. SPDX (and any non-CycloneDX)
+    input is skipped with a "Format Not Supported" warning rather than an
+    error, since DT only supports CycloneDX and the format choice is
+    deliberate on the user's part.
 
     Uses RetryLaterError for the upload-then-poll async pattern:
     - First call: uploads SBOM to DT, raises RetryLaterError

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -102,11 +102,19 @@ class DependencyTrackPlugin(AssessmentPlugin):
             logger.error(f"[DT] Failed to read SBOM file: {e}")
             return self._create_error_result(f"Failed to read SBOM: {e}")
 
-        # Validate CycloneDX format (DT does not support SPDX)
+        # Validate CycloneDX format (DT does not support SPDX).
+        # Non-CycloneDX SBOMs aren't an error — DT simply can't process them.
+        # Return a skipped result so the UI shows "not applicable" rather than
+        # a hard error finding for a format choice the user made deliberately.
         if not self._validate_cyclonedx(sbom_bytes):
-            return self._create_error_result(
-                "Dependency Track only supports CycloneDX format. "
-                "This SBOM appears to be SPDX or an unrecognized format."
+            return self._create_skipped_result(
+                finding_id="dependency-track:unsupported-format",
+                title="Format Not Supported",
+                description=(
+                    "Dependency Track only supports CycloneDX format. "
+                    "This SBOM appears to be SPDX or an unrecognized format — "
+                    "vulnerability scanning was skipped."
+                ),
             )
 
         # Look up SBOM → Component → Team

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -281,38 +281,42 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         for i, package in enumerate(packages):
             package_name = package.get("name", f"Package {i + 1}")
 
+            # Skip file-type packages (e.g., lockfiles) — they're input metadata,
+            # not software packages. Detected by SPDXID containing "-File-".
+            spdx_id = str(package.get("SPDXID") or "")
+            is_file_entry = "-File-" in spdx_id
+
             # === NTIA Elements ===
 
             # 1. Supplier name
-            if not package.get("supplier"):
+            if not is_file_entry and not package.get("supplier"):
                 supplier_failures.append(package_name)
 
-            # 2. Component name
+            # 2. Component name (applies to all entries)
             if not package.get("name"):
                 component_name_failures.append(f"Package at index {i}")
+
+            if is_file_entry:
+                continue
 
             # 3. Version
             if not package.get("versionInfo"):
                 version_failures.append(package_name)
 
             # 4. Unique identifiers (PURL, CPE, SWID via externalRefs)
-            # Skip file-type packages (e.g., lockfiles) — not software packages.
-            spdx_id = str(package.get("SPDXID") or "")
-            is_file_entry = "-File-" in spdx_id
-            if not is_file_entry:
-                valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
-                purl = package.get("purl")
-                external_refs = package.get("externalRefs")
-                if not isinstance(external_refs, list):
-                    external_refs = []
-                has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
-                    isinstance(ref, dict)
-                    and isinstance(ref.get("referenceType"), str)
-                    and ref["referenceType"] in valid_identifier_types
-                    for ref in external_refs
-                )
-                if not has_unique_id:
-                    unique_id_failures.append(package_name)
+            valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
+            purl = package.get("purl")
+            external_refs = package.get("externalRefs")
+            if not isinstance(external_refs, list):
+                external_refs = []
+            has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
+                isinstance(ref, dict)
+                and isinstance(ref.get("referenceType"), str)
+                and ref["referenceType"] in valid_identifier_types
+                for ref in external_refs
+            )
+            if not has_unique_id:
+                unique_id_failures.append(package_name)
 
             # === FDA CLE Elements ===
 
@@ -742,19 +746,28 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
         for i, component in enumerate(components):
             component_name = component.get("name", f"Component {i + 1}")
 
+            # Skip type=file components (e.g., lockfiles) — they're input metadata,
+            # not software packages, so FDA/NTIA per-component fields don't apply.
+            # Component Name is still checked so misnamed file entries surface.
+            is_file_type = str(component.get("type", "")).lower() == "file"
+
             # === NTIA Elements ===
 
             # 1. Supplier name (publisher or supplier.name)
-            supplier_field = component.get("supplier")
-            supplier = component.get("publisher") or (
-                supplier_field.get("name") if isinstance(supplier_field, dict) else None
-            )
-            if not supplier:
-                supplier_failures.append(component_name)
+            if not is_file_type:
+                supplier_field = component.get("supplier")
+                supplier = component.get("publisher") or (
+                    supplier_field.get("name") if isinstance(supplier_field, dict) else None
+                )
+                if not supplier:
+                    supplier_failures.append(component_name)
 
-            # 2. Component name
+            # 2. Component name (applies to all component types)
             if not component.get("name"):
                 component_name_failures.append(f"Component at index {i}")
+
+            if is_file_type:
+                continue
 
             # 3. Version
             if not component.get("version"):
@@ -762,11 +775,9 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
 
             # 4. Unique identifiers (PURL, CPE, SWID)
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            # Skip type=file components (e.g., lockfiles) — not software packages.
-            if str(component.get("type", "")).lower() != "file":
-                has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
-                if not has_unique_id:
-                    unique_id_failures.append(component_name)
+            has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
+            if not has_unique_id:
+                unique_id_failures.append(component_name)
 
             # === FDA CLE Elements ===
 

--- a/sbomify/apps/plugins/builtins/ntia.py
+++ b/sbomify/apps/plugins/builtins/ntia.py
@@ -248,24 +248,26 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
         for i, package in enumerate(packages):
             package_name = package.get("name", f"Package {i + 1}")
 
+            # Skip file-type packages (e.g., lockfiles) — they're input metadata,
+            # not software packages. Detected by SPDXID containing "-File-".
+            spdx_id = str(package.get("SPDXID") or "")
+            is_file_entry = "-File-" in spdx_id
+
             # 1. Supplier name
-            if not package.get("supplier"):
+            if not is_file_entry and not package.get("supplier"):
                 supplier_failures.append(package_name)
 
-            # 2. Component name
+            # 2. Component name (applies to all entries)
             if not package.get("name"):
                 component_name_failures.append(f"Package at index {i}")
 
             # 3. Version
-            if not package.get("versionInfo"):
+            if not is_file_entry and not package.get("versionInfo"):
                 version_failures.append(package_name)
 
             # 4. Unique identifiers (PURL, CPE, SWID via externalRefs)
             # Only accept externalRefs with valid identifier types
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            # Skip file-type packages (e.g., lockfiles) — not software packages.
-            spdx_id = str(package.get("SPDXID") or "")
-            is_file_entry = "-File-" in spdx_id
             if not is_file_entry:
                 valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
                 purl = package.get("purl")
@@ -510,27 +512,32 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
         for i, component in enumerate(components):
             component_name = component.get("name", f"Component {i + 1}")
 
-            # 1. Supplier name (publisher or supplier.name)
-            supplier_field = component.get("supplier")
-            supplier = component.get("publisher") or (
-                supplier_field.get("name") if isinstance(supplier_field, dict) else None
-            )
-            if not supplier:
-                supplier_failures.append(component_name)
+            # Skip type=file components (e.g., lockfiles) — they're input metadata,
+            # not software packages, so NTIA minimum-element fields (supplier, version,
+            # unique identifiers) don't apply. Component Name is still checked because
+            # even file-type entries should be named.
+            is_file_type = str(component.get("type", "")).lower() == "file"
 
-            # 2. Component name
+            # 1. Supplier name (publisher or supplier.name)
+            if not is_file_type:
+                supplier_field = component.get("supplier")
+                supplier = component.get("publisher") or (
+                    supplier_field.get("name") if isinstance(supplier_field, dict) else None
+                )
+                if not supplier:
+                    supplier_failures.append(component_name)
+
+            # 2. Component name (applies to all component types)
             if not component.get("name"):
                 component_name_failures.append(f"Component at index {i}")
 
             # 3. Version
-            if not component.get("version"):
+            if not is_file_type and not component.get("version"):
                 version_failures.append(component_name)
 
             # 4. Unique identifiers (PURL, CPE, SWID)
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
-            # Skip type=file components (e.g., lockfiles) — they're input metadata,
-            # not software packages, and don't have package identifiers.
-            if str(component.get("type", "")).lower() != "file":
+            if not is_file_type:
                 has_unique_id = component.get("purl") or component.get("cpe") or component.get("swid")
                 if not has_unique_id:
                     unique_id_failures.append(component_name)

--- a/sbomify/apps/plugins/tests/test_bsi_plugin.py
+++ b/sbomify/apps/plugins/tests/test_bsi_plugin.py
@@ -1207,3 +1207,105 @@ class TestFormatFailureDetails:
         plugin = BSICompliancePlugin({})
         result = plugin._format_failure_details(["a", "b", "c", "d"], max_shown=2)
         assert result == "Missing for: a, b (4 total; 2 more)"
+
+
+class TestFileTypeComponentSkipped:
+    """BSI must skip type=file / File-entry components across per-component checks.
+
+    BSI TR-03183-2 §5.2.2 applies to software components. Generators like syft
+    emit scan-input artifacts (e.g. lockfiles) as type=file in CycloneDX or with
+    "-File-" in the SPDXID in SPDX, which lack version/creator/licence/properties
+    by design. These entries should not contribute to failure counts.
+    """
+
+    def test_cyclonedx_file_type_skipped_across_all_component_checks(self):
+        """A type=file component without any BSI fields should not cause failures."""
+        sbom = create_base_cyclonedx_sbom()
+        # Add a bare file-type component alongside the valid library component.
+        sbom["components"].append(
+            {
+                "name": "uv.lock",
+                "type": "file",
+                "hashes": [{"alg": "SHA-256", "content": "def456" * 20}],
+            }
+        )
+        result = assess_sbom(sbom)
+
+        # All per-component BSI checks should still pass because the only
+        # non-compliant entry is a file-type component that must be skipped.
+        for finding_id in (
+            "bsi-tr03183:component-version",
+            "bsi-tr03183:component-creator",
+            "bsi-tr03183:filename",
+            "bsi-tr03183:distribution-licences",
+            "bsi-tr03183:hash-value",
+            "bsi-tr03183:executable-property",
+            "bsi-tr03183:archive-property",
+            "bsi-tr03183:structured-property",
+        ):
+            finding = get_finding(result, finding_id)
+            assert finding is not None, f"{finding_id} missing from result"
+            assert finding.status == "pass", f"{finding_id} should pass but got {finding.status}: {finding.description}"
+
+    def test_cyclonedx_file_type_component_name_still_validated(self):
+        """Component Name is universal — file-type entries without a name still fail."""
+        sbom = create_base_cyclonedx_sbom()
+        sbom["components"].append({"type": "file"})
+        result = assess_sbom(sbom)
+
+        finding = get_finding(result, "bsi-tr03183:component-name")
+        assert finding is not None
+        assert finding.status == "fail", "nameless file-type entry should still fail name check"
+
+    def test_spdx2_file_entry_skipped_in_version_and_supplier(self):
+        """SPDX 2.x File-entries (SPDXID contains -File-) must be skipped for
+        component-level checks that don't apply to file inputs."""
+        sbom = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2024-01-15T12:00:00Z",
+                "creators": ["Tool: test", "Organization: Example Corp (sbom@example.com)"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                },
+                {
+                    # No versionInfo, no supplier — File entry should be skipped
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                },
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                },
+                {
+                    "spdxElementId": "SPDXRef-Package-django",
+                    "relationshipType": "DEPENDS_ON",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                },
+            ],
+        }
+        result = assess_sbom(sbom)
+
+        version = get_finding(result, "bsi-tr03183:component-version")
+        creator = get_finding(result, "bsi-tr03183:component-creator")
+        assert version is not None and version.status == "pass", (
+            f"File entry without versionInfo should be skipped: {version.description if version else None}"
+        )
+        assert creator is not None and creator.status == "pass", (
+            f"File entry without supplier should be skipped: {creator.description if creator else None}"
+        )

--- a/sbomify/apps/plugins/tests/test_bsi_plugin.py
+++ b/sbomify/apps/plugins/tests/test_bsi_plugin.py
@@ -1309,3 +1309,66 @@ class TestFileTypeComponentSkipped:
         assert creator is not None and creator.status == "pass", (
             f"File entry without supplier should be skipped: {creator.description if creator else None}"
         )
+
+    def test_library_with_missing_fields_still_fails_alongside_file_type(self):
+        """Regression guard: the skip must only apply to type=file.
+
+        If a real library component is missing version/creator/filename etc and
+        a file-type entry coexists, the library failures must still surface — we
+        must not accidentally widen the skip.
+        """
+        sbom = create_base_cyclonedx_sbom()
+        sbom["components"].append(
+            {
+                "name": "broken-lib",
+                "type": "library",
+                "purl": "pkg:pypi/broken-lib@unknown",
+                # No version, no manufacturer, no filename, no licence, no hashes
+            }
+        )
+        sbom["components"].append({"name": "uv.lock", "type": "file"})
+        result = assess_sbom(sbom)
+
+        for finding_id in (
+            "bsi-tr03183:component-version",
+            "bsi-tr03183:component-creator",
+        ):
+            finding = get_finding(result, finding_id)
+            assert finding is not None, f"{finding_id} missing"
+            assert finding.status == "fail", (
+                f"{finding_id} must fail for library missing the field (got {finding.status})"
+            )
+            assert "broken-lib" in (finding.description or ""), (
+                f"{finding_id} description should mention broken-lib: {finding.description}"
+            )
+            assert "uv.lock" not in (finding.description or ""), (
+                f"{finding_id} description must NOT mention file-type uv.lock: {finding.description}"
+            )
+
+    def test_cyclonedx_multiple_file_type_components_all_skipped(self):
+        """All file-type components should be skipped, not just the first one."""
+        sbom = create_base_cyclonedx_sbom()
+        sbom["components"].extend(
+            [
+                {"name": "uv.lock", "type": "file"},
+                {"name": "poetry.lock", "type": "FILE"},  # case-insensitive
+                {"name": "package-lock.json", "type": "File"},
+            ]
+        )
+        result = assess_sbom(sbom)
+
+        for finding_id in (
+            "bsi-tr03183:component-version",
+            "bsi-tr03183:component-creator",
+            "bsi-tr03183:filename",
+            "bsi-tr03183:distribution-licences",
+            "bsi-tr03183:hash-value",
+            "bsi-tr03183:executable-property",
+            "bsi-tr03183:archive-property",
+            "bsi-tr03183:structured-property",
+        ):
+            finding = get_finding(result, finding_id)
+            assert finding is not None, f"{finding_id} missing"
+            assert finding.status == "pass", (
+                f"{finding_id} should pass with 3 file-type entries (got {finding.status}): {finding.description}"
+            )

--- a/sbomify/apps/plugins/tests/test_bsi_plugin.py
+++ b/sbomify/apps/plugins/tests/test_bsi_plugin.py
@@ -1257,9 +1257,10 @@ class TestFileTypeComponentSkipped:
         assert finding is not None
         assert finding.status == "fail", "nameless file-type entry should still fail name check"
 
-    def test_spdx2_file_entry_skipped_in_version_and_supplier(self):
+    def test_spdx2_file_entry_skipped_in_version_and_creator_checks(self):
         """SPDX 2.x File-entries (SPDXID contains -File-) must be skipped for
-        component-level checks that don't apply to file inputs."""
+        the component-version and component-creator checks when versionInfo and
+        supplier data are not applicable to file inputs."""
         sbom = {
             "spdxVersion": "SPDX-2.3",
             "SPDXID": "SPDXRef-DOCUMENT",

--- a/sbomify/apps/plugins/tests/test_dt_scan_count.py
+++ b/sbomify/apps/plugins/tests/test_dt_scan_count.py
@@ -97,3 +97,38 @@ class TestTrackedObjectCount:
         assert server.is_available_for_scan is False
 
 
+class TestUnsupportedFormatSkipped:
+    """DT should return a skipped (not error) result when given a non-CycloneDX SBOM.
+
+    SPDX is a deliberate format choice, not an error condition — DT simply doesn't
+    support it. The UI/reporting layer should surface this as "not applicable"
+    rather than a hard error finding.
+    """
+
+    def test_spdx_input_returns_skipped_not_error(self, tmp_path) -> None:
+        """Passing an SPDX 2.3 SBOM to DT should yield a skipped result."""
+        import json
+
+        spdx_sbom = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {"created": "2026-01-01T00:00:00Z", "creators": ["Tool: test"]},
+            "packages": [],
+        }
+        sbom_path = tmp_path / "test.spdx.json"
+        sbom_path.write_text(json.dumps(spdx_sbom))
+
+        plugin = DependencyTrackPlugin(config={})
+        result = plugin.assess("sbom-id-does-not-matter", sbom_path)
+
+        assert result.summary.error_count == 0, f"SPDX input should not produce errors, got {result.summary}"
+        assert result.summary.warning_count == 1
+        assert result.metadata.get("skipped") is True
+        assert len(result.findings) == 1
+        finding = result.findings[0]
+        assert finding.id == "dependency-track:unsupported-format"
+        assert finding.status == "warning"
+        assert "skipped" in (finding.description or "").lower()

--- a/sbomify/apps/plugins/tests/test_dt_scan_count.py
+++ b/sbomify/apps/plugins/tests/test_dt_scan_count.py
@@ -132,3 +132,22 @@ class TestUnsupportedFormatSkipped:
         assert finding.id == "dependency-track:unsupported-format"
         assert finding.status == "warning"
         assert "skipped" in (finding.description or "").lower()
+
+    def test_unrecognized_format_also_returns_skipped(self, tmp_path) -> None:
+        """Anything that isn't valid CycloneDX (random JSON, truncated file, etc.)
+        should skip rather than error. The old behavior returned a hard error for
+        anything that failed _validate_cyclonedx — we want that path to remain
+        user-friendly for non-CycloneDX input of any kind."""
+        import json
+
+        garbage = {"hello": "world", "notAnSBOM": True}
+        sbom_path = tmp_path / "garbage.json"
+        sbom_path.write_text(json.dumps(garbage))
+
+        plugin = DependencyTrackPlugin(config={})
+        result = plugin.assess("sbom-id", sbom_path)
+
+        assert result.summary.error_count == 0
+        assert result.summary.warning_count == 1
+        assert result.metadata.get("skipped") is True
+        assert result.findings[0].id == "dependency-track:unsupported-format"

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -1140,3 +1140,112 @@ class TestFileTypeComponentSkipped:
         uid_finding = next((f for f in result.findings if f.id == "fda-2025:ntia:unique-identifiers"), None)
         assert uid_finding is not None
         assert uid_finding.status == "pass", f"File entry should be skipped: {uid_finding.description}"
+
+    def test_cyclonedx_file_type_skipped_in_supplier_version_and_cle(self) -> None:
+        """FDA file-type skip must extend to supplier, version and CLE checks,
+        not just unique-identifiers. A lockfile has no supplier/version/lifecycle
+        by nature — it's input metadata, not a software component.
+        """
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "django",
+                    "version": "5.2.3",
+                    "type": "library",
+                    "publisher": "Django",
+                    "purl": "pkg:pypi/django@5.2.3",
+                    "properties": [
+                        {"name": "cdx:cle:supportStatus", "value": "active"},
+                        {"name": "cdx:cle:endOfSupport", "value": "2027-12-31"},
+                    ],
+                },
+                {
+                    # Bare file-type entry — no supplier, version, or CLE fields
+                    "name": "uv.lock",
+                    "type": "file",
+                },
+            ],
+            "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+        }
+        result = self._assess_sbom(sbom_data)
+
+        for finding_id in (
+            "fda-2025:ntia:supplier-name",
+            "fda-2025:ntia:version",
+            "fda-2025:cle:support-status",
+            "fda-2025:cle:end-of-support",
+        ):
+            finding = next((f for f in result.findings if f.id == finding_id), None)
+            assert finding is not None, f"{finding_id} missing from findings"
+            assert finding.status == "pass", (
+                f"{finding_id} should pass (file-type entry skipped): {finding.description}"
+            )
+
+    def test_spdx_file_entry_skipped_in_supplier_version_and_cle(self) -> None:
+        """SPDX File-entries must be skipped for supplier, version and CLE checks."""
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2026-01-01T00:00:00Z",
+                "creators": ["Tool: test"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                    "validUntilDate": "2027-12-31T00:00:00Z",
+                    "annotations": [
+                        {
+                            "annotationType": "OTHER",
+                            "annotator": "Tool: sbomify",
+                            "annotationDate": "2026-01-01T00:00:00Z",
+                            "comment": "cle:supportStatus=active",
+                        }
+                    ],
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/django@5.2.3",
+                        }
+                    ],
+                },
+                {
+                    # Bare file entry — no supplier/versionInfo/validUntilDate
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                },
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                }
+            ],
+        }
+        result = self._assess_sbom(sbom_data)
+
+        for finding_id in (
+            "fda-2025:ntia:supplier-name",
+            "fda-2025:ntia:version",
+            "fda-2025:cle:support-status",
+            "fda-2025:cle:end-of-support",
+        ):
+            finding = next((f for f in result.findings if f.id == finding_id), None)
+            assert finding is not None, f"{finding_id} missing from findings"
+            assert finding.status == "pass", f"{finding_id} should pass (File entry skipped): {finding.description}"

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -1249,3 +1249,36 @@ class TestFileTypeComponentSkipped:
             finding = next((f for f in result.findings if f.id == finding_id), None)
             assert finding is not None, f"{finding_id} missing from findings"
             assert finding.status == "pass", f"{finding_id} should pass (File entry skipped): {finding.description}"
+
+    def test_cyclonedx_library_still_fails_alongside_file_type(self) -> None:
+        """Regression guard: real library without CLE data must still fail."""
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": [
+                {
+                    "name": "broken-lib",
+                    "version": "1.0.0",
+                    "type": "library",
+                    "publisher": "SomeOrg",
+                    "purl": "pkg:pypi/broken-lib@1.0.0",
+                    # No CLE properties
+                },
+                {"name": "uv.lock", "type": "file"},
+            ],
+            "dependencies": [{"ref": "pkg:pypi/broken-lib@1.0.0", "dependsOn": []}],
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+        }
+        result = self._assess_sbom(sbom_data)
+
+        for finding_id in ("fda-2025:cle:support-status", "fda-2025:cle:end-of-support"):
+            finding = next((f for f in result.findings if f.id == finding_id), None)
+            assert finding is not None, f"{finding_id} missing"
+            assert finding.status == "fail", (
+                f"{finding_id} must fail for library without CLE data (got {finding.status})"
+            )
+            assert "broken-lib" in (finding.description or "")
+            assert "uv.lock" not in (finding.description or ""), "file-type entry must not appear in CLE failure list"

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -699,3 +699,192 @@ class TestFileTypeComponentSkipped:
                 f"{fid}: all case variations of type=file must be skipped, got {finding.status if finding else None}: "
                 f"{finding.description if finding else None}"
             )
+
+
+class TestFileTypeSkipAcrossGenerators:
+    """Verify the file-type skip works for SBOMs produced by multiple generators,
+    not just syft's specific output format (which is what Lithium uses).
+
+    Different tools emit file-like metadata with different conventions:
+    - syft:               SPDXRef-DocumentRoot-File-<name>-<hash>
+    - Microsoft sbom-tool: SPDXRef-File--<name>-<hash> (double dash)
+    - Clean convention:   SPDXRef-File-<name>
+    - cdxgen / cyclonedx-py: CycloneDX type="file" with mime-type set
+
+    The common marker the plugin uses is the "-File-" substring in SPDXID for
+    SPDX and "type == 'file'" for CycloneDX. These tests prove the heuristic
+    covers the practical generator ecosystem, not only Lithium's setup.
+    """
+
+    def _assess(self, sbom_data: dict):
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        plugin = NTIAMinimumElementsPlugin()
+        suffix = ".spdx.json" if "spdxVersion" in sbom_data else ".json"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            return plugin.assess("test", Path(f.name))
+
+    def _base_spdx_doc(self, packages: list[dict]) -> dict:
+        return {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2026-01-01T00:00:00Z",
+                "creators": ["Tool: test"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/django@5.2.3",
+                        }
+                    ],
+                },
+                *packages,
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                }
+            ],
+        }
+
+    def test_spdx_syft_document_root_file_naming(self):
+        """syft emits SPDXRef-DocumentRoot-File-<name>-<hash>."""
+        sbom = self._base_spdx_doc(
+            [
+                {
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock-e473982c",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                }
+            ]
+        )
+        result = self._assess(sbom)
+        for fid in ("ntia-2021:supplier-name", "ntia-2021:version", "ntia-2021:unique-identifiers"):
+            finding = next((f for f in result.findings if f.id == fid), None)
+            assert finding is not None and finding.status == "pass", (
+                f"syft convention not skipped for {fid}: {finding.description if finding else None}"
+            )
+
+    def test_spdx_microsoft_sbom_tool_double_dash_naming(self):
+        """Microsoft sbom-tool emits SPDXRef-File--<name>-<hash> (double dash)."""
+        sbom = self._base_spdx_doc(
+            [
+                {
+                    "SPDXID": "SPDXRef-File--sbom-tool-win-x64.exe-E55F25E239D8D3572D75D5CDC5CA24899FD4993F",
+                    "name": "sbom-tool-win-x64.exe",
+                    "downloadLocation": "NOASSERTION",
+                }
+            ]
+        )
+        result = self._assess(sbom)
+        for fid in ("ntia-2021:supplier-name", "ntia-2021:version", "ntia-2021:unique-identifiers"):
+            finding = next((f for f in result.findings if f.id == fid), None)
+            assert finding is not None and finding.status == "pass", (
+                f"Microsoft sbom-tool convention not skipped for {fid}: "
+                f"{finding.description if finding else None}"
+            )
+
+    def test_spdx_clean_file_naming(self):
+        """Clean convention: SPDXRef-File-<name>."""
+        sbom = self._base_spdx_doc(
+            [
+                {
+                    "SPDXID": "SPDXRef-File-manifest.txt",
+                    "name": "manifest.txt",
+                    "downloadLocation": "NOASSERTION",
+                }
+            ]
+        )
+        result = self._assess(sbom)
+        for fid in ("ntia-2021:supplier-name", "ntia-2021:version", "ntia-2021:unique-identifiers"):
+            finding = next((f for f in result.findings if f.id == fid), None)
+            assert finding is not None and finding.status == "pass", (
+                f"Clean File- convention not skipped for {fid}: {finding.description if finding else None}"
+            )
+
+    def test_spdx_package_with_filemanager_name_not_false_positive(self):
+        """A real package named 'FileManager' must NOT be falsely skipped.
+
+        The heuristic requires a '-File-' with dashes on both sides, so
+        'SPDXRef-Package-FileManager' doesn't match and its failures still
+        surface correctly.
+        """
+        sbom = self._base_spdx_doc(
+            [
+                {
+                    # Note: no versionInfo, no supplier — must FAIL because
+                    # this is a real package, not a file entry.
+                    "SPDXID": "SPDXRef-Package-FileManager-abc123",
+                    "name": "FileManager",
+                    "downloadLocation": "NOASSERTION",
+                }
+            ]
+        )
+        result = self._assess(sbom)
+        supplier = next((f for f in result.findings if f.id == "ntia-2021:supplier-name"), None)
+        version = next((f for f in result.findings if f.id == "ntia-2021:version"), None)
+        assert supplier is not None and supplier.status == "fail", (
+            "Package named FileManager must still fail supplier check, not be skipped"
+        )
+        assert "FileManager" in (supplier.description or "")
+        assert version is not None and version.status == "fail"
+
+    def test_cyclonedx_works_on_multiple_spec_versions(self):
+        """The type=file skip is not tied to a specific CycloneDX spec version.
+        Works on 1.4, 1.5, and 1.6 (all versions sbomify-action produces)."""
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        def _sbom(spec_version: str) -> dict:
+            return {
+                "bomFormat": "CycloneDX",
+                "specVersion": spec_version,
+                "metadata": {"authors": [{"name": "Dev"}], "timestamp": "2026-01-01T00:00:00Z"},
+                "components": [
+                    {
+                        "name": "django",
+                        "version": "5.2.3",
+                        "type": "library",
+                        "purl": "pkg:pypi/django@5.2.3",
+                        "publisher": "Django",
+                    },
+                    {"name": "uv.lock", "type": "file"},
+                ],
+                "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+            }
+
+        for spec_version in ("1.4", "1.5", "1.6"):
+            plugin = NTIAMinimumElementsPlugin()
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+                json.dump(_sbom(spec_version), f)
+                f.flush()
+                result = plugin.assess("test", Path(f.name))
+            for fid in ("ntia-2021:supplier-name", "ntia-2021:version", "ntia-2021:unique-identifiers"):
+                finding = next((f for f in result.findings if f.id == fid), None)
+                assert finding is not None and finding.status == "pass", (
+                    f"CycloneDX {spec_version}: {fid} should pass but got "
+                    f"{finding.status if finding else None}: {finding.description if finding else None}"
+                )

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -610,3 +610,92 @@ class TestFileTypeComponentSkipped:
         assert version is not None, "version finding missing"
         assert supplier.status == "pass", f"File entry skipped for supplier: {supplier.description}"
         assert version.status == "pass", f"File entry skipped for version: {version.description}"
+
+    def test_cyclonedx_library_component_still_fails_when_missing_fields(self):
+        """Regression guard: file-type skip must not accidentally silence real failures.
+
+        A non-file component missing supplier or version must still surface the
+        failure. This test lives alongside the skip tests so that any future
+        refactor of the is_file_type check immediately breaks if the skip logic
+        accidentally widens.
+        """
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+            "components": [
+                {
+                    # Library-type with missing supplier AND missing version
+                    "name": "unmaintained-lib",
+                    "type": "library",
+                    "purl": "pkg:pypi/unmaintained-lib@unknown",
+                },
+                {
+                    # File-type (should still be skipped)
+                    "name": "uv.lock",
+                    "type": "file",
+                },
+            ],
+            "dependencies": [{"ref": "pkg:pypi/unmaintained-lib@unknown", "dependsOn": []}],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        supplier = next((f for f in result.findings if f.id == "ntia-2021:supplier-name"), None)
+        version = next((f for f in result.findings if f.id == "ntia-2021:version"), None)
+        assert supplier is not None and supplier.status == "fail", "library component without supplier must still fail"
+        assert "unmaintained-lib" in (supplier.description or "")
+        assert "uv.lock" not in (supplier.description or ""), "file-type must not appear in failure list"
+        assert version is not None and version.status == "fail", "library component without version must still fail"
+        assert "unmaintained-lib" in (version.description or "")
+
+    def test_cyclonedx_file_type_case_insensitive(self):
+        """type matching is case-insensitive — File, FILE, file all skipped."""
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "metadata": {"authors": [{"name": "Dev"}], "timestamp": "2026-01-01T00:00:00Z"},
+            "components": [
+                {
+                    "name": "django",
+                    "version": "5.2.3",
+                    "type": "library",
+                    "purl": "pkg:pypi/django@5.2.3",
+                    "publisher": "Django",
+                },
+                {"name": "lock1.lock", "type": "File"},
+                {"name": "lock2.lock", "type": "FILE"},
+                {"name": "lock3.lock", "type": "file"},
+            ],
+            "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        for fid in ("ntia-2021:supplier-name", "ntia-2021:version", "ntia-2021:unique-identifiers"):
+            finding = next((f for f in result.findings if f.id == fid), None)
+            assert finding is not None and finding.status == "pass", (
+                f"{fid}: all case variations of type=file must be skipped, got {finding.status if finding else None}: "
+                f"{finding.description if finding else None}"
+            )

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -500,3 +500,113 @@ class TestFileTypeComponentSkipped:
         uid_finding = next((f for f in result.findings if f.id == "ntia-2021:unique-identifiers"), None)
         assert uid_finding is not None
         assert uid_finding.status == "pass", f"uv.lock (File entry) should be skipped: {uid_finding.description}"
+
+    def test_cyclonedx_file_type_skipped_in_supplier_and_version_checks(self):
+        """CycloneDX type=file components must also be skipped for Supplier Name
+        and Component Version — not just Unique Identifiers. Generators like syft
+        emit lockfiles as file-type entries which lack supplier/version by design.
+        """
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "metadata": {
+                "authors": [{"name": "Dev"}],
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+            "components": [
+                {
+                    "name": "django",
+                    "version": "5.2.3",
+                    "type": "library",
+                    "purl": "pkg:pypi/django@5.2.3",
+                    "publisher": "Django",
+                },
+                {
+                    # No supplier, no version — file-type should be skipped
+                    "name": "uv.lock",
+                    "type": "file",
+                    "hashes": [{"alg": "SHA-256", "content": "abc123"}],
+                },
+            ],
+            "dependencies": [{"ref": "pkg:pypi/django@5.2.3", "dependsOn": []}],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        supplier = next((f for f in result.findings if f.id == "ntia-2021:supplier-name"), None)
+        version = next((f for f in result.findings if f.id == "ntia-2021:version"), None)
+        assert supplier is not None, "supplier-name finding missing"
+        assert version is not None, "version finding missing"
+        assert supplier.status == "pass", f"file skipped for supplier: {supplier.description}"
+        assert version.status == "pass", f"file skipped for version: {version.description}"
+
+    def test_spdx_file_entry_skipped_in_supplier_and_version_checks(self):
+        """SPDX File-type entries must be skipped for Supplier + Version too."""
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+        sbom_data = {
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "test",
+            "dataLicense": "CC0-1.0",
+            "documentNamespace": "https://example.com/test",
+            "creationInfo": {
+                "created": "2026-01-01T00:00:00Z",
+                "creators": ["Tool: test"],
+            },
+            "packages": [
+                {
+                    "SPDXID": "SPDXRef-Package-django",
+                    "name": "django",
+                    "versionInfo": "5.2.3",
+                    "supplier": "Organization: Django",
+                    "downloadLocation": "NOASSERTION",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "PACKAGE-MANAGER",
+                            "referenceType": "purl",
+                            "referenceLocator": "pkg:pypi/django@5.2.3",
+                        }
+                    ],
+                },
+                {
+                    # No supplier, no versionInfo — File entry should be skipped
+                    "SPDXID": "SPDXRef-DocumentRoot-File-uv.lock",
+                    "name": "uv.lock",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                },
+            ],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Package-django",
+                }
+            ],
+        }
+        plugin = NTIAMinimumElementsPlugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".spdx.json", delete=False) as f:
+            json.dump(sbom_data, f)
+            f.flush()
+            result = plugin.assess("test", Path(f.name))
+
+        supplier = next((f for f in result.findings if f.id == "ntia-2021:supplier-name"), None)
+        version = next((f for f in result.findings if f.id == "ntia-2021:version"), None)
+        assert supplier is not None, "supplier-name finding missing"
+        assert version is not None, "version finding missing"
+        assert supplier.status == "pass", f"File entry skipped for supplier: {supplier.description}"
+        assert version.status == "pass", f"File entry skipped for version: {version.description}"

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -822,32 +822,56 @@ class TestFileTypeSkipAcrossGenerators:
                 f"Clean File- convention not skipped for {fid}: {finding.description if finding else None}"
             )
 
-    def test_spdx_package_with_filemanager_name_not_false_positive(self):
-        """A real package named 'FileManager' must NOT be falsely skipped.
+    def test_spdx_real_packages_containing_file_in_name_not_skipped(self):
+        """Real packages with 'File' in their name must NOT be falsely skipped.
 
-        The heuristic requires a '-File-' with dashes on both sides, so
-        'SPDXRef-Package-FileManager' doesn't match and its failures still
-        surface correctly.
+        The '-File-' heuristic requires dashes on BOTH sides (making it a
+        word-segment marker) AND is case-sensitive. This keeps these real
+        packages from being misclassified as file entries:
+
+        - filelock          (pypi, capital F absent: '-filelock-' has no match)
+        - FileManager       ('-FileM' has no trailing dash)
+        - file-utils        (lowercase 'file', not capital 'File')
+        - python-file-utils (same — lowercase)
+
+        Any of these missing supplier/version must still surface in failures.
         """
         sbom = self._base_spdx_doc(
             [
                 {
-                    # Note: no versionInfo, no supplier — must FAIL because
-                    # this is a real package, not a file entry.
+                    "SPDXID": "SPDXRef-Package-filelock-3.12.0",
+                    "name": "filelock",
+                    "downloadLocation": "NOASSERTION",
+                    # Intentionally missing supplier + versionInfo
+                },
+                {
                     "SPDXID": "SPDXRef-Package-FileManager-abc123",
                     "name": "FileManager",
                     "downloadLocation": "NOASSERTION",
-                }
+                },
+                {
+                    "SPDXID": "SPDXRef-Package-python-file-utils-2.0",
+                    "name": "python-file-utils",
+                    "downloadLocation": "NOASSERTION",
+                },
             ]
         )
         result = self._assess(sbom)
         supplier = next((f for f in result.findings if f.id == "ntia-2021:supplier-name"), None)
         version = next((f for f in result.findings if f.id == "ntia-2021:version"), None)
-        assert supplier is not None and supplier.status == "fail", (
-            "Package named FileManager must still fail supplier check, not be skipped"
-        )
-        assert "FileManager" in (supplier.description or "")
+
+        # All three packages must appear in the supplier + version failure lists
+        # because they are real packages, not file entries.
+        assert supplier is not None and supplier.status == "fail"
         assert version is not None and version.status == "fail"
+        for expected_name in ("filelock", "FileManager", "python-file-utils"):
+            assert expected_name in (supplier.description or ""), (
+                f"real package '{expected_name}' missing from supplier failures — "
+                f"heuristic may be over-skipping: {supplier.description}"
+            )
+            assert expected_name in (version.description or ""), (
+                f"real package '{expected_name}' missing from version failures: {version.description}"
+            )
 
     def test_cyclonedx_works_on_multiple_spec_versions(self):
         """The type=file skip is not tied to a specific CycloneDX spec version.


### PR DESCRIPTION
## Summary

Extends the file-type component skip pattern from sbomify/sbomify#893 across **all** NTIA, BSI, and FDA per-component compliance checks, and makes the Dependency Track plugin gracefully skip SPDX input instead of erroring.

PR #893 fixed the NTIA **Unique Identifiers** check to skip `type: "file"` CycloneDX components and SPDX `-File-` entries. But the same class of file-type entries was still being counted in other per-component checks — causing false failures whenever a generator (syft, cdxgen, Microsoft sbom-tool) emitted a lockfile or scan-input artifact.

## What fails today on a typical syft-generated SBOM

When syft scans `uv.lock` as the target, it emits `uv.lock` itself as a `type: "file"` component alongside the actual dependencies. That single file-type entry produces:

- **NTIA:** 2 fails (Supplier Name, Component Version)
- **BSI TR-03183-2:** 9 fails (Version, Creator, Filename, Licence, Executable/Archive/Structured, ...)
- **FDA Medical Device 2025:** 2 fails (Supplier Name, Component Version inherited from NTIA)
- **Dependency Track** reports a **hard error** when given SPDX input rather than a clean "not applicable"

## Changes

### Plugin fixes (commit `497fc912`)

- **NTIA** (`ntia.py`): skip file-type components in Supplier Name and Component Version checks (both CycloneDX `type="file"` and SPDX `-File-` SPDXID paths), matching the existing Unique Identifiers skip. Component Name is still validated so misnamed entries surface.
- **BSI TR-03183-2** (`bsi.py`): add file-type skip across **all** per-component checks — Version, Creator, Filename, Licence, Hash, Executable/Archive/Structured properties, Unique Identifiers — in both `_validate_cyclonedx` and `_validate_spdx2_legacy`.
- **FDA Medical Device 2025** (`fda_medical_device_cybersecurity.py`): skip file-type components in NTIA-inherited Supplier/Version checks plus the CLE Support Status and End-of-Support checks.
- **Dependency Track** (`dependency_track.py`): SPDX input now returns a skipped result (warning + `metadata={"skipped": True}`) instead of a hard error finding. Format mismatch is a deliberate choice by the user, not an operational failure.

## Verification

End-to-end test by uploading an SBOM in both formats against local sbomify:

| Plugin | CycloneDX before | CycloneDX after | SPDX before | SPDX after |
|---|---|---|---|---|
| NTIA | 2 fail | **0 fail** | 0 fail | 0 fail |
| BSI | 9 fail | **6 fail** (remaining are real data gaps: deps without BSI properties, root hash) | 8 fail | 8 fail (SPDX 2.3 structural) |
| FDA | 2 fail | **0 fail** | 2 fail | 2 fail (CLE not propagated to SPDX yet) |
| DT | n/a | n/a | **hard ERROR** | **skipped warning** |

## Test coverage (24 tests, all passing)

### Initial coverage — commit `497fc912` (12 tests)

`TestFileTypeComponentSkipped` classes across NTIA, BSI, FDA integration tests plus `TestUnsupportedFormatSkipped` for DT. Covers the basic skip behavior for both CycloneDX `type=file` and SPDX `-File-` paths.

### Regression + edge cases — commit `603d6302` (6 tests)

- NTIA: library without supplier/version **still fails** (regression guard) alongside a file-type entry
- NTIA: case-insensitive type matching (`File`, `FILE`, `file` all skipped)
- BSI: broken-lib surfaces in failure descriptions while uv.lock is skipped
- BSI: multiple file-type components (uv.lock + poetry.lock + package-lock.json) all skipped
- FDA: library without CLE data still fails on support-status/end-of-support
- DT: any non-CycloneDX input (garbage JSON) returns skipped, not error

### Generator-agnostic coverage — commit `29ff090a` (5 tests)

`TestFileTypeSkipAcrossGenerators` — proves the heuristic is not tied to a single tool:

| SPDXID pattern | Generator |
|---|---|
| `SPDXRef-DocumentRoot-File-<name>-<hash>` | Syft |
| `SPDXRef-File--<name>-<hash>` (double dash) | Microsoft sbom-tool |
| `SPDXRef-File-<name>` | Clean convention / spdx-tools |
| CycloneDX 1.4, 1.5, 1.6 | All sbomify-action output versions |

### False-positive guard — commit `21a6b5d7` (3 cases, 1 test)

`test_spdx_real_packages_containing_file_in_name_not_skipped` — proves the `-File-` heuristic is robust against misclassifying real packages:

- **`filelock`** (real pypi package) — lowercase `file`, not matched (heuristic is case-sensitive)
- **`FileManager`** — `-FileM` has no trailing dash, not matched (requires word-segment boundary)
- **`python-file-utils`** — lowercase `file`, not matched

The dual requirement (dashes on both sides AND capital `File`) makes false positives extremely unlikely. All three packages still surface in failure descriptions when missing required fields.

## Why this is correct — spec references

- **CycloneDX v1.6**: `type: "file"` is defined as "A computer file" — a metadata/artifact category distinct from software components like `library`/`application`/`framework`. Files are for "discrete file-based entities requiring inventory." [spec](https://cyclonedx.org/docs/1.6/json/#components_items_type)
- **SPDX v2.3**: Packages are "higher-level containers that describe distributions or collections of software"; Files are "granular individual files contained within packages." Different tiers of granularity. [spec](https://spdx.github.io/spdx-spec/v2.3/package-information/)
- **NTIA Minimum Elements (2021)**: "The NTIA framework focuses on tracking identifiable **software components (such as libraries, packages, and applications)** with their relationships and metadata, **rather than individual files or low-level data artifacts**." [report](https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom)
- **BSI TR-03183-2 §5.2.2**: per-component fields (Executable/Archive/Structured property, etc.) are not applicable to lockfile input artifacts — they describe software components. [spec PDF](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.pdf)

## Test plan

- [x] All 651 plugin tests pass (24 new, 0 regressions)
- [x] `ruff check` / `ruff format` clean on changed files
- [x] `mypy` clean
- [x] Verified via real SBOM upload: CycloneDX NTIA/FDA failures drop to 0, BSI drops from 9 to 6 (remaining are real data gaps)
- [x] Verified via real SBOM upload: DT returns skipped (not error) on SPDX
- [x] Heuristic verified across syft, Microsoft sbom-tool, clean SPDX conventions, and CycloneDX 1.4/1.5/1.6
- [x] False-positive guard verified against `filelock`, `FileManager`, `python-file-utils`

## Not in scope

Known-remaining failures that are **real data gaps** or **structural format limits**, not file-type misclassification:

- CycloneDX BSI `Component Creator` missing for `cffi`, `crispy-bootstrap5` — PyPI metadata gap (enrichment PR)
- CycloneDX BSI `Hash SHA-512` on synthetic root — design decision
- CycloneDX BSI Executable/Archive/Structured on library deps — syft doesn't emit these properties
- SPDX BSI structural fails — user chose SPDX 2.3; BSI mandates 3.0.1+
- SPDX FDA CLE — enrichment currently only propagates CLE properties to CycloneDX (follow-up)
- `github-attestation` stuck at `pending` on CycloneDX — separate plugin scheduling issue

## Commits

- `497fc912` — plugin fixes + initial 12 tests
- `603d6302` — 6 regression + edge case tests
- `29ff090a` — 5 generator-agnostic tests (syft, Microsoft sbom-tool, clean SPDX, CycloneDX 1.4/1.5/1.6)
- `21a6b5d7` — broader false-positive guard (filelock, FileManager, python-file-utils)