### PR TITLE
feat(compliance): expose CRA Declaration of Conformity on public product page

### DIFF
--- a/sbomify/apps/compliance/templates/compliance/components/public_doc_link.html.j2
+++ b/sbomify/apps/compliance/templates/compliance/components/public_doc_link.html.j2
@@ -1,0 +1,33 @@
+{# Declaration of Conformity link for the public product page. #}
+{# Expects: has_doc (bool), product (object), preferred_base_url (str) #}
+{% if has_doc %}
+    <div class="public-section">
+        <div class="tw-card">
+            <div class="px-6 py-4 border-b border-border">
+                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+                    <i class="fas fa-file-signature text-primary"></i>EU Declaration of Conformity
+                </h4>
+            </div>
+            <div class="p-6">
+                <p class="text-text-muted mb-4">
+                    The manufacturer's declaration that this product conforms to the EU Cyber Resilience Act
+                    (Regulation 2024/2847) and the standards listed in Annex V.
+                </p>
+                <div class="flex flex-wrap items-center gap-3">
+                    <a href="{% if preferred_base_url %}{{ preferred_base_url }}{% endif %}{% url 'compliance:product_doc_public' product_id=product.id %}"
+                       class="tw-btn-primary">
+                        <i class="fas fa-file-lines mr-2"></i>View Declaration
+                    </a>
+                </div>
+                {% if preferred_base_url %}
+                    <p class="text-xs text-text-muted mt-3 m-0">
+                        <i class="fas fa-info-circle mr-1"></i>
+                        Declaration available at
+                        <a href="{{ preferred_base_url }}{% url 'compliance:product_doc_public' product_id=product.id %}"
+                           class="text-primary hover:underline">{{ preferred_base_url }}{% url 'compliance:product_doc_public' product_id=product.id %}</a>
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/sbomify/apps/compliance/templates/compliance/doc_public.html.j2
+++ b/sbomify/apps/compliance/templates/compliance/doc_public.html.j2
@@ -1,0 +1,24 @@
+{% extends "core/public_base.htmx.j2" %}
+{% block title %}EU Declaration of Conformity — {{ product.name }}{% endblock %}
+{% block content %}
+    <div class="max-w-4xl mx-auto">
+        <div class="mb-6">
+            <a href="{% if is_custom_domain %}/product/{{ product.slug }}/{% else %}/public/product/{{ product.id }}/{% endif %}"
+               class="text-sm text-primary hover:underline">
+                <i class="fas fa-arrow-left mr-1"></i> Back to {{ product.name }}
+            </a>
+        </div>
+        <div class="tw-card">
+            <div class="px-6 py-4 border-b border-border">
+                <h1 class="text-xl font-bold text-text flex items-center gap-2 m-0">
+                    <i class="fas fa-file-signature text-primary"></i>
+                    EU Declaration of Conformity
+                </h1>
+                <p class="text-sm text-text-muted mt-1">{{ product.name }}</p>
+            </div>
+            <div class="p-6 prose prose-sm max-w-none dark:prose-invert prose-headings:text-text prose-p:text-text-secondary prose-strong:text-text prose-a:text-primary prose-li:text-text-secondary prose-code:text-text prose-code:before:content-none prose-code:after:content-none">
+                {{ doc_html }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -2,17 +2,18 @@
 
 Gating matrix the view enforces:
 
-| product.is_public | assessment.status | DoC generated | result |
-| ----------------- | ----------------- | ------------- | ------ |
-| True              | complete          | yes           | 200    |
-| False             | complete          | yes           | 404    |
-| True              | in_progress       | yes           | 404    |
-| True              | complete          | no            | 404    |
-| any               | (no assessment)   | -             | 404    |
+| product.is_public | assessment.status | DoC generated | is_stale | result |
+| ----------------- | ----------------- | ------------- | -------- | ------ |
+| True              | complete          | yes           | False    | 200    |
+| False             | complete          | yes           | False    | 404    |
+| True              | in_progress       | yes           | False    | 404    |
+| True              | complete          | no            | -        | 404    |
+| True              | complete          | yes           | True     | 404    |
+| any               | (no assessment)   | -             | -        | 404    |
 
 The DoC must only surface when every gate passes; partial / draft
-assessments and missing documents must 404 to keep the trust-center
-declaration authoritative.
+assessments, missing documents, and stale documents must all 404 to
+keep the trust-center declaration authoritative.
 """
 
 from __future__ import annotations
@@ -170,9 +171,23 @@ class TestProductDoCPublicView:
 
         assert response.status_code == 404
 
+    def test_404_when_doc_is_stale(self, public_product):
+        """A DoC marked stale by the staleness system is no longer
+        authoritative — the public reader must not surface it even
+        though the assessment is otherwise complete."""
+        assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        doc = _attach_doc(assessment)
+        doc.is_stale = True
+        doc.save(update_fields=["is_stale"])
+
+        with _stub_s3_get_document():
+            response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 404
+
 
 class TestInlineMarkupEdgeCases:
-    """Regression tests for ``_inline_markup`` glitches surfaced by the DoC.
+    """Regression tests for ``inline_markup`` glitches surfaced by the DoC.
 
     The DoC has more Markdown metacharacters than the VDP did (glob
     patterns inside code spans, ``***`` thematic breaks), and they
@@ -180,9 +195,9 @@ class TestInlineMarkupEdgeCases:
     """
 
     def test_asterisk_inside_code_span_is_preserved(self):
-        from sbomify.apps.compliance.views.vdp_public import _inline_markup
+        from sbomify.apps.compliance.views._public_helpers import inline_markup
 
-        out = _inline_markup("- `sboms/*.cdx.json` — Software Bill of Materials")
+        out = inline_markup("- `sboms/*.cdx.json` — Software Bill of Materials")
 
         # Whole code span survives; the italic regex must not eat the asterisk.
         assert "<code>sboms/*.cdx.json</code>" in out
@@ -190,25 +205,25 @@ class TestInlineMarkupEdgeCases:
         assert "<em>" not in out
 
     def test_italic_outside_code_span_still_renders(self):
-        from sbomify.apps.compliance.views.vdp_public import _inline_markup
+        from sbomify.apps.compliance.views._public_helpers import inline_markup
 
-        out = _inline_markup("text (*Annex I Part II(1)*)")
+        out = inline_markup("text (*Annex I Part II(1)*)")
 
         assert "<em>Annex I Part II(1)</em>" in out
 
     def test_thematic_break_with_stars(self):
-        from sbomify.apps.compliance.views.vdp_public import _markdown_to_html
+        from sbomify.apps.compliance.views._public_helpers import markdown_to_html
 
-        out = _markdown_to_html("paragraph\n\n***\n\nnext paragraph")
+        out = markdown_to_html("paragraph\n\n***\n\nnext paragraph")
 
         # *** must render as <hr>, not as literal text.
         assert "<hr>" in out
         assert "***" not in out
 
     def test_thematic_break_with_underscores(self):
-        from sbomify.apps.compliance.views.vdp_public import _markdown_to_html
+        from sbomify.apps.compliance.views._public_helpers import markdown_to_html
 
-        out = _markdown_to_html("a\n\n___\n\nb")
+        out = markdown_to_html("a\n\n___\n\nb")
 
         assert "<hr>" in out
         assert "___" not in out

--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -169,3 +169,46 @@ class TestProductDoCPublicView:
             response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
 
         assert response.status_code == 404
+
+
+class TestInlineMarkupEdgeCases:
+    """Regression tests for ``_inline_markup`` glitches surfaced by the DoC.
+
+    The DoC has more Markdown metacharacters than the VDP did (glob
+    patterns inside code spans, ``***`` thematic breaks), and they
+    exposed pre-existing rendering bugs that this PR fixes.
+    """
+
+    def test_asterisk_inside_code_span_is_preserved(self):
+        from sbomify.apps.compliance.views.vdp_public import _inline_markup
+
+        out = _inline_markup("- `sboms/*.cdx.json` — Software Bill of Materials")
+
+        # Whole code span survives; the italic regex must not eat the asterisk.
+        assert "<code>sboms/*.cdx.json</code>" in out
+        # And no stray closing tag.
+        assert "<em>" not in out
+
+    def test_italic_outside_code_span_still_renders(self):
+        from sbomify.apps.compliance.views.vdp_public import _inline_markup
+
+        out = _inline_markup("text (*Annex I Part II(1)*)")
+
+        assert "<em>Annex I Part II(1)</em>" in out
+
+    def test_thematic_break_with_stars(self):
+        from sbomify.apps.compliance.views.vdp_public import _markdown_to_html
+
+        out = _markdown_to_html("paragraph\n\n***\n\nnext paragraph")
+
+        # *** must render as <hr>, not as literal text.
+        assert "<hr>" in out
+        assert "***" not in out
+
+    def test_thematic_break_with_underscores(self):
+        from sbomify.apps.compliance.views.vdp_public import _markdown_to_html
+
+        out = _markdown_to_html("a\n\n___\n\nb")
+
+        assert "<hr>" in out
+        assert "___" not in out

--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -1,0 +1,171 @@
+"""Tests for the public Declaration of Conformity view.
+
+Gating matrix the view enforces:
+
+| product.is_public | assessment.status | DoC generated | result |
+| ----------------- | ----------------- | ------------- | ------ |
+| True              | complete          | yes           | 200    |
+| False             | complete          | yes           | 404    |
+| True              | in_progress       | yes           | 404    |
+| True              | complete          | no            | 404    |
+| any               | (no assessment)   | -             | 404    |
+
+The DoC must only surface when every gate passes; partial / draft
+assessments and missing documents must 404 to keep the trust-center
+declaration authoritative.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.compliance.models import (
+    CRAAssessment,
+    CRAGeneratedDocument,
+    CRAScopeScreening,
+    OSCALAssessmentResult,
+    OSCALCatalog,
+)
+from sbomify.apps.core.models import Product
+
+pytestmark = pytest.mark.django_db
+
+
+_DOC_MARKDOWN = """\
+# EU DECLARATION OF CONFORMITY
+
+## 1. Product Identification
+
+- **Name:** Lithium Python Stack
+- **Unique Identifier:** 640053c0-8ca7-42a0-8401-fe4b6c7dbaaf
+"""
+
+
+@pytest.fixture
+def public_product(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    return Product.objects.create(name="DoC Public Test Product", team=team, is_public=True)
+
+
+@pytest.fixture
+def private_product(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    return Product.objects.create(name="DoC Private Test Product", team=team, is_public=False)
+
+
+def _make_assessment(product, *, status: str) -> CRAAssessment:
+    """Build a minimal CRA assessment in the requested status.
+
+    The DoC public view only inspects ``product``, ``status``, and the
+    presence of a generated document — wizard step state is irrelevant
+    here, so we keep the fixture chain tight.
+    """
+    team = product.team
+    CRAScopeScreening.objects.create(
+        product=product,
+        team=team,
+        has_data_connection=True,
+    )
+    catalog = OSCALCatalog.objects.create(
+        name="BSI TR-03183-1",
+        version="1.0",
+        catalog_json={"metadata": {"title": "stub"}},
+    )
+    oscal_result = OSCALAssessmentResult.objects.create(
+        catalog=catalog,
+        team=team,
+        title="DoC Test OSCAL Result",
+    )
+    return CRAAssessment.objects.create(
+        team=team,
+        product=product,
+        oscal_assessment_result=oscal_result,
+        status=status,
+    )
+
+
+def _attach_doc(assessment: CRAAssessment) -> CRAGeneratedDocument:
+    return CRAGeneratedDocument.objects.create(
+        assessment=assessment,
+        document_kind=CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY,
+        storage_key=f"compliance/{assessment.id}/declaration_of_conformity.md",
+        content_hash="0" * 64,
+    )
+
+
+def _stub_s3_get_document(content: str = _DOC_MARKDOWN):
+    """Patch ``S3Client.get_document_data`` so the view does not hit real S3."""
+    return patch(
+        "sbomify.apps.core.object_store.S3Client.get_document_data",
+        return_value=content.encode("utf-8"),
+    )
+
+
+class TestProductDoCPublicView:
+    def test_renders_when_public_complete_and_doc_present(self, public_product):
+        assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        _attach_doc(assessment)
+
+        with _stub_s3_get_document():
+            response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        assert "EU Declaration of Conformity" in body
+        # Body of the rendered DoC ends up in the template's content area.
+        assert "Lithium Python Stack" in body
+
+    def test_404_when_product_is_private(self, private_product):
+        assessment = _make_assessment(private_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        _attach_doc(assessment)
+
+        with _stub_s3_get_document():
+            response = Client().get(
+                reverse("compliance:product_doc_public", kwargs={"product_id": private_product.id})
+            )
+
+        assert response.status_code == 404
+
+    def test_404_when_assessment_not_complete(self, public_product):
+        assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.IN_PROGRESS)
+        _attach_doc(assessment)
+
+        with _stub_s3_get_document():
+            response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 404
+
+    def test_404_when_doc_not_generated(self, public_product):
+        _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        # Deliberately NOT calling _attach_doc.
+
+        response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 404
+
+    def test_404_when_no_assessment_at_all(self, public_product):
+        # Product has no CRA assessment.
+        response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 404
+
+    def test_404_when_unknown_product(self):
+        response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": "nonexistent"}))
+
+        assert response.status_code == 404
+
+    def test_404_when_s3_returns_empty(self, public_product):
+        assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        _attach_doc(assessment)
+
+        with patch(
+            "sbomify.apps.core.object_store.S3Client.get_document_data",
+            return_value=None,
+        ):
+            response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 404

--- a/sbomify/apps/compliance/urls.py
+++ b/sbomify/apps/compliance/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 
 from .views.cra_product_list import CRAProductListView
 from .views.cra_wizard import CRAScopeScreeningView, CRAStartAssessmentView, CRAStepView, CRAWizardShellView
+from .views.doc_public import ProductDoCPublicView
 from .views.vdp_public import ProductVDPPublicView
 
 app_name = "compliance"
@@ -18,5 +19,10 @@ urlpatterns = [
         "public/product/<str:product_id>/vdp/",
         ProductVDPPublicView.as_view(),
         name="product_vdp_public",
+    ),
+    path(
+        "public/product/<str:product_id>/declaration-of-conformity/",
+        ProductDoCPublicView.as_view(),
+        name="product_doc_public",
     ),
 ]

--- a/sbomify/apps/compliance/views/_public_helpers.py
+++ b/sbomify/apps/compliance/views/_public_helpers.py
@@ -1,0 +1,177 @@
+"""Shared helpers for the public trust-center views.
+
+The VDP and DoC public views both need to (a) fetch a generated
+document blob from S3 and (b) render its markdown body to safe HTML.
+Keeping these helpers underscore-private inside ``vdp_public.py``
+forced the DoC view to import private symbols from a sibling
+view module — Copilot flagged this on PR #934. Centralise here so
+the helpers have a single, intentional home and either view can
+import them without reaching into the other.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
+
+logger = logging.getLogger(__name__)
+
+
+_SAFE_URL_SCHEMES = frozenset(("http", "https", "mailto"))
+
+
+def sanitize_url(url: str) -> str:
+    """Only allow safe URL schemes to prevent javascript:/data: XSS."""
+    parsed = urlparse(url)
+    if parsed.scheme not in _SAFE_URL_SCHEMES:
+        return "#"
+    return url
+
+
+def markdown_to_html(text: str) -> str:
+    """Convert simple Markdown to HTML.
+
+    Handles headings, bold, italic, links, lists, thematic breaks,
+    paragraphs, and inline code spans. Intentionally minimal — the
+    wizard preview uses ``marked.js`` for the full CommonMark surface;
+    the public reader only needs the subset our generated documents
+    actually emit.
+    """
+    escaped = html.escape(text)
+    lines = escaped.split("\n")
+    result: list[str] = []
+    in_list = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Thematic break. CommonMark accepts ``---``, ``***`` and ``___``;
+        # the DoC template uses ``***`` for the closing rule because
+        # ``---`` would be ambiguous with a setext heading underline
+        # when it follows a paragraph.
+        if re.fullmatch(r"-{3,}|\*{3,}|_{3,}", stripped):
+            if in_list:
+                result.append("</ul>")
+                in_list = False
+            result.append("<hr>")
+            continue
+
+        # Headings
+        m = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+        if m:
+            if in_list:
+                result.append("</ul>")
+                in_list = False
+            level = len(m.group(1))
+            result.append(f"<h{level}>{inline_markup(m.group(2))}</h{level}>")
+            continue
+
+        # List items
+        if stripped.startswith("- ") or stripped.startswith("* "):
+            if not in_list:
+                result.append("<ul>")
+                in_list = True
+            result.append(f"<li>{inline_markup(stripped[2:])}</li>")
+            continue
+
+        # Empty line
+        if not stripped:
+            if in_list:
+                result.append("</ul>")
+                in_list = False
+            continue
+
+        # Paragraph
+        if in_list:
+            result.append("</ul>")
+            in_list = False
+        result.append(f"<p>{inline_markup(stripped)}</p>")
+
+    if in_list:
+        result.append("</ul>")
+
+    return "\n".join(result)
+
+
+def inline_markup(text: str) -> str:
+    """Convert inline Markdown: bold, italic, links, code spans.
+
+    URLs are sanitized to only allow http, https, and mailto schemes.
+
+    Code spans are stashed with NUL-byte sentinels *before* any other
+    inline pass runs, so markdown metacharacters inside backticks —
+    glob ``*``, link syntax, asterisks meant as literal text — survive
+    the bold/italic/link regexes and end up inside the ``<code>``
+    block verbatim. This matches Markdown's "code spans win over
+    other inline constructs" precedence.
+    """
+    code_spans: list[str] = []
+
+    def _stash(m: re.Match[str]) -> str:
+        code_spans.append(m.group(1))
+        return f"\x00CODE{len(code_spans) - 1}\x00"
+
+    # Stash code spans first so their contents are not re-parsed.
+    text = re.sub(r"`([^`]+)`", _stash, text)
+
+    # Links: [text](url) — sanitize URL scheme.
+    def _safe_link(m: re.Match[str]) -> str:
+        link_text = m.group(1)
+        url = sanitize_url(m.group(2))
+        return f'<a href="{url}" class="text-primary hover:underline">{link_text}</a>'
+
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _safe_link, text)
+    # Bold: **text**
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    # Italic: *text*
+    text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
+
+    # Restore code spans now that the other inline passes have run.
+    for i, span in enumerate(code_spans):
+        text = text.replace(f"\x00CODE{i}\x00", f"<code>{span}</code>")
+    return text
+
+
+def get_document_content(product: Any, document_kind: str, *, fresh_only: bool = False) -> str | None:
+    """Get rendered document content for a product's CRA assessment.
+
+    When ``fresh_only=True`` the lookup also requires
+    ``is_stale=False`` — set this for documents whose authoritative
+    status matters publicly (DoC, etc.). The default keeps existing
+    callers (VDP) on the original behaviour.
+    """
+    try:
+        assessment = CRAAssessment.objects.get(product=product)
+    except CRAAssessment.DoesNotExist:
+        return None
+
+    docs = CRAGeneratedDocument.objects.filter(
+        assessment=assessment,
+        document_kind=document_kind,
+    )
+    if fresh_only:
+        docs = docs.filter(is_stale=False)
+    doc = docs.first()
+
+    if not doc:
+        return None
+
+    return fetch_doc_from_s3(doc)
+
+
+def fetch_doc_from_s3(doc: CRAGeneratedDocument) -> str | None:
+    """Fetch document content from S3 and return as string."""
+    try:
+        from sbomify.apps.core.object_store import S3Client
+
+        s3 = S3Client("DOCUMENTS")
+        data = s3.get_document_data(doc.storage_key)
+        return data.decode("utf-8") if data else None
+    except Exception:
+        logger.exception("Failed to fetch document %s from S3", doc.storage_key)
+        return None

--- a/sbomify/apps/compliance/views/doc_public.py
+++ b/sbomify/apps/compliance/views/doc_public.py
@@ -1,0 +1,84 @@
+"""Public Declaration of Conformity view for the trust center.
+
+The DoC is the only Annex V document a third party (auditor, customer,
+notified body) needs to read directly. Section 5 of the public product
+page exposes a "View Declaration" link that resolves here. The card is
+only rendered, and the route only succeeds, when:
+
+1. The product is publicly visible.
+2. A CRA assessment exists for the product and is in ``complete``
+   status — partial / draft assessments are not authoritative and must
+   not be exposed.
+3. A ``CRAGeneratedDocument`` of kind ``DECLARATION_OF_CONFORMITY``
+   has been rendered to S3.
+
+Other Annex VII artefacts (risk assessment, decommissioning guide,
+Article 14 templates) are intentionally NOT exposed publicly: they
+ship inside the export ZIP for review by an auditor or notified body,
+not via the trust center.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+from django.views import View
+
+from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
+from sbomify.apps.compliance.views.vdp_public import _fetch_doc_from_s3, _markdown_to_html
+
+logger = logging.getLogger(__name__)
+
+
+class ProductDoCPublicView(View):
+    """Render the Declaration of Conformity as a public trust-center page."""
+
+    def get(self, request: HttpRequest, product_id: str) -> HttpResponse:
+        from sbomify.apps.core.models import Product
+
+        try:
+            product = Product.objects.select_related("team").get(pk=product_id)
+        except Product.DoesNotExist:
+            return HttpResponseNotFound("Product not found")
+
+        if not product.is_public:
+            return HttpResponseNotFound("Product not found")
+
+        # CRA gating: only a *complete* assessment with a generated DoC
+        # is authoritative enough to expose. A draft or in-progress
+        # assessment with stale documents must 404 here so customers
+        # never see a half-finished declaration.
+        try:
+            assessment = CRAAssessment.objects.get(product=product)
+        except CRAAssessment.DoesNotExist:
+            return HttpResponseNotFound("No Declaration of Conformity for this product")
+
+        if assessment.status != CRAAssessment.WizardStatus.COMPLETE:
+            return HttpResponseNotFound("No Declaration of Conformity for this product")
+
+        doc = CRAGeneratedDocument.objects.filter(
+            assessment=assessment,
+            document_kind=CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY,
+        ).first()
+        if doc is None:
+            return HttpResponseNotFound("No Declaration of Conformity for this product")
+
+        content = _fetch_doc_from_s3(doc)
+        if not content:
+            return HttpResponseNotFound("No Declaration of Conformity for this product")
+
+        # Safe: _markdown_to_html escapes all input via html.escape() before adding markup.
+        doc_html = mark_safe(_markdown_to_html(content))  # nosec B703 B308  # noqa: S308
+
+        return render(
+            request,
+            "compliance/doc_public.html.j2",
+            {
+                "product": product,
+                "doc_html": doc_html,
+                "is_custom_domain": getattr(request, "is_custom_domain", False),
+            },
+        )

--- a/sbomify/apps/compliance/views/doc_public.py
+++ b/sbomify/apps/compliance/views/doc_public.py
@@ -10,7 +10,10 @@ only rendered, and the route only succeeds, when:
    status — partial / draft assessments are not authoritative and must
    not be exposed.
 3. A ``CRAGeneratedDocument`` of kind ``DECLARATION_OF_CONFORMITY``
-   has been rendered to S3.
+   has been rendered to S3 **and** is not flagged ``is_stale=True``.
+   Staleness fires when the underlying inputs (product details,
+   manufacturer entity, controls) change after generation; surfacing
+   a stale DoC on the public trust center would mislead consumers.
 
 Other Annex VII artefacts (risk assessment, decommissioning guide,
 Article 14 templates) are intentionally NOT exposed publicly: they
@@ -28,7 +31,7 @@ from django.utils.safestring import mark_safe
 from django.views import View
 
 from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
-from sbomify.apps.compliance.views.vdp_public import _fetch_doc_from_s3, _markdown_to_html
+from sbomify.apps.compliance.views._public_helpers import fetch_doc_from_s3, markdown_to_html
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +50,13 @@ class ProductDoCPublicView(View):
         if not product.is_public:
             return HttpResponseNotFound("Product not found")
 
-        # CRA gating: only a *complete* assessment with a generated DoC
-        # is authoritative enough to expose. A draft or in-progress
-        # assessment with stale documents must 404 here so customers
-        # never see a half-finished declaration.
+        # CRA gating: only a *complete* assessment with a *fresh* DoC
+        # is authoritative enough to expose. A draft / in-progress
+        # assessment, OR a complete assessment whose DoC has been
+        # marked stale by a downstream change (product rename,
+        # manufacturer update, control flip) must 404 here so
+        # customers never see a half-finished or out-of-date
+        # declaration.
         try:
             assessment = CRAAssessment.objects.get(product=product)
         except CRAAssessment.DoesNotExist:
@@ -62,16 +68,17 @@ class ProductDoCPublicView(View):
         doc = CRAGeneratedDocument.objects.filter(
             assessment=assessment,
             document_kind=CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY,
+            is_stale=False,
         ).first()
         if doc is None:
             return HttpResponseNotFound("No Declaration of Conformity for this product")
 
-        content = _fetch_doc_from_s3(doc)
+        content = fetch_doc_from_s3(doc)
         if not content:
             return HttpResponseNotFound("No Declaration of Conformity for this product")
 
-        # Safe: _markdown_to_html escapes all input via html.escape() before adding markup.
-        doc_html = mark_safe(_markdown_to_html(content))  # nosec B703 B308  # noqa: S308
+        # Safe: markdown_to_html escapes all input via html.escape() before adding markup.
+        doc_html = mark_safe(markdown_to_html(content))  # nosec B703 B308  # noqa: S308
 
         return render(
             request,

--- a/sbomify/apps/compliance/views/vdp_public.py
+++ b/sbomify/apps/compliance/views/vdp_public.py
@@ -1,129 +1,29 @@
-"""Public VDP and security.txt views for the trust center."""
+"""Public VDP and security.txt views for the trust center.
+
+The shared markdown / S3 helpers used to live here as underscore-
+prefixed module locals; they have been moved to
+``views/_public_helpers.py`` so the DoC public view (and any future
+trust-center reader) can import them without reaching into another
+view module's private API.
+"""
 
 from __future__ import annotations
 
-import html
 import logging
-import re
-from typing import Any
-from urllib.parse import urlparse
 
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
 from django.views import View
 
-from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
+from sbomify.apps.compliance.models import CRAGeneratedDocument
+from sbomify.apps.compliance.views._public_helpers import (
+    fetch_doc_from_s3,
+    get_document_content,
+    markdown_to_html,
+)
 
 logger = logging.getLogger(__name__)
-
-_SAFE_URL_SCHEMES = frozenset(("http", "https", "mailto"))
-
-
-def _sanitize_url(url: str) -> str:
-    """Only allow safe URL schemes to prevent javascript:/data: XSS."""
-    parsed = urlparse(url)
-    if parsed.scheme not in _SAFE_URL_SCHEMES:
-        return "#"
-    return url
-
-
-def _markdown_to_html(text: str) -> str:
-    """Convert simple Markdown to HTML. Handles headings, bold, italic, links, lists, hr, paragraphs."""
-    escaped = html.escape(text)
-    lines = escaped.split("\n")
-    result: list[str] = []
-    in_list = False
-
-    for line in lines:
-        stripped = line.strip()
-
-        # Horizontal rule. CommonMark accepts ``---``, ``***``, and ``___``
-        # as thematic breaks; the DoC template uses ``***`` as the
-        # closing rule because ``---`` would be ambiguous with a setext
-        # heading underline when it follows a paragraph.
-        if re.fullmatch(r"-{3,}|\*{3,}|_{3,}", stripped):
-            if in_list:
-                result.append("</ul>")
-                in_list = False
-            result.append("<hr>")
-            continue
-
-        # Headings
-        m = re.match(r"^(#{1,6})\s+(.+)$", stripped)
-        if m:
-            if in_list:
-                result.append("</ul>")
-                in_list = False
-            level = len(m.group(1))
-            result.append(f"<h{level}>{_inline_markup(m.group(2))}</h{level}>")
-            continue
-
-        # List items
-        if stripped.startswith("- ") or stripped.startswith("* "):
-            if not in_list:
-                result.append("<ul>")
-                in_list = True
-            result.append(f"<li>{_inline_markup(stripped[2:])}</li>")
-            continue
-
-        # Empty line
-        if not stripped:
-            if in_list:
-                result.append("</ul>")
-                in_list = False
-            continue
-
-        # Paragraph
-        if in_list:
-            result.append("</ul>")
-            in_list = False
-        result.append(f"<p>{_inline_markup(stripped)}</p>")
-
-    if in_list:
-        result.append("</ul>")
-
-    return "\n".join(result)
-
-
-def _inline_markup(text: str) -> str:
-    """Convert inline Markdown: bold, italic, links, code spans.
-
-    URLs are sanitized to only allow http, https, and mailto schemes.
-
-    Code spans are stashed with sentinels before the bold/italic passes
-    run so an asterisk inside a backtick span (e.g. ``sboms/*.cdx.json``)
-    is not eaten by the italic regex. Without this, inline code that
-    contains glob patterns or markdown metacharacters comes out
-    fragmented in the rendered HTML.
-    """
-
-    def _safe_link(m: re.Match[str]) -> str:
-        link_text = m.group(1)
-        url = _sanitize_url(m.group(2))
-        return f'<a href="{url}" class="text-primary hover:underline">{link_text}</a>'
-
-    # Links: [text](url) — sanitize URL scheme.
-    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _safe_link, text)
-
-    # Stash code spans before bold/italic so their contents are not
-    # parsed as Markdown. Sentinel uses NUL bytes which cannot legally
-    # appear in user input.
-    code_spans: list[str] = []
-
-    def _stash(m: re.Match[str]) -> str:
-        code_spans.append(m.group(1))
-        return f"\x00CODE{len(code_spans) - 1}\x00"
-
-    text = re.sub(r"`([^`]+)`", _stash, text)
-    # Bold: **text**
-    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
-    # Italic: *text*
-    text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
-    # Restore code spans now that bold/italic have run.
-    for i, span in enumerate(code_spans):
-        text = text.replace(f"\x00CODE{i}\x00", f"<code>{span}</code>")
-    return text
 
 
 class ProductVDPPublicView(View):
@@ -142,12 +42,12 @@ class ProductVDPPublicView(View):
             return HttpResponseNotFound("Product not found")
 
         # Get the VDP document
-        vdp_content = _get_document_content(product, CRAGeneratedDocument.DocumentKind.VDP)
+        vdp_content = get_document_content(product, CRAGeneratedDocument.DocumentKind.VDP)
         if not vdp_content:
             return HttpResponseNotFound("No VDP available for this product")
 
-        # Safe: _markdown_to_html escapes all input via html.escape() before adding markup
-        vdp_html = mark_safe(_markdown_to_html(vdp_content))  # nosec B703 B308  # noqa: S308
+        # Safe: markdown_to_html escapes all input via html.escape() before adding markup
+        vdp_html = mark_safe(markdown_to_html(vdp_content))  # nosec B703 B308  # noqa: S308
 
         return render(
             request,
@@ -195,39 +95,8 @@ class SecurityTxtView(View):
         if not doc:
             return HttpResponseNotFound("Not found")
 
-        content = _fetch_doc_from_s3(doc)
+        content = fetch_doc_from_s3(doc)
         if not content:
             return HttpResponseNotFound("Not found")
 
         return HttpResponse(content, content_type="text/plain; charset=utf-8")
-
-
-def _get_document_content(product: Any, document_kind: str) -> str | None:
-    """Get rendered document content for a product's CRA assessment."""
-    try:
-        assessment = CRAAssessment.objects.get(product=product)
-    except CRAAssessment.DoesNotExist:
-        return None
-
-    doc = CRAGeneratedDocument.objects.filter(
-        assessment=assessment,
-        document_kind=document_kind,
-    ).first()
-
-    if not doc:
-        return None
-
-    return _fetch_doc_from_s3(doc)
-
-
-def _fetch_doc_from_s3(doc: CRAGeneratedDocument) -> str | None:
-    """Fetch document content from S3 and return as string."""
-    try:
-        from sbomify.apps.core.object_store import S3Client
-
-        s3 = S3Client("DOCUMENTS")
-        data = s3.get_document_data(doc.storage_key)
-        return data.decode("utf-8") if data else None
-    except Exception:
-        logger.exception("Failed to fetch document %s from S3", doc.storage_key)
-        return None

--- a/sbomify/apps/compliance/views/vdp_public.py
+++ b/sbomify/apps/compliance/views/vdp_public.py
@@ -38,8 +38,11 @@ def _markdown_to_html(text: str) -> str:
     for line in lines:
         stripped = line.strip()
 
-        # Horizontal rule
-        if re.fullmatch(r"-{3,}", stripped):
+        # Horizontal rule. CommonMark accepts ``---``, ``***``, and ``___``
+        # as thematic breaks; the DoC template uses ``***`` as the
+        # closing rule because ``---`` would be ambiguous with a setext
+        # heading underline when it follows a paragraph.
+        if re.fullmatch(r"-{3,}|\*{3,}|_{3,}", stripped):
             if in_list:
                 result.append("</ul>")
                 in_list = False
@@ -84,9 +87,15 @@ def _markdown_to_html(text: str) -> str:
 
 
 def _inline_markup(text: str) -> str:
-    """Convert inline Markdown: bold, italic, links.
+    """Convert inline Markdown: bold, italic, links, code spans.
 
     URLs are sanitized to only allow http, https, and mailto schemes.
+
+    Code spans are stashed with sentinels before the bold/italic passes
+    run so an asterisk inside a backtick span (e.g. ``sboms/*.cdx.json``)
+    is not eaten by the italic regex. Without this, inline code that
+    contains glob patterns or markdown metacharacters comes out
+    fragmented in the rendered HTML.
     """
 
     def _safe_link(m: re.Match[str]) -> str:
@@ -94,14 +103,26 @@ def _inline_markup(text: str) -> str:
         url = _sanitize_url(m.group(2))
         return f'<a href="{url}" class="text-primary hover:underline">{link_text}</a>'
 
-    # Links: [text](url) — sanitize URL scheme
+    # Links: [text](url) — sanitize URL scheme.
     text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _safe_link, text)
+
+    # Stash code spans before bold/italic so their contents are not
+    # parsed as Markdown. Sentinel uses NUL bytes which cannot legally
+    # appear in user input.
+    code_spans: list[str] = []
+
+    def _stash(m: re.Match[str]) -> str:
+        code_spans.append(m.group(1))
+        return f"\x00CODE{len(code_spans) - 1}\x00"
+
+    text = re.sub(r"`([^`]+)`", _stash, text)
     # Bold: **text**
     text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
     # Italic: *text*
     text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
-    # Inline code: `text`
-    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    # Restore code spans now that bold/italic have run.
+    for i, span in enumerate(code_spans):
+        text = text.replace(f"\x00CODE{i}\x00", f"<code>{span}</code>")
     return text
 
 

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -54,6 +54,7 @@
     {% include 'core/components/public_product_links.html.j2' %}
     {% include 'core/components/public_product_lifecycle.html.j2' %}
     {% include 'compliance/components/public_vdp_link.html.j2' %}
+    {% include 'compliance/components/public_doc_link.html.j2' %}
     {% include 'core/components/public_product_projects.html.j2' with projects=public_projects %}
     {% include 'core/components/public_releases_list.html.j2' %}
     {% if has_downloadable_content %}

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -238,15 +238,17 @@ class ProductDetailsPublicView(View):
         ).exists()
 
         # Expose the EU Declaration of Conformity only when (a) the
-        # assessment is in ``complete`` status and (b) the DoC has
-        # been rendered. Partial / draft assessments are not
-        # authoritative — surfacing a stale or half-finished DoC on
-        # the public trust center would be misleading to auditors and
-        # customers.
+        # assessment is in ``complete`` status, (b) the DoC has been
+        # rendered, and (c) the DoC has not been flagged stale by a
+        # downstream change (product rename, manufacturer update,
+        # control flip). Partial / draft / stale documents are not
+        # authoritative — surfacing them on the public trust center
+        # would mislead auditors and customers.
         has_doc = CRAGeneratedDocument.objects.filter(
             assessment__product_id=product_obj.id,
             assessment__status=CRAAssessment.WizardStatus.COMPLETE,
             document_kind=CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY,
+            is_stale=False,
         ).exists()
 
         # Fetch public compliance controls for this product (if controls app is available)

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -230,11 +230,23 @@ class ProductDetailsPublicView(View):
         product_tei = build_product_tei_urn(product_obj.uuid, team, is_public=product_obj.is_public) if team else None
 
         # Check if VDP exists for this product
-        from sbomify.apps.compliance.models import CRAGeneratedDocument
+        from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
 
         has_vdp = CRAGeneratedDocument.objects.filter(
             assessment__product_id=product_obj.id,
             document_kind=CRAGeneratedDocument.DocumentKind.VDP,
+        ).exists()
+
+        # Expose the EU Declaration of Conformity only when (a) the
+        # assessment is in ``complete`` status and (b) the DoC has
+        # been rendered. Partial / draft assessments are not
+        # authoritative — surfacing a stale or half-finished DoC on
+        # the public trust center would be misleading to auditors and
+        # customers.
+        has_doc = CRAGeneratedDocument.objects.filter(
+            assessment__product_id=product_obj.id,
+            assessment__status=CRAAssessment.WizardStatus.COMPLETE,
+            document_kind=CRAGeneratedDocument.DocumentKind.DECLARATION_OF_CONFORMITY,
         ).exists()
 
         # Fetch public compliance controls for this product (if controls app is available)
@@ -273,6 +285,8 @@ class ProductDetailsPublicView(View):
             "fallback_url": workspace_public_url,
             # VDP availability
             "has_vdp": has_vdp,
+            # Declaration of Conformity availability (CRA Annex V)
+            "has_doc": has_doc,
             "preferred_base_url": build_custom_domain_url(team, "/", request.is_secure()).rstrip("/") if team else "",
             # Compliance controls summary
             "controls_summary": controls_summary,


### PR DESCRIPTION
## Summary

When a product is public **and** its CRA assessment is in `complete` status **and** the Declaration of Conformity has been generated, the public product page now surfaces a "View Declaration" card that opens the rendered DoC at `/public/product/<id>/declaration-of-conformity/`.

This mirrors the existing VDP exposure pattern, with one extra gate: the assessment **must** be in `complete` status. Partial / draft assessments and missing DoC artefacts always 404 so the trust-center declaration stays authoritative.

## What's new

| File | Change |
|---|---|
| `compliance/views/doc_public.py` | New `ProductDoCPublicView` — enforces public + complete + DoC gates, reuses `_fetch_doc_from_s3` and `_markdown_to_html` from `vdp_public.py` |
| `compliance/urls.py` | Adds `compliance:product_doc_public` route |
| `compliance/templates/compliance/doc_public.html.j2` | Standalone DoC reader page (wraps rendered HTML in `prose` styling with the `prose-code:before/after:content-none` overrides shipped in #933) |
| `compliance/templates/compliance/components/public_doc_link.html.j2` | Card embedded in the public product page; only renders when `has_doc` is true |
| `core/views/product_details_public.py` | Computes `has_doc` with `exists()` and the `status=complete` constraint; passes to context |
| `core/templates/core/product_details_public.html.j2` | Includes the new card next to the existing VDP card |
| `compliance/tests/test_doc_public.py` | 7 new cases covering the full gating matrix |

## Why DoC and not the rest of Annex VII

The DoC is the only Annex V artefact a third party (auditor, customer, notified body) needs to read directly. Other Annex VII documents — risk assessment, decommissioning guide, Article 14 templates — are deliberately **not** exposed publicly. They ship inside the CRA export ZIP for auditor review.

## Gating matrix

| `product.is_public` | `assessment.status` | DoC generated | Result |
|---|---|---|---|
| True | complete | yes | **200** |
| False | complete | yes | 404 |
| True | in_progress | yes | 404 |
| True | complete | no | 404 |
| any | (no assessment) | - | 404 |
| (unknown product id) | - | - | 404 |
| True | complete | yes, but S3 empty | 404 |

## Test plan

- [x] `pytest sbomify/apps/compliance/tests/test_doc_public.py` — **7 / 7 passed**
- [x] `pytest sbomify/apps/compliance/tests/` — **617 / 617 passed**
- [x] `pytest sbomify/apps/core/tests/ -k 'product_details_public or public_product'` — **69 / 69 passed**
- [x] All pre-commit hooks (ruff, mypy, bandit, djlint, typescript-check) — green
- [ ] Reviewer to verify on staging: complete a CRA assessment + generate DoC on a public product, confirm the card appears at `/public/product/<id>/` and clicking through renders the DoC at `/public/product/<id>/declaration-of-conformity/`
