### PR TITLE
screencast(plugins): add per-plugin enablement clips for FAQ use

### DIFF
--- a/.github/workflows/screencasts.yml
+++ b/.github/workflows/screencasts.yml
@@ -138,11 +138,13 @@ jobs:
         if: always()
         run: |
           sudo chown -R $USER:$USER screencasts/output/ 2>/dev/null || true
-          # Remove Playwright's random-named temp .webm files, keep only named screencasts
+          # Playwright writes temp files as 32-char hex hashes before the
+          # fixture renames them; drop only those so named recordings
+          # (including parametrized ones without a matching .py stem) stay.
           for webm in screencasts/output/*.webm; do
             [ -f "$webm" ] || continue
             name=$(basename "$webm" .webm)
-            if [ ! -f "screencasts/${name}.py" ]; then
+            if [[ "$name" =~ ^[a-f0-9]{32}$ ]]; then
               rm -f "$webm"
             fi
           done

--- a/bin/record_screencasts.sh
+++ b/bin/record_screencasts.sh
@@ -70,13 +70,13 @@ run_screencast() {
 }
 
 clean_temp_videos() {
-    # Playwright generates random-named .webm files alongside our named ones.
-    # Keep only files whose names match a screencast script.
+    # Playwright writes temp files named as 32-char hex hashes before the
+    # fixture renames them to the test-name filename.  Drop only those.
     for webm in "$OUTPUT_DIR"/*.webm; do
         [ -f "$webm" ] || continue
         local name
         name=$(basename "$webm" .webm)
-        if [ ! -f "$SCREENCASTS_DIR/${name}.py" ]; then
+        if [[ "$name" =~ ^[a-f0-9]{32}$ ]]; then
             rm -f "$webm"
         fi
     done

--- a/screencasts/conftest.py
+++ b/screencasts/conftest.py
@@ -75,6 +75,20 @@ _screenshot_state: dict[str, Any] = {
 }
 
 
+def _recording_name(request: pytest.FixtureRequest) -> str:
+    """Filename stem for the recorded artifacts.
+
+    For parametrized tests, produces ``<func>_<param_id>`` so the
+    pytest brackets do not end up in filenames (which trips shell
+    globs and downstream cleanup heuristics).
+    """
+    node = request.node
+    callspec = getattr(node, "callspec", None)
+    if callspec is not None:
+        return f"{node.originalname}_{callspec.id}"
+    return node.name
+
+
 def _maybe_capture_screenshot(page: Page) -> None:
     out_dir = _screenshot_state["dir"]
     if out_dir is None:
@@ -275,6 +289,34 @@ def create_global_document_component(page: Page, name: str) -> None:
 
     page.wait_for_load_state("networkidle")
     pace(page, 800)
+
+
+def enable_and_save_plugin(page: Page, plugin_slug: str) -> None:
+    """Navigate to Plugins, toggle the given plugin on, and save.
+
+    Shared by the per-plugin FAQ screencasts in plugin_enablement.py.
+    """
+    navigate_to_plugins(page)
+
+    page.locator("#plugin-settings-form").wait_for(state="visible", timeout=15_000)
+    pace(page, 1500)
+
+    # Attribute selector (not #id) because some plugin slugs contain dots
+    # (e.g. bsi-tr03183-v2.1-compliance) which have CSS-special meaning.
+    toggle = page.locator(f"[id='plugin-{plugin_slug}']")
+    toggle.scroll_into_view_if_needed()
+    pace(page, 600)
+    hover_and_click(page, toggle)
+    pace(page, 1200)
+
+    save_btn = page.locator("button[type='submit'][form='plugin-settings-form']")
+    save_btn.scroll_into_view_if_needed()
+    pace(page, 500)
+    hover_and_click(page, save_btn)
+
+    page.wait_for_load_state("networkidle")
+    dismiss_toasts(page)
+    pace(page, 2000)
 
 
 def enable_and_configure_trust_center(page: Page) -> None:
@@ -601,7 +643,9 @@ def recording_page(
     # visible while the first real navigation loads.
     page.set_content(SPLASH_HTML, wait_until="commit")
 
-    screenshot_dir = OUTPUT_DIR / "screenshots" / request.node.name
+    recording_name = _recording_name(request)
+
+    screenshot_dir = OUTPUT_DIR / "screenshots" / recording_name
     screenshot_dir.mkdir(parents=True, exist_ok=True)
     _screenshot_state["dir"] = screenshot_dir
     _screenshot_state["last_time"] = 0.0
@@ -618,5 +662,5 @@ def recording_page(
     page.close()
 
     if video:
-        final_path = OUTPUT_DIR / f"{request.node.name}.webm"
+        final_path = OUTPUT_DIR / f"{recording_name}.webm"
         video.save_as(str(final_path))

--- a/screencasts/plugin_enablement.py
+++ b/screencasts/plugin_enablement.py
@@ -1,0 +1,30 @@
+"""Record one FAQ-length screencast per plugin.
+
+Produces ``plugin_enablement_<slug>.webm`` for each plugin. Each clip
+navigates to the Plugins page, flips the plugin's toggle on, and saves.
+Billing is disabled in the screencast fixture so every plugin (including
+ones that are plan-gated in production) is clickable here.
+"""
+
+import pytest
+from playwright.sync_api import Page
+
+from conftest import enable_and_save_plugin, start_on_dashboard
+
+PLUGIN_SLUGS = [
+    "osv",
+    "dependency-track",
+    "ntia-minimum-elements-2021",
+    "bsi-tr03183-v2.1-compliance",
+    "fda-medical-device-2025",
+    "github-attestation",
+    "sbom-verification",
+]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("plugin_slug", PLUGIN_SLUGS, ids=PLUGIN_SLUGS)
+def plugin_enablement(recording_page: Page, plugin_slug: str) -> None:
+    page = recording_page
+    start_on_dashboard(page)
+    enable_and_save_plugin(page, plugin_slug)


### PR DESCRIPTION
## Summary
- Adds `screencasts/plugin_enablement.py`, a parametrized screencast that produces one short clip per registered plugin (navigate → toggle → save) for direct FAQ embedding
- Covers the 7 plugins registered in `plugins/apps.py`: `osv`, `dependency-track`, `ntia-minimum-elements-2021`, `bsi-tr03183-v2.1-compliance`, `fda-medical-device-2025`, `github-attestation`, `sbom-verification`
- `cisa-minimum-elements-2025` and `checksum` have builtin files but are not registered, so they are excluded for now
- New `enable_and_save_plugin` helper in `conftest.py`; uses an attribute selector because some slugs contain dots (e.g. `bsi-tr03183-v2.1-compliance`) which are CSS-special
- Filename sanitizer in `recording_page` so parametrized runs land as `plugin_enablement_<slug>.webm` instead of `foo[bar].webm`
- Cleanup heuristic in `bin/record_screencasts.sh` and `.github/workflows/screencasts.yml` tightened to delete only 32-char hex Playwright temp files, so parametrized recordings without a matching `.py` stem survive

## Test plan
- [x] Recorded all 7 plugins locally via pytest in Docker; each completes in ~15s and produces a clean `.webm` plus a `screenshots/<name>/` subdirectory
- [x] Verified the BSI slug with dots works via the attribute selector
- [ ] Trigger the `Record Screencasts` workflow in CI and confirm the 7 new files publish to R2 under `screencasts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)