### PR TITLE
fix(onboarding): cap drip eligibility at ONBOARDING_DRIP_MAX_AGE_DAYS

### DIFF
--- a/sbomify/apps/onboarding/models.py
+++ b/sbomify/apps/onboarding/models.py
@@ -102,19 +102,49 @@ class OnboardingStatus(models.Model):
         """Calculate days since user signup."""
         return (timezone.now() - self.created_at).days
 
+    @property
+    def is_drip_window_expired(self) -> bool:
+        """Past the signup-anchored window in which drip emails still make sense.
+
+        Caps eligibility for `quick_start`, `first_component`, and `collaboration`.
+        Without this, a long scheduler outage would cause every backlog user
+        to receive every drip type simultaneously when the scheduler comes online.
+        """
+        from django.conf import settings
+
+        return self.days_since_signup > settings.ONBOARDING_DRIP_MAX_AGE_DAYS
+
+    @property
+    def is_first_sbom_window_expired(self) -> bool:
+        """Past the first-component-anchored window for the SBOM upload reminder.
+
+        Anchored separately from signup: a user who creates a component late but
+        never uploads an SBOM should still get the reminder within the window
+        following the component creation.
+        """
+        from django.conf import settings
+
+        if self.first_component_created_at is None:
+            return False
+        days_since_component = (timezone.now() - self.first_component_created_at).days
+        return days_since_component > settings.ONBOARDING_DRIP_MAX_AGE_DAYS
+
     def should_receive_component_reminder(self, days_threshold: int = 3) -> bool:
         """
         Check if user should receive BOM component creation reminder.
 
         Only for workspace owners who:
         - Have had welcome email sent
-        - Signed up X+ days ago
+        - Signed up X+ days ago (and within the drip window)
         - Haven't created any BOM components in their workspace
         """
         if not self.welcome_email_sent:
             return False
 
         if self.days_since_signup < days_threshold:
+            return False
+
+        if self.is_drip_window_expired:
             return False
 
         # Check if user is a workspace owner
@@ -140,12 +170,15 @@ class OnboardingStatus(models.Model):
 
         Only for workspace owners who:
         - Have had welcome email sent
-        - Signed up at least 1 day ago
+        - Signed up at least 1 day ago (and within the drip window)
         """
         if not self.welcome_email_sent:
             return False
 
         if self.user_role != "owner":
+            return False
+
+        if self.is_drip_window_expired:
             return False
 
         return self.days_since_signup >= days_threshold
@@ -156,13 +189,16 @@ class OnboardingStatus(models.Model):
 
         Only for workspace owners who:
         - Have had welcome email sent
-        - Signed up 10+ days ago
+        - Signed up 10+ days ago (and within the drip window)
         - Are still the only member in their workspace (no invites sent)
         """
         if not self.welcome_email_sent:
             return False
 
         if self.days_since_signup < days_threshold:
+            return False
+
+        if self.is_drip_window_expired:
             return False
 
         if self.user_role != "owner":
@@ -183,7 +219,7 @@ class OnboardingStatus(models.Model):
 
         Only for workspace owners who:
         - Have created components
-        - Created components X+ days ago
+        - Created components X+ days ago (and within the drip window)
         - Haven't uploaded any SBOMs to their workspace
         """
         if not self.has_created_component:
@@ -194,6 +230,9 @@ class OnboardingStatus(models.Model):
 
         days_since_component = (timezone.now() - self.first_component_created_at).days
         if days_since_component < days_threshold:
+            return False
+
+        if self.is_first_sbom_window_expired:
             return False
 
         # Check if user is a workspace owner

--- a/sbomify/apps/onboarding/tests/test_onboarding.py
+++ b/sbomify/apps/onboarding/tests/test_onboarding.py
@@ -161,6 +161,70 @@ class TestOnboardingStatusModel:
         SBOM.objects.create(name="test-sbom", component=component)
         assert not status.should_receive_sbom_reminder(days_threshold=7)
 
+    def test_drip_window_caps_signup_anchored_emails(self, settings) -> None:
+        """Users past ONBOARDING_DRIP_MAX_AGE_DAYS skip signup-anchored drip emails.
+
+        Without this guard, a long scheduler outage would cause every backlog
+        user past every threshold to receive every drip email simultaneously.
+        """
+        settings.ONBOARDING_DRIP_MAX_AGE_DAYS = 30
+
+        test_user = User.objects.create_user(
+            username="oldsignup", email="oldsignup@example.com", password="testpass123"
+        )
+        test_team = Team.objects.create(name="Old Signup Team", key="old-signup-team")
+        Member.objects.create(user=test_user, team=test_team, role="owner", is_default_team=True)
+
+        status = OnboardingStatus.objects.get(user=test_user)
+        status.mark_welcome_email_sent()
+        # Push signup back beyond the drip window
+        status.created_at = timezone.now() - timedelta(days=90)
+        status.save()
+
+        assert status.is_drip_window_expired
+        assert not status.should_receive_quick_start()
+        assert not status.should_receive_component_reminder()
+        assert not status.should_receive_collaboration()
+
+        # In-window users still receive the drip
+        status.created_at = timezone.now() - timedelta(days=12)
+        status.save()
+        assert not status.is_drip_window_expired
+        assert status.should_receive_quick_start()
+        assert status.should_receive_component_reminder()
+        assert status.should_receive_collaboration()
+
+    def test_first_sbom_window_caps_late_uploaders(self, settings) -> None:
+        """Users whose first component is older than the drip window skip the SBOM reminder.
+
+        The SBOM reminder is anchored to first-component creation, not signup,
+        so it has its own independent window check.
+        """
+        settings.ONBOARDING_DRIP_MAX_AGE_DAYS = 30
+
+        test_user = User.objects.create_user(
+            username="latesbom", email="latesbom@example.com", password="testpass123"
+        )
+        test_team = Team.objects.create(name="Late SBOM Team", key="late-sbom-team")
+        Member.objects.create(user=test_user, team=test_team, role="owner", is_default_team=True)
+
+        status = OnboardingStatus.objects.get(user=test_user)
+        status.mark_component_created()
+        Component.objects.create(name="late-component", team=test_team)
+
+        # Component created 90 days ago — past the window
+        status.first_component_created_at = timezone.now() - timedelta(days=90)
+        status.save()
+
+        assert status.is_first_sbom_window_expired
+        assert not status.should_receive_sbom_reminder(days_threshold=7)
+
+        # Component created 14 days ago — still in window
+        status.first_component_created_at = timezone.now() - timedelta(days=14)
+        status.save()
+        assert not status.is_first_sbom_window_expired
+        assert status.should_receive_sbom_reminder(days_threshold=7)
+
 
 @pytest.mark.django_db
 class TestOnboardingEmailModel:

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -792,6 +792,14 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))
 TRIAL_ENDING_NOTIFICATION_DAYS = int(os.environ.get("TRIAL_ENDING_NOTIFICATION_DAYS", "3"))
 
+# Maximum age (in days, since signup or first-component creation) at which a
+# user is still eligible for an onboarding-drip email. Past this window the
+# sequence narrative no longer makes sense — sending "your quick start guide"
+# to someone who joined months ago feels off, and a long scheduler outage
+# could cause every backlog user to receive every drip simultaneously without
+# this guard.
+ONBOARDING_DRIP_MAX_AGE_DAYS = int(os.environ.get("ONBOARDING_DRIP_MAX_AGE_DAYS", "30"))
+
 # Enable specific notification providers
 NOTIFICATION_PROVIDERS = [
     "sbomify.apps.billing.notifications.get_notifications",


### PR DESCRIPTION
## Summary

Follow-up to #940 / #942. Prevents the email burst that would otherwise hit existing users on the first-ever scheduler firing in prod.

## Problem

The drip cadence is anchored to user signup (`OnboardingStatus.created_at`) for three of the four email types — `quick_start` (day 1), `first_component` (day 3), and `collaboration` (day 10). The fourth (`first_sbom`, day 7) is anchored to first-component creation.

When the scheduler comes online for the first time after #942 deploys, every welcome-emailed user past day 10 trips every signup-anchored threshold simultaneously. Worst case per user: 3–4 emails in the same minute, with no narrative coherence (a "your quick start guide" email arriving the same minute as "invite your team!" to a user who signed up three months ago).

This is a code-level fix that prevents the burst without requiring an operator pre-mark.

## Change

- New setting `ONBOARDING_DRIP_MAX_AGE_DAYS` (default `30`, env-overridable)
- New `OnboardingStatus.is_drip_window_expired` property (signup-anchored)
- New `OnboardingStatus.is_first_sbom_window_expired` property (first-component-anchored)
- All four `should_receive_*` methods now return `False` once the user is past the relevant window
- Two new unit tests cover both the signup-anchored cap and the first-component-anchored cap

## Behavior

| User state | Before this PR | After this PR |
|---|---|---|
| Signup 5 days ago, welcome sent, no component | Eligible for `quick_start` and `first_component` | Same — well within window |
| Signup 90 days ago, welcome sent, no component | Eligible for `quick_start` + `first_component` + `collaboration` simultaneously | Skipped — past `ONBOARDING_DRIP_MAX_AGE_DAYS` |
| First component created 5 days ago, no SBOM | Eligible for `first_sbom` (after day 7) | Same — well within window |
| First component created 90 days ago, no SBOM | Eligible for `first_sbom` | Skipped — past first-component window |

## Why this is the right fix

- Prevents the immediate backlog burst without an operator-action snippet
- Provides a permanent guardrail against future scheduler outages — no matter how long cron is dark, recovery never produces a torrent
- Configurable via env var, so operators can tune (or disable, by setting to a very large value) per environment
- Doesn't change the cadence for normal users (default 30 days is well past every existing threshold)

## Verification

- ✅ `bun test` for the two new unit tests passes
- ✅ All 78 onboarding tests pass
- ✅ ruff, mypy, bandit clean
- ✅ Verified locally: a 90-day-old user is filtered out of `OnboardingEmailService.get_users_for_onboarding_sequence()`; a 12-day-old user is included

## Test plan

- [ ] CI green
- [ ] `OnboardingStatus.is_drip_window_expired` returns `True` for users with `created_at` older than `ONBOARDING_DRIP_MAX_AGE_DAYS`
- [ ] All four eligibility methods return `False` for out-of-window users
- [ ] In-window users continue to be eligible as before
- [ ] `OnboardingEmailService.get_users_for_onboarding_sequence()` no longer includes backlog users