### PR TITLE
chore: bump version to 26.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sbomify-frontend-components",
   "private": true,
-  "version": "26.1.0",
+  "version": "26.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbomify"
-version = "26.1.0"
+version = "26.2.0"
 description = "sbomify - the security artifact hub"
 authors = [{ name = "sbomify", email = "hello@sbomify.com" }]
 requires-python = ">=3.13,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2686,7 +2686,7 @@ wheels = [
 
 [[package]]
 name = "sbomify"
-version = "26.1.0"
+version = "26.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Bump version from 26.1.0 to 26.2.0 in `pyproject.toml`, `package.json`, and `uv.lock`

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)