### PR TITLE
docs(deployment): mount CA volume on sbomify-scheduler too

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -316,12 +316,25 @@ services:
     environment:
       REDIS_CA_CERTS: /certs/root_ca.crt
 
+  sbomify-scheduler:
+    volumes:
+      - *ca-volume
+    environment:
+      REDIS_CA_CERTS: /certs/root_ca.crt
+
   sbomify-migrations:
     volumes:
       - *ca-volume
     environment:
       DATABASE_SSLROOTCERT: /certs/root_ca.crt
 ```
+
+> **Important:** Every service that talks to Redis must mount the CA volume,
+> not just have `REDIS_CA_CERTS` set in its environment. The `sbomify-scheduler`
+> service in particular fires Dramatiq actor sends from APScheduler — if its
+> container can read the env var but cannot read the file at that path, the
+> first scheduled job crashes the scheduler with `FileNotFoundError` from
+> `ssl.load_verify_locations`.
 
 Deploy with:
 


### PR DESCRIPTION
## Summary

- The PKI override example in `docs/deployment.md` listed `sbomify-backend`, `sbomify-worker`, and `sbomify-migrations` but missed `sbomify-scheduler` (the service was added in 08c55052, after this section was last touched).
- Operators following the docs end up with `REDIS_CA_CERTS=/certs/root_ca.crt` set on the scheduler via the `common-env` anchor, but with no file at that path. APScheduler fires the first heartbeat, dramatiq's broker tries to enqueue, and the SSL handshake crashes the container with `FileNotFoundError` from `ssl.load_verify_locations` — not the more obvious `CERTIFICATE_VERIFY_FAILED`, which is what makes this surprising.
- Adds the missing `sbomify-scheduler` block to the example, plus a callout explaining why "env var set, volume not mounted" produces this specific failure mode (so future readers don't have to rediscover it).

Verified in production: adding the volume + env block to `sbomify-scheduler` fixes the crash loop.

## Test plan

- [x] Reproduced in prod: scheduler crashes with `FileNotFoundError` on first heartbeat when only env is set
- [x] Verified manually adding `*ca-volume` mount to `sbomify-scheduler` fixes it
- [ ] Doc-only change — no automated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)