### PR TITLE
ci: make ghcr.io the primary registry, Docker Hub the mirror

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -611,7 +611,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          DOCKER_IMAGE: ${{ needs.docker-build.outputs.docker-hub-image }}:${{ steps.version.outputs.docker_tag }}
+          DOCKER_IMAGE: ${{ needs.docker-build.outputs.github-image }}:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: dockerfile_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -758,7 +758,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          DOCKER_IMAGE: ${{ needs.docker-build.outputs.docker-hub-image }}:${{ steps.version.outputs.docker_tag }}
+          DOCKER_IMAGE: ${{ needs.docker-build.outputs.github-image }}:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: dockerfile_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       retries: 5
 
   sbomify-backend:
-    image: ${SBOMIFY_IMAGE:-sbomifyhub/sbomify}:${SBOMIFY_TAG:-latest}
+    image: ${SBOMIFY_IMAGE:-ghcr.io/sbomify/sbomify}:${SBOMIFY_TAG:-latest}
     build:
       context: ${BUILD_CONTEXT:-.}
       target: ${BUILD_TARGET:-python-app-prod}
@@ -127,7 +127,7 @@ services:
     stop_grace_period: 10s
 
   sbomify-migrations:
-    image: ${SBOMIFY_IMAGE:-sbomifyhub/sbomify}:${SBOMIFY_TAG:-latest}
+    image: ${SBOMIFY_IMAGE:-ghcr.io/sbomify/sbomify}:${SBOMIFY_TAG:-latest}
     build:
       context: ${BUILD_CONTEXT:-.}
       target: ${BUILD_TARGET:-python-app-prod}
@@ -143,7 +143,7 @@ services:
         condition: service_healthy
 
   sbomify-worker:
-    image: ${SBOMIFY_IMAGE:-sbomifyhub/sbomify}:${SBOMIFY_TAG:-latest}
+    image: ${SBOMIFY_IMAGE:-ghcr.io/sbomify/sbomify}:${SBOMIFY_TAG:-latest}
     build:
       context: ${BUILD_CONTEXT:-.}
       target: ${BUILD_TARGET:-python-app-prod}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -406,15 +406,15 @@ Example bucket policy for media:
 If you prefer not to use the deploy script:
 
 ```bash
-docker pull sbomifyhub/sbomify:latest
-DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' sbomifyhub/sbomify:latest | cut -d'@' -f2)
+docker pull ghcr.io/sbomify/sbomify:latest
+DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/sbomify/sbomify:latest | cut -d'@' -f2)
 
 # Verify (optional)
 cosign verify-attestation \
   --type https://slsa.dev/provenance/v1 \
   --certificate-identity-regexp "^https://github.com/sbomify/sbomify/.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  "sbomifyhub/sbomify@${DIGEST}"
+  "ghcr.io/sbomify/sbomify@${DIGEST}"
 
 # Deploy
 docker compose --env-file ./override.env up -d --force-recreate --remove-orphans

--- a/sbomify/apps/sboms/js/ci-cd-info.spec.ts
+++ b/sbomify/apps/sboms/js/ci-cd-info.spec.ts
@@ -197,7 +197,7 @@ describe('CI/CD Info Business Logic', () => {
             const lines = [
                 'upload-sbom:',
                 '  stage: deploy',
-                '  image: sbomifyhub/sbomify-action'
+                '  image: ghcr.io/sbomify/sbomify-action'
             ]
 
             if (sourceType === 'docker') {
@@ -243,7 +243,7 @@ describe('CI/CD Info Business Logic', () => {
                 outputFile: true
             })
 
-            expect(yaml).toContain('image: sbomifyhub/sbomify-action')
+            expect(yaml).toContain('image: ghcr.io/sbomify/sbomify-action')
             expect(yaml).toContain(`COMPONENT_ID: '${testComponentId}'`)
             expect(yaml).toContain("LOCK_FILE: 'poetry.lock'")
             expect(yaml).toContain('sbomify-action')
@@ -274,7 +274,7 @@ describe('CI/CD Info Business Logic', () => {
                 '  default:',
                 '    - step:',
                 '        name: Upload SBOM',
-                '        image: sbomifyhub/sbomify-action',
+                '        image: ghcr.io/sbomify/sbomify-action',
                 '        services:',
                 '          - docker'
             ]
@@ -385,7 +385,7 @@ describe('CI/CD Info Business Logic', () => {
 
             const lastLine = dockerLines[dockerLines.length - 1]
             dockerLines[dockerLines.length - 1] = lastLine.replace(/ \\$/, '')
-            dockerLines.push('        sbomifyhub/sbomify-action')
+            dockerLines.push('        ghcr.io/sbomify/sbomify-action')
 
             lines.push(...dockerLines)
 
@@ -414,7 +414,7 @@ describe('CI/CD Info Business Logic', () => {
             expect(yaml).toContain('AUGMENT=true')
             expect(yaml).toContain('ENRICH=true')
             expect(yaml).toContain('OUTPUT_FILE=/code/sbom.cdx.json')
-            expect(yaml).toContain('sbomifyhub/sbomify-action')
+            expect(yaml).toContain('ghcr.io/sbomify/sbomify-action')
             expect(yaml).toContain('displayName: Upload SBOM')
         })
 
@@ -501,7 +501,7 @@ describe('CI/CD Info Business Logic', () => {
 
             const lastLine = lines[lines.length - 1]
             lines[lines.length - 1] = lastLine.replace(/ \\\\$/, '')
-            lines.push('                          sbomifyhub/sbomify-action')
+            lines.push('                          ghcr.io/sbomify/sbomify-action')
 
             lines.push(
                 '                    """',
@@ -533,7 +533,7 @@ describe('CI/CD Info Business Logic', () => {
             expect(jenkinsfile).toContain('AUGMENT=true')
             expect(jenkinsfile).toContain('ENRICH=true')
             expect(jenkinsfile).toContain('OUTPUT_FILE=/code/sbom.cdx.json')
-            expect(jenkinsfile).toContain('sbomifyhub/sbomify-action')
+            expect(jenkinsfile).toContain('ghcr.io/sbomify/sbomify-action')
         })
 
         test('should generate Jenkinsfile with SBOM file source', () => {
@@ -603,7 +603,7 @@ describe('CI/CD Info Business Logic', () => {
             if (config.enrich) cmd.push('  -e ENRICH=true \\\\')
             if (config.outputFile) cmd.push('  -e OUTPUT_FILE=sbom.cdx.json \\\\')
 
-            cmd.push('  sbomifyhub/sbomify-action')
+            cmd.push('  ghcr.io/sbomify/sbomify-action')
 
             return cmd.join('\n')
         }
@@ -618,7 +618,7 @@ describe('CI/CD Info Business Logic', () => {
             expect(cmd).toContain('docker run -it --rm')
             expect(cmd).toContain(`COMPONENT_ID=${testComponentId}`)
             expect(cmd).toContain('poetry.lock:/app/poetry.lock')
-            expect(cmd).toContain('sbomifyhub/sbomify-action')
+            expect(cmd).toContain('ghcr.io/sbomify/sbomify-action')
         })
 
         test('should mount docker socket for docker source', () => {

--- a/sbomify/apps/sboms/js/ci-cd-info.ts
+++ b/sbomify/apps/sboms/js/ci-cd-info.ts
@@ -145,7 +145,7 @@ export function registerCiCdInfo() {
             const lines = [
                 'upload-sbom:',
                 '  stage: deploy',
-                '  image: sbomifyhub/sbomify-action'
+                '  image: ghcr.io/sbomify/sbomify-action'
             ];
 
             if (this.sourceType === 'docker') {
@@ -190,7 +190,7 @@ export function registerCiCdInfo() {
                 '  default:',
                 '    - step:',
                 '        name: Upload SBOM',
-                '        image: sbomifyhub/sbomify-action',
+                '        image: ghcr.io/sbomify/sbomify-action',
                 '        services:',
                 '          - docker'
             ];
@@ -276,7 +276,7 @@ export function registerCiCdInfo() {
             // Add the image name (remove trailing backslash from last line)
             const lastLine = dockerLines[dockerLines.length - 1];
             dockerLines[dockerLines.length - 1] = lastLine.replace(/ \\$/, '');
-            dockerLines.push('        sbomifyhub/sbomify-action');
+            dockerLines.push('        ghcr.io/sbomify/sbomify-action');
 
             lines.push(...dockerLines);
 
@@ -343,7 +343,7 @@ export function registerCiCdInfo() {
             // Remove trailing backslash from last line and add image
             const lastLine = lines[lines.length - 1];
             lines[lines.length - 1] = lastLine.replace(/ \\\\$/, '');
-            lines.push('                          sbomifyhub/sbomify-action');
+            lines.push('                          ghcr.io/sbomify/sbomify-action');
 
             lines.push(
                 '                    """',


### PR DESCRIPTION
## Summary

Mirror of [sbomify-action#226](https://github.com/sbomify/sbomify-action/pull/226) for this repo — standardize on **GHCR** as the canonical published artifact identity, with Docker Hub remaining as a mirror push.

- `.github/workflows/ci-cd.yml`: container self-SBOM `DOCKER_IMAGE` now uses the `github-image` output (was `docker-hub-image`) for both the staging and production matrices, so the published container SBOMs reference the GHCR image.
- `docker-compose.yml`: `SBOMIFY_IMAGE` defaults repointed to `ghcr.io/sbomify/sbomify` across `sbomify-backend`, `sbomify-migrations`, and `sbomify-worker`.
- `docs/deployment.md`: manual deployment `docker pull` / `docker inspect` / `cosign verify-attestation` snippet repointed to `ghcr.io/sbomify/sbomify`.
- `sbomify/apps/sboms/js/ci-cd-info.ts` (+ matching `.spec.ts` helpers and assertions): GitLab, Bitbucket, Azure, Jenkins, and generic `docker run` templates surfaced in the UI now reference `ghcr.io/sbomify/sbomify-action`.

Dual-registry push order is **unchanged** — Docker Hub still receives the same tags via the existing `docker login` (`username: sbomifyhub`) + `docker.io/sbomifyhub/...` mirror tag in the build step.

## Test plan

- [ ] CI passes on this branch
- [ ] On master push, the `docker-build` job still publishes to both `ghcr.io/sbomify/sbomify:latest` and `docker.io/sbomifyhub/sbomify:latest`
- [ ] Container SBOMs (staging + production) generated against the GHCR image resolve correctly
- [ ] `bun test sbomify/apps/sboms/js/ci-cd-info.spec.ts` passes (verified locally: 26 pass)
- [ ] Spot-check the in-app CI/CD info widget renders the new `ghcr.io/sbomify/sbomify-action` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)