### PR TITLE
fix(compliance): clean up Declaration of Conformity formatting

### DIFF
--- a/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
+++ b/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
@@ -70,11 +70,15 @@ The following artefacts accompanying this declaration demonstrate conformity:
 - `metadata/manifest.json` + `metadata/manifest.sha256` — per-file SHA-256 manifest + self-hash for integrity verification
 
 ---
-**Signed for and on behalf of:**
-**Place:** _______________
-**Date:** {{ date }}
-**Name:** _______________
-**Function:** _______________
-**Signature:** _______________
----
+
+## Signed for and on behalf of the manufacturer
+
+- **Place:** _______________
+- **Date:** {{ date }}
+- **Name:** _______________
+- **Function:** _______________
+- **Signature:** _______________
+
+***
+
 *This declaration is drawn up in accordance with CRA Article 28 and Annex V.*

--- a/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
+++ b/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
@@ -4,26 +4,20 @@
 
 ## 1. Product Identification
 
-**Name:** {{ product_name }}
-{% if product_description %}
-**Type/Model:** {{ product_description }}
-{% endif %}
-**Unique Identifier:** {{ product_uuid }}
+- **Name:** {{ product_name }}
+- **Unique Identifier:** {{ product_uuid }}
 
 ## 2. Manufacturer
 
-**Name:** {{ manufacturer_name }}
-{% if manufacturer_is_placeholder %}
+- **Name:** {{ manufacturer_name }}
+{% if manufacturer_address %}- **Address:** {{ manufacturer_address }}
+{% endif %}{% if manufacturer_email %}- **Email:** {{ manufacturer_email }}
+{% endif %}{% if manufacturer_website %}- **Website:** {{ manufacturer_website }}
+{% endif %}{% if manufacturer_is_placeholder %}
 > ⚠️  Annex V item 2 requires the manufacturer's legal name. This
 > placeholder MUST be replaced before the declaration is signed —
 > configure the manufacturer entity on the team profile and regenerate
 > the document.
-{% endif %}
-{% if manufacturer_address %}
-**Address:** {{ manufacturer_address }}
-{% endif %}
-{% if manufacturer_website %}
-**Website:** {{ manufacturer_website }}
 {% endif %}
 
 ## 3. Responsibility Statement
@@ -32,7 +26,9 @@ This EU declaration of conformity is issued under the sole responsibility of the
 
 ## 4. Object of Declaration
 
-{{ product_name }}{% if product_description %} — {{ product_description }}{% endif %}
+{{ product_name }}{% if product_description %}
+
+{{ product_description }}{% endif %}
 
 ## 5. Conformity Statement
 
@@ -54,10 +50,9 @@ The object of the declaration described above is in conformity with Regulation (
 
 ## 7. Conformity Assessment
 
-**Product Category:** {{ product_category_display }}
-**Procedure:** {{ conformity_procedure_display }}
-{% if support_period_end %}
-**Support Period Ends:** {{ support_period_end }} (Article 13(8))
+- **Product Category:** {{ product_category_display }}
+- **Procedure:** {{ conformity_procedure_display }}
+{% if support_period_end %}- **Support Period Ends:** {{ support_period_end }} (Article 13(8))
 {% endif %}
 
 ## 8. Supporting Documentation (Annex VII)

--- a/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
+++ b/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
@@ -10,10 +10,16 @@
 ## 2. Manufacturer
 
 - **Name:** {{ manufacturer_name }}
-{% if manufacturer_address %}- **Address:** {{ manufacturer_address }}
-{% endif %}{% if manufacturer_email %}- **Email:** {{ manufacturer_email }}
-{% endif %}{% if manufacturer_website %}- **Website:** {{ manufacturer_website }}
-{% endif %}{% if manufacturer_is_placeholder %}
+{% if manufacturer_address %}
+- **Address:** {{ manufacturer_address }}
+{% endif %}
+{% if manufacturer_email %}
+- **Email:** {{ manufacturer_email }}
+{% endif %}
+{% if manufacturer_website %}
+- **Website:** {{ manufacturer_website }}
+{% endif %}
+{% if manufacturer_is_placeholder %}
 > ⚠️  Annex V item 2 requires the manufacturer's legal name. This
 > placeholder MUST be replaced before the declaration is signed —
 > configure the manufacturer entity on the team profile and regenerate
@@ -52,7 +58,8 @@ The object of the declaration described above is in conformity with Regulation (
 
 - **Product Category:** {{ product_category_display }}
 - **Procedure:** {{ conformity_procedure_display }}
-{% if support_period_end %}- **Support Period Ends:** {{ support_period_end }} (Article 13(8))
+{% if support_period_end %}
+- **Support Period Ends:** {{ support_period_end }} (Article 13(8))
 {% endif %}
 
 ## 8. Supporting Documentation (Annex VII)

--- a/sbomify/apps/compliance/templates/compliance/cra_step_5.html.j2
+++ b/sbomify/apps/compliance/templates/compliance/cra_step_5.html.j2
@@ -241,7 +241,13 @@
                                 </div>
                             </template>
                             <template x-if="!isLoadingPreview">
-                                <div class="prose prose-sm max-w-none text-text prose-headings:text-text prose-strong:text-text prose-a:text-primary prose-code:text-text prose-table:text-sm prose-td:py-1 prose-th:py-1 prose-hr:border-border/50"
+                                {% comment %}
+                                prose-code:before/after override strips the literal backticks Tailwind Typography
+                                wraps inline-code spans with. They were rendering as visible characters around
+                                each path in DoC §8 (the markdown emits proper <code> spans; the backticks were
+                                CSS decoration, not template output).
+                                {% endcomment %}
+                                <div class="prose prose-sm max-w-none text-text prose-headings:text-text prose-strong:text-text prose-a:text-primary prose-code:text-text prose-code:before:content-none prose-code:after:content-none prose-table:text-sm prose-td:py-1 prose-th:py-1 prose-hr:border-border/50"
                                      x-html="previewContent"></div>
                             </template>
                         </div>


### PR DESCRIPTION
## Summary

Three formatting fixes to the CRA Declaration of Conformity template, surfaced while filling in real data on staging against the Lithium Python Stack product:

1. **Run-on lines in Sections 1, 2, 7.** Markdown collapses adjacent non-blank lines into a single paragraph, so

   ```jinja
   **Product Category:** {{ product_category_display }}
   **Procedure:** {{ conformity_procedure_display }}
   ```

   rendered as `Product Category: Default Procedure: Module A` on a single line. Switching each labelled field to a hyphenated bullet gives every entry its own `<li>` and makes the rendered DoC match the source. Same fix for Section 1 (Name / Unique Identifier) and Section 2 (Manufacturer block).

2. **Manufacturer email never rendered.** `manufacturer_email` was already in `_build_common_context()` but absent from the template — only Name, Address and Website were emitted. CRA Annex V Section 2 expects the manufacturer's electronic-address contact, so the new block walks Name → Address → Email → Website with each field guarded by its own `{% if %}`.

3. **Type/Model showed the product description.** The description was already the second paragraph of Section 4 (Object of Declaration); showing it again under a "Type/Model" label was both duplicative and semantically wrong — Annex V Section 1 expects a model/serial identifier, not free-text marketing copy. Section 1 now carries only Name + Unique Identifier; Section 4 keeps the description under the correct heading and now separates product name and description into two paragraphs.

## Before / After (against staging assessment `OpLwDQ4Brh2Q`)

**Before:**

```text
1. Product Identification
Name: Lithium CRA Test Co.
Type/Model: Lithium is a Django-based Python web application stack used as a CRA / SBOM compliance reference.
Unique Identifier: 640053c0-8ca7-42a0-8401-fe4b6c7dbaaf

2. Manufacturer
Name: Lithium CRA Test Co.

7. Conformity Assessment
Product Category: Default Procedure: Module A
Support Period Ends: 2027-12-31 (Article 13(8))
```

**After:**

```text
1. Product Identification
- Name: Lithium Python Stack
- Unique Identifier: 640053c0-8ca7-42a0-8401-fe4b6c7dbaaf

2. Manufacturer
- Name: Lithium Project
- Email: aurangzaib048@gmail.com
- Website: https://github.com/aurangzaib048/lithium

7. Conformity Assessment
- Product Category: Default
- Procedure: Module A
- Support Period Ends: 2027-12-31 (Article 13(8))
```

## Test plan

- [x] Pre-commit (ruff, mypy, bandit, typescript-check) passes
- [x] `test_document_generation.py` — 170 tests pass; assertions only check that DoC renders without error, no string assertions to update
- [x] Direct render via `Engine.get_template('declaration_of_conformity.md.dtl').render(Context(...))` produces the post-state markdown above
- [ ] Reviewer to regenerate DoC on a staging assessment and confirm the four-list rendering renders correctly through the in-app preview modal