### PR TITLE
test(emails): cover new_user_email in send_test_emails

### DIFF
--- a/sbomify/apps/core/management/commands/send_test_emails.py
+++ b/sbomify/apps/core/management/commands/send_test_emails.py
@@ -239,6 +239,29 @@ class Command(BaseCommand):
                     "invitation": mock_invitation,
                 },
             },
+            # Sent from ``teams/signals.py`` once the post-signup trial
+            # subscription is provisioned. The signal is gated behind
+            # Stripe + a real User row, so the management command
+            # synthesises the same context the signal would build and
+            # exercises the template directly. Without this entry the
+            # path is silently untested.
+            {
+                "subject": "Welcome to sbomify",
+                "template_html": "teams/emails/new_user_email.html.j2",
+                "template_txt": "teams/emails/new_user_email.txt",
+                "context": {
+                    **base_context,
+                    "user": mock_user,
+                    "team": mock_team,
+                    "TRIAL_PERIOD_DAYS": 14,
+                    "trial_end_date": timezone.now() + timedelta(days=14),
+                    "plan_limits": {
+                        "max_products": 10,
+                        "max_projects": 25,
+                        "max_components": 100,
+                    },
+                },
+            },
             # Onboarding emails
             {
                 "subject": "Welcome to sbomify - Let's Get Started!",

--- a/sbomify/apps/core/management/commands/send_test_emails.py
+++ b/sbomify/apps/core/management/commands/send_test_emails.py
@@ -46,6 +46,15 @@ class Command(BaseCommand):
         website_base_url = normalize_base_url(getattr(settings, "WEBSITE_BASE_URL", base_url))
         recipient = options["recipient"]
 
+        # Mirror the production trial length so the rendered email
+        # text matches what a real signup would see — ``teams/signals.py``
+        # builds its context from ``settings.TRIAL_PERIOD_DAYS``, and
+        # hard-coding a different value here would silently drift the
+        # moment that setting changes. ``14`` is a safe fallback for
+        # ``test_settings`` / dev shells that haven't loaded the env.
+        trial_period_days = int(getattr(settings, "TRIAL_PERIOD_DAYS", 14))
+        trial_end_date = timezone.now() + timedelta(days=trial_period_days)
+
         # Mock data for templates
         mock_team = type("Team", (), {"name": "Acme Corp", "key": "acme-corp"})()
         mock_user = type(
@@ -253,8 +262,8 @@ class Command(BaseCommand):
                     **base_context,
                     "user": mock_user,
                     "team": mock_team,
-                    "TRIAL_PERIOD_DAYS": 14,
-                    "trial_end_date": timezone.now() + timedelta(days=14),
+                    "TRIAL_PERIOD_DAYS": trial_period_days,
+                    "trial_end_date": trial_end_date,
                     "plan_limits": {
                         "max_products": 10,
                         "max_projects": 25,
@@ -274,8 +283,8 @@ class Command(BaseCommand):
                     "workspace_name": "Acme Corp",
                     "app_base_url": base_url,
                     "is_trial": True,
-                    "trial_end_date": timezone.now() + timedelta(days=14),
-                    "TRIAL_PERIOD_DAYS": 14,
+                    "trial_end_date": trial_end_date,
+                    "TRIAL_PERIOD_DAYS": trial_period_days,
                     "plan_limits": {
                         "max_products": 10,
                         "max_projects": 25,


### PR DESCRIPTION
## Summary

The ``send_test_emails`` management command exercised 18 of the 20 production email templates. ``teams/emails/new_user_email`` (the post-signup welcome triggered from ``teams/signals.py:78-86`` once the trial subscription provisions) was the only live template not covered. This PR adds a synthesised context block that mirrors what the signal builds and renders both HTML + text variants the same way.

Locally the command now reports ``Emails sent: 21/21`` against MailHog. Confirms every templated production email path can render and dispatch cleanly through SMTP.

## Coverage now

| Template | Status |
|---|---|
| 20 production templates | All covered by ``send_test_emails`` |
| ``billing/emails/test_template.html.j2`` | Orphan — only used by ``billing/tests/test_email_notifications.py``, no production trigger. Out of scope here. |
| Support contact + Enterprise inquiry | Programmatic ``EmailMessage`` (no template), still go through the same SMTP path. Out of scope here. |

## Test plan

- [x] ``docker compose exec sbomify-backend uv run python manage.py send_test_emails --recipient=test@example.com`` reports ``Emails sent: 21/21`` with MailHog running
- [x] MailHog UI shows the new "Welcome to sbomify" message rendered with the trial period, end date, and plan limits substituted in
- [x] ``ruff check`` clean
- [x] No regressions in the existing 18 entries