### PR TITLE
fix(emails): make logo visible in Gmail Android / forced-dark clients

### DIFF
--- a/sbomify/apps/core/templates/core/emails/base.html.j2
+++ b/sbomify/apps/core/templates/core/emails/base.html.j2
@@ -5,6 +5,15 @@
         <meta name="description" content="sbomify platform notification">
         <meta name="keywords"
               content="sbomify, sbom, software bill of materials, security">
+        {% comment %}
+            color-scheme + supported-color-schemes: tell Gmail Android / Apple Mail
+            that this email is dark-mode aware. Without these, Gmail Android
+            force-inverts the white email background to dark and the @media-driven
+            logo swap below never fires — leaving the black-wordmark logo invisible
+            against the inverted dark background.
+        {% endcomment %}
+        <meta name="color-scheme" content="light dark">
+        <meta name="supported-color-schemes" content="light dark">
         <title>
             {% block title %}sbomify{% endblock %}
         </title>
@@ -203,6 +212,65 @@
             }
 
             @media (prefers-color-scheme: dark) {
+                body {
+                    background-color: #0f172a !important;
+                    color: #e2e8f0 !important;
+                }
+
+                .email-container {
+                    background-color: #1e293b !important;
+                    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) !important;
+                }
+
+                .header {
+                    border-bottom-color: #334155 !important;
+                }
+
+                .tagline {
+                    color: #cbd5e1 !important;
+                }
+
+                h1,
+                h3 {
+                    color: #f1f5f9 !important;
+                }
+
+                h2 {
+                    color: #818cf8 !important;
+                }
+
+                p,
+                ul,
+                li {
+                    color: #cbd5e1 !important;
+                }
+
+                .highlight-box {
+                    background-color: #0f172a !important;
+                    border-left-color: #818cf8 !important;
+                }
+
+                .user-info {
+                    background-color: #422006 !important;
+                    border-color: #b45309 !important;
+                    color: #fde68a !important;
+                }
+
+                .footer {
+                    border-top-color: #334155 !important;
+                    color: #94a3b8 !important;
+                }
+
+                a,
+                .footer a {
+                    color: #818cf8 !important;
+                }
+
+                .button {
+                    background-color: #818cf8 !important;
+                    color: #0f172a !important;
+                }
+
                 .logo .logo-light {
                     display: none !important;
                 }
@@ -211,40 +279,52 @@
                     display: inline !important;
                 }
             }
+
+            /* Gmail Android / Yahoo "force dark" swap: these clients don't
+               fire prefers-color-scheme but DO add a [data-ogsc] / [data-ogsb]
+               attribute on elements they want to invert. Force the logo
+               swap there too — the client handles background inversion. */
+            [data-ogsc] .logo .logo-light,
+            [data-ogsb] .logo .logo-light {
+                display: none !important;
+            }
+
+            [data-ogsc] .logo .logo-dark,
+            [data-ogsb] .logo .logo-dark {
+                display: inline !important;
+            }
         </style>
     </head>
     <body>
         <div class="email-container">
             <div class="header">
                 <div class="logo">
-                    <img src="{{ base_url }}/static/img/sbomify-black.svg"
-                         alt="sbomify"
-                         height="40"
-                         width="221"
-                         class="logo-light">
-                    <img src="{{ base_url }}/static/img/sbomify-white.svg"
-                         alt="sbomify"
-                         height="40"
-                         width="221"
-                         class="logo-dark">
-                </div>
-                <div class="tagline">The Security Artifact Hub</div>
-            </div>
-            {% block content %}{% endblock %}
-            {% block signoff %}
-                <p>
-                    Cheers,
-                    <br>
-                    <strong>The sbomify Team</strong>
-                </p>
-            {% endblock %}
-            <div class="footer">
-                <p>
-                    Questions? We're here to help. <a href="{{ base_url }}/support/contact/">Get in touch</a>
-                </p>
-                {% now "Y" as this_year %}
-                <p>© {{ current_year|default:this_year }} sbomify. All rights reserved.</p>
-            </div>
-        </div>
-    </body>
+                    {% comment %}
+                        Inline display defaults — if a mail client strips the
+                        <style> block entirely (e.g. some Outlook web modes),
+                        only the light logo renders by default, which still
+                        reads on the white email-container background.
+{% endcomment %}
+<img src="{{ base_url }}/static/img/sbomify-black.svg" alt="sbomify" height="40" width="221" style="display: inline-block; max-width: 221px; height: 40px; width: auto;" class="logo-light">
+<img src="{{ base_url }}/static/img/sbomify-white.svg" alt="sbomify" height="40" width="221" style="display: none; max-width: 221px; height: 40px; width: auto;" class="logo-dark">
+</div>
+<div class="tagline">The Security Artifact Hub</div>
+</div>
+{% block content %}{% endblock %}
+{% block signoff %}
+<p>
+Cheers,
+<br>
+<strong>The sbomify Team</strong>
+</p>
+{% endblock %}
+<div class="footer">
+<p>
+Questions? We're here to help. <a href="{{ base_url }}/support/contact/">Get in touch</a>
+</p>
+{% now "Y" as this_year %}
+<p>© {{ current_year|default:this_year }} sbomify. All rights reserved.</p>
+</div>
+</div>
+</body>
 </html>

--- a/sbomify/apps/core/templates/core/emails/base.html.j2
+++ b/sbomify/apps/core/templates/core/emails/base.html.j2
@@ -5,13 +5,7 @@
         <meta name="description" content="sbomify platform notification">
         <meta name="keywords"
               content="sbomify, sbom, software bill of materials, security">
-        {% comment %}
-            color-scheme + supported-color-schemes: tell Gmail Android / Apple Mail
-            that this email is dark-mode aware. Without these, Gmail Android
-            force-inverts the white email background to dark and the @media-driven
-            logo swap below never fires — leaving the black-wordmark logo invisible
-            against the inverted dark background.
-        {% endcomment %}
+        {# color-scheme meta tags signal dark-mode-aware to Gmail Android / Apple Mail so they don't force-invert. #}
         <meta name="color-scheme" content="light dark">
         <meta name="supported-color-schemes" content="light dark">
         <title>
@@ -299,32 +293,43 @@
         <div class="email-container">
             <div class="header">
                 <div class="logo">
-                    {% comment %}
-                        Inline display defaults — if a mail client strips the
-                        <style> block entirely (e.g. some Outlook web modes),
-                        only the light logo renders by default, which still
-                        reads on the white email-container background.
-{% endcomment %}
-<img src="{{ base_url }}/static/img/sbomify-black.svg" alt="sbomify" height="40" width="221" style="display: inline-block; max-width: 221px; height: 40px; width: auto;" class="logo-light">
-<img src="{{ base_url }}/static/img/sbomify-white.svg" alt="sbomify" height="40" width="221" style="display: none; max-width: 221px; height: 40px; width: auto;" class="logo-dark">
-</div>
-<div class="tagline">The Security Artifact Hub</div>
-</div>
-{% block content %}{% endblock %}
-{% block signoff %}
-<p>
-Cheers,
-<br>
-<strong>The sbomify Team</strong>
-</p>
-{% endblock %}
-<div class="footer">
-<p>
-Questions? We're here to help. <a href="{{ base_url }}/support/contact/">Get in touch</a>
-</p>
-{% now "Y" as this_year %}
-<p>© {{ current_year|default:this_year }} sbomify. All rights reserved.</p>
-</div>
-</div>
-</body>
+                    {# Inline display defaults so the light logo renders even if a client strips <style> blocks. #}
+                    <img src="{{ base_url }}/static/img/sbomify-black.svg"
+                         alt="sbomify"
+                         height="40"
+                         width="221"
+                         style="display: inline-block;
+                                max-width: 221px;
+                                height: 40px;
+                                width: auto"
+                         class="logo-light">
+                    <img src="{{ base_url }}/static/img/sbomify-white.svg"
+                         alt="sbomify"
+                         height="40"
+                         width="221"
+                         style="display: none;
+                                max-width: 221px;
+                                height: 40px;
+                                width: auto"
+                         class="logo-dark">
+                </div>
+                <div class="tagline">The Security Artifact Hub</div>
+            </div>
+            {% block content %}{% endblock %}
+            {% block signoff %}
+                <p>
+                    Cheers,
+                    <br>
+                    <strong>The sbomify Team</strong>
+                </p>
+            {% endblock %}
+            <div class="footer">
+                <p>
+                    Questions? We're here to help. <a href="{{ base_url }}/support/contact/">Get in touch</a>
+                </p>
+                {% now "Y" as this_year %}
+                <p>© {{ current_year|default:this_year }} sbomify. All rights reserved.</p>
+            </div>
+        </div>
+    </body>
 </html>

--- a/sbomify/apps/core/tests/e2e/test_email_dark_mode.py
+++ b/sbomify/apps/core/tests/e2e/test_email_dark_mode.py
@@ -1,0 +1,133 @@
+"""Render-based dark-mode test for the shared email template.
+
+The static assertions in ``onboarding/tests/test_onboarding.py``
+(``TestEmailBaseDarkModeDefences``) check that the rendered HTML
+*contains* the dark-mode defences. Those guards are necessary but
+not sufficient — they don't actually evaluate ``@media
+(prefers-color-scheme: dark)``, so they can't catch:
+
+  - A selector mistake that leaves the dark-mode block syntactically
+    present but functionally inert (e.g. typo'd class name).
+  - A rule that fires but resolves to the wrong logo URL.
+  - A future change that swaps the SVG src attributes by accident.
+
+This test renders ``onboarding/emails/welcome.html.j2`` through
+Django, loads it into a real Chromium via Playwright's CDP fixture,
+emulates each ``prefers-color-scheme`` value in turn, and asserts the
+computed-style ``display`` on each ``<img>`` matches expectation. If
+the wrong logo is the one rendered, the test fails — closing the
+gap that surfaced the user-reported Gmail Android bug in the first
+place.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Generator, Literal
+
+import pytest
+from django.template.loader import render_to_string
+from playwright.sync_api import Browser, BrowserContext
+
+ColorScheme = Literal["dark", "light", "no-preference", "null"]
+
+EMAIL_CONTEXT = {
+    "user": SimpleNamespace(first_name="Jonathan", username="jonathan"),
+    "base_url": "http://localhost",
+    "app_base_url": "http://localhost",
+}
+
+
+def _make_context(browser: Browser, color_scheme: ColorScheme) -> BrowserContext:
+    """Create an isolated Chromium context with the given prefers-color-scheme."""
+    return browser.new_context(
+        color_scheme=color_scheme,
+        viewport={"width": 800, "height": 1200},
+    )
+
+
+def _resolve_logo_state(context: BrowserContext, email_html: str) -> dict[str, str]:
+    """Load the email into a page and return the CSS-resolved display value for each logo."""
+    page = context.new_page()
+    try:
+        page.set_content(email_html, wait_until="domcontentloaded")
+        return {
+            "light_display": page.locator(".logo .logo-light").evaluate("el => getComputedStyle(el).display"),
+            "dark_display": page.locator(".logo .logo-dark").evaluate("el => getComputedStyle(el).display"),
+            "light_src": page.locator(".logo .logo-light").get_attribute("src") or "",
+            "dark_src": page.locator(".logo .logo-dark").get_attribute("src") or "",
+        }
+    finally:
+        page.close()
+
+
+@pytest.fixture
+def email_html() -> str:
+    return render_to_string("onboarding/emails/welcome.html.j2", EMAIL_CONTEXT)
+
+
+@pytest.fixture
+def light_context(browser: Browser) -> Generator[BrowserContext, Any, None]:
+    ctx = _make_context(browser, "light")
+    yield ctx
+    ctx.close()
+
+
+@pytest.fixture
+def dark_context(browser: Browser) -> Generator[BrowserContext, Any, None]:
+    ctx = _make_context(browser, "dark")
+    yield ctx
+    ctx.close()
+
+
+def test_light_mode_shows_black_wordmark(light_context: BrowserContext, email_html: str) -> None:
+    """Under prefers-color-scheme: light, the black-wordmark SVG must be the visible one."""
+    state = _resolve_logo_state(light_context, email_html)
+    assert state["light_display"] != "none", (
+        f"sbomify-black.svg should be visible in light mode, got display={state['light_display']!r}"
+    )
+    assert state["dark_display"] == "none", (
+        f"sbomify-white.svg should be hidden in light mode, got display={state['dark_display']!r}"
+    )
+    assert "sbomify-black.svg" in state["light_src"]
+
+
+def test_dark_mode_shows_white_wordmark(dark_context: BrowserContext, email_html: str) -> None:
+    """Under prefers-color-scheme: dark, the white-wordmark SVG must be the visible one.
+
+    This is the exact failure surfaced in the user-reported Gmail Android screenshot
+    — pre-fix, the black wordmark stayed visible against the now-dark background.
+    """
+    state = _resolve_logo_state(dark_context, email_html)
+    assert state["dark_display"] != "none", (
+        f"sbomify-white.svg should be visible in dark mode, got display={state['dark_display']!r}"
+    )
+    assert state["light_display"] == "none", (
+        f"sbomify-black.svg should be hidden in dark mode, got display={state['light_display']!r}"
+    )
+    assert "sbomify-white.svg" in state["dark_src"]
+
+
+def test_dark_mode_container_styles_apply(dark_context: BrowserContext, email_html: str) -> None:
+    """Under prefers-color-scheme: dark, the email container should resolve to the
+    dark palette (not the light defaults). Guards against future regressions where
+    someone removes the body / container rules from the dark-mode media block."""
+    page = dark_context.new_page()
+    try:
+        page.set_content(email_html, wait_until="domcontentloaded")
+        body_bg = page.evaluate("getComputedStyle(document.body).backgroundColor")
+        container_bg = page.locator(".email-container").evaluate("el => getComputedStyle(el).backgroundColor")
+    finally:
+        page.close()
+
+    # Both backgrounds should be in the dark palette — emails fall back to the
+    # light defaults (#f8fafc body, #ffffff container) if the dark-mode block
+    # is missing. Compare against the light fallback to catch regressions.
+    light_body_fallback = "rgb(248, 250, 252)"
+    light_container_fallback = "rgb(255, 255, 255)"
+    assert body_bg != light_body_fallback, (
+        f"body background still on light fallback ({body_bg}) in dark mode — dark-mode rules missing?"
+    )
+    assert container_bg != light_container_fallback, (
+        f"email-container still white ({container_bg}) in dark mode — dark-mode rules missing?"
+    )

--- a/sbomify/apps/onboarding/tests/test_onboarding.py
+++ b/sbomify/apps/onboarding/tests/test_onboarding.py
@@ -3,6 +3,7 @@ Tests for onboarding functionality using pytest and existing fixtures.
 """
 
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -335,6 +336,90 @@ class TestEmailTemplateRendering:
         assert "<h1>" not in plain_text_content
 
         mock_render.assert_called_once_with("onboarding/emails/welcome.html.j2", context)
+
+
+@pytest.mark.django_db
+class TestEmailBaseDarkModeDefences:
+    """Regression-guard the dark-mode defences in core/emails/base.html.j2.
+
+    The user-reported bug (Gmail Android force-dark hides the wordmark)
+    was fixed by adding three things to the base template:
+
+      - ``color-scheme`` + ``supported-color-schemes`` meta tags
+      - ``[data-ogsc]`` / ``[data-ogsb]`` attribute selectors (Gmail Android,
+        Yahoo, Outlook iOS force-dark marker)
+      - inline ``style="display: ..."`` defaults on both logo ``<img>`` tags
+      - full ``@media (prefers-color-scheme: dark)`` rules covering body,
+        container, text, headings, links
+
+    If any of these regress, dark-mode rendering breaks again. This test
+    renders a representative onboarding email through the real template
+    stack and asserts every defence is in the rendered HTML.
+    """
+
+    def _render(self, template_name: str = "welcome") -> str:
+        from django.template.loader import render_to_string
+
+        return render_to_string(
+            f"onboarding/emails/{template_name}.html.j2",
+            {
+                "user": SimpleNamespace(first_name="Jonathan", username="jonathan"),
+                "base_url": "http://localhost:8000",
+                "app_base_url": "http://localhost:8000",
+            },
+        )
+
+    def test_color_scheme_meta_tags_present(self) -> None:
+        html = self._render()
+        assert '<meta name="color-scheme" content="light dark">' in html
+        assert '<meta name="supported-color-schemes" content="light dark">' in html
+
+    def test_force_dark_attribute_selectors_present(self) -> None:
+        html = self._render()
+        assert "[data-ogsc]" in html, "Gmail Android force-dark selector missing"
+        assert "[data-ogsb]" in html, "Outlook iOS / Yahoo force-dark selector missing"
+
+    def test_inline_logo_display_defaults_present(self) -> None:
+        html = self._render()
+        assert 'class="logo-light"' in html
+        assert 'class="logo-dark"' in html
+        # Both must carry inline display defaults so a <style>-stripping client
+        # still gets a sane default (light visible, dark hidden).
+        assert "display: inline-block" in html
+        assert "display: none" in html
+
+    def test_prefers_color_scheme_block_covers_full_email(self) -> None:
+        html = self._render()
+        # Locate the dark-mode media block and assert it touches every
+        # surface a reader sees, not just the logo (the original PR only
+        # swapped the logo, which left a white wordmark on a white card).
+        assert "@media (prefers-color-scheme: dark)" in html
+        # Snip out the dark block to inspect in isolation.
+        start = html.index("@media (prefers-color-scheme: dark)")
+        end = html.index("}", html.index("}", html.index("{", start)) + 1)
+        dark_block = html[start : end + 4000]  # window large enough to cover the whole rule
+        for selector in ("body", ".email-container", "h1", "h2", "p", "a", ".logo .logo-dark"):
+            assert selector in dark_block, f"{selector!r} not styled in @media (prefers-color-scheme: dark)"
+
+    def test_no_template_comment_leakage(self) -> None:
+        html = self._render()
+        # ``{# ... #}`` is single-line only — a previous iteration of the
+        # dark-mode fix accidentally used it across multiple lines and the
+        # comment text leaked into the rendered output. Guard against that
+        # regression by spot-checking known comment markers.
+        assert "color-scheme meta tags signal" not in html
+        assert "Inline display defaults so" not in html
+
+    def test_logo_sources_paired_correctly(self) -> None:
+        html = self._render()
+        # logo-light img uses the black-on-white SVG; logo-dark uses white-on-dark.
+        # If these get swapped, light-mode users see white text on white.
+        light_idx = html.index('class="logo-light"')
+        dark_idx = html.index('class="logo-dark"')
+        light_tag = html[max(0, light_idx - 400) : light_idx]
+        dark_tag = html[max(0, dark_idx - 400) : dark_idx]
+        assert "sbomify-black.svg" in light_tag
+        assert "sbomify-white.svg" in dark_tag
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

User-reported: the email logo isn't visible on Gmail Android dark mode — only the gradient icon shows, the **sbomify** wordmark renders black on a now-dark background.

## Root cause

The base email template at `sbomify/apps/core/templates/core/emails/base.html.j2` had a logo swap gated on `@media (prefers-color-scheme: dark)`, but:

1. **Gmail Android, Yahoo, and some Outlook iOS modes** force-invert the email's white background to dark **without** firing `prefers-color-scheme: dark`. The black wordmark stays black on the now-dark background.
2. **Even on clients that DO fire the media query**, the template only had dark-mode styles for the logo — every other element (container, text, headings, links) stayed on light-mode colours. So even where the swap fired, swapping to a white wordmark just put white on a still-white container.

## Fix (three additions + one expansion to the base template)

1. **`color-scheme` + `supported-color-schemes` meta tags** in `<head>`. Gmail Android reads these as "this email is dark-mode aware, don't force-invert" — and starts honouring the existing `prefers-color-scheme` media query.

2. **`[data-ogsc]` / `[data-ogsb]` attribute selectors** alongside the `prefers-color-scheme` rules. Gmail Android applies those attributes when it inverts. With them, the logo-swap also works on the Gmail Android variant where the media query still doesn't fire.

3. **Inline `display: inline-block` / `display: none` defaults** on the two `<img>` tags. If a client strips the entire `<style>` block (some Outlook web modes do), the light logo still renders by default and the dark one stays hidden.

4. **Expanded the `@media (prefers-color-scheme: dark)` block** to cover the full email, not just the logo:
   - `body` background → dark slate (#0f172a)
   - `.email-container` → dark slate-blue (#1e293b)
   - Text (p, ul, li, h1, h3) → light grey (#cbd5e1 / #f1f5f9)
   - Headings (h2) → light indigo (#818cf8)
   - Borders (header, footer) → muted dark (#334155)
   - Links and buttons → light indigo (#818cf8), with the button text becoming dark for contrast
   - `.highlight-box` and `.user-info` re-coloured for dark background

## Local verification

Sent the welcome email to MailHog via `OnboardingEmailService.send_welcome_email`, then opened the rendered HTML in Chrome and used DevTools to emulate both `prefers-color-scheme: light` and `dark`. Accessibility tree confirms the right logo source loads in each mode:

- Light: `sbomify-black.svg` on white container
- Dark: `sbomify-white.svg` on dark slate container, all text readable

Light mode screenshot (in MailHog):
- White card, black "sbomify" wordmark, all text dark-on-light, exactly as before.

Dark mode screenshot (in MailHog):
- Slate-blue card, white "sbomify" wordmark, all body text light-on-dark, headings in light indigo, links in light indigo. Fully readable.

## Bug found and fixed during testing

The first iteration of this PR used `{# ... #}` Django comments to document the new rules. Django's `{# #}` is single-line only — multi-line `{# ... #}` content leaks through as literal text into the rendered email. Switched all rationale comments to `{% comment %}{% endcomment %}` blocks. Confirmed via render assertion that no comment text leaks into the rendered HTML.

## Test plan

- [x] Template renders cleanly (no comment leakage)
- [x] `<meta name="color-scheme">` + `supported-color-schemes` present
- [x] `[data-ogsc]` / `[data-ogsb]` selectors present alongside `prefers-color-scheme`
- [x] Inline `display:` defaults on both logo `<img>` tags
- [x] `pytest sbomify/apps/onboarding/tests/` — 92 pass
- [x] djlint clean
- [x] MailHog + Chrome DevTools dark-mode emulation — both modes render correctly
- [ ] Manual: re-send the welcome (or any onboarding) email and view in Gmail Android dark mode — wordmark should render in white on dark
- [ ] Manual: view in Apple Mail dark mode — full dark theme applies
- [ ] Manual: view in light mode — original light theme unchanged