### PR TITLE
fix: pass --type slsaprovenance1 to cosign v3 attestation verification

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,7 +29,7 @@ if command -v cosign &> /dev/null; then
 
     # Try attestation verification with timeout
     if timeout 30 cosign verify-attestation \
-        --type https://slsa.dev/provenance/v1 \
+        --type slsaprovenance1 \
         --certificate-identity-regexp "^https://github.com/sbomify/sbomify/.*" \
         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
         "${SBOMIFY_IMAGE}@${DIGEST}" > /dev/null 2>&1; then

--- a/sbomify/apps/plugins/builtins/github_attestation.py
+++ b/sbomify/apps/plugins/builtins/github_attestation.py
@@ -102,6 +102,11 @@ class GitHubAttestationPlugin(AssessmentPlugin):
     DEFAULT_CERTIFICATE_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
     DEFAULT_TIMEOUT = 60  # seconds
 
+    # cosign v3 strictly validates --type against the attestation's predicate type when
+    # --new-bundle-format is active (default in v3). actions/attest-build-provenance emits
+    # https://slsa.dev/provenance/v1, which cosign aliases to "slsaprovenance1".
+    ATTESTATION_PREDICATE_TYPE = "slsaprovenance1"
+
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         """Initialize the plugin with configuration.
 
@@ -702,6 +707,8 @@ class GitHubAttestationPlugin(AssessmentPlugin):
             "--bundle",
             str(bundle_path),
             "--new-bundle-format",
+            "--type",
+            self.ATTESTATION_PREDICATE_TYPE,
             "--certificate-identity-regexp",
             certificate_identity_regexp,
             "--certificate-oidc-issuer",

--- a/sbomify/apps/plugins/tests/test_github_attestation_plugin.py
+++ b/sbomify/apps/plugins/tests/test_github_attestation_plugin.py
@@ -591,6 +591,9 @@ class TestCosignVerification:
         assert "verify-blob-attestation" in call_args
         assert "--bundle" in call_args
         assert "--new-bundle-format" in call_args  # Required for Sigstore bundle v0.3 (used by GitHub)
+        assert "--type" in call_args
+        type_idx = call_args.index("--type")
+        assert call_args[type_idx + 1] == "slsaprovenance1"
         assert "/tmp/bundle.jsonl" in call_args
         assert "/tmp/sbom.json" in call_args
 


### PR DESCRIPTION
## Summary

- After bumping cosign to v3.0.6 (#915), the GitHub Attestation plugin started failing with `invalid predicate type, expected custom got https://slsa.dev/provenance/v1`.
- Root cause: cosign v3 flips `--new-bundle-format` to default-on, and that code path strictly validates the attestation's predicate type against `--type` (default `"custom"`). GitHub's `actions/attest-build-provenance@v4.1.0` emits `https://slsa.dev/provenance/v1`, so the plugin must pass `--type slsaprovenance1` to match.
- Also updates `bin/deploy.sh` to use the shorthand for consistency (the `verify-attestation` subcommand accepts both URI and shorthand in v2 and v3).

## Changes

- `sbomify/apps/plugins/builtins/github_attestation.py` — add `ATTESTATION_PREDICATE_TYPE = "slsaprovenance1"` class constant; pass `--type` to `cosign verify-blob-attestation`.
- `sbomify/apps/plugins/tests/test_github_attestation_plugin.py` — assert the flag is present with the correct value at the correct position.
- `bin/deploy.sh` — switch `--type https://slsa.dev/provenance/v1` to `--type slsaprovenance1`.

## Test plan

- [x] Existing unit tests pass (60/60 in `test_github_attestation_plugin.py`)
- [x] Ruff check + format clean
- [x] Reproduced the user-reported error on cosign v3.0.6 using the pre-fix command
- [x] End-to-end verified inside the real `python-app-prod` container image: invoked `GitHubAttestationPlugin().assess()` against a real production SBOM (`MFuug7MS3fNx`) with its real GitHub attestation bundle — result: `pass_count=1`, finding status `pass`, title `"GitHub Attestation Verified"`
- [ ] Smoke test `bin/deploy.sh` on a host with cosign v3 against the signed `sbomifyhub/sbomify:latest` image after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)