### PR TITLE
fix(scheduler): drop Redis lock for cron scheduler — TLS-incompatible

### DIFF
--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -463,13 +463,16 @@ DRAMATIQ_RESULT_BACKEND = {
     "BACKEND_OPTIONS": _dramatiq_redis_options,
 }
 
-# Redis-backed lock for the cron scheduler. The dedicated `sbomify-scheduler`
-# service runs `manage.py crontab` with replicas pinned to 1, so the lock
-# isn't strictly required today — but it makes accidental scaling safe (any
-# extra replica exits cleanly with "Another scheduler is already running.").
-DRAMATIQ_CRONTAB = {
-    "REDIS_URL": REDIS_WORKER_URL,
-}
+# Single-leader scheduling is enforced by `replicas: 1` on the
+# `sbomify-scheduler` Compose service (and the equivalent in any prod
+# orchestrator). We deliberately do NOT configure DRAMATIQ_CRONTAB.REDIS_URL
+# because upstream `dramatiq-crontab` builds its Redis lock via
+# `redis.Redis.from_url(url)` with no API for `ssl_ca_certs` — that fails
+# SSL handshake against private-CA Redis (rediss:// + REDIS_CA_CERTS), which
+# is how prod is deployed. Without REDIS_URL the package falls back to
+# FakeLock; brief overlap during rolling deploys is safe because every
+# scheduled actor is either idempotent (scans, purges, health checks) or
+# has actor-level dedup (OnboardingEmail unique_together for drip emails).
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
## Summary

Follow-up to #940. The cron scheduler container crash-loops in prod with:

```
redis.exceptions.ConnectionError: Error 1 connecting to redis-00.svc.hel1.internal:6379.
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
```

Root cause: upstream `dramatiq-crontab` builds its scheduler-leadership lock at module-import time via `redis.Redis.from_url(redis_url)`, with no API for passing `ssl_ca_certs`. Against private-CA Redis (`rediss://` + `REDIS_CA_CERTS`, how prod is deployed) the SSL handshake fails on first lock acquisition.

This PR removes `DRAMATIQ_CRONTAB.REDIS_URL` so the package falls back to its `FakeLock` (no-op) and the scheduler container starts cleanly.

## Why FakeLock is safe

The Redis lock was **defense-in-depth against accidental scaling, not on the firing path**. Removing it does not change steady-state cron behavior:

- Single-leader scheduling is enforced by `replicas: 1` on the `sbomify-scheduler` Compose service (and the equivalent in any prod orchestrator).
- Cron jobs continue to fire on schedule — APScheduler ticks the clock and calls `actor.send()` with or without a lock.

The only new risk is brief duplicate firing during rolling deploys (when an old scheduler container overlaps with a new one). Every scheduled actor handles this gracefully:

| Actor | Why two-fire is benign |
|---|---|
| `daily_onboarding_reminders` → drip cascade | `OnboardingEmail.unique_together(\"user\", \"email_type\")` prevents double-insert; service code catches `IntegrityError` |
| `purge_soft_deleted_users` | Filtered DELETE — second fire's `filter()` finds nothing |
| `daily_stale_trial_check` | Idempotent — Stripe API read, DB sync to same state |
| `daily_osv_scan_task`, `weekly_osv_scan_task`, `hourly_dt_scan_task` | Plugin orchestrator already has \"reuse existing run\" logic |
| `check_dependency_track_health_task` | Idempotent HTTP probe |
| `periodic_domain_verification` | Backoff logic skips already-recently-checked domains |
| `heartbeat` | Cosmetic |

## Verification

- ✅ Scheduler container restarts cleanly: `Loaded tasks from … sbomify.apps.onboarding.`, `Scheduling heartbeat.`, `Starting scheduler…` (no `Acquiring lock…` line — `FakeLock.__enter__` is a no-op)
- ✅ `type(dramatiq_crontab.utils.lock).__name__` → `FakeLock`
- ✅ Manual fire of `daily_onboarding_reminders.send()` → worker processed `[TASK_process_all_onboarding_reminders] Starting comprehensive onboarding email processing` end-to-end

## Recommended deploy strategy

Use a deployment strategy that minimises overlap of two scheduler containers:
- **k8s**: `Deployment.spec.strategy.type: Recreate` for `sbomify-scheduler` (terminate old before starting new — brief downtime, zero overlap)
- **Compose**: default `up --force-recreate` already terminates before starting

## Out of scope (recommended follow-up)

File an issue + PR upstream against [voiio/dramatiq-crontab](https://github.com/voiio/dramatiq-crontab) to accept a pre-built Redis client in `DRAMATIQ_CRONTAB` settings (analogous to how dramatiq's `RedisBroker` accepts `OPTIONS[\"client\"]`). Once merged, we can reinstate real Redis-based leadership using the same TLS-aware client construction we already use for the broker (`_dramatiq_redis_options`).

## Test plan

- [ ] CI green (ruff, mypy, bandit pass)
- [ ] `docker compose up -d sbomify-scheduler` boots without SSL handshake errors in prod-like env (rediss:// + REDIS_CA_CERTS)
- [ ] Scheduler logs show `Starting scheduler…` (with no `Acquiring lock…` line)
- [ ] `dramatiq_crontab.utils.lock` is a `FakeLock` instance
- [ ] Existing cron jobs continue to fire on schedule