### PR TITLE
fix(auth): require auth on list endpoints and reject invalid bearer tokens

### DIFF
--- a/sbomify/apps/access_tokens/auth.py
+++ b/sbomify/apps/access_tokens/auth.py
@@ -34,7 +34,9 @@ def _reject_invalid_bearer(func: Callable[..., Any]) -> Callable[..., Any]:
 
     def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> Any:
         scheme, _, raw_token = request.headers.get("Authorization", "").partition(" ")
-        if scheme == "Bearer":
+        # RFC 7235: auth scheme is case-insensitive. Treat `bearer`, `BEARER`, etc.
+        # as Bearer so that a bad-token request can't bypass the 401 by lowercasing.
+        if scheme.casefold() == "bearer":
             token = raw_token.strip()
             if not token or not PersonalAccessTokenAuth().authenticate(request, token):
                 return JsonResponse({"detail": "Unauthorized"}, status=401)

--- a/sbomify/apps/access_tokens/auth.py
+++ b/sbomify/apps/access_tokens/auth.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from django.http import HttpRequest
-from ninja.security import HttpBearer, django_auth
+from django.http import HttpRequest, JsonResponse
+from ninja.security import HttpBearer
 
 from .utils import get_user_and_token_record
 
@@ -24,42 +24,26 @@ class PersonalAccessTokenAuth(HttpBearer):
         return user, token
 
 
-class OptionalAuthBase(HttpBearer):
-    def authenticate(self, request: HttpRequest, token: str | None = None) -> bool:
-        # If there's a token, try Personal Access Token auth
-        if token:
-            auth_result = PersonalAccessTokenAuth().authenticate(request, token)
-            if auth_result:
-                return True
-
-        # Try Django auth
-        if django_auth.authenticate(request, None):
-            return True
-
-        # Always return True for optional auth
-        return True
-
-
-def optional_auth(func: Callable[..., Any]) -> Callable[..., Any]:
-    auth_instance = OptionalAuthBase()
+# Applied via ninja's `decorate_view`, which wraps `Operation.run` outside ninja's
+# exception handler — so we can't raise `ninja.errors.HttpError` here; the
+# wrapper has to return an `HttpResponse` directly. `JsonResponse({"detail":
+# "Unauthorized"}, status=401)` matches the shape ninja produces when its own
+# router-level auth rejects a request.
+def _reject_invalid_bearer(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Allow anonymous access, but reject a presented-but-invalid bearer token with 401."""
 
     def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> Any:
         auth_header = request.headers.get("Authorization")
-        token = None
         if auth_header and auth_header.startswith("Bearer "):
             token = auth_header.split(" ")[1]
-        auth_instance.authenticate(request, token)
+            if not PersonalAccessTokenAuth().authenticate(request, token):
+                return JsonResponse({"detail": "Unauthorized"}, status=401)
         return func(request, *args, **kwargs)
 
     return wrapper
 
 
-def optional_token_auth(func: Callable[..., Any]) -> Callable[..., Any]:
-    def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> Any:
-        auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header.split(" ")[1]
-            PersonalAccessTokenAuth().authenticate(request, token)
-        return func(request, *args, **kwargs)
-
-    return wrapper
+# Two names are kept for call-site documentation of intent. Behaviour is identical:
+# anonymous access is permitted, a bad bearer token returns 401.
+optional_auth = _reject_invalid_bearer
+optional_token_auth = _reject_invalid_bearer

--- a/sbomify/apps/access_tokens/auth.py
+++ b/sbomify/apps/access_tokens/auth.py
@@ -33,10 +33,10 @@ def _reject_invalid_bearer(func: Callable[..., Any]) -> Callable[..., Any]:
     """Allow anonymous access, but reject a presented-but-invalid bearer token with 401."""
 
     def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> Any:
-        auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header.split(" ")[1]
-            if not PersonalAccessTokenAuth().authenticate(request, token):
+        scheme, _, raw_token = request.headers.get("Authorization", "").partition(" ")
+        if scheme == "Bearer":
+            token = raw_token.strip()
+            if not token or not PersonalAccessTokenAuth().authenticate(request, token):
                 return JsonResponse({"detail": "Unauthorized"}, status=401)
         return func(request, *args, **kwargs)
 

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -439,3 +439,37 @@ def test_optional_token_auth_multiple_spaces_extracts_token(sample_user):  # noq
 
     assert calls == ["ran"]
     assert result == sample_user.id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("scheme", ["bearer", "BEARER", "BeArEr"])
+def test_optional_token_auth_scheme_is_case_insensitive_for_invalid_token(scheme):
+    """RFC 7235: auth scheme is case-insensitive. A bad token under any casing must 401,
+    or the 'invalid token silently downgrades to anonymous' bug returns via lowercasing.
+    """
+    from django.http import JsonResponse
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"{scheme} not-a-real-token")
+
+    response = view(request)
+
+    assert isinstance(response, JsonResponse)
+    assert response.status_code == 401
+    assert calls == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("scheme", ["bearer", "BEARER", "BeArEr"])
+def test_optional_token_auth_scheme_case_insensitive_for_valid_token(sample_user, scheme):  # noqa: F811
+    """A valid token must authenticate regardless of scheme casing."""
+    token_str = create_personal_access_token(sample_user)
+    AccessToken.objects.create(user=sample_user, encoded_token=token_str, description="t")
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"{scheme} {token_str}")
+
+    result = view(request)
+
+    assert calls == ["ran"]
+    assert result == sample_user.id

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -12,7 +12,7 @@ from sbomify.apps.core.utils import number_to_random_token, verify_item_access
 from sbomify.apps.teams.fixtures import sample_team, sample_team_with_owner_member  # noqa: F401
 from sbomify.apps.teams.models import Member, Team
 
-from .auth import PersonalAccessTokenAuth
+from .auth import PersonalAccessTokenAuth, optional_token_auth
 from .models import AccessToken
 from .utils import (
     create_personal_access_token,
@@ -320,3 +320,84 @@ def test_scoped_token_create_component(sample_team_with_owner_member):  # noqa: 
     data = response.json()
     assert data["name"] == "Scoped Token Component"
     assert data["team_id"] == str(team.id)
+
+
+# -- optional_token_auth decorator contract -----------------------------------
+#
+# The decorator wraps view handlers that allow anonymous access. The contract:
+# no Authorization header → anonymous (handler runs); valid bearer → handler
+# runs with request.user set; invalid bearer → 401 (handler must not run).
+# Anything else lets clients use the endpoint as an auth probe and silently
+# downgrades bad credentials to anonymous (issue: presented-but-invalid token
+# was indistinguishable from no token at all).
+
+
+def _make_dummy_view():
+    calls: list[str] = []
+
+    @optional_token_auth
+    def view(request):
+        calls.append("ran")
+        user = getattr(request, "user", None)
+        return getattr(user, "id", None)
+
+    return view, calls
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_no_header_runs_anonymously():
+    """No Authorization header: handler runs, no user set on request."""
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/")
+
+    result = view(request)
+
+    assert calls == ["ran"]
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_invalid_bearer_returns_401():
+    """A presented-but-invalid bearer must 401 — never silently downgrade to anonymous.
+
+    The decorator wraps `Operation.run` outside ninja's exception handler, so the
+    contract is "return a 401 HttpResponse," not "raise an exception."
+    """
+    from django.http import JsonResponse
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION="Bearer not-a-real-token")
+
+    response = view(request)
+
+    assert isinstance(response, JsonResponse)
+    assert response.status_code == 401
+    assert json.loads(response.content) == {"detail": "Unauthorized"}
+    assert calls == []  # handler must not run
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_valid_bearer_authenticates(sample_user):  # noqa: F811
+    """A valid bearer authenticates the request and the handler runs as that user."""
+    token_str = create_personal_access_token(sample_user)
+    AccessToken.objects.create(user=sample_user, encoded_token=token_str, description="t")
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"Bearer {token_str}")
+
+    result = view(request)
+
+    assert calls == ["ran"]
+    assert result == sample_user.id
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_non_bearer_header_runs_anonymously():
+    """Non-Bearer schemes are ignored (treated as anonymous), not 401'd."""
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION="Basic dXNlcjpwYXNz")
+
+    result = view(request)
+
+    assert calls == ["ran"]
+    assert result is None

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -401,3 +401,41 @@ def test_optional_token_auth_non_bearer_header_runs_anonymously():
 
     assert calls == ["ran"]
     assert result is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Bearer",  # no separator, no token
+        "Bearer ",  # trailing space, empty token
+        "Bearer    ",  # whitespace-only token
+    ],
+)
+def test_optional_token_auth_malformed_bearer_returns_401(header):
+    """`Bearer` with no token (any whitespace variant) is unauthorized, not anonymous."""
+    from django.http import JsonResponse
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=header)
+
+    response = view(request)
+
+    assert isinstance(response, JsonResponse)
+    assert response.status_code == 401
+    assert calls == []  # handler must not run
+
+
+@pytest.mark.django_db
+def test_optional_token_auth_multiple_spaces_extracts_token(sample_user):  # noqa: F811
+    """`Bearer    <token>` (extra whitespace) must still authenticate the real token."""
+    token_str = create_personal_access_token(sample_user)
+    AccessToken.objects.create(user=sample_user, encoded_token=token_str, description="t")
+
+    view, calls = _make_dummy_view()
+    request = RequestFactory().get("/", HTTP_AUTHORIZATION=f"Bearer    {token_str}")
+
+    result = view(request)
+
+    assert calls == ["ran"]
+    assert result == sample_user.id

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -644,25 +644,22 @@ def create_product(request: HttpRequest, payload: ProductCreateSchema) -> Any:
 @router.get(
     "/products",
     response={200: PaginatedProductsResponse, 403: ErrorResponse},
-    auth=None,
 )
-@decorate_view(optional_token_auth)
 def list_products(request: HttpRequest, page: int = Query(1), page_size: int = Query(15)) -> Any:  # type: ignore[type-arg]
-    """List all products - public products for unauthenticated users, team products for authenticated users."""
+    """List products for the authenticated user's workspace."""
     try:
-        is_internal_member = _is_internal_member(request)
-        # For authenticated non-guest users, show their team's products
-        if is_internal_member:
-            team_id = _get_user_team_id(request)
-            if not team_id:
-                return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
+        if _is_guest_member(request):
+            return 403, {
+                "detail": "Guest members can only access public pages",
+                "error_code": ErrorCode.FORBIDDEN,
+            }
 
-            products_queryset = optimize_product_queryset(Product.objects.filter(team_id=team_id))
-            has_crud_permissions = _get_team_crud_permission(request, team_id)
-        else:
-            # For unauthenticated or guest users, show only public products
-            products_queryset = optimize_product_queryset(Product.objects.filter(is_public=True))
-            has_crud_permissions = False
+        team_id = _get_user_team_id(request)
+        if not team_id:
+            return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
+
+        products_queryset = optimize_product_queryset(Product.objects.filter(team_id=team_id))
+        has_crud_permissions = _get_team_crud_permission(request, team_id)
 
         # Apply pagination
         paginated_products, pagination_meta = _paginate_queryset(products_queryset, page, page_size)
@@ -1532,35 +1529,28 @@ def create_component(request: HttpRequest, payload: ComponentCreateSchema) -> An
 @router.get(
     "/components",
     response={200: PaginatedComponentsResponse, 400: ErrorResponse, 403: ErrorResponse},
-    auth=None,
     tags=["Components"],
 )
-@decorate_view(optional_token_auth)
 def list_components(
     request: HttpRequest,
     page: int = Query(1),  # type: ignore[type-arg]
     page_size: int = Query(15),  # type: ignore[type-arg]
     is_global: str | None = Query(None),  # type: ignore[type-arg]
 ) -> Any:
-    """List all components - public components for unauthenticated users, team components for authenticated users."""
+    """List components for the authenticated user's workspace."""
     try:
-        is_internal_member = _is_internal_member(request)
-        # For authenticated non-guest users, show their team's components
-        if is_internal_member:
-            team_id = _get_user_team_id(request)
-            if not team_id:
-                return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
+        if _is_guest_member(request):
+            return 403, {
+                "detail": "Guest members can only access public pages",
+                "error_code": ErrorCode.FORBIDDEN,
+            }
 
-            # Include ALL components for internal members (public, private, and gated)
-            # No visibility filter - internal members see all components in their team
-            components_queryset = optimize_component_queryset(Component.objects.filter(team_id=team_id))
-            has_crud_permissions = _get_team_crud_permission(request, team_id)
-        else:
-            # For unauthenticated or guest users, show only public components
-            components_queryset = optimize_component_queryset(
-                Component.objects.filter(visibility=Component.Visibility.PUBLIC)
-            )
-            has_crud_permissions = False
+        team_id = _get_user_team_id(request)
+        if not team_id:
+            return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
+
+        components_queryset = optimize_component_queryset(Component.objects.filter(team_id=team_id))
+        has_crud_permissions = _get_team_crud_permission(request, team_id)
 
         if isinstance(is_global, str):
             normalized = is_global.lower()

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -396,10 +396,9 @@ def test_delete_component_success(
 
 @pytest.mark.django_db
 def test_crud_operations_require_authentication():
-    """Test that create operations require authentication, but list operations allow public access."""
+    """Test that create AND list operations require authentication (no anonymous enumeration)."""
     client = Client()
 
-    # Create operations should require authentication
     create_urls = [
         reverse("api-1:create_product"),
         reverse("api-1:create_component"),
@@ -409,18 +408,18 @@ def test_crud_operations_require_authentication():
         response = client.post(url, json.dumps({"name": "test"}), content_type="application/json")
         assert response.status_code in [401, 403]  # Unauthorized or Forbidden
 
-    # List operations should allow public access (return 200 with empty items for no public items)
     list_urls = [
         reverse("api-1:list_products"),
         reverse("api-1:list_components"),
     ]
 
     for url in list_urls:
+        # No header → 401
         response = client.get(url)
-        assert response.status_code == 200  # Public access allowed
-        data = response.json()
-        assert "items" in data
-        assert "pagination" in data
+        assert response.status_code == 401, f"{url} must require authentication"
+        # Invalid bearer token must not be silently downgraded to anonymous
+        response = client.get(url, HTTP_AUTHORIZATION="Bearer not-a-real-token")
+        assert response.status_code == 401, f"{url} must reject invalid bearer tokens"
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_permission_consistency.py
+++ b/sbomify/apps/core/tests/test_permission_consistency.py
@@ -264,8 +264,11 @@ class TestPermissionConsistencyPatterns:
 
         for endpoint in public_endpoints:
             response = client.get(endpoint)
-            assert response.status_code != 403, (
-                f"Endpoint {endpoint} incorrectly requires authentication for public items"
+            # Tight equality (rather than `!= 403`) so a regression to 401 or any
+            # other non-success status is caught instead of silently passing.
+            assert response.status_code == 200, (
+                f"Endpoint {endpoint} must remain reachable without auth for public items "
+                f"(got {response.status_code})"
             )
 
         for endpoint in (reverse("api-1:list_products"), reverse("api-1:list_components")):

--- a/sbomify/apps/core/tests/test_permission_consistency.py
+++ b/sbomify/apps/core/tests/test_permission_consistency.py
@@ -16,27 +16,24 @@ from sbomify.apps.core.models import Component, Product
 class TestListEndpointPermissions:
     """Test that all list endpoints properly handle public vs private access."""
 
-    def test_list_products_public_access(self, sample_team, sample_user):  # noqa: F811
-        """Test that public products can be listed without authentication."""
+    def test_list_products_requires_auth(self, sample_team, sample_user):  # noqa: F811
+        """Listing products requires authentication — no anonymous enumeration of public items."""
         Product.objects.create(name="Public Product", team=sample_team, is_public=True)
         Product.objects.create(name="Private Product", team=sample_team, is_public=False)
 
         client = Client()
         url = reverse("api-1:list_products")
 
+        # No Authorization header → 401
         response = client.get(url)
-        assert response.status_code == 200
+        assert response.status_code == 401
 
-        data = response.json()
-        assert "items" in data
-        assert "pagination" in data
+        # Garbage bearer token → 401 (not silently downgraded to anonymous)
+        response = client.get(url, HTTP_AUTHORIZATION="Bearer not-a-real-token")
+        assert response.status_code == 401
 
-        product_names = [item["name"] for item in data["items"]]
-        assert "Public Product" in product_names
-        assert "Private Product" not in product_names
-
-    def test_list_components_public_access(self, sample_team, sample_product):  # noqa: F811
-        """Test that public components can be listed without authentication."""
+    def test_list_components_requires_auth(self, sample_team, sample_product):  # noqa: F811
+        """Listing components requires authentication — no anonymous enumeration of public items."""
         public_component = Component.objects.create(
             name="Public Component",
             team=sample_team,
@@ -54,16 +51,13 @@ class TestListEndpointPermissions:
         client = Client()
         url = reverse("api-1:list_components")
 
+        # No Authorization header → 401
         response = client.get(url)
-        assert response.status_code == 200
+        assert response.status_code == 401
 
-        data = response.json()
-        assert "items" in data
-        assert "pagination" in data
-
-        component_names = [item["name"] for item in data["items"]]
-        assert "Public Component" in component_names
-        assert "Private Component" not in component_names
+        # Garbage bearer token → 401 (not silently downgraded to anonymous)
+        response = client.get(url, HTTP_AUTHORIZATION="Bearer not-a-real-token")
+        assert response.status_code == 401
 
     def test_list_endpoints_authenticated_access(self, authenticated_api_client, sample_team, sample_product):  # noqa: F811
         """Test that authenticated users see their team's items."""
@@ -112,6 +106,21 @@ class TestGetEndpointPermissions:
         data = response.json()
         assert data["name"] == "Public Component"
         assert data["visibility"] == "public"
+
+    def test_get_component_invalid_bearer_rejected(self, sample_team, sample_product):  # noqa: F811
+        """A public-by-id endpoint must 401 a bad bearer instead of downgrading to anonymous."""
+        public_component = Component.objects.create(
+            name="Public Component",
+            team=sample_team,
+            visibility=Component.Visibility.PUBLIC,
+        )
+        sample_product.components.add(public_component)
+
+        client = Client()
+        url = reverse("api-1:get_component", kwargs={"component_id": public_component.id})
+
+        response = client.get(url, HTTP_AUTHORIZATION="Bearer not-a-real-token")
+        assert response.status_code == 401
 
     def test_get_component_private_access_denied(self, sample_team, sample_product):  # noqa: F811
         """Test that private components cannot be accessed without authentication."""
@@ -235,7 +244,7 @@ class TestPermissionConsistencyPatterns:
             assert expected_message in data["detail"], f"Endpoint {endpoint} has inconsistent error message"
 
     def test_authentication_decorator_consistency(self, sample_team):  # noqa: F811
-        """Test that endpoints that should allow public access all use the same authentication pattern."""
+        """Public per-id endpoints stay reachable without auth; list endpoints don't (enumeration ban)."""
         client = Client()
 
         public_product = Product.objects.create(name="Public Product", team=sample_team, is_public=True)
@@ -249,8 +258,6 @@ class TestPermissionConsistencyPatterns:
         public_endpoints = [
             reverse("api-1:get_product", kwargs={"product_id": public_product.id}),
             reverse("api-1:get_component", kwargs={"component_id": public_component.id}),
-            reverse("api-1:list_products"),
-            reverse("api-1:list_components"),
             reverse("api-1:list_product_identifiers", kwargs={"product_id": public_product.id}),
             reverse("api-1:list_product_links", kwargs={"product_id": public_product.id}),
         ]
@@ -259,4 +266,10 @@ class TestPermissionConsistencyPatterns:
             response = client.get(endpoint)
             assert response.status_code != 403, (
                 f"Endpoint {endpoint} incorrectly requires authentication for public items"
+            )
+
+        for endpoint in (reverse("api-1:list_products"), reverse("api-1:list_components")):
+            response = client.get(endpoint)
+            assert response.status_code == 401, (
+                f"Endpoint {endpoint} must require authentication — no anonymous enumeration"
             )


### PR DESCRIPTION
## Summary

`GET /api/v1/products` and `GET /api/v1/components` previously returned **HTTP 200 with the public catalog** when called with:
- no `Authorization` header, or
- a clearly-invalid token (e.g. `Bearer fake`)

This had two failure modes:

1. **Anonymous enumeration of every public item across all workspaces** — not a private-data leak (visibility filtering was intact), but every public product/component on the platform was listable by anyone.
2. **Auth-probe degradation** — clients using these endpoints to verify a token (e.g. [sbomify-action's wizard](https://github.com/sbomify/sbomify-action/pull/228)) would see 200 for `Bearer fake`, conclude "I'm authenticated," and render the public showcase catalog as if it were the user's workspace.

Compare: `GET /api/v1/workspaces` already returns 401 on missing/invalid auth.

## Changes

**1. List endpoints now require auth** (`sbomify/apps/core/apis.py`)

`list_products` and `list_components` drop their `auth=None` override and stop branching on anonymous-vs-authenticated. Anonymous enumeration is gone; guest members get an explicit 403 (consistent with the rest of the workspace API).

**2. `optional_token_auth` / `optional_auth` decorators no longer swallow bad tokens** (`sbomify/apps/access_tokens/auth.py`)

These wrap ~17 lookup-by-id endpoints that still legitimately allow anonymous access (e.g. `GET /api/v1/products/{id}` for a public product). Previously, when given an invalid bearer, the decorators discarded the auth result and let the request through as anonymous. Now an invalid bearer returns 401.

- No `Authorization` header → still anonymous (unchanged; shareable public links still work).
- Valid bearer → unchanged.
- Invalid/expired/revoked bearer → **was silently downgraded, now 401**.

Implementation note: returns `JsonResponse({"detail": "Unauthorized"}, status=401)` rather than `raise HttpError(...)` — `ninja.decorators.decorate_view` wraps `Operation.run` *outside* ninja's exception handler, so an exception would propagate past the API boundary. There's an in-code comment explaining this for future maintainers.

The two decorators (`optional_auth` and `optional_token_auth`) were already functionally identical — the only difference was a no-op `django_auth.authenticate` call. They now share one implementation; both names are kept for call-site readability.

## Behavior change — narrow but real

One subtle scope change worth flagging: a request that sends *both* a valid Django session cookie *and* an invalid bearer token used to silently succeed via session auth. After this PR it 401s. Defensible — the client explicitly tried to authenticate with a token and failed; we shouldn't quietly substitute a different credential — but if any internal client relies on that combination it will start failing.

## Out of scope

- `/api/v1/projects` is mentioned in the original report but was removed in `b19f5f58` (2026-05-07) before this work began.

## Test plan

- [x] `optional_token_auth` decorator: no header → anonymous; bad bearer → 401, handler not invoked; valid bearer → handler runs with `request.user` set; non-Bearer scheme → anonymous.
- [x] `GET /api/v1/products`, `GET /api/v1/components` with no auth → 401.
- [x] `GET /api/v1/products`, `GET /api/v1/components` with `Bearer not-a-real-token` → 401.
- [x] `GET /api/v1/products`, `GET /api/v1/components` with a valid token → 200, scoped to the token's team.
- [x] `GET /api/v1/components/{id}` (public-by-id) with no auth → 200 (unchanged).
- [x] `GET /api/v1/components/{id}` with bad bearer → 401 (was 200).
- [x] Full backend suite: **3057 passed, 7 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)