### PR TITLE
fix(plugins): finalize AssessmentRun when RetryLaterError budget exhausts

### DIFF
--- a/sbomify/apps/plugins/orchestrator.py
+++ b/sbomify/apps/plugins/orchestrator.py
@@ -345,12 +345,21 @@ class PluginOrchestrator:
         — one ``error`` finding wrapping the retry-exhausted message —
         writes it onto the run, and flips status to ``COMPLETED``. The
         run now appears in the orchestrator's ``_check_one_of`` query
-        and ``_is_passing`` returns ``False`` (one fail finding), so
-        the gate correctly reports the plugin in ``failed_plugins``.
+        and ``_is_passing`` returns ``False`` (``error_count > 0`` is
+        treated identically to ``fail_count > 0``), so the gate
+        correctly reports the plugin in ``failed_plugins``.
+
+        Concurrency: the status flip is performed via a conditional
+        ``UPDATE ... WHERE status IN (pending, running)`` so a worker
+        that races us to legitimate completion can't be clobbered. If
+        the conditional update affects zero rows we return the latest
+        row state without mutating it.
 
         Idempotent: if the run is already in a terminal state, no-op.
         Returns the run on success, ``None`` if the run isn't found.
         """
+        from django.db import transaction
+
         try:
             run = AssessmentRun.objects.get(id=run_id)
         except AssessmentRun.DoesNotExist:
@@ -361,14 +370,19 @@ class PluginOrchestrator:
             # Already terminal — keep what's there.
             return run
 
+        now = timezone.now()
+        # ``schema_version`` mirrors ``AssessmentResult.to_dict()`` (sdk/results.py)
+        # so retry-exhausted payloads share the same on-disk shape as plugin-emitted
+        # ones — consumers that key off ``result["schema_version"]`` keep working.
         synthesized_result = {
+            "schema_version": "1.0",
             "plugin_name": run.plugin_name,
             "plugin_version": run.plugin_version,
             "category": run.category,
-            "assessed_at": timezone.now().isoformat(),
+            "assessed_at": now.isoformat(),
             "summary": {
                 "total_findings": 1,
-                "pass_count": 0,
+                "pass_count": 0,  # nosec B105
                 "fail_count": 0,
                 "warning_count": 0,
                 "error_count": 1,
@@ -390,11 +404,34 @@ class PluginOrchestrator:
             "metadata": {"retry_exhausted": True},
         }
 
-        run.status = RunStatus.COMPLETED.value
-        run.result = synthesized_result
-        run.error_message = f"Retry budget exhausted: {error_message}"  # surfaces in run-detail UI alongside findings
-        run.completed_at = timezone.now()
-        run.save(update_fields=["status", "result", "error_message", "completed_at"])
+        with transaction.atomic():
+            updated = AssessmentRun.objects.filter(
+                id=run_id,
+                status__in=(RunStatus.PENDING.value, RunStatus.RUNNING.value),
+            ).update(
+                status=RunStatus.COMPLETED.value,
+                result=synthesized_result,
+                result_schema_version="1.0",
+                error_message=f"Retry budget exhausted: {error_message}",
+                completed_at=now,
+            )
+            if updated == 0:
+                # Another worker finished the run between the read and the
+                # update. Re-fetch and return the canonical row — never
+                # overwrite legitimate result data.
+                run.refresh_from_db()
+                logger.info(
+                    f"[PLUGIN] finalize_retry_exhausted: run {run_id} was finalised by another path "
+                    f"(status={run.status}); leaving its result in place"
+                )
+                return run
+
+            run.refresh_from_db()
+            # Populate the AssessmentRun↔Release M2M from the current ReleaseArtifact
+            # state so retry-exhausted runs surface against the correct releases —
+            # same contract as a normal completion.
+            self._sync_run_releases(run, str(run.sbom_id))
+
         logger.info(f"[PLUGIN] finalize_retry_exhausted: marked run {run_id} as COMPLETED with retry-exhausted finding")
         return run
 

--- a/sbomify/apps/plugins/orchestrator.py
+++ b/sbomify/apps/plugins/orchestrator.py
@@ -325,6 +325,79 @@ class PluginOrchestrator:
         assessment_run.completed_at = timezone.now()
         assessment_run.save(update_fields=["status", "error_message", "completed_at"])
 
+    def finalize_retry_exhausted(self, run_id: str, error_message: str) -> AssessmentRun | None:
+        """Settle a run that has burnt through every ``RetryLaterError`` slot.
+
+        The orchestrator's ``RetryLaterError`` handler resets the run to
+        ``PENDING`` so the task layer can re-queue it. When the task layer
+        gives up after the configured retry budget, **the run is left
+        dangling in PENDING forever** unless someone finalises it. That
+        breaks downstream consumers in two ways:
+
+        - BSI's ``requires_one_of: attestation`` query filters by
+          ``status=COMPLETED``; a permanently-pending run is invisible
+          to the gate, so BSI keeps reporting "No attestation plugin
+          has been run for this SBOM" even though one was attempted.
+        - The SBOM detail page shows the card stuck on a spinner
+          forever.
+
+        This method synthesises a minimal failing ``AssessmentResult``
+        — one ``error`` finding wrapping the retry-exhausted message —
+        writes it onto the run, and flips status to ``COMPLETED``. The
+        run now appears in the orchestrator's ``_check_one_of`` query
+        and ``_is_passing`` returns ``False`` (one fail finding), so
+        the gate correctly reports the plugin in ``failed_plugins``.
+
+        Idempotent: if the run is already in a terminal state, no-op.
+        Returns the run on success, ``None`` if the run isn't found.
+        """
+        try:
+            run = AssessmentRun.objects.get(id=run_id)
+        except AssessmentRun.DoesNotExist:
+            logger.warning(f"[PLUGIN] finalize_retry_exhausted: run {run_id} not found")
+            return None
+
+        if run.status not in (RunStatus.PENDING.value, RunStatus.RUNNING.value):
+            # Already terminal — keep what's there.
+            return run
+
+        synthesized_result = {
+            "plugin_name": run.plugin_name,
+            "plugin_version": run.plugin_version,
+            "category": run.category,
+            "assessed_at": timezone.now().isoformat(),
+            "summary": {
+                "total_findings": 1,
+                "pass_count": 0,
+                "fail_count": 0,
+                "warning_count": 0,
+                "error_count": 1,
+            },
+            "findings": [
+                {
+                    "id": f"{run.plugin_name}:retry-exhausted",
+                    "title": "Assessment Retry Budget Exhausted",
+                    "description": (
+                        "The plugin reported a transient condition for every retry attempt "
+                        "in the configured budget. The condition may have become permanent "
+                        f"(e.g., the upstream resource never became available). Last error: {error_message}"
+                    ),
+                    "status": "error",
+                    "severity": "high",
+                    "metadata": {"retry_exhausted": True, "last_error": error_message},
+                }
+            ],
+            "metadata": {"retry_exhausted": True},
+        }
+
+        run.status = RunStatus.COMPLETED.value
+        run.result = synthesized_result
+        run.error_message = f"Retry budget exhausted: {error_message}"  # surfaces in run-detail UI alongside findings
+        run.completed_at = timezone.now()
+        run.save(update_fields=["status", "result", "error_message", "completed_at"])
+        logger.info(f"[PLUGIN] finalize_retry_exhausted: marked run {run_id} as COMPLETED with retry-exhausted finding")
+        return run
+
     def _sync_run_releases(self, assessment_run: AssessmentRun, sbom_id: str) -> None:
         """Populate AssessmentRun.releases M2M from current ReleaseArtifact state.
 

--- a/sbomify/apps/plugins/tasks/__init__.py
+++ b/sbomify/apps/plugins/tasks/__init__.py
@@ -228,12 +228,20 @@ def run_assessment_task(
                     response["assessment_run_id"] = run_id
                 return response
             else:
-                # All retries exhausted - return graceful failure
+                # All retries exhausted - finalise the run so it leaves PENDING.
+                # Without this step the AssessmentRun row stays stuck on the
+                # last ``status = PENDING`` write the orchestrator made when
+                # propagating the RetryLaterError, which makes the run invisible
+                # to ``_check_one_of`` (filters by status=COMPLETED) and leaves
+                # the SBOM detail page spinning indefinitely.
                 logger.warning(
                     f"[TASK_run_assessment] Transient condition persists for SBOM {sbom_id} "
                     f"(run: {run_id or 'unknown'}) "
-                    f"after {len(RETRY_LATER_DELAYS_MS)} retries. Returning graceful failure."
+                    f"after {len(RETRY_LATER_DELAYS_MS)} retries. Finalising run as completed-with-error."
                 )
+
+                if run_id is not None:
+                    PluginOrchestrator().finalize_retry_exhausted(run_id, str(retry_error))
 
                 response = {
                     "status": "retry_exhausted",

--- a/sbomify/apps/plugins/tasks/__init__.py
+++ b/sbomify/apps/plugins/tasks/__init__.py
@@ -241,7 +241,19 @@ def run_assessment_task(
                 )
 
                 if run_id is not None:
-                    PluginOrchestrator().finalize_retry_exhausted(run_id, str(retry_error))
+                    # Retry-exhaustion is meant to be terminal — never let a
+                    # finalisation hiccup (DB blip, JSON serialisation issue,
+                    # etc.) bubble up to the outer ``except Exception`` and
+                    # cause Dramatiq to re-queue the task again. Log and
+                    # carry on; the row stays in PENDING but at least the
+                    # exhaustion event is recorded.
+                    try:
+                        PluginOrchestrator().finalize_retry_exhausted(run_id, str(retry_error))
+                    except Exception as finalize_err:  # noqa: BLE001
+                        logger.error(
+                            f"[TASK_run_assessment] finalize_retry_exhausted failed for run {run_id}: {finalize_err}",
+                            exc_info=True,
+                        )
 
                 response = {
                     "status": "retry_exhausted",

--- a/sbomify/apps/plugins/tests/test_orchestrator.py
+++ b/sbomify/apps/plugins/tests/test_orchestrator.py
@@ -682,6 +682,11 @@ class TestFinalizeRetryExhausted:
 
         # Synthesised payload shape — exactly what BSI's gate consumes.
         assert run.result is not None
+        # ``schema_version`` mirrors ``AssessmentResult.to_dict()`` so
+        # retry-exhausted runs round-trip through any schema-version
+        # consumer the same as plugin-emitted runs.
+        assert run.result["schema_version"] == "1.0"
+        assert run.result_schema_version == "1.0"
         summary = run.result["summary"]
         assert summary["fail_count"] == 0
         assert summary["error_count"] == 1

--- a/sbomify/apps/plugins/tests/test_orchestrator.py
+++ b/sbomify/apps/plugins/tests/test_orchestrator.py
@@ -647,3 +647,111 @@ class TestDependencyChecking:
 
         orchestrator = PluginOrchestrator()
         assert orchestrator._is_passing(run) is True
+
+
+@pytest.mark.django_db
+class TestFinalizeRetryExhausted:
+    """``finalize_retry_exhausted`` flips a stuck-PENDING run to a terminal state.
+
+    Regression for the production-discovered bug where the task layer's
+    ``RetryLaterError`` exhaustion branch returned a response dict
+    without updating the AssessmentRun row, leaving it stuck in
+    ``PENDING`` forever — invisible to ``_check_one_of`` (which filters
+    on ``status=COMPLETED``) and producing endless spinners on the
+    SBOM detail page.
+    """
+
+    def test_pending_run_finalised_with_retry_exhausted_finding(self, test_sbom, db) -> None:
+        run = AssessmentRun.objects.create(
+            sbom_id=test_sbom.id,
+            plugin_name="sbom-verification",
+            plugin_version="2.0.0",
+            category="attestation",
+            run_reason="on_upload",
+            status=RunStatus.PENDING.value,
+        )
+
+        orchestrator = PluginOrchestrator()
+        result = orchestrator.finalize_retry_exhausted(str(run.id), "GitHub returned 404 for sha256:abc...")
+
+        assert result is not None
+        run.refresh_from_db()
+        assert run.status == RunStatus.COMPLETED.value
+        assert run.completed_at is not None
+        assert run.error_message and "Retry budget exhausted" in run.error_message
+
+        # Synthesised payload shape — exactly what BSI's gate consumes.
+        assert run.result is not None
+        summary = run.result["summary"]
+        assert summary["fail_count"] == 0
+        assert summary["error_count"] == 1
+        assert summary["pass_count"] == 0
+        assert summary["total_findings"] == 1
+
+        finding = run.result["findings"][0]
+        assert finding["id"] == "sbom-verification:retry-exhausted"
+        assert finding["status"] == "error"
+        assert "GitHub returned 404" in finding["description"]
+        assert finding["metadata"]["retry_exhausted"] is True
+
+    def test_finalised_run_satisfies_check_one_of_query(self, test_sbom, db) -> None:
+        """After finalising, BSI's ``_check_one_of`` sees the run as failed_plugins.
+
+        This is the actual production symptom: the SBOM detail page kept
+        spinning and BSI kept saying "No attestation plugin run" because
+        the orchestrator's gate query filters on ``status=COMPLETED``.
+        Once the run is finalised, the gate correctly classifies it as
+        a failed attestation source.
+        """
+        run = AssessmentRun.objects.create(
+            sbom_id=test_sbom.id,
+            plugin_name="sbom-verification",
+            plugin_version="2.0.0",
+            category="attestation",
+            run_reason="on_upload",
+            status=RunStatus.PENDING.value,
+        )
+
+        orchestrator = PluginOrchestrator()
+        # Before finalise: no completed attestation runs.
+        before = orchestrator._check_one_of(str(test_sbom.id), [{"type": "category", "value": "attestation"}])
+        assert before == {"satisfied": False, "passing_plugins": [], "failed_plugins": []}
+
+        orchestrator.finalize_retry_exhausted(str(run.id), "transient condition persists")
+
+        # After finalise: BSI sees ``sbom-verification`` in failed_plugins so the gate
+        # produces an actionable failure message instead of "no attestation run".
+        after = orchestrator._check_one_of(str(test_sbom.id), [{"type": "category", "value": "attestation"}])
+        assert after["satisfied"] is False
+        assert after["failed_plugins"] == ["sbom-verification"]
+        assert after["passing_plugins"] == []
+
+    def test_finalize_is_idempotent_on_terminal_state(self, test_sbom, db) -> None:
+        """A run that's already COMPLETED/FAILED is left untouched."""
+        run = AssessmentRun.objects.create(
+            sbom_id=test_sbom.id,
+            plugin_name="sbom-verification",
+            plugin_version="2.0.0",
+            category="attestation",
+            run_reason="on_upload",
+            status=RunStatus.COMPLETED.value,
+            result={"summary": {"pass_count": 1, "fail_count": 0, "error_count": 0}},
+            completed_at=datetime.now(timezone.utc),
+        )
+        original_completed_at = run.completed_at
+        original_result = run.result
+
+        orchestrator = PluginOrchestrator()
+        result = orchestrator.finalize_retry_exhausted(str(run.id), "shouldn't matter")
+
+        run.refresh_from_db()
+        assert result is not None
+        assert run.status == RunStatus.COMPLETED.value
+        # Original payload preserved — no overwrite of legitimate run data.
+        assert run.result == original_result
+        assert run.completed_at == original_completed_at
+
+    def test_finalize_returns_none_when_run_not_found(self, db) -> None:
+        orchestrator = PluginOrchestrator()
+        result = orchestrator.finalize_retry_exhausted("00000000-0000-0000-0000-000000000000", "nope")
+        assert result is None


### PR DESCRIPTION
## Summary

Production bug discovered during staging verification of #927: a plugin run that burns through every `RetryLaterError` retry slot stays stuck in `status="PENDING"` **forever**.

The orchestrator's `RetryLaterError` handler resets the run to `PENDING` so the task layer can re-queue it. The task layer's exhaustion branch (in `run_assessment_task`) only logged a warning and returned a response dict — the AssessmentRun row was never finalised.

## Symptoms

- BSI's `_check_one_of(category=attestation)` query filters by `status=COMPLETED`. A permanently-pending run is invisible to the gate, so BSI keeps reporting *"No attestation plugin has been run for this SBOM"* even though one was attempted multiple times.
- The SBOM detail page renders a spinning `Pending` card forever (verified on staging — `sbom-verification` row started at 16:23:42 UTC was still `pending` at 17:07 UTC, well past the 32-min retry budget of 2/5/10/15 min).
- Most visible on the unified `sbom-verification` plugin because the GitHub-attestation flow legitimately raises `AttestationNotYetAvailableError` on 404s, and most third-party SBOMs in the wild don't have published GitHub attestations — so the retry budget exhausts deterministically.

## Fix

- New `PluginOrchestrator.finalize_retry_exhausted(run_id, error)` method. Idempotent. Synthesises a single `error` finding tagged `retry_exhausted=True`, writes a fail-summary (`error_count=1`, `pass_count=0`), flips status to `COMPLETED`, and stamps `completed_at`. Already-terminal runs are left as-is so legitimate scan results aren't overwritten.
- `run_assessment_task` calls `finalize_retry_exhausted` in the exhaustion branch before returning the response dict.

Downstream consumers (BSI's gate, the SBOM detail page badges) now see a completed-with-error run and surface the plugin name in `failed_plugins` so operators have a clickable remediation target.

## Verification (local DB had 7 stuck runs from earlier testing)

| Check | Before | After |
|---|---|---|
| AssessmentRun status | `pending` (forever) | `completed` with `verification:retry-exhausted` finding |
| BSI's `_check_one_of(attestation)` | `{satisfied: False, passing_plugins: [], failed_plugins: []}` | `{satisfied: False, passing_plugins: [], failed_plugins: ["sbom-verification"]}` |
| BSI attestation finding text | "No attestation plugin has been run" | "Attestation plugin(s) ran but did not pass: sbom-verification" |
| SBOM Verification card on detail page | Stuck on "Pending" spinner | "1 Issue" badge |

## Test plan

- [x] 4 new orchestrator tests cover: pending → completed with retry-exhausted finding, gate visibility post-finalise, idempotency on terminal state, missing-run no-op
- [x] All 29 orchestrator tests pass
- [x] `ruff`, `mypy`, `djlint` clean
- [x] End-to-end browser-verified locally — BSI's gate refreshes correctly after retry-exhaustion