### PR TITLE
fix(migrations): reorder 0062 ProjectComponent ops to drop unique before field

### DIFF
--- a/sbomify/apps/sboms/migrations/0062_remove_product_projects_remove_project_products_and_more.py
+++ b/sbomify/apps/sboms/migrations/0062_remove_product_projects_remove_project_products_and_more.py
@@ -152,13 +152,18 @@ class Migration(migrations.Migration):
             model_name="component",
             name="projects",
         ),
-        migrations.RemoveField(
-            model_name="projectcomponent",
-            name="project",
-        ),
+        # Drop the (project, component) unique_together BEFORE removing the
+        # `project` field. Django's _delete_composed_index needs to resolve
+        # each field name to a DB column name, which fails with
+        # FieldDoesNotExist once RemoveField has dropped the field from the
+        # in-memory model state.
         migrations.AlterUniqueTogether(
             name="projectcomponent",
             unique_together=None,
+        ),
+        migrations.RemoveField(
+            model_name="projectcomponent",
+            name="project",
         ),
         migrations.RemoveField(
             model_name="projectcomponent",

--- a/sbomify/apps/sboms/migrations/0062_remove_product_projects_remove_project_products_and_more.py
+++ b/sbomify/apps/sboms/migrations/0062_remove_product_projects_remove_project_products_and_more.py
@@ -65,7 +65,28 @@ def demote_visibility_for_previously_hidden_components(apps: Any, schema_editor:
     counts at deploy time. The `projects` reverse relation is still
     available on the historical model state because RunPython runs before
     any of the schema ops below.
+
+    SAFE-RESUME GUARD: if this migration previously failed partway through
+    (e.g. the earlier buggy operation order in this file), the
+    ``sboms_projects_components.project_id`` column will already be gone and
+    the JOINs below would raise ``ProgrammingError: column ... does not
+    exist``. RunPython commits independently because this migration is
+    non-atomic, so the demote has already been applied to live data on the
+    prior failed run. Probe for the column and no-op if it's missing.
     """
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_name = 'sboms_projects_components' AND column_name = 'project_id' "
+        "LIMIT 1"
+    )
+    if cursor.fetchone() is None:
+        logger.info(
+            "migration 0062: skipping visibility demote — sboms_projects_components.project_id "
+            "is already gone, indicating the demote ran on a prior partial-apply attempt"
+        )
+        return
+
     Component = apps.get_model("sboms", "Component")
     PUBLIC = "public"
     GATED = "gated"
@@ -128,54 +149,49 @@ class Migration(migrations.Migration):
             demote_visibility_for_previously_hidden_components,
             migrations.RunPython.noop,
         ),
-        migrations.RemoveField(
-            model_name="product",
-            name="projects",
-        ),
-        migrations.RemoveField(
-            model_name="project",
-            name="products",
-        ),
-        migrations.AlterUniqueTogether(
-            name="project",
-            unique_together=None,
-        ),
-        migrations.RemoveField(
-            model_name="project",
-            name="components",
-        ),
-        migrations.RemoveField(
-            model_name="project",
-            name="team",
-        ),
-        migrations.RemoveField(
-            model_name="component",
-            name="projects",
-        ),
-        # Drop the (project, component) unique_together BEFORE removing the
-        # `project` field. Django's _delete_composed_index needs to resolve
-        # each field name to a DB column name, which fails with
-        # FieldDoesNotExist once RemoveField has dropped the field from the
-        # in-memory model state.
-        migrations.AlterUniqueTogether(
-            name="projectcomponent",
-            unique_together=None,
-        ),
-        migrations.RemoveField(
-            model_name="projectcomponent",
-            name="project",
-        ),
-        migrations.RemoveField(
-            model_name="projectcomponent",
-            name="component",
-        ),
-        migrations.DeleteModel(
-            name="ProductProject",
-        ),
-        migrations.DeleteModel(
-            name="Project",
-        ),
-        migrations.DeleteModel(
-            name="ProjectComponent",
+        # Idempotent schema rewrite. The legacy Project layer consists of
+        # three tables (``sboms_projects``, ``sboms_products_projects``,
+        # ``sboms_projects_components``) plus a ``team_id`` FK column on
+        # the projects table that gets cascade-dropped with the table.
+        # Dropping them with ``IF EXISTS ... CASCADE`` is safe on:
+        #   - Fresh DBs (all three tables exist; CASCADE handles the FKs
+        #     from the through tables back to ``sboms_projects``).
+        #   - Partially-applied DBs left behind by the earlier buggy
+        #     operation order (some tables/columns already gone — every
+        #     DROP is a no-op when its target is missing).
+        #   - Re-applied DBs (the migration was forcefully marked
+        #     applied — every DROP is a no-op).
+        # ``state_operations`` keeps Django's in-memory model graph in
+        # sync so downstream migrations see Project/ProductProject/
+        # ProjectComponent as gone.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    "DROP TABLE IF EXISTS sboms_products_projects CASCADE;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+                migrations.RunSQL(
+                    "DROP TABLE IF EXISTS sboms_projects_components CASCADE;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+                migrations.RunSQL(
+                    "DROP TABLE IF EXISTS sboms_projects CASCADE;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+            state_operations=[
+                migrations.RemoveField(model_name="product", name="projects"),
+                migrations.RemoveField(model_name="project", name="products"),
+                migrations.AlterUniqueTogether(name="project", unique_together=None),
+                migrations.RemoveField(model_name="project", name="components"),
+                migrations.RemoveField(model_name="project", name="team"),
+                migrations.RemoveField(model_name="component", name="projects"),
+                migrations.AlterUniqueTogether(name="projectcomponent", unique_together=None),
+                migrations.RemoveField(model_name="projectcomponent", name="project"),
+                migrations.RemoveField(model_name="projectcomponent", name="component"),
+                migrations.DeleteModel(name="ProductProject"),
+                migrations.DeleteModel(name="Project"),
+                migrations.DeleteModel(name="ProjectComponent"),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary

Migration `sboms.0062_remove_product_projects_remove_project_products_and_more` from PR #946 fails on every fresh deploy with:

```
django.core.exceptions.FieldDoesNotExist: ProjectComponent has no field named 'project'
```

and is **non-recoverable on partial-apply** — because the migration is non-atomic, ops 1-7 (data demote + most field removals) commit to the DB before op 8 crashes, leaving the deploy in a broken intermediate state. Retries crash differently with `ProgrammingError: column u1.project_id does not exist` from the RunPython JOIN.

## Root cause

1. **Wrong operation order.** `RemoveField(projectcomponent, project)` ran **before** `AlterUniqueTogether(projectcomponent, unique_together=None)`. Django's `_delete_composed_index` (`django/db/backends/base/schema.py:651`) resolves each field name in the OLD `unique_together` to a DB column name on the in-memory model state, which by then has already pruned `project`.

2. **Non-recoverable on partial-apply.** The migration is non-atomic (intentionally, to avoid long-locking the schema during the demote), so the data migration and partial schema ops committed before the crash. Retries then fail because the historical model query `Component.objects.filter(projects__is_public=True, projects__products__is_public=True)` JOINs through `sboms_projects_components.project_id` — which was already dropped on the previous failed run.

## Fix

Make the migration **fully idempotent** so it succeeds on any of:

- **Fresh DB**: original codepath runs cleanly.
- **Partial-apply DB**: previous-run side effects are detected and skipped.
- **Already-applied DB**: every op is a no-op (defense in depth).

### Changes

1. **RunPython safe-resume guard**: probe for `sboms_projects_components.project_id` via `information_schema.columns`. If gone, the demote ran on a prior failed attempt — log and no-op.

2. **Schema ops rewritten via `SeparateDatabaseAndState`**:
   - `database_operations`: three `DROP TABLE IF EXISTS ... CASCADE` statements covering all three legacy Project-layer tables (`sboms_products_projects`, `sboms_projects_components`, `sboms_projects`). CASCADE handles residual FKs; IF EXISTS handles partial-apply.
   - `state_operations`: the original 12 declarative `RemoveField` / `AlterUniqueTogether` / `DeleteModel` ops, kept so Django's in-memory model graph stays in sync for downstream migrations and introspection.

## Verification

Locally tested all three states with `bin/release.py` invoking the migration container's actual entry point:

### Fresh DB

```
Applying sboms.0062_..._and_more...
  migration 0062: demoted visibility=PRIVATE on 0 component rows ... OK
Applying sboms.0063_..._and_more... OK
Applying sboms.0064_alter_component_is_global... OK
```

### Partial-apply DB (reproduced the PR #946 bug, then ran fixed migration)

```
Applying sboms.0062_..._and_more...
  migration 0062: skipping visibility demote — sboms_projects_components.project_id
  is already gone, indicating the demote ran on a prior partial-apply attempt ... OK
Applying sboms.0063_..._and_more... OK
Applying sboms.0064_alter_component_is_global... OK
```

### Regression

```
$ pytest sbomify/apps/sboms/tests/ -q
347 passed, 5 skipped
```

End-state schema verified clean: no `sboms_projects*` tables remain; `django_migrations` shows 0060-0064 applied.

## Test plan
- [x] Bandit / ruff / mypy clean
- [x] Pre-commit hooks pass
- [x] Fresh-DB migration chain 0001-0064 applies cleanly
- [x] Partial-apply DB (broken state from previous run) recovers on retry
- [x] All sboms tests pass (347 passed, 5 skipped)