### PR TITLE
chore(deps): bump cosign to v3.0.6 and osv-scanner to v2.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG PYTHON_VERSION=3.14-slim-trixie@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe4
 ARG BUILD_ENV=production # Default to production
 ARG OSV_SCANNER_VERSION=v2.3.5
 # For releases, see: https://github.com/sigstore/cosign/releases
-# v2.6.2 includes security fix for GHSA-whqx-f9j3-ch6m
+# Pin Cosign to a current release to pick up security fixes and ensure reproducible builds.
 ARG COSIGN_VERSION=v3.0.6
 # Chainguard distroless Python for production, pinned by digest for reproducibility.
 # IMPORTANT: This image must provide the same Python minor version as PYTHON_VERSION above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Base Python version
 ARG PYTHON_VERSION=3.14-slim-trixie@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
 ARG BUILD_ENV=production # Default to production
-ARG OSV_SCANNER_VERSION=v2.3.3
+ARG OSV_SCANNER_VERSION=v2.3.5
 # For releases, see: https://github.com/sigstore/cosign/releases
 # v2.6.2 includes security fix for GHSA-whqx-f9j3-ch6m
-ARG COSIGN_VERSION=v2.6.2
+ARG COSIGN_VERSION=v3.0.6
 # Chainguard distroless Python for production, pinned by digest for reproducibility.
 # IMPORTANT: This image must provide the same Python minor version as PYTHON_VERSION above.
 # To update: docker pull cgr.dev/chainguard/python:latest && docker inspect --format '{{index .RepoDigests 0}}'


### PR DESCRIPTION
## Summary
- Bumps cosign from v2.6.2 to v3.0.6 and osv-scanner from v2.3.3 to v2.3.5 in the Dockerfile.
- Cosign v3 defaults to the new Sigstore bundle format (v0.3) and OCI 1.1 referrer artifacts, which aligns deploy-side `cosign verify-attestation` with the attestations already produced by `actions/attest-build-provenance@v4.1.0` in CI.
- Picks up security fixes GHSA-whqx-f9j3-ch6m (v3.0.4), GHSA-wfqv-66vq-46rm (v3.0.5), GHSA-w6c6-c85g-mmv6 (v3.0.6).

## Changelog audit
Reviewed the full v3.0.x changelog against our usages:

- `bin/deploy.sh` — `cosign verify-attestation` with `--type`, `--certificate-identity-regexp`, `--certificate-oidc-issuer`: all still supported. `cosign version` still emits the `GitVersion:` line the script parses.
- `sbomify/apps/plugins/builtins/github_attestation.py` — `cosign verify-blob-attestation` with `--bundle`, `--new-bundle-format`, `--certificate-identity-regexp`, `--certificate-oidc-issuer`: all still supported. `--new-bundle-format` is now the default but the explicit flag is still accepted.
- v3.0.6 PR #4762 "Disallow --new-bundle-format and --rfc3161-timestamp" disallows the *combination* of both flags, not `--new-bundle-format` itself. We never pass `--rfc3161-timestamp`, so unaffected.
- v3.0.x deprecations (`--offline`, `--tlog-upload`, `--rekor-entry-type`, `cosign triangulate`, `cosign copy`, `--b64`, `--output*`, `--issue-certificate`): none used in our code.
- Release asset naming (`cosign-linux-${ARCH}`, `cosign_checksums.txt`) is unchanged, so the Dockerfile download flow works as-is.

## Test plan
- [ ] Docker image builds successfully with the new `COSIGN_VERSION` and `OSV_SCANNER_VERSION` args.
- [ ] `cosign version` inside the built image reports v3.0.6 and the `bin/deploy.sh` version check still passes (major >= 2).
- [ ] Run the `github_attestation` plugin against a real SBOM with a GitHub attestation bundle and confirm `cosign verify-blob-attestation` still succeeds.
- [ ] Run `bin/deploy.sh` against a signed sbomify image tag and confirm `cosign verify-attestation` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)