### PR TITLE
fix(ci): upload screencasts to bucket root so marketing-site videos resolve

### DIFF
--- a/.github/workflows/screencasts.yml
+++ b/.github/workflows/screencasts.yml
@@ -159,7 +159,7 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
-          aws s3 sync screencasts/output/ "s3://${R2_BUCKET}/screencasts/" \
+          aws s3 sync screencasts/output/ "s3://${R2_BUCKET}/" \
             --endpoint-url "$R2_ENDPOINT" \
             --content-type video/webm \
             --cache-control "public, max-age=300" \


### PR DESCRIPTION
## Summary

The marketing site's FAQ and compliance pages embed screencast videos via URLs of the form `https://marketing-assets.sbomify.com/<name>.webm` — directly at the R2 bucket root. When the Cloudflare R2 sync step landed in `84d3c9d0` (Apr 24), it was configured to upload under a `/screencasts/` key prefix. Every recording produced by the workflow since then has landed at a path the marketing site doesn't read, while the FAQ URLs fall through to older manually-uploaded copies that pre-date the workflow.

That mismatch is why 8 video embeds 404 in production right now:

| FAQ URL | Broken video |
|---|---|
| `/faq/how-do-i-use-cra-compliance/` | `cra_compliance.webm` (never existed at either path) |
| `/faq/how-do-i-use-signature-files/` | `document_signatures.webm` (never existed at either path) |
| `/faq/how-do-i-enable-vulnerability-scanning/` | `plugin_enablement_osv.webm`, `plugin_enablement_dependency-track.webm` |
| `/faq/how-do-i-sign-an-sbom/` | `plugin_enablement_github-attestation.webm`, `plugin_enablement_sbom-verification.webm` |
| `/faq/how-do-i-achieve-ntia-cisa-compliance/` | `plugin_enablement_ntia-minimum-elements-2021.webm` |
| `/compliance/bsi-tr-03183/` | `plugin_enablement_bsi-tr03183-v2.1-compliance.webm` |
| `/compliance/fda-medical-device/` | `plugin_enablement_fda-medical-device-2025.webm` |

Probe of all 16 video URLs the marketing site references confirms the pattern: 8/16 work at root (pre-workflow uploads), 15/16 work under `/screencasts/` (post-workflow uploads). `document_signatures.webm` and `cra_compliance.webm` 404 at both — they've never been recorded.

## Change

One YAML line — strip the `/screencasts/` prefix from the R2 sync destination so the workflow uploads land where the marketing site expects.

```diff
-          aws s3 sync screencasts/output/ "s3://${R2_BUCKET}/screencasts/" \
+          aws s3 sync screencasts/output/ "s3://${R2_BUCKET}/" \
```

Screenshots stay under `/screenshots/` (their own bucket prefix, consumers unaffected).

## After merge

Trigger `screencasts.yml` with input `screencast: all` (~15-20 min CI run). That records every screencast script and uploads them to the bucket root, populating the 2 never-recorded files (`cra_compliance.webm`, `document_signatures.webm`) and refreshing the 7 plugin-enablement videos that today sit at the wrong path.

**Trade-off to flag:** re-running `all` will overwrite the 9 currently-working videos at root with newer recordings. Those are 6+ months old and don't reflect current UI, so the refresh is a feature — but worth knowing if anyone depends on a frozen older version (e.g., blog screenshots).

## Test plan

- [x] Local diff verified — single string substitution
- [ ] After merge, dispatch with `screencast: all` and confirm `https://marketing-assets.sbomify.com/cra_compliance.webm` returns 200
- [ ] Open each of the 7 listed FAQ/compliance pages and confirm video plays