### PR TITLE
fix: accept CycloneDX SBOMs without metadata.component

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -392,11 +392,15 @@ def sbom_upload_cyclonedx(
         sbom_dict = obj_extract(
             obj_in=payload,
             fields=[
-                ExtractSpec("metadata.component.name", required=True, rename_to="name"),
+                ExtractSpec("metadata.component.name", required=False, default="", rename_to="name"),
                 ExtractSpec("metadata.component.version", required=False, rename_to="version"),
                 ExtractSpec("specVersion", required=True, rename_to="format_version"),
             ],
         )
+
+        # metadata.component is optional in CycloneDX; fall back to the sbomify Component name
+        if not sbom_dict.get("name"):
+            sbom_dict["name"] = component.name
 
         # Version if present is a Version class and needs to be converted to string.
         if "version" in sbom_dict and not isinstance(sbom_dict["version"], str):
@@ -1011,11 +1015,15 @@ def sbom_upload_file(
             sbom_dict = obj_extract(
                 obj_in=cdx_payload,
                 fields=[
-                    ExtractSpec("metadata.component.name", required=True, rename_to="name"),
+                    ExtractSpec("metadata.component.name", required=False, default="", rename_to="name"),
                     ExtractSpec("metadata.component.version", required=False, rename_to="version"),
                     ExtractSpec("specVersion", required=True, rename_to="format_version"),
                 ],
             )
+
+            # metadata.component is optional in CycloneDX; fall back to the sbomify Component name
+            if not sbom_dict.get("name"):
+                sbom_dict["name"] = component.name
 
             # Version if present is a Version class and needs to be converted to string.
             if "version" in sbom_dict and not isinstance(sbom_dict["version"], str):

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -359,11 +359,13 @@ class ReleaseCycloneDXBuilder(BaseCycloneDXBuilder):
 
             # Extract component metadata
             component_dict = sbom_data.get("metadata", {}).get("component")
-            if not component_dict:
-                log.warning(f"SBOM {sbom_path.name} missing component metadata")
-                continue
-
-            name, component_type, version = extract_component_info(component_dict)
+            if component_dict:
+                name, component_type, version = extract_component_info(component_dict)
+            else:
+                # metadata.component is optional in CycloneDX; fall back to stored component name
+                name = sbom_instance.component.name
+                component_type = "library"
+                version = ""
 
             # Create CycloneDX component
             try:
@@ -763,11 +765,13 @@ class ProjectCycloneDXBuilder(BaseCycloneDXBuilder):
 
             # Extract component metadata
             component_dict = sbom_data.get("metadata", {}).get("component")
-            if not component_dict:
-                log.warning(f"SBOM {sbom_path.name} missing component metadata")
-                continue
-
-            name, component_type, version = extract_component_info(component_dict)
+            if component_dict:
+                name, component_type, version = extract_component_info(component_dict)
+            else:
+                # metadata.component is optional in CycloneDX; fall back to stored component name
+                name = component_obj.name
+                component_type = "library"
+                version = ""
 
             # Create CycloneDX component
             try:

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -302,6 +302,48 @@ def test_sbom_upload_api_cyclonedx_invalid_json(
 
 
 @pytest.mark.django_db
+def test_sbom_upload_api_cyclonedx_without_metadata_component(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """CycloneDX SBOMs without metadata.component should succeed, falling back to component name."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+
+    SBOM.objects.all().delete()
+
+    sbom_data = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {
+            "timestamp": "2026-04-19T00:00:00+00:00",
+            "tools": {"components": [{"type": "application", "name": "cyclonedx-py", "version": "7.3.0"}]},
+        },
+        "components": [
+            {"type": "library", "name": "some-lib", "version": "1.0.0", "bom-ref": "some-lib@1.0.0"},
+        ],
+    }
+
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    response = client.post(
+        url,
+        data=json.dumps(sbom_data),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 201
+    sbom = SBOM.objects.get(id=response.json()["id"])
+    assert sbom.format == "cyclonedx"
+    assert sbom.format_version == "1.6"
+    assert sbom.name == sample_component.name
+    assert sbom.version == ""
+
+
+@pytest.mark.django_db
 def test_cyclonedx_1_6_manufacturer_field(
     sample_access_token: AccessToken,  # noqa: F811
     sample_component: Component,  # noqa: F811
@@ -2705,6 +2747,49 @@ def test_sbom_upload_file_cyclonedx(
     assert sbom.format == "cyclonedx"
     assert sbom.source == "manual_upload"
     assert patched_upload_data_as_file.call_count == 1
+    assert SBOM.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_sbom_upload_file_cyclonedx_without_metadata_component(
+    sample_user,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """File upload of CycloneDX without metadata.component should succeed."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    sbom_data = json.dumps({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {
+            "timestamp": "2026-04-19T00:00:00+00:00",
+            "tools": {"components": [{"type": "application", "name": "cyclonedx-py", "version": "7.3.0"}]},
+        },
+        "components": [
+            {"type": "library", "name": "some-lib", "version": "1.0.0", "bom-ref": "some-lib@1.0.0"},
+        ],
+    }).encode()
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    sbom_file = SimpleUploadedFile("sbom.json", sbom_data, content_type="application/json")
+
+    client = Client()
+    client.force_login(sample_user)
+
+    url = reverse("api-1:sbom_upload_file", kwargs={"component_id": sample_component.id})
+    response = client.post(url, data={"sbom_file": sbom_file}, format="multipart")
+
+    assert response.status_code == 201
+    sbom = SBOM.objects.get(id=response.json()["id"])
+    assert sbom.format == "cyclonedx"
+    assert sbom.source == "manual_upload"
+    assert sbom.name == sample_component.name
+    assert sbom.version == ""
     assert SBOM.objects.count() == 1
 
 

--- a/sbomify/apps/sboms/tests/test_utils.py
+++ b/sbomify/apps/sboms/tests/test_utils.py
@@ -425,6 +425,75 @@ def test_project_sbom_file_generation_with_components(sample_project, tmp_path):
 
 
 @pytest.mark.django_db
+def test_project_sbom_builder_without_metadata_component(sample_project, tmp_path):  # noqa: F811
+    """Test that ProjectSBOMBuilder handles CycloneDX SBOMs without metadata.component."""
+
+    from sbomify.apps.sboms.models import SBOM, Component, ProjectComponent
+
+    sample_project.is_public = True
+    sample_project.save()
+
+    component = Component.objects.create(
+        name="no-meta-component",
+        team=sample_project.team,
+        component_type="bom",
+        visibility=Component.Visibility.PUBLIC,
+    )
+
+    SBOM.objects.create(
+        name="no-meta-component",
+        component=component,
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="no_meta.cdx.json",
+    )
+
+    ProjectComponent.objects.create(project=sample_project, component=component)
+
+    with patch("sbomify.apps.core.object_store.S3Client") as mock_s3:
+        mock_s3_instance = mock_s3.return_value
+
+        def mock_get_sbom_data(filename):
+            if filename == "no_meta.cdx.json":
+                return json.dumps(
+                    {
+                        "bomFormat": "CycloneDX",
+                        "specVersion": "1.6",
+                        "version": 1,
+                        "metadata": {
+                            "timestamp": "2026-04-19T00:00:00+00:00",
+                            "tools": {
+                                "components": [{"type": "application", "name": "cyclonedx-py", "version": "7.3.0"}]
+                            },
+                        },
+                        "components": [
+                            {
+                                "type": "library",
+                                "name": "some-lib",
+                                "version": "1.0.0",
+                                "bom-ref": "some-lib@1.0.0",
+                            },
+                        ],
+                    }
+                ).encode()
+            raise Exception(f"Unexpected filename: {filename}")
+
+        mock_s3_instance.get_sbom_data.side_effect = mock_get_sbom_data
+
+        from sbomify.apps.sboms.utils import get_project_sbom_package
+
+        sbom_path = get_project_sbom_package(sample_project, tmp_path)
+
+        assert sbom_path.exists()
+        project_sbom_data = json.loads(sbom_path.read_text())
+
+        assert project_sbom_data["bomFormat"] == "CycloneDX"
+        components = project_sbom_data.get("components", [])
+        assert len(components) == 1
+        assert components[0]["name"] == "no-meta-component"
+
+
+@pytest.mark.django_db
 def test_simple_external_reference_creation():
     """Test creating ExternalReference objects to isolate serialization issues."""
 


### PR DESCRIPTION
## Summary

- CycloneDX `metadata.component` is optional per spec, but both upload endpoints required it — rejecting valid SBOMs with 400
- `builders.py` silently skipped these SBOMs during product/project assembly
- Fall back to the parent sbomify Component name when `metadata.component` is absent

Fixes #897

## Test plan

- [x] New test: `test_sbom_upload_api_cyclonedx_without_metadata_component` — JSON upload endpoint
- [x] New test: `test_sbom_upload_file_cyclonedx_without_metadata_component` — file upload endpoint
- [x] All 20 existing CycloneDX tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)