### PR TITLE
feat(ui): use relative time + tooltip for 'Created at' columns (#919)

### DIFF
--- a/sbomify/apps/core/templates/core/component_item.html.j2
+++ b/sbomify/apps/core/templates/core/component_item.html.j2
@@ -98,7 +98,9 @@
                 <div class="flex items-center gap-1.5 px-3 py-1.5 bg-surface border border-border rounded-md text-sm">
                     <i class="fas fa-calendar text-primary text-xs"></i>
                     <span class="text-text-muted">Uploaded:</span>
-                    <span class="font-semibold text-text">{{ item.created_at|date:"M d, Y" }}</span>
+                    <span class="font-semibold text-text">
+                        {% include 'core/components/relative_time.html.j2' with timestamp=item.created_at %}
+                    </span>
                 </div>
                 <div class="flex items-center gap-1.5 px-3 py-1.5 bg-info/10 border border-info/30 rounded-md text-sm">
                     <i class="fas fa-upload text-info text-xs"></i>
@@ -132,7 +134,9 @@
                 <div class="flex items-center gap-1.5 px-3 py-1.5 bg-surface border border-border rounded-md text-sm">
                     <i class="fas fa-calendar text-primary text-xs"></i>
                     <span class="text-text-muted">Uploaded:</span>
-                    <span class="font-semibold text-text">{{ item.created_at|date:"M d, Y" }}</span>
+                    <span class="font-semibold text-text">
+                        {% include 'core/components/relative_time.html.j2' with timestamp=item.created_at %}
+                    </span>
                 </div>
                 <div class="flex items-center gap-1.5 px-3 py-1.5 bg-surface border border-border rounded-md text-sm">
                     <i class="fas fa-upload text-primary text-xs"></i>

--- a/sbomify/apps/core/templates/core/components/pending_items.html.j2
+++ b/sbomify/apps/core/templates/core/components/pending_items.html.j2
@@ -45,7 +45,8 @@ Parameters:
                                         </p>
                                         {% if request.created_at %}
                                             <p class="text-xs text-text-muted mt-1">
-                                                <i class="fas fa-clock mr-1"></i>{{ request.created_at|timesince }} ago
+                                                <i class="fas fa-clock mr-1"></i>
+                                                {% include 'core/components/relative_time.html.j2' with timestamp=request.created_at %}
                                             </p>
                                         {% endif %}
                                     </div>

--- a/sbomify/apps/core/templates/core/components/relative_time.html.j2
+++ b/sbomify/apps/core/templates/core/components/relative_time.html.j2
@@ -1,28 +1,26 @@
-{# Render a timestamp as a human-readable relative time ("5 days ago") with a
-   hover-over tooltip showing the absolute date + time.
+{% comment %}
+Render a timestamp as a human-readable relative time ("5 days ago") with a
+hover-over tooltip showing the absolute date + time.
 
-   Required kwarg:
-     timestamp — a `datetime` or `date` value. The component renders nothing
-                 if the value is falsy (uses `fallback` instead).
+Required kwarg:
+  timestamp - a `datetime` or `date` value. The component renders the
+              fallback if the value is falsy.
 
-   Optional kwargs:
-     fallback  — displayed when `timestamp` is None/empty. Default: "—"
-     suffix    — string appended after the relative time. Default: "ago"
+Optional kwarg:
+  fallback - displayed when `timestamp` is None/empty. Default: "—"
 
-   Usage examples:
-     {% include 'core/components/relative_time.html.j2' with timestamp=item.created_at %}
-     {% include 'core/components/relative_time.html.j2' with timestamp=invitation.created_at suffix='' %}
-     {% include 'core/components/relative_time.html.j2' with timestamp=record.updated_at fallback='Never' %}
+Usage:
+  {% include 'core/components/relative_time.html.j2' with timestamp=item.created_at %}
+  {% include 'core/components/relative_time.html.j2' with timestamp=record.updated_at fallback='Never' %}
 
-   The component uses BOTH a native `title=` attribute (works without JS) AND
-   the project's `x-tooltip` Alpine directive (richer styling when Alpine is
-   loaded). #}
+Only the `x-tooltip` Alpine directive is bound (no native `title=`); having
+both would show two stacked tooltips in JS-enabled sessions. The tooltip
+text degrades gracefully — when Alpine isn't loaded, the span just shows
+the relative time, which is still useful.
+{% endcomment %}
 {% if timestamp %}
     <span class="cursor-help"
-          title="{{ timestamp|date:'M j, Y, H:i:s' }}"
-          x-tooltip="'{{ timestamp|date:'M j, Y, H:i:s'|escapejs }}'">{{ timestamp|timesince }}
-        {% if suffix|default:'ago' %}{{ suffix|default:'ago' }}{% endif %}
-    </span>
+          x-tooltip="'{{ timestamp|date:'M j, Y, H:i:s'|escapejs }}'">{{ timestamp|timesince }} ago</span>
 {% else %}
     <span class="text-text-muted">{{ fallback|default:"—" }}</span>
 {% endif %}

--- a/sbomify/apps/core/templates/core/components/relative_time.html.j2
+++ b/sbomify/apps/core/templates/core/components/relative_time.html.j2
@@ -24,10 +24,12 @@ that includes BOTH the relative-time text AND the absolute timestamp so
 screen-reader users get the full context in one announcement.
 {% endcomment %}
 {% if timestamp %}
-    <span class="cursor-help"
-          tabindex="0"
-          aria-label="{{ timestamp|timesince }} ago ({{ timestamp|date:'M j, Y, H:i:s' }})"
-          x-tooltip="'{{ timestamp|date:'M j, Y, H:i:s'|escapejs }}'">{{ timestamp|timesince }} ago</span>
+    {% with absolute=timestamp|date:"M j, Y, H:i:s" relative=timestamp|timesince %}
+        <span class="cursor-help"
+              tabindex="0"
+              aria-label="{{ relative }} ago ({{ absolute }})"
+              x-tooltip="'{{ absolute|escapejs }}'">{{ relative }} ago</span>
+    {% endwith %}
 {% else %}
     <span class="text-text-muted">{{ fallback|default:"—" }}</span>
 {% endif %}

--- a/sbomify/apps/core/templates/core/components/relative_time.html.j2
+++ b/sbomify/apps/core/templates/core/components/relative_time.html.j2
@@ -1,0 +1,28 @@
+{# Render a timestamp as a human-readable relative time ("5 days ago") with a
+   hover-over tooltip showing the absolute date + time.
+
+   Required kwarg:
+     timestamp — a `datetime` or `date` value. The component renders nothing
+                 if the value is falsy (uses `fallback` instead).
+
+   Optional kwargs:
+     fallback  — displayed when `timestamp` is None/empty. Default: "—"
+     suffix    — string appended after the relative time. Default: "ago"
+
+   Usage examples:
+     {% include 'core/components/relative_time.html.j2' with timestamp=item.created_at %}
+     {% include 'core/components/relative_time.html.j2' with timestamp=invitation.created_at suffix='' %}
+     {% include 'core/components/relative_time.html.j2' with timestamp=record.updated_at fallback='Never' %}
+
+   The component uses BOTH a native `title=` attribute (works without JS) AND
+   the project's `x-tooltip` Alpine directive (richer styling when Alpine is
+   loaded). #}
+{% if timestamp %}
+    <span class="cursor-help"
+          title="{{ timestamp|date:'M j, Y, H:i:s' }}"
+          x-tooltip="'{{ timestamp|date:'M j, Y, H:i:s'|escapejs }}'">{{ timestamp|timesince }}
+        {% if suffix|default:'ago' %}{{ suffix|default:'ago' }}{% endif %}
+    </span>
+{% else %}
+    <span class="text-text-muted">{{ fallback|default:"—" }}</span>
+{% endif %}

--- a/sbomify/apps/core/templates/core/components/relative_time.html.j2
+++ b/sbomify/apps/core/templates/core/components/relative_time.html.j2
@@ -17,9 +17,16 @@ Only the `x-tooltip` Alpine directive is bound (no native `title=`); having
 both would show two stacked tooltips in JS-enabled sessions. The tooltip
 text degrades gracefully — when Alpine isn't loaded, the span just shows
 the relative time, which is still useful.
+
+Accessibility: the span carries `tabindex="0"` so keyboard users can
+focus it (which also triggers the Alpine tooltip), and an `aria-label`
+that includes BOTH the relative-time text AND the absolute timestamp so
+screen-reader users get the full context in one announcement.
 {% endcomment %}
 {% if timestamp %}
     <span class="cursor-help"
+          tabindex="0"
+          aria-label="{{ timestamp|timesince }} ago ({{ timestamp|date:'M j, Y, H:i:s' }})"
           x-tooltip="'{{ timestamp|date:'M j, Y, H:i:s'|escapejs }}'">{{ timestamp|timesince }} ago</span>
 {% else %}
     <span class="text-text-muted">{{ fallback|default:"—" }}</span>

--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/members.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/members.html.j2
@@ -192,7 +192,8 @@
                                 <div class="flex items-center gap-4 mt-1">
                                     <span class="text-xs text-text-muted flex items-center gap-1">
                                         <i class="fas fa-calendar-plus"></i>
-                                        Sent {{ invitation.created_at|date:"M j, Y" }}
+                                        Sent
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=invitation.created_at %}
                                     </span>
                                     <span class="text-xs text-text-muted flex items-center gap-1">
                                         <i class="fas fa-hourglass-half"></i>

--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -560,7 +560,7 @@
                             <div class="flex items-center gap-3 text-sm text-text-muted">
                                 <span class="flex items-center gap-1">
                                     <i class="fas fa-calendar-alt text-xs"></i>
-                                    {{ company_nda_document.created_at|date:"M d, Y" }}
+                                    {% include 'core/components/relative_time.html.j2' with timestamp=company_nda_document.created_at %}
                                 </span>
                                 {% if company_nda_document.file_size %}
                                     <span class="flex items-center gap-1">

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -114,7 +114,8 @@
                                 <h6 class="font-medium text-text m-0 truncate">{{ token.description }}</h6>
                                 <p class="text-sm text-text-muted m-0">
                                     <i class="fas fa-clock text-xs mr-1"></i>
-                                    Created {{ token.created_at|timesince }} ago
+                                    Created
+                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
                                 </p>
                             </div>
                             <div class="flex-shrink-0">
@@ -144,7 +145,8 @@
                                 </p>
                                 <p class="text-sm text-text-muted m-0">
                                     <i class="fas fa-clock text-xs mr-1"></i>
-                                    Created {{ token.created_at|timesince }} ago
+                                    Created
+                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
                                 </p>
                             </div>
                             <div class="flex-shrink-0">

--- a/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/vulnerability_scans.html.j2
+++ b/sbomify/apps/vulnerability_scanning/templates/vulnerability_scanning/vulnerability_scans.html.j2
@@ -109,8 +109,9 @@
                                     <span class="tw-badge-secondary capitalize">{{ scan.run_reason|default:"on_upload" }}</span>
                                 </td>
                                 <td class="px-6 py-4">
-                                    <div class="font-semibold text-text">{{ scan.created_at|date:"M j, Y" }}</div>
-                                    <div class="text-sm text-text-muted">{{ scan.created_at|date:"H:i" }}</div>
+                                    <div class="font-semibold text-text">
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=scan.created_at %}
+                                    </div>
                                 </td>
                                 <td class="px-6 py-4 text-right">
                                     <div class="inline-flex rounded-lg border border-border overflow-hidden">


### PR DESCRIPTION
Closes #919.

## What

Replaces absolute "Created at" timestamps (e.g. `Mar 5, 2026`) with Django's `|timesince` filter (`3 days ago`) plus a hover tooltip showing the full absolute date + time. Per Viktor's request in the issue: *"Instead of showing the date that we are currently doing (for things like SBOMs), let's instead use `django.utils.timesince.timesince()`. Perhaps with a hover over that shows you the full date."*

## New reusable partial

`sbomify/apps/core/templates/core/components/relative_time.html.j2` — used wherever the codebase needs to show "Created N days ago".

**Kwargs:**
- `timestamp` (required) — `datetime`/`date`. Falsy → fallback.
- `fallback` (optional) — string shown when `timestamp` is falsy. Default: `—`.

**Output:**
```html
<span class="cursor-help"
      tabindex="0"
      aria-label="3 days ago (Mar 5, 2026, 14:32:45)"
      x-tooltip="'Mar 5, 2026, 14:32:45'">3 days ago</span>
```

The visible text is the relative time. Hovering or focusing (keyboard tab) reveals the absolute date+time via the project's existing Alpine `x-tooltip` directive.

**Accessibility:** `tabindex="0"` makes the span keyboard-focusable (Alpine x-tooltip listens for `focus` events too). `aria-label` carries BOTH the relative time AND the absolute timestamp so screen-reader users get the full context in one announcement.

**One tooltip layer.** The component only uses `x-tooltip` — no native `title=`. Doing both would stack two tooltips in JS-enabled sessions. The `aria-label` is the no-JS fallback for assistive tech.

```jinja
{% include 'core/components/relative_time.html.j2' with timestamp=sbom.created_at %}
```

## Touched templates

| File | Site |
|---|---|
| `core/component_item.html.j2` | SBOM + document upload date in the per-component item card (2 sites) |
| `vulnerability_scanning/vulnerability_scans.html.j2` | scan table date column (collapses the date+time two-line display into one relative line; full timestamp lives in the tooltip) |
| `teams/team_settings_tabs/members.html.j2` | invitation "Sent on" line |
| `teams/team_settings_tabs/trust_center.html.j2` | company NDA document upload date |
| `teams/team_tokens.html.j2` | "Created N days ago" for scoped and unscoped access tokens (upgrade — was already `|timesince`, just adds the tooltip) |
| `core/components/pending_items.html.j2` | pending access request age (upgrade — same pattern) |

## What stayed untouched

- Places that already use `|naturaltime` (releases, document access queue) — they show relative-time already.
- Absolute dates outside "Created at" contexts: release lifecycle events (`release_date`, `end_of_support`, `end_of_life`), invitation expiry dates, license expiry, etc. Those are properties of the entity itself rather than "when was this row created" — keeping them absolute reads correctly.

## Test plan

- [x] djlint formatting + lint pass on all touched templates
- [x] Focused pytest sweep: full `test_team_tokens.py` + `test_template_recursion.py` green (incl. the recursion test that catches the multi-line `{# #}` gotcha)
- [x] Browser-tested at `/workspaces/<key>#tokens` — relative time renders, hover tooltip shows the absolute timestamp (`Apr 8, 2026, 21:51:30` style), keyboard focus also triggers the tooltip, screen-reader `aria-label` includes both texts.