### PR TITLE
fix(compliance): stop CRA Step 2 leaking template-comment tail into check titles

### DIFF
--- a/sbomify/apps/compliance/templates/compliance/cra_step_2.html.j2
+++ b/sbomify/apps/compliance/templates/compliance/cra_step_2.html.j2
@@ -165,7 +165,7 @@
                                                     <div class="flex-1 min-w-0">
                                                         <p class="text-sm font-medium text-text m-0 flex items-center gap-2">
                                                             <span x-text="check.title"></span>
-                                                            {# issue #907: remediation_type badge — operators understand what to do at a glance rather than reading the remediation prose. Kept as single-line {# #} so it parses in both Django and Jinja2 engines. #}
+                                                            {# issue #907: remediation_type badge — operators understand what to do at a glance rather than reading the remediation prose. Kept on a single line so it parses cleanly in both Django and Jinja2 engines. #}
                                                             <template x-if="check.remediation_type === 'tooling_limitation'">
                                                                 <span class="tw-badge-warning text-[10px] font-normal px-1.5 py-0.5"
                                                                       data-testid="step-2-tooling-limitation-badge">


### PR DESCRIPTION
## Summary

Every failing BSI check on the CRA Step 2 wizard renders its title with a leaked template-comment tail, e.g.

> **Component Creator** so it parses in both Django and Jinja2 engines. #}

A ``{# ... #}`` comment on line 168 of ``cra_step_2.html.j2`` contained a literal ``{# #}`` example inside its prose. Django/Jinja2 comment syntax does not nest, so the parser closed the comment at the first inner ``#}`` and rendered the remainder of the line as visible text. The comment was introduced in 8d1ed0b3 (April, PR #914) and has been leaking on every CRA wizard load since.

The fix removes the literal ``{# #}`` sample from the prose. The meaning (\"kept on a single line so both engines parse it cleanly\") is preserved.

## Test plan
- [x] Visual: spotted on https://stage.sbomify.com — every failing-check title carries the leaked tail
- [x] ``djlint`` clean
- [x] Pre-commit hooks pass

## Screenshot of bug
The user reported the leak on the BSI TR-03183-2 Fixes panel for Webapp (Python) — affects "Component Creator", "Digital Signature Attestation", and any other failing check.