### PR TITLE
fix(deps): resolve Dependabot security alerts; supersede #958

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ authors = [{ name = "sbomify", email = "hello@sbomify.com" }]
 requires-python = ">=3.13,<4"
 readme = "README.md"
 dependencies = [
-    "django>=5.2.13,<7",
-    "python-dotenv>=1.1.1,<2",
+    "django>=5.2.14,<6",
+    "python-dotenv>=1.2.2,<2",
+    "urllib3>=2.7.0,<3",
     "psycopg2-binary>=2.9.9,<3",
     "django-extensions~=4.1",
     "django-widget-tweaks>=1.5.0,<2",
@@ -34,9 +35,9 @@ dependencies = [
     "license-expression>=30.4.4,<31",
     "pyyaml>=6.0.2,<7",
     "dramatiq-crontab>=1.0.12,<2",
-    "uvicorn[standard]>=0.45.0,<0.46",
+    "uvicorn[standard]>=0.45.0,<0.47",
     "uvicorn-worker>=0.4.0,<0.5",
-    "gunicorn>=25.0.3,<26",
+    "gunicorn>=25.0.3,<27",
     "django-dramatiq>=0.15.0",
     "channels>=4.0.0,<5",
     "channels-redis>=4.2.0,<5",
@@ -62,7 +63,7 @@ dependencies = [
     # so we avoid maintaining a second renderer. System deps for
     # WeasyPrint (libpango, libjpeg, libopenjp2, libffi) are added in
     # the Dockerfile's python-common-code stage.
-    "weasyprint>=66.0,<67",
+    "weasyprint>=68.0,<69",
 ]
 
 [project.urls]
@@ -85,7 +86,7 @@ dev = [
     "types-boto3>=1.42.0,<2",
     "types-psycopg2>=2.9.21,<3",
     "types-PyYAML>=6.0.12,<7",
-    "types-gunicorn>=25.1.0,<26",
+    "types-gunicorn>=25.1.0,<27",
     "types-channels>=4.3.0,<5",
     "types-requests>=2.32.0,<3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -754,16 +754,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.13"
+version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
 ]
 
 [[package]]
@@ -2363,11 +2363,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -2725,6 +2725,7 @@ dependencies = [
     { name = "stripe" },
     { name = "tenacity" },
     { name = "tzdata" },
+    { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "uvicorn-worker" },
     { name = "weasyprint" },
@@ -2769,7 +2770,7 @@ requires-dist = [
     { name = "channels-redis", specifier = ">=4.2.0,<5" },
     { name = "compliance-trestle", specifier = ">=4.0.1,<5" },
     { name = "dj-database-url", specifier = ">=3.0.1,<4" },
-    { name = "django", specifier = ">=5.2.13,<7" },
+    { name = "django", specifier = ">=5.2.14,<6" },
     { name = "django-allauth", specifier = ">=65.11.2,<66" },
     { name = "django-anymail", extras = ["sendgrid"], specifier = "~=15.0" },
     { name = "django-dramatiq", specifier = ">=0.15.0" },
@@ -2783,14 +2784,14 @@ requires-dist = [
     { name = "dramatiq", extras = ["redis", "watch"], specifier = ">=2.0.0,<3" },
     { name = "dramatiq-crontab", specifier = ">=1.0.12,<2" },
     { name = "email-validator", specifier = ">=2.3.0,<3" },
-    { name = "gunicorn", specifier = ">=25.0.3,<26" },
+    { name = "gunicorn", specifier = ">=25.0.3,<27" },
     { name = "libtea", specifier = "==0.5.1" },
     { name = "license-expression", specifier = ">=30.4.4,<31" },
     { name = "posthog", specifier = ">=3.20.0,<8" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<3" },
     { name = "pydantic", specifier = ">=2.11.9,<3" },
     { name = "pyjwt", specifier = ">=2.12.0,<3" },
-    { name = "python-dotenv", specifier = ">=1.1.1,<2" },
+    { name = "python-dotenv", specifier = ">=1.2.2,<2" },
     { name = "python-keycloak", specifier = ">=7.1.1,<8" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "redis", specifier = ">=4.0.0" },
@@ -2800,9 +2801,10 @@ requires-dist = [
     { name = "stripe", specifier = ">=14.0.0,<16" },
     { name = "tenacity", specifier = ">=9.1.2,<10" },
     { name = "tzdata", specifier = ">=2025.2" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.45.0,<0.46" },
+    { name = "urllib3", specifier = ">=2.7.0,<3" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.45.0,<0.47" },
     { name = "uvicorn-worker", specifier = ">=0.4.0,<0.5" },
-    { name = "weasyprint", specifier = ">=66.0,<67" },
+    { name = "weasyprint", specifier = ">=68.0,<69" },
     { name = "whitenoise", specifier = ">=6.11.0,<7" },
 ]
 
@@ -2821,7 +2823,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15.0,<0.16" },
     { name = "types-boto3", specifier = ">=1.42.0,<2" },
     { name = "types-channels", specifier = ">=4.3.0,<5" },
-    { name = "types-gunicorn", specifier = ">=25.1.0,<26" },
+    { name = "types-gunicorn", specifier = ">=25.1.0,<27" },
     { name = "types-psycopg2", specifier = ">=2.9.21,<3" },
     { name = "types-pyyaml", specifier = ">=6.0.12,<7" },
     { name = "types-requests", specifier = ">=2.32.0,<3" },
@@ -3239,11 +3241,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -3425,7 +3427,7 @@ wheels = [
 
 [[package]]
 name = "weasyprint"
-version = "66.0"
+version = "68.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
@@ -3437,9 +3439,9 @@ dependencies = [
     { name = "tinycss2" },
     { name = "tinyhtml5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/99/480b5430b7eb0916e7d5df1bee7d9508b28b48fee28da894d0a050e0e930/weasyprint-66.0.tar.gz", hash = "sha256:da71dc87dc129ac9cffdc65e5477e90365ab9dbae45c744014ec1d06303dde40", size = 504224, upload-time = "2025-07-24T11:44:42.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/3e/65c0f176e6fb5c2b0a1ac13185b366f727d9723541babfa7fa4309998169/weasyprint-68.1.tar.gz", hash = "sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e", size = 1542379, upload-time = "2026-02-06T15:04:11.203Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/d1/c5d9b341bf3d556c1e4c6566b3efdda0b1bb175510aa7b09dd3eee246923/weasyprint-66.0-py3-none-any.whl", hash = "sha256:82b0783b726fcd318e2c977dcdddca76515b30044bc7a830cc4fbe717582a6d0", size = 301965, upload-time = "2025-07-24T11:44:40.968Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/dd/14eb73cea481ad8162d3b18a4850d4a84d6e804a22840cca207648532265/weasyprint-68.1-py3-none-any.whl", hash = "sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be", size = 319789, upload-time = "2026-02-06T15:04:09.189Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Resolves all 8 Dependabot vulnerability alerts that have an upstream patch (Django, urllib3, python-dotenv, weasyprint)
- Keeps Django on the 5.2 LTS line — constraint tightened from `<7` to `<6` so we don't accidentally jump off LTS
- Folds in #958 (uvicorn/gunicorn/types-gunicorn upper-bound widening + weasyprint bump)

## Alerts resolved

| Alert # | Package | From → To | Severity | GHSA |
|---|---|---|---|---|
| #75, #74, #73 | django | 5.2.13 → 5.2.14 | medium/low | GHSA-w26r-rmm8-9c29, GHSA-5hrc-gvxj-w55p, GHSA-7h2m-m8vj-598h |
| #78, #77 | urllib3 | 2.6.3 → 2.7.0 | high | GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j |
| #70 | python-dotenv | 1.1.1 → 1.2.2 | medium | GHSA-mf9w-mj56-hr94 |
| #72, #71 | weasyprint | 66.0 → 68.1 | high | GHSA-983w-rhvv-gwmv |

## Not in scope

Two alerts have no upstream fix available and are left in place:
- **#76 paramiko** (low, GHSA-r374-rxx8-8654) — no patched version
- **#60 jwcrypto** (medium, GHSA-fjrm-76x2-c4q4) — no patched version

## Notes

- `urllib3` was previously transitive; pinned explicitly as a direct dependency to enforce the floor.
- `python-dotenv` is still in active use (`sbomify/settings.py`, `conftest.py`).
- This supersedes #958 — same intent (broaden upper bounds), but also bumps lockfile versions for the security alerts. #958 can be closed after this merges.

## Test plan

- [ ] CI green (pytest + lint)
- [ ] Verify `weasyprint==68.1` renders CRA bundle PDF correctly (system deps in Docker image are already libpango/libjpeg/libopenjp2/libffi)
- [ ] Verify Django app boots with 5.2.14
- [ ] Confirm Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)