### PR TITLE
feat(admin): expose Team.onboarding_goal so admins can read wizard answers

### DIFF
--- a/sbomify/apps/teams/admin.py
+++ b/sbomify/apps/teams/admin.py
@@ -128,6 +128,7 @@ class TeamAdmin(_TeamAdminBase):
         "key",
         "billing_plan",
         "custom_domain",
+        "onboarding_goal",
     )
 
     readonly_fields = (
@@ -138,6 +139,7 @@ class TeamAdmin(_TeamAdminBase):
         "custom_domain_status_display",
         "branding_info",
         "billing_plan_limits",
+        "onboarding_goal",
     )
 
     fieldsets = (
@@ -151,6 +153,15 @@ class TeamAdmin(_TeamAdminBase):
                     "is_public",
                     "created_at",
                 )
+            },
+        ),
+        (
+            "Onboarding",
+            {
+                "fields": ("onboarding_goal",),
+                "description": (
+                    'Free-text answer to the wizard\'s "What are you trying to accomplish?" prompt. Read-only.'
+                ),
             },
         ),
         (


### PR DESCRIPTION
## Summary

The signup wizard captures a free-text answer to "What are you trying to accomplish?" and persists it on `Team.onboarding_goal` (forms.py:202 → onboarding_wizard.py:455 → models.py:198). The Team admin never referenced the field, so admins had no way to read those answers without dropping to the DB.

## Changes

- New "Onboarding" fieldset in `TeamAdmin.fieldsets` showing the goal read-only with an inline description of which prompt produced it.
- Added `onboarding_goal` to `search_fields` so admins can search for teams by keywords in the answer text.
- Added `onboarding_goal` to `readonly_fields` — this is user-supplied data; admin shouldn't silently rewrite it.

## Test plan

- [x] `pytest sbomify/apps/teams/tests/` → 389 passing
- [x] `ruff check`, `ruff format`, `mypy sbomify/apps/teams/admin.py` clean
- [ ] Manual: open `/admin/teams/team/<id>/change/` and confirm the new "Onboarding" section is visible with the goal text below it.