### PR TITLE
fix(ui): tighten trust-center pages — tokens, hierarchy, mobile

### DIFF
--- a/sbomify/apps/core/templates/core/component_details_public_base.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_public_base.html.j2
@@ -87,13 +87,13 @@
                     </div>
                 {% elif access_request_status == 'pending' %}
                     <div class="flex items-center gap-2 p-4 rounded-lg bg-info/10 border border-info/30 text-text">
-                        <i class="fas fa-clock text-info"></i>
+                        <i class="fas fa-clock text-info" aria-hidden="true"></i>
                         <span><strong>Access Request Pending:</strong> Your request for access is being reviewed.</span>
                     </div>
                 {% elif access_request_status == 'rejected' %}
                     <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 rounded-lg bg-danger/10 border border-danger/30">
                         <span class="flex items-center gap-2 text-text">
-                            <i class="fas fa-times-circle text-danger"></i>
+                            <i class="fas fa-times-circle text-danger" aria-hidden="true"></i>
                             <span><strong>Access Request Rejected:</strong> Your request was not approved. You can request access again.</span>
                         </span>
                         <a href="{% url 'documents:request_access' team.key %}"
@@ -102,7 +102,7 @@
                 {% else %}
                     <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 rounded-lg bg-warning/10 border border-warning/30">
                         <span class="flex items-center gap-2 text-text">
-                            <i class="fas fa-lock text-warning"></i>
+                            <i class="fas fa-lock text-warning" aria-hidden="true"></i>
                             <span><strong>Gated Component:</strong> This component requires approval to download.</span>
                         </span>
                         <a href="{% url 'documents:request_access' team.key %}"

--- a/sbomify/apps/core/templates/core/component_details_public_base.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_public_base.html.j2
@@ -25,13 +25,13 @@
             </a>
         {% endif %}
         <h1 class="text-3xl font-bold text-text flex items-center gap-4 mb-3">
-            <span class="w-12 h-12 rounded-xl bg-info/10 flex items-center justify-center text-info">
+            <span class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center text-primary">
                 <i class="fas fa-cube"></i>
             </span>
             {{ component.name }}
         </h1>
         <div class="flex flex-wrap gap-2 mb-6">
-            <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-warning/10 text-warning flex items-center gap-2">
+            <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text-muted flex items-center gap-2">
                 <i class="fas fa-tag"></i>
                 {{ component.component_type_display }}
             </span>
@@ -68,7 +68,7 @@
                             </span>
                         </span>
                         <a href="{% url 'documents:sign_nda' team.key nda_access_request_id %}"
-                           class="tw-btn-primary text-sm whitespace-nowrap">
+                           class="tw-btn-primary text-sm min-h-10 inline-flex items-center whitespace-nowrap">
                             <i class="fas fa-signature mr-1"></i> Sign NDA
                         </a>
                     </div>
@@ -84,7 +84,7 @@
                             <span><strong>NDA Required:</strong> Please sign the NDA to complete your access request.</span>
                         </span>
                         <a href="{% url 'documents:sign_nda' team.key pending_request_id %}"
-                           class="tw-btn-primary text-sm whitespace-nowrap">
+                           class="tw-btn-primary text-sm min-h-10 inline-flex items-center whitespace-nowrap">
                             <i class="fas fa-signature mr-1"></i> Sign NDA
                         </a>
                     </div>
@@ -94,13 +94,13 @@
                         <span><strong>Access Request Pending:</strong> Your request for access is being reviewed.</span>
                     </div>
                 {% elif access_request_status == 'rejected' %}
-                    <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 rounded-lg bg-warning/10 border border-warning/30">
+                    <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 rounded-lg bg-danger/10 border border-danger/30">
                         <span class="flex items-center gap-2 text-text">
-                            <i class="fas fa-times-circle text-warning"></i>
+                            <i class="fas fa-times-circle text-danger"></i>
                             <span><strong>Access Request Rejected:</strong> Your request was not approved. You can request access again.</span>
                         </span>
                         <a href="{% url 'documents:request_access' team.key %}"
-                           class="tw-btn-primary text-sm whitespace-nowrap">Request Access Again</a>
+                           class="tw-btn-primary text-sm min-h-10 inline-flex items-center whitespace-nowrap">Request Access Again</a>
                     </div>
                 {% else %}
                     <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 p-4 rounded-lg bg-warning/10 border border-warning/30">
@@ -109,7 +109,7 @@
                             <span><strong>Gated Component:</strong> This component requires approval to download.</span>
                         </span>
                         <a href="{% url 'documents:request_access' team.key %}"
-                           class="tw-btn-primary text-sm whitespace-nowrap">
+                           class="tw-btn-primary text-sm min-h-10 inline-flex items-center whitespace-nowrap">
                             <i class="fas fa-key mr-1"></i> Request Access
                         </a>
                     </div>

--- a/sbomify/apps/core/templates/core/component_details_public_base.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_public_base.html.j2
@@ -15,22 +15,19 @@
     {% breadcrumb component 'component' %}
 {% endblock %}
 {% block content %}
-    <div class="public-item-header">
-        {% if back_url or fallback_url %}
-            <a href="{{ fallback_url|default:back_url }}"
-               class="inline-flex items-center gap-2 text-text-muted hover:text-text mb-4 no-underline"
-               onclick="if (window.history.length > 1) { window.history.back(); return false; }">
-                <i class="fas fa-arrow-left" aria-hidden="true"></i>
-                Back
-            </a>
-        {% endif %}
-        <h1 class="text-3xl font-bold text-text flex items-center gap-4 mb-3">
+    <div class="public-item-header flex flex-col gap-3">
+        {# Parent navigation comes from the breadcrumb (`Trust Center > Product`). #}
+        <h1 class="text-3xl font-bold text-text flex items-center gap-4 m-0">
             <span class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center text-primary">
-                <i class="fas fa-cube"></i>
+                {% if component.component_type == 'document' %}
+                    <i class="fas fa-file-lines" aria-hidden="true"></i>
+                {% else %}
+                    <i class="fas fa-cube" aria-hidden="true"></i>
+                {% endif %}
             </span>
             {{ component.name }}
         </h1>
-        <div class="flex flex-wrap gap-2 mb-6">
+        <div class="flex flex-wrap gap-2">
             <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text-muted flex items-center gap-2">
                 <i class="fas fa-tag"></i>
                 {{ component.component_type_display }}

--- a/sbomify/apps/core/templates/core/component_details_public_base.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_public_base.html.j2
@@ -29,18 +29,18 @@
         </h1>
         <div class="flex flex-wrap gap-2">
             <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text-muted flex items-center gap-2">
-                <i class="fas fa-tag"></i>
+                <i class="fas fa-tag" aria-hidden="true"></i>
                 {{ component.component_type_display }}
             </span>
             {% if component.is_global %}
                 <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-primary/10 text-primary flex items-center gap-2">
-                    <i class="fas fa-building"></i>
+                    <i class="fas fa-building" aria-hidden="true"></i>
                     Workspace-wide
                 </span>
             {% endif %}
             {% if component.visibility == 'gated' %}
                 <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text flex items-center gap-2">
-                    <i class="fas fa-lock"></i>
+                    <i class="fas fa-lock" aria-hidden="true"></i>
                     Gated Access
                 </span>
             {% endif %}

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -1,9 +1,11 @@
-{# Public Product Identifiers — server-rendered
+{% comment %}
+Public Product Identifiers — server-rendered.
 
-   Single responsive layout: each identifier is one row that flows
-   vertically under md and as a 3-column grid at md+. There's only one
-   <svg data-barcode-id="..."> per identifier, so renderBarcode runs
-   exactly once and the document.querySelector lookup is unambiguous. #}
+Single responsive layout: each identifier is one row that flows
+vertically under md and as a 3-column grid at md+. There's only one
+<svg data-barcode-id="..."> per identifier, so renderBarcode runs
+exactly once and the document.querySelector lookup is unambiguous.
+{% endcomment %}
 {% load static %}
 {% if product_identifiers %}
     <div class="public-section" x-data="productIdentifiersBarcodes()">

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -3,11 +3,7 @@
 {% if product_identifiers %}
     <div class="public-section" x-data="productIdentifiersBarcodes()">
         <div class="tw-card">
-            <div class="px-6 py-4 border-b border-border">
-                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                    <i class="fas fa-fingerprint text-primary"></i>Product Identifiers
-                </h4>
-            </div>
+            {% include 'core/components/public_section_header.html.j2' with title='Product Identifiers' icon='fa-fingerprint' %}
             <div class="p-6">
                 <div class="overflow-x-auto">
                     <table class="tw-table w-full text-sm">
@@ -32,7 +28,7 @@
                                             <div class="barcode-wrapper inline-block"
                                                  x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
                                                 <svg data-barcode-id="{{ identifier.id }}"
-                                                     class="barcode-svg max-w-[150px] h-auto"
+                                                     class="barcode-svg max-w-40 h-auto"
                                                      x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']">
                                                 </svg>
                                                 <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -28,7 +28,7 @@
                                             <div class="barcode-wrapper inline-block"
                                                  x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
                                                 <svg data-barcode-id="{{ identifier.id }}"
-                                                     class="barcode-svg max-w-40 h-auto"
+                                                     class="barcode-svg max-w-[150px] h-auto"
                                                      x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']">
                                                 </svg>
                                                 <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -16,7 +16,7 @@
                             <div class="barcode-wrapper"
                                  x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
                                 <svg data-barcode-id="{{ identifier.id }}"
-                                     class="barcode-svg max-w-[150px] h-auto"
+                                     class="barcode-svg"
                                      x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
                                      aria-hidden="true">
                                 </svg>
@@ -55,7 +55,7 @@
                                         <div class="barcode-wrapper inline-block"
                                              x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
                                             <svg data-barcode-id="{{ identifier.id }}"
-                                                 class="barcode-svg max-w-[150px] h-auto"
+                                                 class="barcode-svg"
                                                  x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
                                                  aria-hidden="true">
                                             </svg>

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -1,83 +1,57 @@
-{# Public Product Identifiers — server-rendered #}
+{# Public Product Identifiers — server-rendered
+
+   Single responsive layout: each identifier is one row that flows
+   vertically under md and as a 3-column grid at md+. There's only one
+   <svg data-barcode-id="..."> per identifier, so renderBarcode runs
+   exactly once and the document.querySelector lookup is unambiguous. #}
 {% load static %}
 {% if product_identifiers %}
     <div class="public-section" x-data="productIdentifiersBarcodes()">
         <div class="tw-card">
             {% include 'core/components/public_section_header.html.j2' with title='Product Identifiers' icon='fa-fingerprint' %}
-            {# Mobile (<md): stacked cards. Long codes wrap; barcode renders inline below. #}
-            <div class="md:hidden divide-y divide-border/40">
+            {# Column headers — md+ only; mobile cards label inline. #}
+            <div class="hidden md:grid md:grid-cols-[8rem_1fr_10rem] gap-4 px-6 py-3 bg-border/30 text-xs font-medium text-text-muted uppercase tracking-wide">
+                <div>Type</div>
+                <div>Value</div>
+                <div class="text-center">Barcode</div>
+            </div>
+            <div class="divide-y divide-border/40">
                 {% for identifier in product_identifiers %}
-                    <div class="px-6 py-4 flex flex-col gap-2">
-                        <span class="self-start px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
-                            {{ identifier.identifier_type_display }}
-                        </span>
-                        <code class="text-primary bg-primary/5 px-2 py-1 rounded text-sm break-all">{{ identifier.value }}</code>
-                        {% if identifier.identifier_type in barcode_types %}
-                            <div class="barcode-wrapper"
-                                 x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
-                                <svg data-barcode-id="{{ identifier.id }}"
-                                     class="barcode-svg"
-                                     x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
-                                     aria-hidden="true">
-                                </svg>
-                                <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
-                                      class="text-text-muted text-xs">
-                                    <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                    <div class="px-6 py-4 flex flex-col gap-2 md:grid md:grid-cols-[8rem_1fr_10rem] md:items-center md:gap-4 md:py-3 hover:bg-border/10">
+                        <div>
+                            <span class="inline-flex px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
+                                {{ identifier.identifier_type_display }}
+                            </span>
+                        </div>
+                        <div class="min-w-0">
+                            <code class="text-primary bg-primary/5 px-2 py-0.5 rounded text-sm break-all">{{ identifier.value }}</code>
+                        </div>
+                        <div class="md:text-center">
+                            {% if identifier.identifier_type in barcode_types %}
+                                <div class="barcode-wrapper inline-block"
+                                     x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
+                                    <svg data-barcode-id="{{ identifier.id }}"
+                                         class="barcode-svg"
+                                         x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                         aria-hidden="true">
+                                    </svg>
+                                    <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                          class="text-text-muted text-xs">
+                                        <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                                    </span>
+                                    <span x-show="barcodeErrors['{{ identifier.id }}']"
+                                          class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
+                                        <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
+                                    </span>
+                                </div>
+                            {% else %}
+                                <span class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
+                                    <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
                                 </span>
-                            </div>
-                        {% endif %}
+                            {% endif %}
+                        </div>
                     </div>
                 {% endfor %}
-            </div>
-            {# md+: full table. #}
-            <div class="hidden md:block p-6">
-                <table class="tw-table w-full text-sm">
-                    <thead>
-                        <tr class="bg-border/30">
-                            <th class="text-left py-3 px-4 font-medium text-text-muted">Type</th>
-                            <th class="text-left py-3 px-4 font-medium text-text-muted">Value</th>
-                            <th class="text-center py-3 px-4 font-medium text-text-muted">Barcode</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for identifier in product_identifiers %}
-                            <tr class="hover:bg-border/10">
-                                <td class="py-3 px-4 align-middle">
-                                    <span class="px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
-                                        {{ identifier.identifier_type_display }}
-                                    </span>
-                                </td>
-                                <td class="py-3 px-4 align-middle">
-                                    <code class="text-primary bg-primary/5 px-2 py-0.5 rounded break-all">{{ identifier.value }}</code>
-                                </td>
-                                <td class="py-3 px-4 align-middle text-center">
-                                    {% if identifier.identifier_type in barcode_types %}
-                                        <div class="barcode-wrapper inline-block"
-                                             x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
-                                            <svg data-barcode-id="{{ identifier.id }}"
-                                                 class="barcode-svg"
-                                                 x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
-                                                 aria-hidden="true">
-                                            </svg>
-                                            <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
-                                                  class="text-text-muted">
-                                                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
-                                            </span>
-                                            <span x-show="barcodeErrors['{{ identifier.id }}']"
-                                                  class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
-                                                <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
-                                            </span>
-                                        </div>
-                                    {% else %}
-                                        <span class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
-                                            <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
-                                        </span>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
             </div>
         </div>
     </div>

--- a/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_identifiers.html.j2
@@ -1,56 +1,83 @@
-{# Public Product Identifiers - server-rendered #}
+{# Public Product Identifiers — server-rendered #}
 {% load static %}
 {% if product_identifiers %}
     <div class="public-section" x-data="productIdentifiersBarcodes()">
         <div class="tw-card">
             {% include 'core/components/public_section_header.html.j2' with title='Product Identifiers' icon='fa-fingerprint' %}
-            <div class="p-6">
-                <div class="overflow-x-auto">
-                    <table class="tw-table w-full text-sm">
-                        <thead>
-                            <tr class="bg-border/30">
-                                <th class="text-left py-3 px-4 font-medium text-text-muted">Type</th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted">Value</th>
-                                <th class="text-center py-3 px-4 font-medium text-text-muted">Barcode</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for identifier in product_identifiers %}
-                                <tr class="hover:bg-border/10">
-                                    <td class="py-3 px-4">
-                                        <span class="px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">{{ identifier.identifier_type_display }}</span>
-                                    </td>
-                                    <td class="py-3 px-4">
-                                        <code class="text-primary bg-primary/5 px-2 py-0.5 rounded">{{ identifier.value }}</code>
-                                    </td>
-                                    <td class="py-3 px-4 text-center">
-                                        {% if identifier.identifier_type in barcode_types %}
-                                            <div class="barcode-wrapper inline-block"
-                                                 x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
-                                                <svg data-barcode-id="{{ identifier.id }}"
-                                                     class="barcode-svg max-w-[150px] h-auto"
-                                                     x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']">
-                                                </svg>
-                                                <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
-                                                      class="text-text-muted">
-                                                    <i class="fas fa-spinner fa-spin"></i>
-                                                </span>
-                                                <span x-show="barcodeErrors['{{ identifier.id }}']"
-                                                      class="px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
-                                                    <i class="fas fa-info-circle mr-1"></i>Not Applicable
-                                                </span>
-                                            </div>
-                                        {% else %}
-                                            <span class="px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
-                                                <i class="fas fa-info-circle mr-1"></i>Not Applicable
+            {# Mobile (<md): stacked cards. Long codes wrap; barcode renders inline below. #}
+            <div class="md:hidden divide-y divide-border/40">
+                {% for identifier in product_identifiers %}
+                    <div class="px-6 py-4 flex flex-col gap-2">
+                        <span class="self-start px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
+                            {{ identifier.identifier_type_display }}
+                        </span>
+                        <code class="text-primary bg-primary/5 px-2 py-1 rounded text-sm break-all">{{ identifier.value }}</code>
+                        {% if identifier.identifier_type in barcode_types %}
+                            <div class="barcode-wrapper"
+                                 x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
+                                <svg data-barcode-id="{{ identifier.id }}"
+                                     class="barcode-svg max-w-[150px] h-auto"
+                                     x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                     aria-hidden="true">
+                                </svg>
+                                <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                      class="text-text-muted text-xs">
+                                    <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                                </span>
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+            {# md+: full table. #}
+            <div class="hidden md:block p-6">
+                <table class="tw-table w-full text-sm">
+                    <thead>
+                        <tr class="bg-border/30">
+                            <th class="text-left py-3 px-4 font-medium text-text-muted">Type</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted">Value</th>
+                            <th class="text-center py-3 px-4 font-medium text-text-muted">Barcode</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for identifier in product_identifiers %}
+                            <tr class="hover:bg-border/10">
+                                <td class="py-3 px-4 align-middle">
+                                    <span class="px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
+                                        {{ identifier.identifier_type_display }}
+                                    </span>
+                                </td>
+                                <td class="py-3 px-4 align-middle">
+                                    <code class="text-primary bg-primary/5 px-2 py-0.5 rounded break-all">{{ identifier.value }}</code>
+                                </td>
+                                <td class="py-3 px-4 align-middle text-center">
+                                    {% if identifier.identifier_type in barcode_types %}
+                                        <div class="barcode-wrapper inline-block"
+                                             x-init="renderBarcode('{{ identifier.id }}', '{{ identifier.value|escapejs }}', '{{ identifier.identifier_type }}')">
+                                            <svg data-barcode-id="{{ identifier.id }}"
+                                                 class="barcode-svg max-w-[150px] h-auto"
+                                                 x-show="barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                                 aria-hidden="true">
+                                            </svg>
+                                            <span x-show="!barcodeRendered['{{ identifier.id }}'] && !barcodeErrors['{{ identifier.id }}']"
+                                                  class="text-text-muted">
+                                                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
                                             </span>
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                                            <span x-show="barcodeErrors['{{ identifier.id }}']"
+                                                  class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
+                                                <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
+                                            </span>
+                                        </div>
+                                    {% else %}
+                                        <span class="inline-flex items-center gap-1 px-2 py-1 text-xs rounded bg-border/50 text-text-muted">
+                                            <i class="fas fa-info-circle" aria-hidden="true"></i>Not Applicable
+                                        </span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/sbomify/apps/core/templates/core/components/public_product_lifecycle.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_lifecycle.html.j2
@@ -1,11 +1,7 @@
 {% if product.release_date or product.end_of_support or product.end_of_life %}
     <div class="public-section">
         <div class="tw-card">
-            <div class="px-6 py-4 border-b border-border">
-                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                    <i class="fas fa-clock text-primary"></i>Lifecycle
-                </h4>
-            </div>
+            {% include 'core/components/public_section_header.html.j2' with title='Lifecycle' icon='fa-clock' %}
             <div class="p-6">
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     {% if product.release_date %}

--- a/sbomify/apps/core/templates/core/components/public_product_links.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_links.html.j2
@@ -4,11 +4,7 @@
 {% if product_links %}
     <div class="public-section">
         <div class="tw-card">
-            <div class="px-6 py-4 border-b border-border">
-                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                    <i class="fas fa-link text-primary"></i>Resources & Links
-                </h4>
-            </div>
+            {% include 'core/components/public_section_header.html.j2' with title='Resources & Links' icon='fa-link' %}
             <div class="p-6">
                 <div class="overflow-x-auto">
                     <table class="tw-table w-full text-sm">

--- a/sbomify/apps/core/templates/core/components/public_product_links.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_product_links.html.j2
@@ -1,44 +1,62 @@
-{# Public Product Links - server-rendered #}
+{# Public Product Links — server-rendered #}
 {% load static %}
 {% load utils %}
 {% if product_links %}
     <div class="public-section">
         <div class="tw-card">
             {% include 'core/components/public_section_header.html.j2' with title='Resources & Links' icon='fa-link' %}
-            <div class="p-6">
-                <div class="overflow-x-auto">
-                    <table class="tw-table w-full text-sm">
-                        <thead>
-                            <tr class="bg-border/30">
-                                <th class="text-left py-3 px-4 font-medium text-text-muted">Type</th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted">Title</th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted">URL</th>
+            {# Mobile (<md): stacked rows so URL link isn't pushed off-screen. #}
+            <div class="md:hidden divide-y divide-border/40">
+                {% for link in product_links %}
+                    <div class="px-6 py-4 flex flex-col gap-2">
+                        <span class="self-start px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">
+                            {{ link.link_type_display }}
+                        </span>
+                        <div class="text-text font-semibold break-words">{{ link.title }}</div>
+                        {% if link.description %}<p class="text-text-muted text-xs m-0">{{ link.description }}</p>{% endif %}
+                        <a href="{% url 'core:product_link_redirect' link_id=link.id %}"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary hover:underline inline-flex items-center gap-1 self-start min-h-10 py-2">
+                            Visit Link
+                            <i class="fas fa-external-link-alt text-xs" aria-hidden="true"></i>
+                        </a>
+                    </div>
+                {% endfor %}
+            </div>
+            {# md+: full table. #}
+            <div class="hidden md:block p-6">
+                <table class="tw-table w-full text-sm">
+                    <thead>
+                        <tr class="bg-border/30">
+                            <th class="text-left py-3 px-4 font-medium text-text-muted">Type</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted">Title</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted">URL</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for link in product_links %}
+                            <tr class="hover:bg-border/10">
+                                <td class="py-3 px-4 align-middle">
+                                    <span class="px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">{{ link.link_type_display }}</span>
+                                </td>
+                                <td class="py-3 px-4 align-middle">
+                                    <div class="text-text font-semibold">{{ link.title }}</div>
+                                    {% if link.description %}<p class="text-text-muted text-xs mt-1 mb-0">{{ link.description }}</p>{% endif %}
+                                </td>
+                                <td class="py-3 px-4 align-middle">
+                                    <a href="{% url 'core:product_link_redirect' link_id=link.id %}"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="text-primary hover:underline inline-flex items-center gap-1">
+                                        Visit Link
+                                        <i class="fas fa-external-link-alt text-xs" aria-hidden="true"></i>
+                                    </a>
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {% for link in product_links %}
-                                <tr class="hover:bg-border/10">
-                                    <td class="py-3 px-4">
-                                        <span class="px-2 py-1 text-xs font-medium rounded bg-border/50 text-text">{{ link.link_type_display }}</span>
-                                    </td>
-                                    <td class="py-3 px-4">
-                                        <strong class="text-text">{{ link.title }}</strong>
-                                        {% if link.description %}<div class="text-text-muted text-xs mt-1">{{ link.description }}</div>{% endif %}
-                                    </td>
-                                    <td class="py-3 px-4">
-                                        <a href="{% url 'core:product_link_redirect' link_id=link.id %}"
-                                           target="_blank"
-                                           rel="noopener noreferrer"
-                                           class="text-primary hover:underline inline-flex items-center gap-1">
-                                            Visit Link
-                                            <i class="fas fa-external-link-alt text-xs"></i>
-                                        </a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
@@ -108,12 +108,21 @@
                                     <td class="py-3 px-4">
                                         <span class="font-medium text-text"
                                               x-text="artifact.artifact_name || 'Unnamed artifact'"></span>
-                                        {# Mobile-only meta — duplicates hidden columns on small screens #}
+                                        {# Mobile-only meta — duplicates the columns hidden under md / lg
+                                           (Component + Format under md, Version + Created under lg). #}
                                         <div class="md:hidden mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
                                             <span x-show="artifact.component_name" x-text="artifact.component_name"></span>
                                             <span x-show="artifact.sbom_format || artifact.document_type"
                                                   class="text-text-muted"
                                                   x-text="getFormatDisplay(artifact)"></span>
+                                            <span x-show="getVersion(artifact)" x-text="'v' + getVersion(artifact)"></span>
+                                            <span x-show="artifact.created_at" x-text="formatDate(artifact.created_at)"></span>
+                                        </div>
+                                        {# Tablet-only meta — Component + Format show in their own columns at md+,
+                                           but Version + Created stay hidden until lg. #}
+                                        <div class="hidden md:flex lg:hidden mt-1 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
+                                            <span x-show="getVersion(artifact)" x-text="'v' + getVersion(artifact)"></span>
+                                            <span x-show="artifact.created_at" x-text="formatDate(artifact.created_at)"></span>
                                         </div>
                                     </td>
                                     <td class="py-3 px-4 text-text hidden md:table-cell"

--- a/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
@@ -4,11 +4,7 @@
     <div class="public-section"
          x-data="{ artifacts: [], search: '', typeFilter: '', sortColumn: 'name', sortDirection: 'asc', init() { this.artifacts = JSON.parse(document.getElementById('public-artifacts-data').textContent); }, get filteredArtifacts() { let items = this.artifacts; if (this.typeFilter) { items = items.filter(a => a.artifact_type === this.typeFilter); } if (this.search) { const q = this.search.toLowerCase(); items = items.filter(a => (a.artifact_name || '').toLowerCase().includes(q) || (a.component_name || '').toLowerCase().includes(q) || (a.sbom_format || '').toLowerCase().includes(q) || (a.document_type || '').toLowerCase().includes(q) ); } return this.sortItems(items); }, sortItems(items) { const col = this.sortColumn; const dir = this.sortDirection === 'asc' ? 1 : -1; return [...items].sort((a, b) => { let valA, valB; switch (col) { case 'type': valA = a.artifact_type || ''; valB = b.artifact_type || ''; break; case 'name': valA = (a.artifact_name || '').toLowerCase(); valB = (b.artifact_name || '').toLowerCase(); break; case 'component': valA = (a.component_name || '').toLowerCase(); valB = (b.component_name || '').toLowerCase(); break; case 'format': valA = (a.sbom_format || a.document_type || '').toLowerCase(); valB = (b.sbom_format || b.document_type || '').toLowerCase(); break; case 'version': valA = (a.sbom_version || a.document_version || '').toLowerCase(); valB = (b.sbom_version || b.document_version || '').toLowerCase(); break; case 'created': valA = a.created_at || ''; valB = b.created_at || ''; break; default: valA = ''; valB = ''; } if (valA < valB) return -1 * dir; if (valA > valB) return 1 * dir; return 0; }); }, sort(col) { if (this.sortColumn === col) { this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'; } else { this.sortColumn = col; this.sortDirection = 'asc'; } }, formatDate(dateStr) { return window.sbomifyFormatDate(dateStr, { fallback: '—' }); }, getFormatDisplay(artifact) { if (artifact.artifact_type === 'sbom' && artifact.sbom_format) { const fmt = artifact.sbom_format.toLowerCase().includes('cyclonedx') ? 'CYCLONEDX' : 'SPDX'; return fmt + (artifact.sbom_format_version ? ' ' + artifact.sbom_format_version : ''); } if (artifact.artifact_type === 'document' && artifact.document_type) { return artifact.document_type.toUpperCase(); } return '—'; }, getFormatClass(artifact) { if (artifact.artifact_type === 'sbom' && artifact.sbom_format) { return artifact.sbom_format.toLowerCase().includes('cyclonedx') ? 'tw-sbom-format tw-sbom-format-cyclonedx' : 'tw-sbom-format tw-sbom-format-spdx'; } return ''; }, isDocument(artifact) { return artifact.artifact_type === 'document'; }, getVersion(artifact) { return artifact.sbom_version || artifact.document_version || ''; } }">
         <div class="tw-card">
-            <div class="px-6 py-4 border-b border-border">
-                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                    <i class="fas fa-puzzle-piece text-primary"></i>Artifacts in this Release
-                </h4>
-            </div>
+            {% include 'core/components/public_section_header.html.j2' with title='Artifacts in this Release' icon='fa-puzzle-piece' %}
             <div class="p-0">
                 {# Search and Filter #}
                 <div class="px-6 py-4 border-b border-border grid grid-cols-1 sm:grid-cols-12 gap-3">
@@ -58,7 +54,7 @@
                                         <span class="tw-table-sort-icon" aria-hidden="true"><i class="fas fa-caret-up"></i><i class="fas fa-caret-down"></i></span>
                                     </button>
                                 </th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted"
+                                <th class="text-left py-3 px-4 font-medium text-text-muted hidden md:table-cell"
                                     :aria-sort="sortColumn === 'component' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
                                     <button type="button"
                                             class="tw-table-sortable"
@@ -68,7 +64,7 @@
                                         <span class="tw-table-sort-icon" aria-hidden="true"><i class="fas fa-caret-up"></i><i class="fas fa-caret-down"></i></span>
                                     </button>
                                 </th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted"
+                                <th class="text-left py-3 px-4 font-medium text-text-muted hidden md:table-cell"
                                     :aria-sort="sortColumn === 'format' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
                                     <button type="button"
                                             class="tw-table-sortable"
@@ -78,7 +74,7 @@
                                         <span class="tw-table-sort-icon" aria-hidden="true"><i class="fas fa-caret-up"></i><i class="fas fa-caret-down"></i></span>
                                     </button>
                                 </th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted"
+                                <th class="text-left py-3 px-4 font-medium text-text-muted hidden lg:table-cell"
                                     :aria-sort="sortColumn === 'version' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
                                     <button type="button"
                                             class="tw-table-sortable"
@@ -88,7 +84,7 @@
                                         <span class="tw-table-sort-icon" aria-hidden="true"><i class="fas fa-caret-up"></i><i class="fas fa-caret-down"></i></span>
                                     </button>
                                 </th>
-                                <th class="text-left py-3 px-4 font-medium text-text-muted"
+                                <th class="text-left py-3 px-4 font-medium text-text-muted hidden lg:table-cell"
                                     :aria-sort="sortColumn === 'created' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
                                     <button type="button"
                                             class="tw-table-sortable"
@@ -112,26 +108,33 @@
                                     <td class="py-3 px-4">
                                         <span class="font-medium text-text"
                                               x-text="artifact.artifact_name || 'Unnamed artifact'"></span>
+                                        {# Mobile-only meta — duplicates hidden columns on small screens #}
+                                        <div class="md:hidden mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
+                                            <span x-show="artifact.component_name" x-text="artifact.component_name"></span>
+                                            <span x-show="artifact.sbom_format || artifact.document_type"
+                                                  class="text-text-muted"
+                                                  x-text="getFormatDisplay(artifact)"></span>
+                                        </div>
                                     </td>
-                                    <td class="py-3 px-4 text-text" x-text="artifact.component_name || '—'"></td>
-                                    <td class="py-3 px-4">
+                                    <td class="py-3 px-4 text-text hidden md:table-cell"
+                                        x-text="artifact.component_name || '—'"></td>
+                                    <td class="py-3 px-4 hidden md:table-cell">
                                         <span x-show="artifact.artifact_type === 'sbom' && artifact.sbom_format"
                                               :class="getFormatClass(artifact)"
                                               x-text="getFormatDisplay(artifact)"></span>
                                         <span x-show="isDocument(artifact) && artifact.document_type"
-                                              class="tw-sbom-format text-text-muted bg-border/20 border"
-                                              style="border-color: color-mix(in srgb, rgb(var(--color-border)) 60%, transparent)"
+                                              class="tw-sbom-format text-text-muted bg-border/20 border border-border/60"
                                               x-text="getFormatDisplay(artifact)"></span>
                                         <span x-show="!artifact.sbom_format && !artifact.document_type"
                                               class="text-text-muted">—</span>
                                     </td>
-                                    <td class="py-3 px-4">
+                                    <td class="py-3 px-4 hidden lg:table-cell">
                                         <span x-show="getVersion(artifact)"
                                               class="text-text"
                                               x-text="getVersion(artifact)"></span>
                                         <span x-show="!getVersion(artifact)" class="text-text-muted">—</span>
                                     </td>
-                                    <td class="py-3 px-4 text-text-muted text-sm"
+                                    <td class="py-3 px-4 text-text-muted text-sm hidden lg:table-cell"
                                         x-text="formatDate(artifact.created_at)"></td>
                                 </tr>
                             </template>
@@ -154,11 +157,7 @@
 {% else %}
     <div class="public-section">
         <div class="tw-card">
-            <div class="px-6 py-4 border-b border-border">
-                <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                    <i class="fas fa-puzzle-piece text-primary"></i>Artifacts in this Release
-                </h4>
-            </div>
+            {% include 'core/components/public_section_header.html.j2' with title='Artifacts in this Release' icon='fa-puzzle-piece' %}
             <div class="p-6 text-center">
                 <i class="fas fa-puzzle-piece text-4xl text-text-muted opacity-50 mb-4"></i>
                 <h5 class="font-semibold text-text mb-2">No artifacts in this release</h5>

--- a/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
@@ -43,7 +43,7 @@
                                         {% if release.version %}
                                             <code class="text-primary bg-primary/5 px-1.5 py-0.5 rounded text-[0.65rem] font-mono">{{ release.version }}</code>
                                         {% endif %}
-                                        <span>{{ release.released_at|default:release.created_at|naturaltime }}</span>
+                                        <span>{{ release.released_at|default_if_none:release.created_at|naturaltime }}</span>
                                     </div>
                                 </td>
                                 <td class="py-3 px-4 hidden md:table-cell">
@@ -80,8 +80,8 @@
                                     {% endif %}
                                 </td>
                                 <td class="py-3 px-4 text-text-muted text-sm whitespace-nowrap hidden md:table-cell">
-                                    <span title="{{ release.released_at|default:release.created_at }}">
-                                        {{ release.released_at|default:release.created_at|naturaltime }}
+                                    <span title="{{ release.released_at|default_if_none:release.created_at }}">
+                                        {{ release.released_at|default_if_none:release.created_at|naturaltime }}
                                     </span>
                                 </td>
                                 <td class="py-3 px-4 text-right">

--- a/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
@@ -23,10 +23,10 @@
                     <thead>
                         <tr class="bg-border/30">
                             <th class="text-left py-3 px-4 font-medium text-text-muted">Release</th>
-                            <th class="text-left py-3 px-4 font-medium text-text-muted">Version</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted hidden md:table-cell">Version</th>
                             <th class="text-left py-3 px-4 font-medium text-text-muted">Status</th>
-                            <th class="text-left py-3 px-4 font-medium text-text-muted">Description</th>
-                            <th class="text-left py-3 px-4 font-medium text-text-muted">Released</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted hidden lg:table-cell">Description</th>
+                            <th class="text-left py-3 px-4 font-medium text-text-muted hidden md:table-cell">Released</th>
                             <th class="text-right py-3 px-4 font-medium text-text-muted"></th>
                         </tr>
                     </thead>
@@ -38,8 +38,15 @@
                                        class="font-semibold text-text hover:text-primary no-underline">
                                         {{ release.name }}
                                     </a>
+                                    {# Mobile-only inline meta — duplicates hidden columns on small screens #}
+                                    <div class="md:hidden mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-muted">
+                                        {% if release.version %}
+                                            <code class="text-primary bg-primary/5 px-1.5 py-0.5 rounded text-[0.65rem] font-mono">{{ release.version }}</code>
+                                        {% endif %}
+                                        <span>{{ release.released_at|default:release.created_at|naturaltime }}</span>
+                                    </div>
                                 </td>
-                                <td class="py-3 px-4">
+                                <td class="py-3 px-4 hidden md:table-cell">
                                     {% if release.version %}
                                         <code class="text-primary bg-primary/5 px-2 py-0.5 rounded text-xs">{{ release.version }}</code>
                                     {% else %}
@@ -65,21 +72,21 @@
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="py-3 px-4 text-text-muted max-w-xs">
+                                <td class="py-3 px-4 text-text-muted max-w-xs hidden lg:table-cell">
                                     {% if release.description %}
                                         <span title="{{ release.description }}">{{ release.description|truncatechars:50 }}</span>
                                     {% else %}
                                         <span class="text-text-muted">—</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-3 px-4 text-text-muted text-sm whitespace-nowrap">
+                                <td class="py-3 px-4 text-text-muted text-sm whitespace-nowrap hidden md:table-cell">
                                     <span title="{{ release.released_at|default:release.created_at }}">
                                         {{ release.released_at|default:release.created_at|naturaltime }}
                                     </span>
                                 </td>
                                 <td class="py-3 px-4 text-right">
                                     <a href="{{ release.public_url }}"
-                                       class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary bg-primary/5 hover:bg-primary/10 rounded-lg transition-colors no-underline">
+                                       class="inline-flex items-center gap-1.5 min-h-9 px-3 py-2 text-xs font-medium text-primary bg-primary/5 hover:bg-primary/10 rounded-lg transition-colors no-underline">
                                         View
                                         <i class="fas fa-arrow-right text-[0.625rem]"></i>
                                     </a>

--- a/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
@@ -41,7 +41,7 @@
                                     {# Mobile-only inline meta — duplicates hidden columns on small screens #}
                                     <div class="md:hidden mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-muted">
                                         {% if release.version %}
-                                            <code class="text-primary bg-primary/5 px-1.5 py-0.5 rounded text-[0.65rem] font-mono">{{ release.version }}</code>
+                                            <code class="text-primary bg-primary/5 px-1.5 py-0.5 rounded text-xs font-mono">{{ release.version }}</code>
                                         {% endif %}
                                         <span>{{ release.released_at|default_if_none:release.created_at|naturaltime }}</span>
                                     </div>
@@ -57,13 +57,13 @@
                                     <div class="flex items-center gap-1.5">
                                         {% if release.is_latest %}
                                             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-success/10 text-success inline-flex items-center gap-1">
-                                                <i class="fas fa-check-circle text-[0.625rem]"></i>
+                                                <i class="fas fa-check-circle text-xs"></i>
                                                 Latest
                                             </span>
                                         {% endif %}
                                         {% if release.is_prerelease %}
                                             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-warning/10 text-warning inline-flex items-center gap-1">
-                                                <i class="fas fa-flask text-[0.625rem]"></i>
+                                                <i class="fas fa-flask text-xs"></i>
                                                 Pre-release
                                             </span>
                                         {% endif %}
@@ -88,7 +88,7 @@
                                     <a href="{{ release.public_url }}"
                                        class="inline-flex items-center gap-1.5 min-h-9 px-3 py-2 text-xs font-medium text-primary bg-primary/5 hover:bg-primary/10 rounded-lg transition-colors no-underline">
                                         View
-                                        <i class="fas fa-arrow-right text-[0.625rem]"></i>
+                                        <i class="fas fa-arrow-right text-xs"></i>
                                     </a>
                                 </td>
                             </tr>

--- a/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_releases_list.html.j2
@@ -7,14 +7,14 @@
             <div class="px-6 py-4 border-b border-border flex justify-between items-center">
                 <div>
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                        <i class="fas fa-tags text-primary"></i>Releases
+                        <i class="fas fa-tags text-primary" aria-hidden="true"></i>Releases
                     </h4>
                     <p class="text-sm text-text-muted mt-1 mb-0">Version history and release information</p>
                 </div>
                 {% if view_all_releases_url %}
                     <a href="{{ view_all_releases_url }}"
                        class="inline-flex items-center gap-2 text-sm text-primary hover:underline flex-shrink-0">
-                        View All<i class="fas fa-arrow-right"></i>
+                        View All<i class="fas fa-arrow-right" aria-hidden="true"></i>
                     </a>
                 {% endif %}
             </div>
@@ -57,13 +57,13 @@
                                     <div class="flex items-center gap-1.5">
                                         {% if release.is_latest %}
                                             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-success/10 text-success inline-flex items-center gap-1">
-                                                <i class="fas fa-check-circle text-xs"></i>
+                                                <i class="fas fa-check-circle text-xs" aria-hidden="true"></i>
                                                 Latest
                                             </span>
                                         {% endif %}
                                         {% if release.is_prerelease %}
                                             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-warning/10 text-warning inline-flex items-center gap-1">
-                                                <i class="fas fa-flask text-xs"></i>
+                                                <i class="fas fa-flask text-xs" aria-hidden="true"></i>
                                                 Pre-release
                                             </span>
                                         {% endif %}
@@ -88,7 +88,7 @@
                                     <a href="{{ release.public_url }}"
                                        class="inline-flex items-center gap-1.5 min-h-9 px-3 py-2 text-xs font-medium text-primary bg-primary/5 hover:bg-primary/10 rounded-lg transition-colors no-underline">
                                         View
-                                        <i class="fas fa-arrow-right text-xs"></i>
+                                        <i class="fas fa-arrow-right text-xs" aria-hidden="true"></i>
                                     </a>
                                 </td>
                             </tr>

--- a/sbomify/apps/core/templates/core/components/public_section_header.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_section_header.html.j2
@@ -1,20 +1,21 @@
-{# Shared header for public trust-center section cards.
-   Use inside a .tw-card. Always rendered (icon + title); optional subtitle and trailing slot.
+{% comment %}
+Shared header for public trust-center section cards.
+Use inside a .tw-card. Always rendered (icon + title); optional subtitle and trailing slot.
 
-   Usage:
-     {% include 'core/components/public_section_header.html.j2' with title='Releases' icon='fa-tags' %}
-     {% include 'core/components/public_section_header.html.j2' with title='Resources & Links' icon='fa-link' subtitle='...' %}
+Usage:
+  {% include 'core/components/public_section_header.html.j2' with title='Releases' icon='fa-tags' %}
+  {% include 'core/components/public_section_header.html.j2' with title='Resources & Links' icon='fa-link' subtitle='...' %}
 
-   Parameters:
-     - title (required): heading text
-     - icon (required): FontAwesome class fragment, e.g. 'fa-link' (rendered as 'fas fa-link')
-     - icon_set (optional): override icon family, defaults to 'fas'
-     - subtitle (optional): smaller muted description under the heading
-     - trailing (optional): extra content rendered right-aligned in the header row.
-       Auto-escaped by default. Callers passing HTML must explicitly mark it safe
-       at the call site (e.g. with `trailing=some_html|safe`) so this partial
-       cannot accidentally render untrusted content unescaped.
-#}
+Parameters:
+  - title (required): heading text
+  - icon (required): FontAwesome class fragment, e.g. 'fa-link' (rendered as 'fas fa-link')
+  - icon_set (optional): override icon family, defaults to 'fas'
+  - subtitle (optional): smaller muted description under the heading
+  - trailing (optional): extra content rendered right-aligned in the header row.
+    Auto-escaped by default. Callers passing HTML must explicitly mark it safe
+    at the call site (e.g. with `trailing=some_html|safe`) so this partial
+    cannot accidentally render untrusted content unescaped.
+{% endcomment %}
 <div class="px-6 py-4 border-b border-border flex items-start justify-between gap-3">
     <div class="min-w-0">
         <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">

--- a/sbomify/apps/core/templates/core/components/public_section_header.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_section_header.html.j2
@@ -1,0 +1,25 @@
+{# Shared header for public trust-center section cards.
+   Use inside a .tw-card. Always rendered (icon + title); optional subtitle and trailing slot.
+
+   Usage:
+     {% include 'core/components/public_section_header.html.j2' with title='Releases' icon='fa-tags' %}
+     {% include 'core/components/public_section_header.html.j2' with title='Resources & Links' icon='fa-link' subtitle='...' %}
+
+   Parameters:
+     - title (required): heading text
+     - icon (required): FontAwesome class fragment, e.g. 'fa-link' (rendered as 'fas fa-link')
+     - icon_set (optional): override icon family, defaults to 'fas'
+     - subtitle (optional): smaller muted description under the heading
+     - trailing (optional): extra HTML rendered right-aligned in the header row
+       (pass via {% include ... with trailing=... %} where the value is a safe-string)
+#}
+<div class="px-6 py-4 border-b border-border flex items-start justify-between gap-3">
+    <div class="min-w-0">
+        <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+            <i class="{{ icon_set|default:'fas' }} {{ icon }} text-primary"
+               aria-hidden="true"></i>{{ title }}
+        </h4>
+        {% if subtitle %}<p class="text-sm text-text-muted mt-1 mb-0">{{ subtitle }}</p>{% endif %}
+    </div>
+    {% if trailing %}<div class="flex items-center gap-2 flex-shrink-0">{{ trailing|safe }}</div>{% endif %}
+</div>

--- a/sbomify/apps/core/templates/core/components/public_section_header.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_section_header.html.j2
@@ -10,8 +10,10 @@
      - icon (required): FontAwesome class fragment, e.g. 'fa-link' (rendered as 'fas fa-link')
      - icon_set (optional): override icon family, defaults to 'fas'
      - subtitle (optional): smaller muted description under the heading
-     - trailing (optional): extra HTML rendered right-aligned in the header row
-       (pass via {% include ... with trailing=... %} where the value is a safe-string)
+     - trailing (optional): extra content rendered right-aligned in the header row.
+       Auto-escaped by default. Callers passing HTML must explicitly mark it safe
+       at the call site (e.g. with `trailing=some_html|safe`) so this partial
+       cannot accidentally render untrusted content unescaped.
 #}
 <div class="px-6 py-4 border-b border-border flex items-start justify-between gap-3">
     <div class="min-w-0">
@@ -21,5 +23,5 @@
         </h4>
         {% if subtitle %}<p class="text-sm text-text-muted mt-1 mb-0">{{ subtitle }}</p>{% endif %}
     </div>
-    {% if trailing %}<div class="flex items-center gap-2 flex-shrink-0">{{ trailing|safe }}</div>{% endif %}
+    {% if trailing %}<div class="flex items-center gap-2 flex-shrink-0">{{ trailing }}</div>{% endif %}
 </div>

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -16,31 +16,25 @@
     {% breadcrumb product 'product' %}
 {% endblock %}
 {% block content %}
-    <div class="public-item-header">
-        {% if back_url or fallback_url %}
-            <a href="{{ fallback_url|default:back_url }}"
-               class="inline-flex items-center gap-2 text-text-muted hover:text-text mb-4 no-underline"
-               onclick="if (window.history.length > 1) { window.history.back(); return false; }">
-                <i class="fas fa-arrow-left" aria-hidden="true"></i>Back
-            </a>
-        {% endif %}
-        <h1 class="text-3xl font-bold text-text flex items-center gap-4 mb-3">
+    <div class="public-item-header flex flex-col gap-3">
+        {# Back navigation comes from the breadcrumb (`Trust Center`) — no redundant Back link. #}
+        <h1 class="text-3xl font-bold text-text flex items-center gap-4 m-0">
             <span class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center text-primary">
-                <i class="fas fa-box"></i>
+                <i class="fas fa-box" aria-hidden="true"></i>
             </span>
             {{ product.name }}
         </h1>
-        {% if product.description %}<p class="text-text-muted text-lg mb-4">{{ product.description }}</p>{% endif %}
+        {% if product.description %}<p class="text-text-muted text-lg m-0">{{ product.description }}</p>{% endif %}
         {% if product_tei %}
-            <div class="flex items-center gap-2 text-sm text-text-muted mb-2">
+            <div class="flex items-center gap-2 text-sm text-text-muted">
                 {% include 'core/components/copyable_value.html.j2' with value=product_tei title="TEI: "|add:product_tei|add:" (click to copy)" %}
             </div>
         {% endif %}
         {% if public_components or passing_assessments %}
-            <div class="flex flex-wrap gap-2 mb-6">
+            <div class="flex flex-wrap gap-2">
                 {% if public_components %}
                     <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text flex items-center gap-2">
-                        <i class="fas fa-puzzle-piece"></i>
+                        <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
                         {{ public_components|length }} Component{{ public_components|length|pluralize }}
                     </span>
                 {% endif %}

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -50,12 +50,52 @@
             </div>
         {% endif %}
     </div>
+    {% if has_downloadable_content %}
+        <div class="public-section">
+            <div class="tw-card">
+                <div class="px-6 py-4 border-b border-border">
+                    <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+                        <i class="fas fa-download text-primary"></i>Download Latest Release
+                    </h4>
+                </div>
+                <div class="p-6">
+                    <p class="text-text-muted mb-4">Combined SBOM from the latest release, containing all artifacts for this product.</p>
+                    <div class="flex gap-3 flex-wrap">
+                        <a class="inline-flex items-center gap-2 min-h-10 px-4 py-2 border border-border rounded-lg text-text hover:bg-border/30 transition-colors no-underline"
+                           href="{% url 'core:sbom_download_product' product.id %}"
+                           title="Download combined SBOM as CycloneDX">
+                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                 alt=""
+                                 class="h-5 w-auto"
+                                 height="20"
+                                 width="20"
+                                 aria-hidden="true">
+                            <span>CycloneDX</span>
+                            <i class="fas fa-download text-primary text-xs ml-1" aria-hidden="true"></i>
+                        </a>
+                        <a class="inline-flex items-center gap-2 min-h-10 px-4 py-2 border border-border rounded-lg text-text hover:bg-border/30 transition-colors no-underline"
+                           href="{% url 'core:sbom_download_product' product.id %}?format=spdx"
+                           title="Download combined SBOM as SPDX">
+                            <img src="{% static 'img/spdx-logo.svg' %}"
+                                 alt=""
+                                 class="h-5 w-auto"
+                                 height="20"
+                                 width="20"
+                                 aria-hidden="true">
+                            <span>SPDX</span>
+                            <i class="fas fa-download text-primary text-xs ml-1" aria-hidden="true"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {% include 'core/components/public_releases_list.html.j2' %}
     {% include 'core/components/public_product_identifiers.html.j2' %}
     {% include 'core/components/public_product_links.html.j2' %}
     {% include 'core/components/public_product_lifecycle.html.j2' %}
     {% include 'compliance/components/public_vdp_link.html.j2' %}
     {% include 'compliance/components/public_doc_link.html.j2' %}
-    {% include 'core/components/public_releases_list.html.j2' %}
     {% if public_components %}
         <div class="public-section">
             <div class="tw-card">
@@ -82,44 +122,6 @@
                         </li>
                     {% endfor %}
                 </ul>
-            </div>
-        </div>
-    {% endif %}
-    {% if has_downloadable_content %}
-        <div class="public-section">
-            <div class="tw-card">
-                <div class="px-6 py-4 border-b border-border">
-                    <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                        <i class="fas fa-download text-primary"></i>Download Latest Release
-                    </h4>
-                </div>
-                <div class="p-6 text-center">
-                    <p class="text-text-muted mb-4">
-                        Download the combined SBOM from the latest release containing all artifacts for this product
-                    </p>
-                    <div class="flex justify-center gap-3 flex-wrap">
-                        <a class="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-text hover:bg-border/30 transition-colors no-underline"
-                           href="{% url 'core:sbom_download_product' product.id %}"
-                           title="Download as CycloneDX">
-                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt="CycloneDX"
-                                 class="h-[18px] w-auto"
-                                 height="18"
-                                 width="18">
-                            <i class="fas fa-download text-primary" aria-hidden="true"></i>
-                        </a>
-                        <a class="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-lg text-text hover:bg-border/30 transition-colors no-underline"
-                           href="{% url 'core:sbom_download_product' product.id %}?format=spdx"
-                           title="Download as SPDX">
-                            <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt="SPDX"
-                                 class="h-[18px] w-auto"
-                                 height="18"
-                                 width="18">
-                            <i class="fas fa-download text-primary" aria-hidden="true"></i>
-                        </a>
-                    </div>
-                </div>
             </div>
         </div>
     {% endif %}

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -49,7 +49,7 @@
             <div class="tw-card">
                 <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                        <i class="fas fa-download text-primary"></i>Download Latest Release
+                        <i class="fas fa-download text-primary" aria-hidden="true"></i>Download Latest Release
                     </h4>
                 </div>
                 <div class="p-6">

--- a/sbomify/apps/core/templates/core/product_releases_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_releases_public.html.j2
@@ -43,7 +43,7 @@
                            class="flex items-center gap-4 px-6 py-4 hover:bg-border/10 transition-colors no-underline group">
                             {# Release Icon #}
                             <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 {% if release.is_latest %}bg-success/10 text-success{% elif release.is_prerelease %}bg-warning/10 text-warning{% else %}bg-primary/10 text-primary{% endif %}">
-                                <i class="fas fa-tag"></i>
+                                <i class="fas fa-tag" aria-hidden="true"></i>
                             </div>
                             {# Release Info #}
                             <div class="flex-1 min-w-0">
@@ -61,7 +61,7 @@
                                 </div>
                                 <div class="flex items-center gap-4 mt-1">
                                     <span class="text-xs text-text-muted flex items-center gap-1">
-                                        <i class="far fa-clock"></i>
+                                        <i class="far fa-clock" aria-hidden="true"></i>
                                         {{ release.released_at|default_if_none:release.created_at|naturaltime }}
                                     </span>
                                     {% if release.description %}
@@ -70,7 +70,8 @@
                                 </div>
                             </div>
                             {# Arrow #}
-                            <i class="fas fa-chevron-right text-text-muted text-sm group-hover:text-primary group-hover:translate-x-0.5 transition-all flex-shrink-0"></i>
+                            <i class="fas fa-chevron-right text-text-muted text-sm group-hover:text-primary group-hover:translate-x-0.5 transition-all flex-shrink-0"
+                               aria-hidden="true"></i>
                         </a>
                     {% endfor %}
                 </div>
@@ -80,7 +81,8 @@
         <div class="public-section">
             <div class="tw-card">
                 <div class="p-6 text-center py-12">
-                    <i class="fas fa-tags text-5xl text-text-muted mb-4 block"></i>
+                    <i class="fas fa-tags text-5xl text-text-muted mb-4 block"
+                       aria-hidden="true"></i>
                     <p class="text-text-muted mb-0">No releases available for this product yet.</p>
                 </div>
             </div>

--- a/sbomify/apps/core/templates/core/product_releases_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_releases_public.html.j2
@@ -41,17 +41,10 @@
     {% if releases %}
         <div class="public-section">
             <div class="tw-card">
-                <div class="px-6 py-4 border-b border-border">
-                    <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
-                        <i class="fas fa-history text-primary"></i>Release History
-                    </h4>
-                    <p class="text-sm text-text-muted mt-1 mb-0">Browse all releases and their artifacts</p>
-                </div>
-                <div>
+                <div class="divide-y divide-border/50">
                     {% for release in releases %}
                         <a href="{% public_url 'core:release_details_public' product_id=product.id product_slug=product.slug release_id=release.id release_slug=release.slug %}"
-                           class="flex items-center gap-4 px-6 py-4 hover:bg-border/10 transition-colors no-underline group"
-                           {% if not forloop.last %}style="border-bottom: 1px solid color-mix(in srgb, rgb(var(--color-border)) 50%, transparent)"{% endif %}>
+                           class="flex items-center gap-4 px-6 py-4 hover:bg-border/10 transition-colors no-underline group">
                             {# Release Icon #}
                             <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 {% if release.is_latest %}bg-success/10 text-success{% elif release.is_prerelease %}bg-warning/10 text-warning{% else %}bg-primary/10 text-primary{% endif %}">
                                 <i class="fas fa-tag"></i>

--- a/sbomify/apps/core/templates/core/product_releases_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_releases_public.html.j2
@@ -16,23 +16,19 @@
     {% breadcrumb releases 'releases' %}
 {% endblock %}
 {% block content %}
-    <div class="public-item-header">
-        <a href="{% url 'core:product_details_public' product.id %}"
-           class="inline-flex items-center gap-2 text-text-muted hover:text-text mb-4 no-underline"
-           onclick="if (window.history.length > 1) { window.history.back(); return false; }">
-            <i class="fas fa-arrow-left"></i>Back
-        </a>
-        <h1 class="text-3xl font-bold text-text flex items-center gap-4 mb-3">
+    <div class="public-item-header flex flex-col gap-3">
+        {# Parent navigation comes from the breadcrumb (`Trust Center > Product`). #}
+        <h1 class="text-3xl font-bold text-text flex items-center gap-4 m-0">
             <span class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center text-primary">
-                <i class="fas fa-tags"></i>
+                <i class="fas fa-tags" aria-hidden="true"></i>
             </span>
             Releases
         </h1>
-        <p class="text-text-muted text-lg mb-4">All software releases for {{ product.name }}</p>
+        <p class="text-text-muted text-lg m-0">All software releases for {{ product.name }}</p>
         {% if releases %}
-            <div class="flex flex-wrap gap-2 mb-6">
+            <div class="flex flex-wrap gap-2">
                 <span class="px-3 py-1.5 text-sm font-medium rounded-full bg-border/50 text-text flex items-center gap-2">
-                    <i class="fas fa-tag"></i>
+                    <i class="fas fa-tag" aria-hidden="true"></i>
                     {{ releases|length }} Release{{ releases|length|pluralize }}
                 </span>
             </div>

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -918,160 +918,223 @@
                 color: var(--brand-color);
                 font-size: 0.75rem;
             }
-</style>
-{% block extra_css %}{% endblock %}
-<title>
-{% block title %}{% endblock %}
--
-{% if brand.name %}
-{{ brand.name }}
-{% else %}
-sbomify
-{% endif %}
-</title>
-{% endblock %}
-{% vite_hmr_client %}
-</head>
-<body class="public-page" data-theme="public">
-<!-- WebSocket connection for authenticated users (enables real-time access request status updates) -->
-{% if request.user.is_authenticated and team and team.key %}
-<div x-data x-init="$store.ws.connect('{{ team.key }}')" class="tw:hidden"></div>
-{% endif %}
-<!-- Public Page Layout -->
-{% include "core/components/messages.html.j2" %}
-<div class="public-page-layout">
-<!-- Brand Header -->
-<header class="public-header">
-<div class="public-header-container">
-<div class="header-spacer"></div>
-<div class="brand-section">
-{% workspace_public_url as trust_center_url %}
-{% if trust_center_url %}
-<a href="{{ trust_center_url }}" class="brand-logo-link" title="Trust Center Home">
-{% if brand.brand_image %}
-<img src="{{ brand.brand_image }}" alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo" class="brand-logo" width="32" height="32">
-{% else %}
-<img src="{% static 'img/sbomify.svg' %}" alt="sbomify Logo" class="brand-logo" width="32" height="32">
-{% endif %}
-</a>
-{% else %}
-{% if brand.brand_image %}
-<img src="{{ brand.brand_image }}" alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo" class="brand-logo" width="32" height="32">
-{% else %}
-<img src="{% static 'img/sbomify.svg' %}" alt="sbomify Logo" class="brand-logo" width="32" height="32">
-{% endif %}
-{% endif %}
-</div>
-<div class="header-actions">
-{# Theme Toggle #}
-<div class="theme-toggle" x-data="themeToggle()" @click.outside="open = false" @keydown.escape.window="open = false">
-<button class="theme-toggle-btn" type="button" @click="open = !open" :aria-expanded="open" :title="'Theme: ' + currentLabel">
-<i :class="currentIcon"></i>
-</button>
-<div class="theme-toggle-menu" x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 transform scale-95" x-transition:enter-end="opacity-100 transform scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 transform scale-100" x-transition:leave-end="opacity-0 transform scale-95" x-cloak>
-<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'light' }" @click="setTheme('light')">
-<span class="item-content">
-<i class="fas fa-sun"></i>
-<span>Light</span>
-</span>
-<i class="fas fa-check check-icon" x-show="theme === 'light'"></i>
-</button>
-<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'dark' }" @click="setTheme('dark')">
-<span class="item-content">
-<i class="fas fa-moon"></i>
-<span>Dark</span>
-</span>
-<i class="fas fa-check check-icon" x-show="theme === 'dark'"></i>
-</button>
-<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'system' }" @click="setTheme('system')">
-<span class="item-content">
-<i class="fas fa-desktop"></i>
-<span>System</span>
-</span>
-<i class="fas fa-check check-icon" x-show="theme === 'system'"></i>
-</button>
-</div>
-</div>
-{% if user.is_authenticated %}
-{% load teams %}
-{% user_workspaces as available_workspaces %}
-{% if available_workspaces|length > 1 %}
-<div class="workspace-dropdown" x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false">
-<button class="workspace-dropdown-btn" type="button" @click="open = !open" :aria-expanded="open" title="Switch workspace">
-<i class="fas fa-briefcase"></i>
-{% if request.session.current_team %}
-<span class="workspace-name-desktop">{{ request.session.current_team.name|workspace_display }}</span>
-<span class="workspace-name-mobile">Workspace</span>
-{% else %}
-<span>Switch Workspace</span>
-{% endif %}
-<i class="fas fa-chevron-down chevron" :class="{ 'rotated': open }"></i>
-</button>
-<div class="workspace-dropdown-menu" x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 transform scale-95" x-transition:enter-end="opacity-100 transform scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 transform scale-100" x-transition:leave-end="opacity-0 transform scale-95" x-cloak>
-<div class="workspace-dropdown-header">Switch Workspace</div>
-{% for t_key, t_info in available_workspaces.items %}
-<a class="workspace-dropdown-item {% if request.session.current_team.key == t_key %}active{% endif %}" href="{% url 'teams:switch_team' t_key %}">
-<span class="item-content">
-<i class="fas fa-folder"></i>
-{{ t_info.name|workspace_display }}
-</span>
-{% if request.session.current_team.key == t_key %}<i class="fas fa-check check-icon"></i>{% endif %}
-</a>
-{% endfor %}
-</div>
-</div>
-{% endif %}
-{% else %}
-<a href="{% url 'core:keycloak_login' %}?next={{ request.path|urlencode }}" class="workspace-dropdown-btn" style="text-decoration: none">
-<i class="fas fa-sign-in-alt"></i>
-<span>Log In</span>
-</a>
-{% endif %}
-</div>
-{% block header_content %}{% endblock %}
-</div>
-</header>
-<!-- Main Content -->
-<main class="public-main">
-<div class="public-content-container">
-<!-- Breadcrumb Navigation -->
-{% block breadcrumb %}{% endblock %}
-<!-- Page Content -->
-{% block content %}{% endblock %}
-</div>
-</main>
-<!-- Footer -->
-<footer class="public-footer">
-<div class="public-footer-container">
-<div class="footer-content-wrapper">
-<div class="footer-title">
-{% if brand.name %}
-{{ brand.name }}
-{% else %}
-sbomify
-{% endif %}
-Trust Center
-</div>
-<div class="footer-divider-full"></div>
-<div class="footer-bottom-row">
-<div class="footer-copyright">
-© {% now "Y" %}
-{% if brand.name %}
-{{ brand.name }}
-{% else %}
-sbomify
-{% endif %}
-</div>
-<div class="footer-powered">
-Powered by <a class="footer-powered-link" href="https://sbomify.com?utm_source=sbomify&utm_medium=trust_center&utm_campaign=powered_by" target="_blank" rel="noopener noreferrer">sbomify</a>
-</div>
-</div>
-</div>
-</div>
-</footer>
-</div>
-{# Theme Toggle Script #}
-<script>
+            </style>
+            {% block extra_css %}{% endblock %}
+            <title>
+                {% block title %}{% endblock %}
+                -
+                {% if brand.name %}
+                    {{ brand.name }}
+                {% else %}
+                    sbomify
+                {% endif %}
+            </title>
+        {% endblock %}
+        {% vite_hmr_client %}
+    </head>
+    <body class="public-page" data-theme="public">
+        <!-- WebSocket connection for authenticated users (enables real-time access request status updates) -->
+        {% if request.user.is_authenticated and team and team.key %}
+            <div x-data x-init="$store.ws.connect('{{ team.key }}')" class="tw:hidden"></div>
+        {% endif %}
+        <!-- Public Page Layout -->
+        {% include "core/components/messages.html.j2" %}
+        <div class="public-page-layout">
+            <!-- Brand Header -->
+            <header class="public-header">
+                <div class="public-header-container">
+                    <div class="header-spacer"></div>
+                    <div class="brand-section">
+                        {% workspace_public_url as trust_center_url %}
+                        {% if trust_center_url %}
+                            <a href="{{ trust_center_url }}"
+                               class="brand-logo-link"
+                               title="Trust Center Home">
+                                {% if brand.brand_image %}
+                                    <img src="{{ brand.brand_image }}"
+                                         alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo"
+                                         class="brand-logo"
+                                         width="32"
+                                         height="32">
+                                {% else %}
+                                    <img src="{% static 'img/sbomify.svg' %}"
+                                         alt="sbomify Logo"
+                                         class="brand-logo"
+                                         width="32"
+                                         height="32">
+                                {% endif %}
+                            </a>
+                        {% else %}
+                            {% if brand.brand_image %}
+                                <img src="{{ brand.brand_image }}"
+                                     alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo"
+                                     class="brand-logo"
+                                     width="32"
+                                     height="32">
+                            {% else %}
+                                <img src="{% static 'img/sbomify.svg' %}"
+                                     alt="sbomify Logo"
+                                     class="brand-logo"
+                                     width="32"
+                                     height="32">
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                    <div class="header-actions">
+                        {# Theme Toggle #}
+                        <div class="theme-toggle"
+                             x-data="themeToggle()"
+                             @click.outside="open = false"
+                             @keydown.escape.window="open = false">
+                            <button class="theme-toggle-btn"
+                                    type="button"
+                                    @click="open = !open"
+                                    :aria-expanded="open"
+                                    :title="'Theme: ' + currentLabel">
+                                <i :class="currentIcon"></i>
+                            </button>
+                            <div class="theme-toggle-menu"
+                                 x-show="open"
+                                 x-transition:enter="transition ease-out duration-100"
+                                 x-transition:enter-start="opacity-0 transform scale-95"
+                                 x-transition:enter-end="opacity-100 transform scale-100"
+                                 x-transition:leave="transition ease-in duration-75"
+                                 x-transition:leave-start="opacity-100 transform scale-100"
+                                 x-transition:leave-end="opacity-0 transform scale-95"
+                                 x-cloak>
+                                <button type="button"
+                                        class="theme-toggle-item"
+                                        :class="{ 'active': theme === 'light' }"
+                                        @click="setTheme('light')">
+                                    <span class="item-content">
+                                        <i class="fas fa-sun"></i>
+                                        <span>Light</span>
+                                    </span>
+                                    <i class="fas fa-check check-icon" x-show="theme === 'light'"></i>
+                                </button>
+                                <button type="button"
+                                        class="theme-toggle-item"
+                                        :class="{ 'active': theme === 'dark' }"
+                                        @click="setTheme('dark')">
+                                    <span class="item-content">
+                                        <i class="fas fa-moon"></i>
+                                        <span>Dark</span>
+                                    </span>
+                                    <i class="fas fa-check check-icon" x-show="theme === 'dark'"></i>
+                                </button>
+                                <button type="button"
+                                        class="theme-toggle-item"
+                                        :class="{ 'active': theme === 'system' }"
+                                        @click="setTheme('system')">
+                                    <span class="item-content">
+                                        <i class="fas fa-desktop"></i>
+                                        <span>System</span>
+                                    </span>
+                                    <i class="fas fa-check check-icon" x-show="theme === 'system'"></i>
+                                </button>
+                            </div>
+                        </div>
+                        {% if user.is_authenticated %}
+                            {% load teams %}
+                            {% user_workspaces as available_workspaces %}
+                            {% if available_workspaces|length > 1 %}
+                                <div class="workspace-dropdown"
+                                     x-data="{ open: false }"
+                                     @click.outside="open = false"
+                                     @keydown.escape.window="open = false">
+                                    <button class="workspace-dropdown-btn"
+                                            type="button"
+                                            @click="open = !open"
+                                            :aria-expanded="open"
+                                            title="Switch workspace">
+                                        <i class="fas fa-briefcase"></i>
+                                        {% if request.session.current_team %}
+                                            <span class="workspace-name-desktop">{{ request.session.current_team.name|workspace_display }}</span>
+                                            <span class="workspace-name-mobile">Workspace</span>
+                                        {% else %}
+                                            <span>Switch Workspace</span>
+                                        {% endif %}
+                                        <i class="fas fa-chevron-down chevron" :class="{ 'rotated': open }"></i>
+                                    </button>
+                                    <div class="workspace-dropdown-menu"
+                                         x-show="open"
+                                         x-transition:enter="transition ease-out duration-100"
+                                         x-transition:enter-start="opacity-0 transform scale-95"
+                                         x-transition:enter-end="opacity-100 transform scale-100"
+                                         x-transition:leave="transition ease-in duration-75"
+                                         x-transition:leave-start="opacity-100 transform scale-100"
+                                         x-transition:leave-end="opacity-0 transform scale-95"
+                                         x-cloak>
+                                        <div class="workspace-dropdown-header">Switch Workspace</div>
+                                        {% for t_key, t_info in available_workspaces.items %}
+                                            <a class="workspace-dropdown-item {% if request.session.current_team.key == t_key %}active{% endif %}"
+                                               href="{% url 'teams:switch_team' t_key %}">
+                                                <span class="item-content">
+                                                    <i class="fas fa-folder"></i>
+                                                    {{ t_info.name|workspace_display }}
+                                                </span>
+                                                {% if request.session.current_team.key == t_key %}<i class="fas fa-check check-icon"></i>{% endif %}
+                                            </a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% else %}
+                            <a href="{% url 'core:keycloak_login' %}?next={{ request.path|urlencode }}"
+                               class="workspace-dropdown-btn"
+                               style="text-decoration: none">
+                                <i class="fas fa-sign-in-alt"></i>
+                                <span>Log In</span>
+                            </a>
+                        {% endif %}
+                    </div>
+                    {% block header_content %}{% endblock %}
+                </div>
+            </header>
+            <!-- Main Content -->
+            <main class="public-main">
+                <div class="public-content-container">
+                    <!-- Breadcrumb Navigation -->
+                    {% block breadcrumb %}{% endblock %}
+                    <!-- Page Content -->
+                    {% block content %}{% endblock %}
+                </div>
+            </main>
+            <!-- Footer -->
+            <footer class="public-footer">
+                <div class="public-footer-container">
+                    <div class="footer-content-wrapper">
+                        <div class="footer-title">
+                            {% if brand.name %}
+                                {{ brand.name }}
+                            {% else %}
+                                sbomify
+                            {% endif %}
+                            Trust Center
+                        </div>
+                        <div class="footer-divider-full"></div>
+                        <div class="footer-bottom-row">
+                            <div class="footer-copyright">
+                                © {% now "Y" %}
+                                {% if brand.name %}
+                                    {{ brand.name }}
+                                {% else %}
+                                    sbomify
+                                {% endif %}
+                            </div>
+                            <div class="footer-powered">
+                                Powered by <a class="footer-powered-link"
+    href="https://sbomify.com?utm_source=sbomify&utm_medium=trust_center&utm_campaign=powered_by"
+    target="_blank"
+    rel="noopener noreferrer">sbomify</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </div>
+        {# Theme Toggle Script #}
+        <script>
             // Helper to apply theme (sets data-theme and CSS variables)
             function applyTheme(isDark) {
                 const html = document.documentElement;
@@ -1137,9 +1200,10 @@ Powered by <a class="footer-powered-link" href="https://sbomify.com?utm_source=s
                     }
                 };
             }
-</script>
-{% block scripts %}{% endblock %}
-{% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
-{% htmx_script %}
-</body>
+        </script>
+        {% block scripts %}
+        {% endblock %}
+        {% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
+        {% htmx_script %}
+    </body>
 </html>

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -23,16 +23,18 @@
             }
             // Also mark if using system preference for the toggle component
             if(!t || t==='system') html.setAttribute('data-theme-source','system');
-            // Set critical CSS variables immediately to prevent flash
+            // Set critical CSS variables on the html element to prevent flash before
+            // the linked stylesheets resolve. Inline style on <html> already beats
+            // selector-based rules — no !important needed.
             var style = html.style;
             if(isDark) {
-                style.setProperty('--color-surface','30 41 59','important');
-                style.setProperty('--color-surface-elevated','51 65 85','important');
-                style.setProperty('--color-border','51 65 85','important');
+                style.setProperty('--color-surface','30 41 59');
+                style.setProperty('--color-surface-elevated','51 65 85');
+                style.setProperty('--color-border','51 65 85');
             } else {
-                style.setProperty('--color-surface','255 255 255','important');
-                style.setProperty('--color-surface-elevated','255 255 255','important');
-                style.setProperty('--color-border','226 232 240','important');
+                style.setProperty('--color-surface','255 255 255');
+                style.setProperty('--color-surface-elevated','255 255 255');
+                style.setProperty('--color-border','226 232 240');
             }
         })();
     </script>
@@ -191,16 +193,18 @@
                 --gray-500: #64748b;
                 --gray-600: #475569;
                 --white: #ffffff;
-                /* Tailwind color variables (RGB triplets) - !important to override Tailwind defaults */
-                --color-surface: 255 255 255 !important;
-                --color-surface-elevated: 255 255 255 !important;
-                --color-surface-hover: 241 245 249 !important;
-                --color-border: 226 232 240 !important;
-                --color-border-light: 241 245 249 !important;
-                --color-text: 15 23 42 !important;
-                --color-text-secondary: 51 65 85 !important;
-                --color-text-muted: 100 116 139 !important;
-                --color-background: 248 250 252 !important;
+                /* Tailwind color variables (RGB triplets) — public trust center is light-default;
+                   the inline <style> block already comes after tokens.css in source order,
+                   so no !important is needed to win the cascade. */
+                --color-surface: 255 255 255;
+                --color-surface-elevated: 255 255 255;
+                --color-surface-hover: 241 245 249;
+                --color-border: 226 232 240;
+                --color-border-light: 241 245 249;
+                --color-text: 15 23 42;
+                --color-text-secondary: 51 65 85;
+                --color-text-muted: 100 116 139;
+                --color-background: 248 250 252;
                 color-scheme: light;
             }
 
@@ -229,16 +233,17 @@
                 --gray-500: #cbd5e1;
                 --gray-600: #e2e8f0;
                 --white: #f8fafc;
-                /* Tailwind color variables (RGB triplets) - !important to override Tailwind defaults */
-                --color-surface: 30 41 59 !important;
-                --color-surface-elevated: 51 65 85 !important;
-                --color-surface-hover: 71 85 105 !important;
-                --color-border: 51 65 85 !important;
-                --color-border-light: 71 85 105 !important;
-                --color-text: 248 250 252 !important;
-                --color-text-secondary: 203 213 225 !important;
-                --color-text-muted: 148 163 184 !important;
-                --color-background: 15 23 42 !important;
+                /* Tailwind color variables — trust center dark uses a slate palette
+                   (intentionally distinct from the app's navy dark; see ADR/brand notes). */
+                --color-surface: 30 41 59;
+                --color-surface-elevated: 51 65 85;
+                --color-surface-hover: 71 85 105;
+                --color-border: 51 65 85;
+                --color-border-light: 71 85 105;
+                --color-text: 248 250 252;
+                --color-text-secondary: 203 213 225;
+                --color-text-muted: 148 163 184;
+                --color-background: 15 23 42;
                 color-scheme: dark;
             }
 
@@ -267,16 +272,16 @@
                 --gray-500: #64748b;
                 --gray-600: #475569;
                 --white: #ffffff;
-                /* Tailwind color variables (RGB triplets) - !important to override Tailwind defaults */
-                --color-surface: 255 255 255 !important;
-                --color-surface-elevated: 255 255 255 !important;
-                --color-surface-hover: 241 245 249 !important;
-                --color-border: 226 232 240 !important;
-                --color-border-light: 241 245 249 !important;
-                --color-text: 15 23 42 !important;
-                --color-text-secondary: 51 65 85 !important;
-                --color-text-muted: 100 116 139 !important;
-                --color-background: 248 250 252 !important;
+                /* Tailwind color variables — system-light defaults match the canonical light theme. */
+                --color-surface: 255 255 255;
+                --color-surface-elevated: 255 255 255;
+                --color-surface-hover: 241 245 249;
+                --color-border: 226 232 240;
+                --color-border-light: 241 245 249;
+                --color-text: 15 23 42;
+                --color-text-secondary: 51 65 85;
+                --color-text-muted: 100 116 139;
+                --color-background: 248 250 252;
                 color-scheme: light;
             }
 
@@ -306,16 +311,16 @@
                     --gray-500: #cbd5e1;
                     --gray-600: #e2e8f0;
                     --white: #f8fafc;
-                    /* Tailwind color variables (RGB triplets) - !important to override Tailwind defaults */
-                    --color-surface: 30 41 59 !important;
-                    --color-surface-elevated: 51 65 85 !important;
-                    --color-surface-hover: 71 85 105 !important;
-                    --color-border: 51 65 85 !important;
-                    --color-border-light: 71 85 105 !important;
-                    --color-text: 248 250 252 !important;
-                    --color-text-secondary: 203 213 225 !important;
-                    --color-text-muted: 148 163 184 !important;
-                    --color-background: 15 23 42 !important;
+                    /* Tailwind color variables — slate dark, mirrors html[data-theme="dark"]. */
+                    --color-surface: 30 41 59;
+                    --color-surface-elevated: 51 65 85;
+                    --color-surface-hover: 71 85 105;
+                    --color-border: 51 65 85;
+                    --color-border-light: 71 85 105;
+                    --color-text: 248 250 252;
+                    --color-text-secondary: 203 213 225;
+                    --color-text-muted: 148 163 184;
+                    --color-background: 15 23 42;
                     color-scheme: dark;
                 }
             }
@@ -327,13 +332,13 @@
                =========================================== */
 
             /* Links use accent color */
-            .public-page a:not(.tw-btn-primary):not(.tw-btn-secondary):not(.tw-btn-outline):not(.brand-logo-link):not(.workspace-dropdown-item):not(.theme-toggle-item) {
+            .public-page a:not(.tw-btn-primary):not(.tw-btn-secondary):not(.tw-btn-outline):not(.brand-logo-link):not(.workspace-dropdown-item):not(.theme-toggle-item):not(.footer-powered-link) {
                 color: var(--accent-color);
                 text-decoration: none;
                 transition: color 0.15s ease;
             }
 
-            .public-page a:not(.tw-btn-primary):not(.tw-btn-secondary):not(.tw-btn-outline):not(.brand-logo-link):not(.workspace-dropdown-item):not(.theme-toggle-item):hover {
+            .public-page a:not(.tw-btn-primary):not(.tw-btn-secondary):not(.tw-btn-outline):not(.brand-logo-link):not(.workspace-dropdown-item):not(.theme-toggle-item):not(.footer-powered-link):hover {
                 color: var(--accent-color-dark);
             }
 
@@ -631,14 +636,15 @@
             }
 
             .footer-powered a {
-                color: var(--brand-color, #6366f1);
+                color: var(--text-secondary, #475569);
                 text-decoration: none;
                 font-weight: 500;
                 transition: color 0.2s ease;
             }
 
             .footer-powered a:hover {
-                color: color-mix(in srgb, var(--brand-color, #6366f1), #000 15%);
+                color: var(--text-primary, #0f172a);
+                text-decoration: underline;
             }
 
             @media (max-width: 768px) {
@@ -704,7 +710,8 @@
                 display: inline-flex;
                 align-items: center;
                 gap: 0.5rem;
-                padding: 0.375rem 0.75rem;
+                min-height: 2.5rem;
+                padding: 0.5rem 0.875rem;
                 font-size: 0.875rem;
                 font-weight: 500;
                 color: var(--text-primary);
@@ -827,8 +834,8 @@
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-                width: 36px;
-                height: 36px;
+                width: 2.5rem;
+                height: 2.5rem;
                 padding: 0;
                 font-size: 1rem;
                 color: var(--text-primary);
@@ -911,222 +918,160 @@
                 color: var(--brand-color);
                 font-size: 0.75rem;
             }
-            </style>
-            {% block extra_css %}{% endblock %}
-            <title>
-                {% block title %}{% endblock %}
-                -
-                {% if brand.name %}
-                    {{ brand.name }}
-                {% else %}
-                    sbomify
-                {% endif %}
-            </title>
-        {% endblock %}
-        {% vite_hmr_client %}
-    </head>
-    <body class="public-page" data-theme="public">
-        <!-- WebSocket connection for authenticated users (enables real-time access request status updates) -->
-        {% if request.user.is_authenticated and team and team.key %}
-            <div x-data x-init="$store.ws.connect('{{ team.key }}')" class="tw:hidden"></div>
-        {% endif %}
-        <!-- Public Page Layout -->
-        {% include "core/components/messages.html.j2" %}
-        <div class="public-page-layout">
-            <!-- Brand Header -->
-            <header class="public-header">
-                <div class="public-header-container">
-                    <div class="header-spacer"></div>
-                    <div class="brand-section">
-                        {% workspace_public_url as trust_center_url %}
-                        {% if trust_center_url %}
-                            <a href="{{ trust_center_url }}"
-                               class="brand-logo-link"
-                               title="Trust Center Home">
-                                {% if brand.brand_image %}
-                                    <img src="{{ brand.brand_image }}"
-                                         alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo"
-                                         class="brand-logo"
-                                         width="32"
-                                         height="32">
-                                {% else %}
-                                    <img src="{% static 'img/sbomify.svg' %}"
-                                         alt="sbomify Logo"
-                                         class="brand-logo"
-                                         width="32"
-                                         height="32">
-                                {% endif %}
-                            </a>
-                        {% else %}
-                            {% if brand.brand_image %}
-                                <img src="{{ brand.brand_image }}"
-                                     alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo"
-                                     class="brand-logo"
-                                     width="32"
-                                     height="32">
-                            {% else %}
-                                <img src="{% static 'img/sbomify.svg' %}"
-                                     alt="sbomify Logo"
-                                     class="brand-logo"
-                                     width="32"
-                                     height="32">
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                    <div class="header-actions">
-                        {# Theme Toggle #}
-                        <div class="theme-toggle"
-                             x-data="themeToggle()"
-                             @click.outside="open = false"
-                             @keydown.escape.window="open = false">
-                            <button class="theme-toggle-btn"
-                                    type="button"
-                                    @click="open = !open"
-                                    :aria-expanded="open"
-                                    :title="'Theme: ' + currentLabel">
-                                <i :class="currentIcon"></i>
-                            </button>
-                            <div class="theme-toggle-menu"
-                                 x-show="open"
-                                 x-transition:enter="transition ease-out duration-100"
-                                 x-transition:enter-start="opacity-0 transform scale-95"
-                                 x-transition:enter-end="opacity-100 transform scale-100"
-                                 x-transition:leave="transition ease-in duration-75"
-                                 x-transition:leave-start="opacity-100 transform scale-100"
-                                 x-transition:leave-end="opacity-0 transform scale-95"
-                                 x-cloak>
-                                <button type="button"
-                                        class="theme-toggle-item"
-                                        :class="{ 'active': theme === 'light' }"
-                                        @click="setTheme('light')">
-                                    <span class="item-content">
-                                        <i class="fas fa-sun"></i>
-                                        <span>Light</span>
-                                    </span>
-                                    <i class="fas fa-check check-icon" x-show="theme === 'light'"></i>
-                                </button>
-                                <button type="button"
-                                        class="theme-toggle-item"
-                                        :class="{ 'active': theme === 'dark' }"
-                                        @click="setTheme('dark')">
-                                    <span class="item-content">
-                                        <i class="fas fa-moon"></i>
-                                        <span>Dark</span>
-                                    </span>
-                                    <i class="fas fa-check check-icon" x-show="theme === 'dark'"></i>
-                                </button>
-                                <button type="button"
-                                        class="theme-toggle-item"
-                                        :class="{ 'active': theme === 'system' }"
-                                        @click="setTheme('system')">
-                                    <span class="item-content">
-                                        <i class="fas fa-desktop"></i>
-                                        <span>System</span>
-                                    </span>
-                                    <i class="fas fa-check check-icon" x-show="theme === 'system'"></i>
-                                </button>
-                            </div>
-                        </div>
-                        {% if user.is_authenticated %}
-                            {% load teams %}
-                            {% user_workspaces as available_workspaces %}
-                            {% if available_workspaces|length > 1 %}
-                                <div class="workspace-dropdown"
-                                     x-data="{ open: false }"
-                                     @click.outside="open = false"
-                                     @keydown.escape.window="open = false">
-                                    <button class="workspace-dropdown-btn"
-                                            type="button"
-                                            @click="open = !open"
-                                            :aria-expanded="open"
-                                            title="Switch workspace">
-                                        <i class="fas fa-briefcase"></i>
-                                        {% if request.session.current_team %}
-                                            <span class="workspace-name-desktop">{{ request.session.current_team.name|workspace_display }}</span>
-                                            <span class="workspace-name-mobile">Workspace</span>
-                                        {% else %}
-                                            <span>Switch Workspace</span>
-                                        {% endif %}
-                                        <i class="fas fa-chevron-down chevron" :class="{ 'rotated': open }"></i>
-                                    </button>
-                                    <div class="workspace-dropdown-menu"
-                                         x-show="open"
-                                         x-transition:enter="transition ease-out duration-100"
-                                         x-transition:enter-start="opacity-0 transform scale-95"
-                                         x-transition:enter-end="opacity-100 transform scale-100"
-                                         x-transition:leave="transition ease-in duration-75"
-                                         x-transition:leave-start="opacity-100 transform scale-100"
-                                         x-transition:leave-end="opacity-0 transform scale-95"
-                                         x-cloak>
-                                        <div class="workspace-dropdown-header">Switch Workspace</div>
-                                        {% for t_key, t_info in available_workspaces.items %}
-                                            <a class="workspace-dropdown-item {% if request.session.current_team.key == t_key %}active{% endif %}"
-                                               href="{% url 'teams:switch_team' t_key %}">
-                                                <span class="item-content">
-                                                    <i class="fas fa-folder"></i>
-                                                    {{ t_info.name|workspace_display }}
-                                                </span>
-                                                {% if request.session.current_team.key == t_key %}<i class="fas fa-check check-icon"></i>{% endif %}
-                                            </a>
-                                        {% endfor %}
-                                    </div>
-                                </div>
-                            {% endif %}
-                        {% else %}
-                            <a href="{% url 'core:keycloak_login' %}?next={{ request.path|urlencode }}"
-                               class="workspace-dropdown-btn"
-                               style="text-decoration: none">
-                                <i class="fas fa-sign-in-alt"></i>
-                                <span>Log In</span>
-                            </a>
-                        {% endif %}
-                    </div>
-                    {% block header_content %}{% endblock %}
-                </div>
-            </header>
-            <!-- Main Content -->
-            <main class="public-main">
-                <div class="public-content-container">
-                    <!-- Breadcrumb Navigation -->
-                    {% block breadcrumb %}{% endblock %}
-                    <!-- Page Content -->
-                    {% block content %}{% endblock %}
-                </div>
-            </main>
-            <!-- Footer -->
-            <footer class="public-footer">
-                <div class="public-footer-container">
-                    <div class="footer-content-wrapper">
-                        <div class="footer-title">
-                            {% if brand.name %}
-                                {{ brand.name }}
-                            {% else %}
-                                sbomify
-                            {% endif %}
-                            Trust Center
-                        </div>
-                        <div class="footer-divider-full"></div>
-                        <div class="footer-bottom-row">
-                            <div class="footer-copyright">
-                                © {% now "Y" %}
-                                {% if brand.name %}
-                                    {{ brand.name }}
-                                {% else %}
-                                    sbomify
-                                {% endif %}
-                            </div>
-                            <div class="footer-powered">
-                                Powered by <a href="https://sbomify.com?utm_source=sbomify&utm_medium=trust_center&utm_campaign=powered_by"
-    target="_blank"
-    rel="noopener noreferrer">sbomify</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </footer>
-        </div>
-        {# Theme Toggle Script #}
-        <script>
+</style>
+{% block extra_css %}{% endblock %}
+<title>
+{% block title %}{% endblock %}
+-
+{% if brand.name %}
+{{ brand.name }}
+{% else %}
+sbomify
+{% endif %}
+</title>
+{% endblock %}
+{% vite_hmr_client %}
+</head>
+<body class="public-page" data-theme="public">
+<!-- WebSocket connection for authenticated users (enables real-time access request status updates) -->
+{% if request.user.is_authenticated and team and team.key %}
+<div x-data x-init="$store.ws.connect('{{ team.key }}')" class="tw:hidden"></div>
+{% endif %}
+<!-- Public Page Layout -->
+{% include "core/components/messages.html.j2" %}
+<div class="public-page-layout">
+<!-- Brand Header -->
+<header class="public-header">
+<div class="public-header-container">
+<div class="header-spacer"></div>
+<div class="brand-section">
+{% workspace_public_url as trust_center_url %}
+{% if trust_center_url %}
+<a href="{{ trust_center_url }}" class="brand-logo-link" title="Trust Center Home">
+{% if brand.brand_image %}
+<img src="{{ brand.brand_image }}" alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo" class="brand-logo" width="32" height="32">
+{% else %}
+<img src="{% static 'img/sbomify.svg' %}" alt="sbomify Logo" class="brand-logo" width="32" height="32">
+{% endif %}
+</a>
+{% else %}
+{% if brand.brand_image %}
+<img src="{{ brand.brand_image }}" alt="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %} Logo" class="brand-logo" width="32" height="32">
+{% else %}
+<img src="{% static 'img/sbomify.svg' %}" alt="sbomify Logo" class="brand-logo" width="32" height="32">
+{% endif %}
+{% endif %}
+</div>
+<div class="header-actions">
+{# Theme Toggle #}
+<div class="theme-toggle" x-data="themeToggle()" @click.outside="open = false" @keydown.escape.window="open = false">
+<button class="theme-toggle-btn" type="button" @click="open = !open" :aria-expanded="open" :title="'Theme: ' + currentLabel">
+<i :class="currentIcon"></i>
+</button>
+<div class="theme-toggle-menu" x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 transform scale-95" x-transition:enter-end="opacity-100 transform scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 transform scale-100" x-transition:leave-end="opacity-0 transform scale-95" x-cloak>
+<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'light' }" @click="setTheme('light')">
+<span class="item-content">
+<i class="fas fa-sun"></i>
+<span>Light</span>
+</span>
+<i class="fas fa-check check-icon" x-show="theme === 'light'"></i>
+</button>
+<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'dark' }" @click="setTheme('dark')">
+<span class="item-content">
+<i class="fas fa-moon"></i>
+<span>Dark</span>
+</span>
+<i class="fas fa-check check-icon" x-show="theme === 'dark'"></i>
+</button>
+<button type="button" class="theme-toggle-item" :class="{ 'active': theme === 'system' }" @click="setTheme('system')">
+<span class="item-content">
+<i class="fas fa-desktop"></i>
+<span>System</span>
+</span>
+<i class="fas fa-check check-icon" x-show="theme === 'system'"></i>
+</button>
+</div>
+</div>
+{% if user.is_authenticated %}
+{% load teams %}
+{% user_workspaces as available_workspaces %}
+{% if available_workspaces|length > 1 %}
+<div class="workspace-dropdown" x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false">
+<button class="workspace-dropdown-btn" type="button" @click="open = !open" :aria-expanded="open" title="Switch workspace">
+<i class="fas fa-briefcase"></i>
+{% if request.session.current_team %}
+<span class="workspace-name-desktop">{{ request.session.current_team.name|workspace_display }}</span>
+<span class="workspace-name-mobile">Workspace</span>
+{% else %}
+<span>Switch Workspace</span>
+{% endif %}
+<i class="fas fa-chevron-down chevron" :class="{ 'rotated': open }"></i>
+</button>
+<div class="workspace-dropdown-menu" x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 transform scale-95" x-transition:enter-end="opacity-100 transform scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 transform scale-100" x-transition:leave-end="opacity-0 transform scale-95" x-cloak>
+<div class="workspace-dropdown-header">Switch Workspace</div>
+{% for t_key, t_info in available_workspaces.items %}
+<a class="workspace-dropdown-item {% if request.session.current_team.key == t_key %}active{% endif %}" href="{% url 'teams:switch_team' t_key %}">
+<span class="item-content">
+<i class="fas fa-folder"></i>
+{{ t_info.name|workspace_display }}
+</span>
+{% if request.session.current_team.key == t_key %}<i class="fas fa-check check-icon"></i>{% endif %}
+</a>
+{% endfor %}
+</div>
+</div>
+{% endif %}
+{% else %}
+<a href="{% url 'core:keycloak_login' %}?next={{ request.path|urlencode }}" class="workspace-dropdown-btn" style="text-decoration: none">
+<i class="fas fa-sign-in-alt"></i>
+<span>Log In</span>
+</a>
+{% endif %}
+</div>
+{% block header_content %}{% endblock %}
+</div>
+</header>
+<!-- Main Content -->
+<main class="public-main">
+<div class="public-content-container">
+<!-- Breadcrumb Navigation -->
+{% block breadcrumb %}{% endblock %}
+<!-- Page Content -->
+{% block content %}{% endblock %}
+</div>
+</main>
+<!-- Footer -->
+<footer class="public-footer">
+<div class="public-footer-container">
+<div class="footer-content-wrapper">
+<div class="footer-title">
+{% if brand.name %}
+{{ brand.name }}
+{% else %}
+sbomify
+{% endif %}
+Trust Center
+</div>
+<div class="footer-divider-full"></div>
+<div class="footer-bottom-row">
+<div class="footer-copyright">
+© {% now "Y" %}
+{% if brand.name %}
+{{ brand.name }}
+{% else %}
+sbomify
+{% endif %}
+</div>
+<div class="footer-powered">
+Powered by <a class="footer-powered-link" href="https://sbomify.com?utm_source=sbomify&utm_medium=trust_center&utm_campaign=powered_by" target="_blank" rel="noopener noreferrer">sbomify</a>
+</div>
+</div>
+</div>
+</div>
+</footer>
+</div>
+{# Theme Toggle Script #}
+<script>
             // Helper to apply theme (sets data-theme and CSS variables)
             function applyTheme(isDark) {
                 const html = document.documentElement;
@@ -1192,10 +1137,9 @@
                     }
                 };
             }
-        </script>
-        {% block scripts %}
-        {% endblock %}
-        {% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
-        {% htmx_script %}
-    </body>
+</script>
+{% block scripts %}{% endblock %}
+{% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
+{% htmx_script %}
+</body>
 </html>

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -1137,17 +1137,21 @@
         <script>
             // Helper to apply theme (sets data-theme and CSS variables)
             function applyTheme(isDark) {
+                // Inline styles on the root element already win the cascade
+                // against the theme selector rules in the inline <style> block,
+                // matching the no-!important pattern set up in the page-load
+                // theme-flash script above.
                 const html = document.documentElement;
                 const style = html.style;
                 html.setAttribute('data-theme', isDark ? 'dark' : 'light');
                 if (isDark) {
-                    style.setProperty('--color-surface', '30 41 59', 'important');
-                    style.setProperty('--color-surface-elevated', '51 65 85', 'important');
-                    style.setProperty('--color-border', '51 65 85', 'important');
+                    style.setProperty('--color-surface', '30 41 59');
+                    style.setProperty('--color-surface-elevated', '51 65 85');
+                    style.setProperty('--color-border', '51 65 85');
                 } else {
-                    style.setProperty('--color-surface', '255 255 255', 'important');
-                    style.setProperty('--color-surface-elevated', '255 255 255', 'important');
-                    style.setProperty('--color-border', '226 232 240', 'important');
+                    style.setProperty('--color-surface', '255 255 255');
+                    style.setProperty('--color-surface-elevated', '255 255 255');
+                    style.setProperty('--color-border', '226 232 240');
                 }
             }
 
@@ -1200,10 +1204,10 @@
                     }
                 };
             }
-        </script>
-        {% block scripts %}
-        {% endblock %}
-        {% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
-        {% htmx_script %}
-    </body>
+</script>
+{% block scripts %}
+{% endblock %}
+{% vite_asset 'sbomify/apps/core/js/htmx-bundle.ts' %}
+{% htmx_script %}
+</body>
 </html>

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -23,9 +23,9 @@
             }
             // Also mark if using system preference for the toggle component
             if(!t || t==='system') html.setAttribute('data-theme-source','system');
-            // Set critical CSS variables on the html element to prevent flash before
-            // the linked stylesheets resolve. Inline style on <html> already beats
-            // selector-based rules — no !important needed.
+            // Set critical CSS variables on the root element to prevent flash before
+            // the linked stylesheets resolve. An inline style on the root element
+            // already beats selector-based rules — no !important needed.
             var style = html.style;
             if(isDark) {
                 style.setProperty('--color-surface','30 41 59');
@@ -194,7 +194,7 @@
                 --gray-600: #475569;
                 --white: #ffffff;
                 /* Tailwind color variables (RGB triplets) — public trust center is light-default;
-                   the inline <style> block already comes after tokens.css in source order,
+                   this inline style block already comes after tokens.css in source order,
                    so no !important is needed to win the cascade. */
                 --color-surface: 255 255 255;
                 --color-surface-elevated: 255 255 255;

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -21,31 +21,24 @@
 {% endblock %}
 {% block content %}
     <div class="space-y-6">
-        {# Back link #}
-        <div>
-            <a href="{% url 'core:product_details_public' release.product.id %}"
-               class="inline-flex items-center gap-2 text-text-muted hover:text-text no-underline transition-colors"
-               onclick="if (window.history.length > 1) { window.history.back(); return false; }">
-                <i class="fas fa-arrow-left" aria-hidden="true"></i>Back to {{ release.product.name }}
-            </a>
-        </div>
+        {# Parent navigation comes from the breadcrumb (`Trust Center > Product`). #}
         {# Page Header #}
         <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
             <div class="flex items-start gap-4">
-                <div class="w-14 h-14 rounded-xl flex items-center justify-center flex-shrink-0 {% if release.is_latest %}bg-success/10{% else %}bg-primary/10{% endif %}">
-                    <i class="fas fa-tag text-2xl {% if release.is_latest %}text-success{% else %}text-primary{% endif %}"></i>
+                <div class="w-14 h-14 rounded-xl flex items-center justify-center flex-shrink-0 bg-primary/10">
+                    <i class="fas fa-tag text-2xl text-primary" aria-hidden="true"></i>
                 </div>
                 <div class="flex-1 min-w-0">
                     <h1 class="text-2xl lg:text-3xl font-bold text-text mb-2 flex items-center gap-3 flex-wrap">
                         <span>{{ release.name }}</span>
                         {% if release.is_latest %}
                             <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-success/10 text-success border border-success/30">
-                                <i class="fas fa-check-circle text-[0.625rem]" aria-hidden="true"></i>Latest
+                                <i class="fas fa-check-circle text-xs" aria-hidden="true"></i>Latest
                             </span>
                         {% endif %}
                         {% if release.is_prerelease %}
                             <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-warning/10 text-warning border border-warning/30">
-                                <i class="fas fa-flask text-[0.625rem]" aria-hidden="true"></i>Pre-release
+                                <i class="fas fa-flask text-xs" aria-hidden="true"></i>Pre-release
                             </span>
                         {% endif %}
                     </h1>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -36,7 +36,19 @@
                     <i class="fas fa-tag text-2xl {% if release.is_latest %}text-success{% else %}text-primary{% endif %}"></i>
                 </div>
                 <div class="flex-1 min-w-0">
-                    <h1 class="text-2xl lg:text-3xl font-bold text-text mb-2">{{ release.name }}</h1>
+                    <h1 class="text-2xl lg:text-3xl font-bold text-text mb-2 flex items-center gap-3 flex-wrap">
+                        <span>{{ release.name }}</span>
+                        {% if release.is_latest %}
+                            <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-success/10 text-success border border-success/30">
+                                <i class="fas fa-check-circle text-[0.625rem]" aria-hidden="true"></i>Latest
+                            </span>
+                        {% endif %}
+                        {% if release.is_prerelease %}
+                            <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-warning/10 text-warning border border-warning/30">
+                                <i class="fas fa-flask text-[0.625rem]" aria-hidden="true"></i>Pre-release
+                            </span>
+                        {% endif %}
+                    </h1>
                     {% if release.description %}
                         <p class="text-text-muted text-sm m-0">{{ release.description }}</p>
                     {% else %}
@@ -47,60 +59,52 @@
             {# Download Buttons - Desktop #}
             {% if release.has_sboms %}
                 <div class="hidden lg:flex gap-2 flex-shrink-0">
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                        href="{% url 'api-1:download_release' release.id %}"
-                       title="Download as CycloneDX">
+                       title="Download release as CycloneDX">
                         <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                             alt="CycloneDX"
+                             alt=""
                              class="h-4 w-auto"
                              width="16"
-                             height="16">
-                        <i class="fas fa-download"></i>
+                             height="16"
+                             aria-hidden="true">
+                        <span>CycloneDX</span>
+                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
                     </a>
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                        href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                       title="Download as SPDX">
+                       title="Download release as SPDX">
                         <img src="{% static 'img/spdx-logo.svg' %}"
-                             alt="SPDX"
+                             alt=""
                              class="h-4 w-auto"
                              width="16"
-                             height="16">
-                        <i class="fas fa-download"></i>
+                             height="16"
+                             aria-hidden="true">
+                        <span>SPDX</span>
+                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
                     </a>
                 </div>
             {% endif %}
         </div>
-        {# Stats Badges #}
-        <div class="flex flex-wrap gap-2">
-            {% if release.is_latest %}
-                <div class="flex items-center gap-1.5 px-3 py-1.5 bg-success/10 border border-success/30 rounded-md text-sm">
-                    <i class="fas fa-check-circle text-success text-xs"></i>
-                    <span class="font-semibold text-success">Latest Release</span>
-                </div>
-            {% endif %}
-            {% if release.is_prerelease %}
-                <div class="flex items-center gap-1.5 px-3 py-1.5 bg-warning/10 border border-warning/30 rounded-md text-sm">
-                    <i class="fas fa-flask text-warning text-xs"></i>
-                    <span class="font-semibold text-warning">Pre-release</span>
-                </div>
-            {% endif %}
-            {% if release.version %}
-                <div class="flex items-center gap-1.5 px-3 py-1.5 bg-primary/10 border border-primary/30 rounded-md text-sm">
-                    <i class="fas fa-code-branch text-primary text-xs"></i>
-                    <span class="font-semibold text-primary">{{ release.version }}</span>
-                </div>
-            {% endif %}
-            <div class="flex items-center gap-1.5 px-3 py-1.5 bg-surface border border-border rounded-md text-sm">
-                <i class="fas fa-calendar text-primary text-xs"></i>
-                <span class="text-text-muted">Released:</span>
+        {# Meta Strip — one muted band with all release facts #}
+        <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-text-muted">
+            <span class="inline-flex items-center gap-1.5">
+                <i class="far fa-calendar" aria-hidden="true"></i>
+                <span>Released</span>
                 <span class="font-semibold text-text">{{ release.released_at|default_if_none:release.created_at|naturaltime }}</span>
-            </div>
+            </span>
+            {% if release.version %}
+                <span class="inline-flex items-center gap-1.5">
+                    <i class="fas fa-code-branch" aria-hidden="true"></i>
+                    <code class="text-text font-mono text-xs px-2 py-0.5 rounded bg-border/30">{{ release.version }}</code>
+                </span>
+            {% endif %}
             {% if release.artifacts_count %}
-                <div class="flex items-center gap-1.5 px-3 py-1.5 bg-info/10 border border-info/30 rounded-md text-sm">
-                    <i class="fas fa-puzzle-piece text-info text-xs"></i>
-                    <span class="font-semibold text-info">{{ release.artifacts_count }}</span>
-                    <span class="text-info">Artifact{{ release.artifacts_count|pluralize }}</span>
-                </div>
+                <span class="inline-flex items-center gap-1.5">
+                    <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                    <span class="font-semibold text-text">{{ release.artifacts_count }}</span>
+                    <span>artifact{{ release.artifacts_count|pluralize }}</span>
+                </span>
             {% endif %}
         </div>
         {# Download Card - Mobile Only #}
@@ -112,28 +116,32 @@
                         Download Release
                     </h4>
                 </div>
-                <div class="p-6 text-center">
-                    <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release</p>
-                    <div class="flex justify-center gap-3 flex-wrap">
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                <div class="p-6">
+                    <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release.</p>
+                    <div class="flex gap-3 flex-wrap">
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                            href="{% url 'api-1:download_release' release.id %}"
-                           title="Download as CycloneDX">
+                           title="Download release as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt="CycloneDX"
-                                 class="h-[18px] w-auto"
-                                 width="18"
-                                 height="18">
-                            <i class="fas fa-download"></i>
+                                 alt=""
+                                 class="h-5 w-auto"
+                                 width="20"
+                                 height="20"
+                                 aria-hidden="true">
+                            <span>CycloneDX</span>
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                            href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                           title="Download as SPDX">
+                           title="Download release as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt="SPDX"
-                                 class="h-[18px] w-auto"
-                                 width="18"
-                                 height="18">
-                            <i class="fas fa-download"></i>
+                                 alt=""
+                                 class="h-5 w-auto"
+                                 width="20"
+                                 height="20"
+                                 aria-hidden="true">
+                            <span>SPDX</span>
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                     </div>
                 </div>

--- a/sbomify/apps/core/templates/core/workspace_public.html.j2
+++ b/sbomify/apps/core/templates/core/workspace_public.html.j2
@@ -32,7 +32,7 @@
                 {% if global_components %}
                     <div class="public-hero-stat">
                         <span class="public-hero-stat-icon">
-                            <i class="fas fa-award"></i>
+                            <i class="fas fa-award" aria-hidden="true"></i>
                         </span>
                         <span class="public-hero-stat-value">{{ global_components|length }}</span>
                         <span class="public-hero-stat-label">Compliance Artifact{{ global_components|length|pluralize }}</span>
@@ -41,7 +41,7 @@
                 {% if products %}
                     <div class="public-hero-stat">
                         <span class="public-hero-stat-icon">
-                            <i class="fas fa-cube"></i>
+                            <i class="fas fa-cube" aria-hidden="true"></i>
                         </span>
                         <span class="public-hero-stat-value">{{ products|length }}</span>
                         <span class="public-hero-stat-label">Product{{ products|length|pluralize }}</span>
@@ -55,7 +55,7 @@
         <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
             <div class="mb-6 pb-4 border-b border-border">
                 <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">
-                    <i class="fas fa-award text-primary"></i>Organization Compliance Artifacts
+                    <i class="fas fa-award text-primary" aria-hidden="true"></i>Organization Compliance Artifacts
                 </h2>
                 <p class="text-sm text-text-muted m-0">
                     Organization-wide compliance documents, certifications, and security attestations
@@ -73,12 +73,12 @@
                         </p>
                         <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
                             <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-primary/10 text-primary flex items-center gap-1">
-                                <i class="fas fa-building"></i>
+                                <i class="fas fa-building" aria-hidden="true"></i>
                                 Organization-Wide
                             </span>
                             <a class="tw-btn-primary text-sm min-h-10 py-2 px-3 inline-flex items-center"
                                href="{% public_url 'core:component_details_public' component_id=component.id component_slug=component.slug %}">
-                                View Details <i class="fas fa-arrow-right ml-1"></i>
+                                View Details <i class="fas fa-arrow-right ml-1" aria-hidden="true"></i>
                             </a>
                         </div>
                     </div>
@@ -91,13 +91,13 @@
         <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
             <div class="mb-6 pb-4 border-b border-border">
                 <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">
-                    <i class="fas fa-cube text-primary"></i>Products
+                    <i class="fas fa-cube text-primary" aria-hidden="true"></i>Products
                 </h2>
                 <p class="text-sm text-text-muted m-0">Explore our products and their software bill of materials (SBOMs)</p>
             </div>
             {% if is_workspace_admin and not has_vulnerability_plugin %}
                 <div class="tw-alert tw-alert-info mb-6">
-                    <i class="fas fa-shield-halved tw-alert-icon"></i>
+                    <i class="fas fa-shield-halved tw-alert-icon" aria-hidden="true"></i>
                     <div class="tw-alert-content">
                         <p class="text-sm m-0">
                             Enable vulnerability scanning to show security status on your products.
@@ -127,7 +127,7 @@
                             </div>
                             <a class="tw-btn-primary text-sm min-h-10 py-2 px-3 inline-flex items-center"
                                href="{% public_url 'core:product_details_public' product_id=product.id product_slug=product.slug %}">
-                                View Details <i class="fas fa-arrow-right ml-1"></i>
+                                View Details <i class="fas fa-arrow-right ml-1" aria-hidden="true"></i>
                             </a>
                         </div>
                     </div>

--- a/sbomify/apps/core/templates/core/workspace_public.html.j2
+++ b/sbomify/apps/core/templates/core/workspace_public.html.j2
@@ -13,16 +13,15 @@
 {% endblock %}
 {% block content %}
     <!-- Hero Section -->
-    <div class="bg-surface rounded-xl p-8 mb-6 shadow-md relative overflow-hidden">
-        <div class="absolute -top-1/2 -right-[30%] w-[600px] h-[600px] bg-[radial-gradient(circle,rgba(var(--brand-color-rgb,var(--brand-primary-rgb)),0.08)_0%,transparent_70%)] pointer-events-none">
-        </div>
-        <div class="relative z-[1]">
-            <div class="uppercase tracking-[0.15em] text-xs font-bold text-primary mb-4 inline-flex items-center gap-2 bg-primary/10 px-3 py-1.5 rounded-lg">
-                <span class="w-1.5 h-1.5 bg-primary rounded-full"></span>
+    <div class="public-hero bg-surface rounded-xl p-8 mb-6 shadow-md relative overflow-hidden">
+        <div class="public-hero-glow" aria-hidden="true"></div>
+        <div class="public-hero-content">
+            <div class="public-eyebrow">
+                <span class="public-eyebrow-dot" aria-hidden="true"></span>
                 TRUST CENTER
             </div>
-            <h1 class="text-2xl font-bold text-text mb-2">{{ workspace.name }} Trust Center</h1>
-            <p class="text-lg text-text-muted leading-relaxed mb-6 max-w-[800px]">
+            <h1 class="text-3xl font-bold text-text mb-2">{{ workspace.name }}</h1>
+            <p class="text-lg text-text-muted leading-relaxed mb-6 max-w-3xl">
                 {% if brand.trust_center_description %}
                     {{ brand.trust_center_description }}
                 {% else %}
@@ -30,27 +29,63 @@
                 {% endif %}
             </p>
             <div class="flex gap-3 flex-wrap">
-                {% if products %}
-                    <div class="bg-border/30 border border-border text-text rounded-xl px-4 py-3 inline-flex items-center gap-3 font-semibold shadow-sm hover:bg-border/50 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                        <span class="w-8 h-8 flex items-center justify-center bg-primary/10 rounded-lg text-primary">
-                            <i class="fas fa-cube"></i>
-                        </span>
-                        <span class="font-bold text-primary">{{ products|length }}</span>
-                        <span class="text-text-muted font-medium">Product{{ products|length|pluralize }}</span>
-                    </div>
-                {% endif %}
                 {% if global_components %}
-                    <div class="bg-border/30 border border-border text-text rounded-xl px-4 py-3 inline-flex items-center gap-3 font-semibold shadow-sm hover:bg-border/50 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                        <span class="w-8 h-8 flex items-center justify-center bg-primary/10 rounded-lg text-primary">
+                    <div class="public-hero-stat">
+                        <span class="public-hero-stat-icon">
                             <i class="fas fa-award"></i>
                         </span>
-                        <span class="font-bold text-primary">{{ global_components|length }}</span>
-                        <span class="text-text-muted font-medium">Compliance Artifact{{ global_components|length|pluralize }}</span>
+                        <span class="public-hero-stat-value">{{ global_components|length }}</span>
+                        <span class="public-hero-stat-label">Compliance Artifact{{ global_components|length|pluralize }}</span>
+                    </div>
+                {% endif %}
+                {% if products %}
+                    <div class="public-hero-stat">
+                        <span class="public-hero-stat-icon">
+                            <i class="fas fa-cube"></i>
+                        </span>
+                        <span class="public-hero-stat-value">{{ products|length }}</span>
+                        <span class="public-hero-stat-label">Product{{ products|length|pluralize }}</span>
                     </div>
                 {% endif %}
             </div>
         </div>
     </div>
+    {% if global_components %}
+        <!-- Organization Compliance Artifacts Section -->
+        <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
+            <div class="mb-6 pb-4 border-b border-border">
+                <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">
+                    <i class="fas fa-award text-primary"></i>Organization Compliance Artifacts
+                </h2>
+                <p class="text-sm text-text-muted m-0">
+                    Organization-wide compliance documents, certifications, and security attestations
+                </p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for component in global_components %}
+                    <div class="bg-card border border-border rounded-xl p-5 h-full flex flex-col transition-all hover:border-primary/30 hover:-translate-y-0.5 hover:shadow-md">
+                        <div class="flex justify-between items-start mb-3 gap-2">
+                            <h3 class="text-lg font-semibold text-text m-0 leading-tight flex-1">{{ component.name }}</h3>
+                            <span class="tw-chip-neutral whitespace-nowrap">{{ component.component_type_display }}</span>
+                        </div>
+                        <p class="text-sm text-text-muted leading-relaxed flex-grow mb-3">
+                            Organization-level compliance artifact available across the entire organization.
+                        </p>
+                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
+                            <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-primary/10 text-primary flex items-center gap-1">
+                                <i class="fas fa-building"></i>
+                                Organization-Wide
+                            </span>
+                            <a class="tw-btn-primary text-sm min-h-10 py-2 px-3 inline-flex items-center"
+                               href="{% public_url 'core:component_details_public' component_id=component.id component_slug=component.slug %}">
+                                View Details <i class="fas fa-arrow-right ml-1"></i>
+                            </a>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endif %}
     {% if products %}
         <!-- Products Section -->
         <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
@@ -77,62 +112,21 @@
                     <div class="bg-card border border-border rounded-xl p-5 h-full flex flex-col transition-all hover:border-primary/30 hover:-translate-y-0.5 hover:shadow-md">
                         <div class="flex justify-between items-start mb-3 gap-2">
                             <h3 class="text-lg font-semibold text-text m-0 leading-tight flex-1">{{ product.name }}</h3>
-                            <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-border/50 text-text-muted">{{ product.component_count }} Component{{ product.component_count|pluralize }}</span>
+                            <span class="tw-chip-neutral whitespace-nowrap">{{ product.component_count }} Component{{ product.component_count|pluralize }}</span>
                         </div>
                         {% if product.description %}
                             <p class="text-sm text-text-muted leading-relaxed flex-grow mb-3">{{ product.description }}</p>
                         {% endif %}
                         <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
-                            <div class="flex items-center gap-2">
-                                <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-warning/15 text-warning flex items-center gap-1">
-                                    <i class="fas fa-tag"></i>Product
-                                </span>
+                            <div class="flex items-center gap-1 flex-wrap">
                                 {% if product.passing_assessments %}
-                                    <div class="flex items-center gap-1">
-                                        {% for assessment in product.passing_assessments %}
-                                            {% include 'plugins/components/public_assessment_icon.html.j2' with assessment=assessment %}
-                                        {% endfor %}
-                                    </div>
+                                    {% for assessment in product.passing_assessments %}
+                                        {% include 'plugins/components/public_assessment_icon.html.j2' with assessment=assessment %}
+                                    {% endfor %}
                                 {% endif %}
                             </div>
-                            <a class="tw-btn-primary text-sm py-1.5 px-3"
+                            <a class="tw-btn-primary text-sm min-h-10 py-2 px-3 inline-flex items-center"
                                href="{% public_url 'core:product_details_public' product_id=product.id product_slug=product.slug %}">
-                                View Details <i class="fas fa-arrow-right ml-1"></i>
-                            </a>
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
-    {% endif %}
-    {% if global_components %}
-        <!-- Workspace Artifacts Section -->
-        <div class="bg-surface rounded-xl p-8 shadow-md">
-            <div class="mb-6 pb-4 border-b border-border">
-                <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">
-                    <i class="fas fa-award text-primary"></i>Organization Compliance Artifacts
-                </h2>
-                <p class="text-sm text-text-muted m-0">
-                    Organization-wide compliance documents, certifications, and security attestations
-                </p>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {% for component in global_components %}
-                    <div class="bg-card border border-border rounded-xl p-5 h-full flex flex-col transition-all hover:border-primary/30 hover:-translate-y-0.5 hover:shadow-md">
-                        <div class="flex justify-between items-start mb-3 gap-2">
-                            <h3 class="text-lg font-semibold text-text m-0 leading-tight flex-1">{{ component.name }}</h3>
-                            <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-warning/15 text-warning">{{ component.component_type_display }}</span>
-                        </div>
-                        <p class="text-sm text-text-muted leading-relaxed flex-grow mb-3">
-                            Organization-level compliance artifact available across the entire organization.
-                        </p>
-                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
-                            <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-primary/10 text-primary flex items-center gap-1">
-                                <i class="fas fa-building"></i>
-                                Organization-Wide
-                            </span>
-                            <a class="tw-btn-primary text-sm py-1.5 px-3"
-                               href="{% public_url 'core:component_details_public' component_id=component.id component_slug=component.slug %}">
                                 View Details <i class="fas fa-arrow-right ml-1"></i>
                             </a>
                         </div>

--- a/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
+++ b/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
@@ -1,0 +1,172 @@
+"""Generates full-page screenshots for the trust-center public views.
+
+Not a regression test — this saves screenshots to /tmp/ux-review/ so they can
+be inspected manually after the trust-center UI changes in PR #966.
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+from sbomify.apps.core.models import Component, Release
+from sbomify.apps.core.tests.e2e.fixtures import *  # noqa: F403
+from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
+
+OUT_DIR = Path("/tmp/ux-review")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# Widths to capture: desktop, narrow desktop, tablet, mobile.
+WIDTHS = [1920, 992, 576, 375]
+
+
+def _full_page_screenshot(page: Page, label: str, width: int) -> Path:
+    page.set_viewport_size({"width": width, "height": 1080})
+    page.wait_for_timeout(600)
+    page.set_viewport_size({"width": width, "height": page.evaluate("document.body.parentNode.scrollHeight")})
+    page.wait_for_timeout(400)
+    out = OUT_DIR / f"{label}__{width}.jpg"
+    page.screenshot(path=out.as_posix(), type="jpeg", full_page=True, quality=80)
+    return out
+
+
+@pytest.fixture
+def trust_center_product(product_factory, component_factory, sbom_factory, document_factory, team_with_business_plan):
+    """Realistic trust-center product: SBOM + doc + identifiers + links + releases."""
+    team_with_business_plan.is_public = True
+    team_with_business_plan.save()
+
+    name = "UX Review Product"
+    _id = hashlib.md5(name.encode()).hexdigest()[:12]
+    product = product_factory(name=name, _id=_id, is_public=True)
+
+    bom = component_factory(
+        "Backend API",
+        Component.ComponentType.BOM,
+        product=product,
+        visibility=Component.Visibility.PUBLIC,
+    )
+    sbom_factory(bom, name="backend-api-sbom.json", version="2.4.1")
+
+    doc = component_factory(
+        "Compliance Pack",
+        Component.ComponentType.DOCUMENT,
+        product=product,
+        visibility=Component.Visibility.PUBLIC,
+    )
+    document_factory(doc, name="soc2-report.pdf", version="2025")
+
+    ProductIdentifier.objects.bulk_create([
+        ProductIdentifier(
+            product=product,
+            identifier_type=ProductIdentifier.IdentifierType.SKU,
+            value="SKU-UX-001",
+            team=product.team,
+        ),
+        ProductIdentifier(
+            product=product,
+            identifier_type=ProductIdentifier.IdentifierType.GTIN_13,
+            value="0123456789012",
+            team=product.team,
+        ),
+        ProductIdentifier(
+            product=product,
+            identifier_type=ProductIdentifier.IdentifierType.CPE,
+            value="cpe:2.3:a:test:product:1.0.0:*:*:*:*:*:*:*",
+            team=product.team,
+        ),
+    ])
+
+    ProductLink.objects.bulk_create([
+        ProductLink(
+            product=product,
+            link_type=ProductLink.LinkType.WEBSITE,
+            title="Product Website",
+            url="https://example.com",
+            team=product.team,
+        ),
+        ProductLink(
+            product=product,
+            link_type=ProductLink.LinkType.REPOSITORY,
+            title="GitHub Repository",
+            url="https://github.com/example/product",
+            team=product.team,
+        ),
+        ProductLink(
+            product=product,
+            link_type=ProductLink.LinkType.DOCUMENTATION,
+            title="Documentation",
+            url="https://docs.example.com",
+            team=product.team,
+        ),
+    ])
+
+    Release.objects.bulk_create([
+        Release(product=product, name="v1.0.0", description="Initial GA release", is_latest=False, is_prerelease=False),
+        Release(product=product, name="v1.1.0", description="Maintenance release", is_latest=False, is_prerelease=False),
+        Release(product=product, name="v2.0.0", description="Major update — new dashboard, faster scans", is_latest=True, is_prerelease=False),
+        Release(product=product, name="v2.1.0-beta", description="Beta — preview of release-channel feature", is_latest=False, is_prerelease=True),
+    ])
+
+    yield product
+
+
+@pytest.fixture
+def trust_center_empty(product_factory, team_with_business_plan):
+    team_with_business_plan.is_public = True
+    team_with_business_plan.save()
+
+    name = "UX Review Empty"
+    _id = hashlib.md5(name.encode()).hexdigest()[:12]
+    yield product_factory(name=name, _id=_id, is_public=True)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("width", WIDTHS)
+class TestUxReviewTrustCenter:
+    def test_workspace_public(self, authenticated_page, trust_center_product, width):
+        # Workspace key derived from team
+        team = trust_center_product.team
+        authenticated_page.goto(f"/public/workspace/{team.key}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "workspace_public", width)
+
+    def test_product_details_public(self, authenticated_page, trust_center_product, width):
+        authenticated_page.goto(f"/public/product/{trust_center_product.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "product_details_public", width)
+
+    def test_product_details_public_empty(self, authenticated_page, trust_center_empty, width):
+        authenticated_page.goto(f"/public/product/{trust_center_empty.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "product_details_public_empty", width)
+
+    def test_product_releases_public(self, authenticated_page, trust_center_product, width):
+        authenticated_page.goto(f"/public/product/{trust_center_product.id}/releases/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "product_releases_public", width)
+
+    def test_release_details_public(self, authenticated_page, trust_center_product, width):
+        latest = trust_center_product.releases.filter(is_latest=True).first()
+        authenticated_page.goto(f"/public/product/{trust_center_product.id}/release/{latest.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "release_details_public_latest", width)
+
+    def test_release_details_public_prerelease(self, authenticated_page, trust_center_product, width):
+        pre = trust_center_product.releases.filter(is_prerelease=True).first()
+        authenticated_page.goto(f"/public/product/{trust_center_product.id}/release/{pre.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "release_details_public_prerelease", width)
+
+    def test_component_details_public_sbom(self, authenticated_page, trust_center_product, width):
+        sbom_comp = trust_center_product.components.filter(component_type=Component.ComponentType.BOM).first()
+        authenticated_page.goto(f"/public/component/{sbom_comp.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "component_details_public_sbom", width)
+
+    def test_component_details_public_document(self, authenticated_page, trust_center_product, width):
+        doc_comp = trust_center_product.components.filter(component_type=Component.ComponentType.DOCUMENT).first()
+        authenticated_page.goto(f"/public/component/{doc_comp.id}/")
+        authenticated_page.wait_for_load_state("networkidle")
+        _full_page_screenshot(authenticated_page, "component_details_public_document", width)

--- a/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
+++ b/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
@@ -2,20 +2,30 @@
 
 Not a regression test — this saves screenshots to /tmp/ux-review/ so they can
 be inspected manually after the trust-center UI changes in PR #966.
+
+Skipped by default in CI because every test passes regardless of output
+(no asserts). Run locally with `RUN_UX_REVIEW=1 pytest ...` when you want
+fresh screenshots.
 """
 
 import hashlib
+import os
 from pathlib import Path
 
 import pytest
 from playwright.sync_api import Page
 
-from sbomify.apps.core.models import Component, Release
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Component, Release
 from sbomify.apps.core.tests.e2e.fixtures import *  # noqa: F403
 from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
 
 OUT_DIR = Path("/tmp/ux-review")
 OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RUN_UX_REVIEW"),
+    reason="UX screenshot generator — set RUN_UX_REVIEW=1 to run.",
+)
 
 # Widths to capture: desktop, narrow desktop, tablet, mobile.
 WIDTHS = [1920, 992, 576, 375]
@@ -102,12 +112,34 @@ def trust_center_product(product_factory, component_factory, sbom_factory, docum
         ),
     ])
 
-    Release.objects.bulk_create([
-        Release(product=product, name="v1.0.0", description="Initial GA release", is_latest=False, is_prerelease=False),
-        Release(product=product, name="v1.1.0", description="Maintenance release", is_latest=False, is_prerelease=False),
-        Release(product=product, name="v2.0.0", description="Major update — new dashboard, faster scans", is_latest=True, is_prerelease=False),
-        Release(product=product, name="v2.1.0-beta", description="Beta — preview of release-channel feature", is_latest=False, is_prerelease=True),
-    ])
+    # Versioned releases: is_latest=False. The model reserves is_latest for
+    # the auto-managed `latest` synthetic release; `.create()` (not bulk) so
+    # save-time validations and signals run.
+    for name_, description, is_prerelease in [
+        ("v1.0.0", "Initial GA release", False),
+        ("v1.1.0", "Maintenance release", False),
+        ("v2.0.0", "Major update — new dashboard, faster scans", False),
+        ("v2.1.0-beta", "Beta — preview of release-channel feature", True),
+    ]:
+        Release.objects.create(
+            product=product,
+            name=name_,
+            description=description,
+            is_latest=False,
+            is_prerelease=is_prerelease,
+        )
+
+    # Synthetic auto-managed `latest` release — created the way the
+    # production code does (via the reserved name + is_latest=True). The
+    # public views filter this out of release lists; the UX-review pages
+    # exercise both the filtered list rendering and the synthetic-release
+    # download CTA.
+    Release.objects.create(
+        product=product,
+        name=LATEST_RELEASE_NAME,
+        is_latest=True,
+        is_prerelease=False,
+    )
 
     yield product
 
@@ -148,8 +180,9 @@ class TestUxReviewTrustCenter:
         _full_page_screenshot(authenticated_page, "product_releases_public", width)
 
     def test_release_details_public(self, authenticated_page, trust_center_product, width):
-        latest = trust_center_product.releases.filter(is_latest=True).first()
-        authenticated_page.goto(f"/public/product/{trust_center_product.id}/release/{latest.id}/")
+        # Capture a real versioned release (not the synthetic auto-`latest`).
+        versioned = trust_center_product.releases.exclude(name=LATEST_RELEASE_NAME).filter(is_prerelease=False).first()
+        authenticated_page.goto(f"/public/product/{trust_center_product.id}/release/{versioned.id}/")
         authenticated_page.wait_for_load_state("networkidle")
         _full_page_screenshot(authenticated_page, "release_details_public_latest", width)
 

--- a/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
+++ b/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
@@ -1,7 +1,7 @@
 """Generates full-page screenshots for the trust-center public views.
 
-Not a regression test — this saves screenshots to /tmp/ux-review/ so they can
-be inspected manually after the trust-center UI changes in PR #966.
+Not a regression test — this saves screenshots to /tmp/ux-review/ so they
+can be inspected manually when reviewing changes to the public pages.
 
 Skipped by default in CI because every test passes regardless of output
 (no asserts). Run locally with `RUN_UX_REVIEW=1 pytest ...` when you want

--- a/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
+++ b/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
@@ -20,7 +20,6 @@ from sbomify.apps.core.tests.e2e.fixtures import *  # noqa: F403
 from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
 
 OUT_DIR = Path("/tmp/ux-review")
-OUT_DIR.mkdir(parents=True, exist_ok=True)
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("RUN_UX_REVIEW"),
@@ -32,6 +31,9 @@ WIDTHS = [1920, 992, 576, 375]
 
 
 def _full_page_screenshot(page: Page, label: str, width: int) -> Path:
+    # Defer dir creation to first call so the module is import-time
+    # side-effect free (pytest still imports the module during collection).
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
     page.set_viewport_size({"width": width, "height": 1080})
     page.wait_for_timeout(600)
     page.set_viewport_size({"width": width, "height": page.evaluate("document.body.parentNode.scrollHeight")})

--- a/sbomify/apps/core/tests/test_product_details_public_view.py
+++ b/sbomify/apps/core/tests/test_product_details_public_view.py
@@ -4,7 +4,7 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
-from sbomify.apps.core.models import Product, Release
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Product, Release
 from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
 from sbomify.apps.teams.models import Team
 
@@ -385,6 +385,42 @@ def test_product_details_shows_releases(public_team, public_product):
 
     assert "v1.0.0" in content
     assert "v0.9.0-beta" in content
+
+
+@pytest.mark.django_db
+def test_product_details_hides_synthetic_latest_release(public_team, public_product):
+    """The synthetic auto-managed `latest` release must not appear in the releases table.
+
+    Two real releases must render normally — the synthetic `latest` (with
+    is_latest=True and the reserved name) is hidden so trust-center visitors
+    don't see two rows competing for the "Latest" badge. The
+    `Download Latest Release` CTA still surfaces the latest artifacts.
+    """
+    client = Client()
+
+    Release.objects.create(name="v1.0.0", product=public_product)
+    Release.objects.create(name="v0.9.0-beta", product=public_product, is_prerelease=True)
+    # Synthetic auto-managed latest — the reserved name + is_latest=True
+    # is what `_ensure_latest_release_exists` would create on demand.
+    Release.objects.create(
+        name=LATEST_RELEASE_NAME,
+        product=public_product,
+        is_latest=True,
+        description="Automatically updated release containing the latest artifacts from all components",
+    )
+
+    url = reverse("core:product_details_public", kwargs={"product_id": public_product.id})
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Versioned rows are present
+    assert "v1.0.0" in content
+    assert "v0.9.0-beta" in content
+    # Synthetic latest's description is the easiest fingerprint to test against
+    # (the literal name `latest` shows up too often elsewhere on the page).
+    assert "Automatically updated release containing the latest artifacts" not in content
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_product_details_public_view.py
+++ b/sbomify/apps/core/tests/test_product_details_public_view.py
@@ -424,6 +424,39 @@ def test_product_details_hides_synthetic_latest_release(public_team, public_prod
 
 
 @pytest.mark.django_db
+def test_releases_public_view_hides_synthetic_latest_release(public_team, public_product):
+    """The dedicated /releases/ page must also exclude the synthetic auto-`latest`.
+
+    `ProductReleasesPublicView` filters items returned from `list_all_releases`
+    so the synthetic release never shows in the list. This is separate from the
+    embedded list on the product details page (covered above) — they share intent
+    but go through different view code paths.
+    """
+    client = Client()
+
+    Release.objects.create(name="v3.0.0", product=public_product)
+    Release.objects.create(name="v2.5.0-rc1", product=public_product, is_prerelease=True)
+    Release.objects.create(
+        name=LATEST_RELEASE_NAME,
+        product=public_product,
+        is_latest=True,
+        description="Automatically updated release containing the latest artifacts from all components",
+    )
+
+    url = reverse("core:product_releases_public", kwargs={"product_id": public_product.id})
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Real versioned rows still render
+    assert "v3.0.0" in content
+    assert "v2.5.0-rc1" in content
+    # Synthetic-latest row is filtered out
+    assert "Automatically updated release containing the latest artifacts" not in content
+
+
+@pytest.mark.django_db
 class TestProductLinkRedirectView:
     """Tests for the ProductLinkRedirectView."""
 

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -10,7 +10,7 @@ from django.views import View
 
 from sbomify.apps.core.apis import get_product
 from sbomify.apps.core.errors import error_response
-from sbomify.apps.core.models import Release, ReleaseArtifact
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Release, ReleaseArtifact
 from sbomify.apps.core.url_utils import (
     add_custom_domain_to_context,
     build_custom_domain_url,
@@ -80,8 +80,12 @@ def _prepare_public_components(product_id: str, is_custom_domain: bool) -> list[
 def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: str, limit: int = 5) -> list[Any]:
     """Get releases for a public product (releases inherit visibility from their product)."""
     # Use annotations to avoid N+1 queries for artifacts_count and has_sboms
+    # Exclude the synthetic auto-`latest` release — the product page surfaces it
+    # via the "Download Latest Release" CTA, so it shouldn't also occupy a row
+    # in the releases table.
     releases = (
         Release.objects.filter(product_id=product_id)
+        .exclude(name=LATEST_RELEASE_NAME)
         .select_related("product")
         .annotate(
             annotated_artifacts_count=Count("artifacts"),

--- a/sbomify/apps/core/views/product_releases_public.py
+++ b/sbomify/apps/core/views/product_releases_public.py
@@ -6,6 +6,7 @@ from django.views import View
 
 from sbomify.apps.core.apis import get_product, list_all_releases
 from sbomify.apps.core.errors import error_response
+from sbomify.apps.core.models import LATEST_RELEASE_NAME
 from sbomify.apps.core.url_utils import (
     add_custom_domain_to_context,
     build_custom_domain_url,
@@ -55,9 +56,14 @@ class ProductReleasesPublicView(View):
         # Get workspace public URL for breadcrumbs
         workspace_public_url = get_workspace_public_url(request, team)
 
+        # Hide the synthetic auto-`latest` release from the public list.
+        # It serves as a stable download URL but is surfaced via the
+        # "Download Latest Release" CTA on the product page, not here.
+        items = [r for r in (releases.get("items") or []) if r.get("name") != LATEST_RELEASE_NAME]
+
         context = {
             "product": product,
-            "releases": releases.get("items"),
+            "releases": items,
             "brand": brand,
             "workspace_public_url": workspace_public_url,
         }

--- a/sbomify/apps/core/views/release_details_public.py
+++ b/sbomify/apps/core/views/release_details_public.py
@@ -67,8 +67,9 @@ class ReleaseDetailsPublicView(View):
             "brand": brand,
             "release": release,
             # `product` is consumed by the breadcrumb tag so the release page
-            # gets a `Trust Center > Product > (current release)` breadcrumb
-            # consistent with the releases list and component pages.
+            # gets a `Trust Center > Product` breadcrumb consistent with the
+            # releases list and component pages. The current release isn't
+            # added as a crumb — the page H1 already conveys it.
             "product": product,
             "workspace_public_url": workspace_public_url,
         }

--- a/sbomify/apps/core/views/release_details_public.py
+++ b/sbomify/apps/core/views/release_details_public.py
@@ -66,6 +66,10 @@ class ReleaseDetailsPublicView(View):
         context = {
             "brand": brand,
             "release": release,
+            # `product` is consumed by the breadcrumb tag so the release page
+            # gets a `Trust Center > Product > (current release)` breadcrumb
+            # consistent with the releases list and component pages.
+            "product": product,
             "workspace_public_url": workspace_public_url,
         }
         add_custom_domain_to_context(request, context, team)

--- a/sbomify/apps/documents/templates/documents/documents_table_content.html.j2
+++ b/sbomify/apps/documents/templates/documents/documents_table_content.html.j2
@@ -54,7 +54,8 @@
                                 </span>
                             </button>
                         </th>
-                        <th :aria-sort="sortColumn === 'document_type' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
+                        <th class="hidden md:table-cell"
+                            :aria-sort="sortColumn === 'document_type' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'">
                             <button type="button"
                                     class="tw-table-sortable"
                                     :class="{ 'sorted-asc': sortColumn === 'document_type' && sortDirection === 'asc', 'sorted-desc': sortColumn === 'document_type' && sortDirection === 'desc' }"
@@ -98,7 +99,7 @@
                 <tbody>
                     <template x-for="item in paginatedData" :key="item.document.id">
                         <tr class="hover:bg-background/50 transition-colors">
-                            <td>
+                            <td class="break-all">
                                 <a :href="'{% if is_public_view %}{% url 'core:component_item_public' component_id=component_id item_type='documents' item_id='DOC_ID' %}{% else %}{% url 'core:component_item' component_id=component_id item_type='documents' item_id='DOC_ID' %}{% endif %}'.replace('DOC_ID', item.document.id)"
                                    class="text-primary font-medium hover:underline"
                                    x-text="item.document.name"></a>
@@ -108,7 +109,7 @@
                                           x-text="item.document.document_type_display || 'Document'"></span>
                                 </div>
                             </td>
-                            <td>
+                            <td class="hidden md:table-cell">
                                 <span class="tw-badge-warning"
                                       x-text="item.document.document_type_display || 'Document'"></span>
                             </td>
@@ -117,7 +118,7 @@
                                       x-text="item.document.version.length > 20 ? item.document.version.slice(0, 20) + '...' : item.document.version"
                                       :title="item.document.version"></span>
                             </td>
-                            <td class="text-text-muted text-sm">
+                            <td class="text-text-muted text-sm whitespace-nowrap">
                                 <span x-text="new Date(item.document.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })"></span>
                             </td>
                             <td class="hidden lg:table-cell">

--- a/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
@@ -96,20 +96,22 @@
                             </button>
                         </th>
                         <th class="hidden lg:table-cell">Releases</th>
+                        <th class="text-center">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
                     <template x-for="item in paginatedData" :key="item.sbom.id">
                         <tr class="hover:bg-background/50 transition-colors"
                             x-data="{ get bomType() { return item.sbom.bom_type || 'sbom' } }">
-                            <td>
+                            <td class="break-all">
                                 <a :href="'{% if is_public_view %}{% url 'core:component_item_public' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% else %}{% url 'core:component_item' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% endif %}'.replace('SBOM_ID', item.sbom.id)"
                                    class="text-primary font-medium hover:underline"
                                    x-text="item.sbom.name"></a>
+                                {# Mobile: format name only — full "<FORMAT> <version>" pair shown in dedicated columns at md+. #}
                                 <div class="md:hidden mt-1">
                                     <span class="tw-sbom-format text-xs"
                                           :class="item.sbom.format.toLowerCase().includes('cyclonedx') ? 'tw-sbom-format-cyclonedx' : 'tw-sbom-format-spdx'"
-                                          x-text="(item.sbom.format_display || item.sbom.format).toUpperCase() + ' ' + item.sbom.format_version"></span>
+                                          x-text="(item.sbom.format_display || item.sbom.format).toUpperCase()"></span>
                                 </div>
                             </td>
                             <td class="hidden md:table-cell">
@@ -169,7 +171,7 @@
                                     </template>
                                 </td>
                             {% endif %}
-                            <td class="text-text text-sm">
+                            <td class="text-text text-sm whitespace-nowrap">
                                 <span x-text="new Date(item.sbom.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })"></span>
                             </td>
                             <td class="hidden lg:table-cell">
@@ -188,11 +190,21 @@
                                     <span class="text-text-muted">—</span>
                                 </template>
                             </td>
+                            <td>
+                                <div class="flex items-center justify-center gap-1">
+                                    <a :href="'{% url 'sboms:sbom_download' 'SBOM_ID' %}'.replace('SBOM_ID', item.sbom.id)"
+                                       title="Download"
+                                       aria-label="Download SBOM"
+                                       class="p-2 rounded-lg text-primary hover:bg-primary/10 transition-colors">
+                                        <i class="fas fa-download" aria-hidden="true"></i>
+                                    </a>
+                                </div>
+                            </td>
                         </tr>
                     </template>
                     <template x-if="paginatedData.length === 0 && search">
                         <tr>
-                            <td colspan="{% if is_public_view %}6{% else %}7{% endif %}"
+                            <td colspan="{% if is_public_view %}7{% else %}8{% endif %}"
                                 class="text-center py-8 text-text-muted">
                                 <i class="fas fa-search text-2xl mb-2 opacity-50"></i>
                                 <p>No BOMs match your search</p>

--- a/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
@@ -197,7 +197,10 @@
                             </td>
                             <td>
                                 <div class="flex items-center justify-center gap-1">
-                                    <a :href="'{% url 'sboms:sbom_download' 'SBOM_ID' %}'.replace('SBOM_ID', item.sbom.id)"
+                                    {# `from_public=true` flag tells SbomDownloadView to render the friendly
+                                       gated-access page instead of a generic 403 when a public visitor hits a
+                                       gated SBOM. Internal downloads omit the flag. #}
+                                    <a :href="'{% url 'sboms:sbom_download' 'SBOM_ID' %}'.replace('SBOM_ID', item.sbom.id){% if is_public_view %} + '?from_public=true'{% endif %}"
                                        title="Download"
                                        aria-label="Download SBOM"
                                        class="p-2 rounded-lg text-primary hover:bg-primary/10 transition-colors">

--- a/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
@@ -107,11 +107,16 @@
                                 <a :href="'{% if is_public_view %}{% url 'core:component_item_public' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% else %}{% url 'core:component_item' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% endif %}'.replace('SBOM_ID', item.sbom.id)"
                                    class="text-primary font-medium hover:underline"
                                    x-text="item.sbom.name"></a>
-                                {# Mobile: format name only — full "<FORMAT> <version>" pair shown in dedicated columns at md+. #}
-                                <div class="md:hidden mt-1">
-                                    <span class="tw-sbom-format text-xs"
+                                {# Mobile fallback for the columns hidden under md: format pill (with format_version)
+                                   plus the SBOM version. flex-wrap lets each pill drop to its own line if the column
+                                   is narrow, so the table doesn't horizontally scroll. #}
+                                <div class="md:hidden mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+                                    <span class="tw-sbom-format"
                                           :class="item.sbom.format.toLowerCase().includes('cyclonedx') ? 'tw-sbom-format-cyclonedx' : 'tw-sbom-format-spdx'"
-                                          x-text="(item.sbom.format_display || item.sbom.format).toUpperCase()"></span>
+                                          x-text="(item.sbom.format_display || item.sbom.format).toUpperCase() + ' ' + item.sbom.format_version"></span>
+                                    <span class="text-text-muted font-mono"
+                                          x-text="'v' + (item.sbom.version.length > 16 ? item.sbom.version.slice(0, 16) + '…' : item.sbom.version)"
+                                          :title="item.sbom.version"></span>
                                 </div>
                             </td>
                             <td class="hidden md:table-cell">

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -2231,6 +2231,19 @@ html.no-transitions * {
   border-bottom: none;
 }
 
+/* Tighter table cell padding on small screens so 3-column tables
+   (Name + Created + Actions) fit in 375px viewports without a horizontal
+   scrollbar. The desktop padding (1rem) eats ~96px of horizontal space
+   across three columns — too much when the viewport is barely 320px wide
+   after card chrome. */
+@media (max-width: 640px) {
+  .tw-table th,
+  .tw-table td {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+}
+
 /* Sortable header */
 .tw-table-sortable {
   cursor: pointer;

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -1604,6 +1604,21 @@ html.no-transitions * {
   border: 1px solid rgb(var(--color-info) / 0.2);
 }
 
+/* Neutral chip — squared variant for table-like contexts (counts, types).
+   Pair with utilities like .whitespace-nowrap as needed. */
+.tw-chip-neutral {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  background-color: rgb(var(--color-border) / 0.5);
+  color: rgb(var(--color-text-muted));
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
 /* Dot Badge - with status indicator */
 .tw-badge-dot {
   gap: 0.375rem;

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -2231,14 +2231,13 @@ html.no-transitions * {
   border-bottom: none;
 }
 
-/* Tighter table cell padding on small screens so 3-column tables
-   (Name + Created + Actions) fit in 375px viewports without a horizontal
-   scrollbar. The desktop padding (1rem) eats ~96px of horizontal space
-   across three columns — too much when the viewport is barely 320px wide
-   after card chrome. */
+/* Tighter table cell padding on small screens for public trust-center
+   pages only, so 3-column tables (Name + Created + Actions) fit in
+   375px viewports without a horizontal scrollbar. Scoped to .public-page
+   so the app-wide tw-table padding stays unchanged on internal pages. */
 @media (max-width: 640px) {
-  .tw-table th,
-  .tw-table td {
+  .public-page .tw-table th,
+  .public-page .tw-table td {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }

--- a/sbomify/static/css/public-base.css
+++ b/sbomify/static/css/public-base.css
@@ -77,90 +77,7 @@
     padding: 2rem 1.5rem;
 }
 
-.public-footer {
-    background: linear-gradient(180deg, rgb(var(--color-surface)) 0%, rgb(var(--color-background)) 100%);
-    border-top: 1px solid rgb(var(--color-border));
-    padding: 1.5rem 0;
-    margin-top: 2rem;
-}
-
-.public-footer-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
-}
-
-.footer-content-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-}
-
-
-.footer-bottom {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 1rem;
-    padding-top: 0;
-}
-
-.footer-powered {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8125rem;
-    color: rgb(var(--color-text-muted));
-}
-
-.footer-powered a {
-    color: #6366f1;
-    text-decoration: none;
-    font-weight: 600;
-    transition: color 0.2s ease;
-}
-
-.footer-powered a:hover {
-    color: rgb(var(--color-primary));
-}
-
-.footer-separator {
-    color: rgb(var(--color-gray-300));
-}
-
-.footer-meta {
-    font-size: 0.8125rem;
-    color: rgb(var(--color-text-muted));
-}
-
-/* Legacy footer classes for backward compatibility */
-.footer-content {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 1rem;
-}
-
-.footer-branding {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--text-muted);
-    font-size: 0.875rem;
-}
-
-.footer-powered-by a {
-    color: var(--accent-color);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s ease;
-}
-
-.footer-powered-by a:hover {
-    color: var(--accent-color-dark);
-}
+/* Footer rules are owned by the inline <style> block in core/public_base.htmx.j2. */
 
 @media (max-width: 768px) {
     .public-header {
@@ -213,16 +130,6 @@
         right: 1rem !important;
         width: auto !important;
         max-width: calc(100% - 2rem);
-    }
-
-    .footer-bottom {
-        flex-direction: column;
-        text-align: center;
-    }
-
-    .footer-content {
-        flex-direction: column;
-        text-align: center;
     }
 }
 

--- a/sbomify/static/css/public-pages.css
+++ b/sbomify/static/css/public-pages.css
@@ -3,12 +3,90 @@
  * Uses design tokens and brand variables for consistency
  */
 
+/* ===== HERO ===== */
+.public-hero {
+    position: relative;
+}
+
+.public-hero-content {
+    position: relative;
+    z-index: 1;
+}
+
+.public-hero-glow {
+    position: absolute;
+    top: -50%;
+    right: -30%;
+    width: 37.5rem;
+    height: 37.5rem;
+    background: radial-gradient(circle,
+        rgba(var(--brand-color-rgb, var(--brand-primary-rgb)), 0.08) 0%,
+        transparent 70%);
+    pointer-events: none;
+}
+
+.public-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--radius-lg);
+    background: rgb(var(--color-primary) / 0.1);
+    color: rgb(var(--color-primary));
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+}
+
+.public-eyebrow-dot {
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: var(--radius-full);
+    background-color: rgb(var(--color-primary));
+}
+
+.public-hero-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--radius-xl);
+    background: rgb(var(--color-border) / 0.3);
+    border: 1px solid rgb(var(--color-border));
+    color: rgb(var(--color-text));
+    font-weight: var(--font-weight-semibold);
+    box-shadow: var(--shadow-sm);
+}
+
+.public-hero-stat-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-lg);
+    background: rgb(var(--color-primary) / 0.1);
+    color: rgb(var(--color-primary));
+}
+
+.public-hero-stat-value {
+    color: rgb(var(--color-primary));
+    font-weight: var(--font-weight-bold);
+}
+
+.public-hero-stat-label {
+    color: rgb(var(--color-text-muted));
+    font-weight: var(--font-weight-medium);
+}
+
 /* ===== PAGE HEADER ===== */
 .public-item-header {
     background: rgb(var(--color-surface));
     border-radius: var(--radius-xl);
     padding: var(--spacing-xl);
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--spacing-lg);
     box-shadow: var(--shadow-md);
 }
 
@@ -111,13 +189,13 @@
 }
 
 .public-badge.badge-type {
-    background: rgb(var(--color-warning) / 0.15);
-    color: rgb(var(--color-warning));
+    background: rgb(var(--color-border) / 0.5);
+    color: rgb(var(--color-text-muted));
 }
 
 .public-badge.badge-workspace {
-    background: rgba(99, 102, 241, 0.1);
-    color: #3730a3;
+    background: rgb(var(--color-info) / 0.1);
+    color: rgb(var(--color-info));
 }
 
 .public-badge.badge-attestation {
@@ -126,20 +204,20 @@
 }
 
 .public-badge.badge-security {
-    background: rgba(139, 92, 246, 0.15);
-    color: #5b21b6;
+    background: rgb(var(--color-accent) / 0.15);
+    color: rgb(var(--color-accent));
 }
 
 .public-badge.badge-license {
-    background: rgba(236, 72, 153, 0.15);
-    color: #9d174d;
+    background: rgb(var(--color-accent-pink) / 0.15);
+    color: rgb(var(--color-accent-pink));
 }
 
 /* Note: Compact compliance icons are in components.css */
 
 /* ===== SECTION CARDS ===== */
 .public-section {
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--spacing-lg);
 }
 
 .public-section:first-child {
@@ -1081,7 +1159,7 @@
 
     /* Section cards */
     .public-section {
-        margin-bottom: 0.5rem;
+        margin-bottom: var(--spacing-md);
     }
 
     .public-section>.card {

--- a/sbomify/static/css/public-pages.css
+++ b/sbomify/static/css/public-pages.css
@@ -1015,7 +1015,7 @@
 @media (max-width: 576px) {
     .public-item-header {
         padding: var(--spacing-md);
-        margin-bottom: var(--spacing-md);
+        margin-bottom: var(--spacing-lg);
     }
 
     .public-item-title {
@@ -1159,7 +1159,7 @@
 
     /* Section cards */
     .public-section {
-        margin-bottom: var(--spacing-md);
+        margin-bottom: var(--spacing-lg);
     }
 
     .public-section>.card {

--- a/sbomify/static/css/public-pages.css
+++ b/sbomify/static/css/public-pages.css
@@ -3,6 +3,14 @@
  * Uses design tokens and brand variables for consistency
  */
 
+/* Public-page barcode SVG.
+   Centralized here so templates can use the .barcode-svg class without
+   per-call arbitrary max-width utilities (previously max-w-[150px]). */
+.barcode-svg {
+    max-width: 150px;
+    height: auto;
+}
+
 /* ===== HERO ===== */
 .public-hero {
     position: relative;


### PR DESCRIPTION
## Summary

Reconnects the public trust-center pages to the design system and fixes long-standing UX issues that made them feel cramped, semantically mismatched, and inconsistent across pages. Outcome of a UI/UX review prompted by user reports that the trust center pages had layout/spacing/hierarchy issues.

## What changed

### Token discipline
- Drop `!important` overrides in `public_base.htmx.j2` inline `<style>` and the inline theme-flash JS; inline-on-`<html>` + source order already win the cascade.
- Recolor `public-pages.css` badge variants (`badge-workspace`, `badge-security`, `badge-license`, `badge-type`) to token-driven values; eliminate raw hex.
- Remove dead duplicate footer rules from `public-base.css` (inline `<style>` owns them).

### Hierarchy & information architecture
- **Workspace landing**: H1 → `text-3xl`, drop redundant "Trust Center" suffix (eyebrow carries it), remove false-affordance hover transforms on non-interactive stat tiles, drop redundant "Product" badge on product cards, reorder compliance artifacts before products.
- **Product page**: lift "Download Latest Release" above identifiers/links/lifecycle — the most likely user action shouldn't be at the bottom.
- **Component page hero icon**: `bg-info/10` → `bg-primary/10` (consistent with product/release pages).
- **Gated-access panels**: rejected state now uses `danger` (was warning yellow), keeping warning for actual blocking states.
- **Release detail**: collapse 5-color badge rainbow into a single muted meta strip; Latest/Pre-release pills moved inline next to H1.
- **Releases list**: drop duplicate inner "Release History" h4 since page H1 says "Releases".

### Consistency & DX
- New `core/components/public_section_header.html.j2` partial; convert lifecycle, links, identifiers, and release-artifacts headers to use it.
- New `.tw-chip-neutral` utility class in `tailwind.src.css`.
- Replace arbitrary Tailwind values (`w-[600px]`, `max-w-[800px]`, `h-[18px]`, `max-w-[150px]`, etc.) with token-aligned utilities or named CSS classes (`.public-hero-glow`, `.public-eyebrow`, `.public-hero-stat`).
- Replace inline `style="border-bottom: color-mix(...)"` patterns with `divide-y divide-border/50` utilities.

### Responsive
- Bump `.public-section` and `.public-item-header` `margin-bottom`: `0.5rem` → `1.5rem` (mobile override matches) — the single biggest visual win.
- Touch targets: theme toggle 36×36 → 40×40, workspace dropdown to `min-h-10`, CTAs (`View Details`, `Sign NDA`, `Request Access`, `View`) bumped to `min-h-10`.
- Mobile-collapse 6-column tables (releases list, release artifacts) via `hidden md:table-cell` with inline meta fallback under the primary cell so info doesn't disappear.

### Footer attribution
- Mute "Powered by sbomify" footer link to a neutral color so the customer's brand color isn't applied to the third-party attribution. Added `.footer-powered-link` to the brand-recoloring exclusion list to win specificity.

## Out of scope (deferred)

- **Extract 800-line inline `<style>` from `public_base.htmx.j2` into a separate file.** High visual-regression risk without rendered testing; should be its own focused PR.
- **Trust center H1s in the display font** (`Agrandir`). Declared in `tailwind.src.css` but the font file isn't loaded; needs licensing/loading work first.

## Test plan

- [ ] `bun run build` succeeds (verified locally; `tw-chip-neutral` appears in compiled bundle)
- [ ] `djlint --check` clean on all touched templates (verified)
- [ ] All 12 affected templates parse with Django engine (verified)
- [ ] Visual: workspace landing — confirm hero, eyebrow, stat tiles, section order (compliance before products)
- [ ] Visual: product page — download CTA appears directly under hero
- [ ] Visual: release detail — Latest/Pre-release pills inline with H1; meta strip is single muted line
- [ ] Visual: component page gated-access states — rejected now reads as danger red, not warning yellow
- [ ] Visual: dark mode — confirm slate (not navy) palette preserved on public pages
- [ ] Mobile (≤640px): tables in releases list / release artifacts no longer require horizontal scroll for primary info
- [ ] Mobile: touch targets feel correctly sized on theme toggle, workspace dropdown, CTAs
- [ ] Cross-page: H1 sizes consistent (`text-3xl`); icon bubble color consistent (`bg-primary/10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)