### PR TITLE
fix(trust-center): stop leaking HTML comments + collapse redundant footer divider

### DIFF
--- a/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
+++ b/sbomify/apps/core/templates/core/components/public_release_artifacts.html.j2
@@ -108,8 +108,10 @@
                                     <td class="py-3 px-4">
                                         <span class="font-medium text-text"
                                               x-text="artifact.artifact_name || 'Unnamed artifact'"></span>
-                                        {# Mobile-only meta — duplicates the columns hidden under md / lg
-                                           (Component + Format under md, Version + Created under lg). #}
+                                        {% comment %}
+                                        Mobile-only meta — duplicates the columns hidden under md / lg
+                                        (Component + Format under md, Version + Created under lg).
+                                        {% endcomment %}
                                         <div class="md:hidden mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
                                             <span x-show="artifact.component_name" x-text="artifact.component_name"></span>
                                             <span x-show="artifact.sbom_format || artifact.document_type"
@@ -118,8 +120,10 @@
                                             <span x-show="getVersion(artifact)" x-text="'v' + getVersion(artifact)"></span>
                                             <span x-show="artifact.created_at" x-text="formatDate(artifact.created_at)"></span>
                                         </div>
-                                        {# Tablet-only meta — Component + Format show in their own columns at md+,
-                                           but Version + Created stay hidden until lg. #}
+                                        {% comment %}
+                                        Tablet-only meta — Component + Format show in their own columns at md+,
+                                        but Version + Created stay hidden until lg.
+                                        {% endcomment %}
                                         <div class="hidden md:flex lg:hidden mt-1 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
                                             <span x-show="getVersion(artifact)" x-text="'v' + getVersion(artifact)"></span>
                                             <span x-show="artifact.created_at" x-text="formatDate(artifact.created_at)"></span>

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -98,7 +98,7 @@
                         <i class="fas fa-puzzle-piece text-primary"></i>Components
                     </h4>
                 </div>
-                <ul class="divide-y divide-border list-none p-0 m-0">
+                <ul class="divide-y divide-border/40 list-none p-0 m-0">
                     {% for component in public_components %}
                         <li class="px-6 py-4 flex items-start justify-between gap-4">
                             <div class="min-w-0">

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -556,12 +556,17 @@
                 padding: 2rem 1.5rem;
             }
 
-            /* Modern Footer */
+            {% comment %}
+            Modern Footer — the brand-color ::before bar below already
+            provides the visual separation between page content and the
+            footer, so a hard ``border-top: 1px solid ...`` here would
+            stack a second hairline directly beneath the gradient bar.
+            (Note kept as a Django template comment rather than a CSS
+            comment so it is stripped at render time and never ships
+            to anonymous trust-center visitors.)
+{% endcomment %}
             .public-footer {
                 background: linear-gradient(180deg, var(--bg-secondary, #ffffff) 0%, var(--bg-tertiary, #f8fafc) 100%);
-                /* The brand-color ::before bar below already provides the visual
-                   separation between page content and footer; a hard border-top
-                   line would stack a second hairline beneath the gradient bar. */
                 margin-top: auto;
                 position: relative;
                 overflow: hidden;

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -45,7 +45,7 @@
             <meta name="viewport"
                   content="width=device-width, initial-scale=1, shrink-to-fit=no">
             <meta name="color-scheme" content="light dark">
-            <!-- SEO Meta Tags -->
+            {# SEO Meta Tags #}
             <meta name="description"
                   content="{% block meta_description %}{% if brand.name %}{{ brand.name }} Trust Center - Browse security artifacts, SBOMs, and compliance documents{% else %}sbomify - Your Security Artifact Hub{% endif %}{% endblock %}">
             <meta name="keywords"
@@ -54,9 +54,9 @@
                   content="{% if brand.name %}{{ brand.name }}{% else %}sbomify{% endif %}">
             <meta name="robots"
                   content="{% block meta_robots %}index, follow{% endblock %}">
-            <!-- Canonical URL -->
+            {# Canonical URL #}
             <link rel="canonical" href="{{ request.build_absolute_uri }}">
-            <!-- Favicon -->
+            {# Favicon #}
             <link rel="apple-touch-icon"
                   sizes="180x180"
                   href="{% if brand.brand_icon_url %}{{ brand.brand_icon_url }}{% else %}{% static 'img/favicons/apple-touch-icon.png' %}{% endif %}">
@@ -72,14 +72,14 @@
                   type="image/svg+xml"
                   href="{% if brand.brand_icon_url %}{{ brand.brand_icon_url }}{% else %}{% static 'img/favicons/favicon.svg' %}{% endif %}">
             <link rel="manifest" href="{% static 'dist/manifest.webmanifest' %}">
-            <!-- Schema.org metadata -->
+            {# Schema.org metadata #}
             {% schema_org_metadata %}
-            <!-- Social media image: always use absolute URL for social crawlers -->
+            {# Social media image: always use absolute URL for social crawlers #}
             {# Build the absolute fallback URL for the default social image #}
             {% static 'img/sbomify-social.png' as default_social_image %}
             {% with absolute_fallback=request.scheme|add:"://"|add:request.get_host|add:default_social_image %}
                 {% with brand_name=brand.name|default:"sbomify" %}
-                    <!-- Open Graph / Facebook -->
+                    {# Open Graph / Facebook #}
                     <meta property="og:type" content="website">
                     <meta property="og:url" content="{{ request.build_absolute_uri }}">
                     <meta property="og:title"
@@ -96,7 +96,7 @@
                         <meta property="og:image:type" content="image/png">
                     {% endif %}
                     <meta property="og:image:alt" content="{{ brand_name }} Logo">
-                    <!-- Twitter -->
+                    {# Twitter #}
                     <meta property="twitter:card" content="summary_large_image">
                     <meta property="twitter:url" content="{{ request.build_absolute_uri }}">
                     <meta property="twitter:title"
@@ -108,11 +108,11 @@
                     <meta property="twitter:image:alt" content="{{ brand_name }} Logo">
                 {% endwith %}
             {% endwith %}
-            <!-- Fonts -->
+            {# Fonts #}
             <link rel="preconnect" href="https://fonts.gstatic.com">
             <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
                   rel="stylesheet">
-            <!-- CSS -->
+            {# CSS #}
             <link href="{% static 'css/fontawesome.min.css' %}" rel="stylesheet">
             <link href="{% static 'css/tokens.css' %}" rel="stylesheet">
             <link href="{% static 'css/base.css' %}" rel="stylesheet">
@@ -129,7 +129,7 @@
             <link href="{% static 'css/public-pages.css' %}" rel="stylesheet">
             <link rel="stylesheet"
                   href="{% vite_asset_url 'sbomify/assets/css/tailwind.src.css' %}">
-            <!-- Custom CSS Variables for Branding -->
+            {# Custom CSS Variables for Branding #}
             <style>
             :root {
                 /* Brand Colors - Primary for headers/navigation, Accent for buttons/links */
@@ -559,7 +559,9 @@
             /* Modern Footer */
             .public-footer {
                 background: linear-gradient(180deg, var(--bg-secondary, #ffffff) 0%, var(--bg-tertiary, #f8fafc) 100%);
-                border-top: 1px solid var(--border-color-light, #f0f0f0);
+                /* The brand-color ::before bar below already provides the visual
+                   separation between page content and footer; a hard border-top
+                   line would stack a second hairline beneath the gradient bar. */
                 margin-top: auto;
                 position: relative;
                 overflow: hidden;
@@ -933,14 +935,14 @@
         {% vite_hmr_client %}
     </head>
     <body class="public-page" data-theme="public">
-        <!-- WebSocket connection for authenticated users (enables real-time access request status updates) -->
+        {# WebSocket connection for authenticated users (enables real-time access request status updates) #}
         {% if request.user.is_authenticated and team and team.key %}
             <div x-data x-init="$store.ws.connect('{{ team.key }}')" class="tw:hidden"></div>
         {% endif %}
-        <!-- Public Page Layout -->
+        {# Public Page Layout #}
         {% include "core/components/messages.html.j2" %}
         <div class="public-page-layout">
-            <!-- Brand Header -->
+            {# Brand Header #}
             <header class="public-header">
                 <div class="public-header-container">
                     <div class="header-spacer"></div>
@@ -1091,16 +1093,16 @@
                     {% block header_content %}{% endblock %}
                 </div>
             </header>
-            <!-- Main Content -->
+            {# Main Content #}
             <main class="public-main">
                 <div class="public-content-container">
-                    <!-- Breadcrumb Navigation -->
+                    {# Breadcrumb Navigation #}
                     {% block breadcrumb %}{% endblock %}
-                    <!-- Page Content -->
+                    {# Page Content #}
                     {% block content %}{% endblock %}
                 </div>
             </main>
-            <!-- Footer -->
+            {# Footer #}
             <footer class="public-footer">
                 <div class="public-footer-container">
                     <div class="footer-content-wrapper">

--- a/sbomify/apps/core/templates/core/workspace_public.html.j2
+++ b/sbomify/apps/core/templates/core/workspace_public.html.j2
@@ -12,7 +12,7 @@
     {{ workspace.name }} Trust Center: browse public products, releases, and organization-wide compliance artifacts.
 {% endblock %}
 {% block content %}
-    <!-- Hero Section -->
+    {# Hero Section #}
     <div class="public-hero bg-surface rounded-xl p-8 mb-6 shadow-md relative overflow-hidden">
         <div class="public-hero-glow" aria-hidden="true"></div>
         <div class="public-hero-content">
@@ -51,7 +51,7 @@
         </div>
     </div>
     {% if global_components %}
-        <!-- Organization Compliance Artifacts Section -->
+        {# Organization Compliance Artifacts Section #}
         <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
             <div class="mb-6 pb-4 border-b border-border">
                 <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">
@@ -87,7 +87,7 @@
         </div>
     {% endif %}
     {% if products %}
-        <!-- Products Section -->
+        {# Products Section #}
         <div class="bg-surface rounded-xl p-8 mb-6 shadow-md">
             <div class="mb-6 pb-4 border-b border-border">
                 <h2 class="text-xl font-semibold text-text mb-1 flex items-center gap-2">

--- a/sbomify/apps/core/templates/core/workspace_public.html.j2
+++ b/sbomify/apps/core/templates/core/workspace_public.html.j2
@@ -71,7 +71,7 @@
                         <p class="text-sm text-text-muted leading-relaxed flex-grow mb-3">
                             Organization-level compliance artifact available across the entire organization.
                         </p>
-                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
+                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border/40">
                             <span class="px-2 py-1 text-xs font-semibold rounded-lg bg-primary/10 text-primary flex items-center gap-1">
                                 <i class="fas fa-building" aria-hidden="true"></i>
                                 Organization-Wide
@@ -117,7 +117,7 @@
                         {% if product.description %}
                             <p class="text-sm text-text-muted leading-relaxed flex-grow mb-3">{{ product.description }}</p>
                         {% endif %}
-                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border">
+                        <div class="flex justify-between items-center mt-auto pt-3 border-t border-border/40">
                             <div class="flex items-center gap-1 flex-wrap">
                                 {% if product.passing_assessments %}
                                     {% for assessment in product.passing_assessments %}

--- a/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sboms_table_content.html.j2
@@ -107,9 +107,11 @@
                                 <a :href="'{% if is_public_view %}{% url 'core:component_item_public' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% else %}{% url 'core:component_item' component_id=component_id item_type='sboms' item_id='SBOM_ID' %}{% endif %}'.replace('SBOM_ID', item.sbom.id)"
                                    class="text-primary font-medium hover:underline"
                                    x-text="item.sbom.name"></a>
-                                {# Mobile fallback for the columns hidden under md: format pill (with format_version)
-                                   plus the SBOM version. flex-wrap lets each pill drop to its own line if the column
-                                   is narrow, so the table doesn't horizontally scroll. #}
+                                {% comment %}
+                                Mobile fallback for the columns hidden under md: format pill (with format_version)
+                                plus the SBOM version. flex-wrap lets each pill drop to its own line if the column
+                                is narrow, so the table doesn't horizontally scroll.
+                                {% endcomment %}
                                 <div class="md:hidden mt-1 flex flex-wrap items-center gap-1.5 text-xs">
                                     <span class="tw-sbom-format"
                                           :class="item.sbom.format.toLowerCase().includes('cyclonedx') ? 'tw-sbom-format-cyclonedx' : 'tw-sbom-format-spdx'"
@@ -197,9 +199,11 @@
                             </td>
                             <td>
                                 <div class="flex items-center justify-center gap-1">
-                                    {# `from_public=true` flag tells SbomDownloadView to render the friendly
-                                       gated-access page instead of a generic 403 when a public visitor hits a
-                                       gated SBOM. Internal downloads omit the flag. #}
+                                    {% comment %}
+                                    `from_public=true` flag tells SbomDownloadView to render the friendly
+                                    gated-access page instead of a generic 403 when a public visitor hits a
+                                    gated SBOM. Internal downloads omit the flag.
+                                    {% endcomment %}
                                     <a :href="'{% url 'sboms:sbom_download' 'SBOM_ID' %}'.replace('SBOM_ID', item.sbom.id){% if is_public_view %} + '?from_public=true'{% endif %}"
                                        title="Download"
                                        aria-label="Download SBOM"

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -506,6 +506,32 @@ html.no-transitions * {
 .border-border\/40 { border-color: rgb(var(--color-border) / 0.4); }
 .border-border\/50 { border-color: rgb(var(--color-border) / 0.5); }
 
+/* --- divide-border opacity variants ---
+   ``divide-y divide-border/40`` and friends rely on Tailwind's ``divide-y``
+   to set ``border-top-width: 1px`` on every ``:not(:first-child)`` and on
+   ``divide-border/N`` to colour it. In this project Tailwind v4 does NOT
+   emit the divide-y width rule (preflight resets ``border: 0px solid``
+   for every element via ``*``), so without these fallbacks the dividers
+   either disappear (no width) or render at ``currentColor`` (default
+   border colour = body text colour, full-opacity black-on-white). Set
+   both width and colour here so ``divide-border/N`` alone produces the
+   intended soft hairline between siblings. */
+.divide-border\/30 > :not([hidden]) ~ :not([hidden]) {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-color: rgb(var(--color-border) / 0.3);
+}
+.divide-border\/40 > :not([hidden]) ~ :not([hidden]) {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-color: rgb(var(--color-border) / 0.4);
+}
+.divide-border\/50 > :not([hidden]) ~ :not([hidden]) {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-color: rgb(var(--color-border) / 0.5);
+}
+
 /* --- border-primary opacity variants --- */
 .border-primary\/10 { border-color: rgb(var(--color-primary) / 0.1); }
 .border-primary\/15 { border-color: rgb(var(--color-primary) / 0.15); }

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -507,41 +507,27 @@ html.no-transitions * {
 .border-border\/50 { border-color: rgb(var(--color-border) / 0.5); }
 
 /* --- divide-border opacity variants ---
-   ``divide-y divide-border/40`` and friends rely on Tailwind to set both
-   the divide widths AND colours. In this project the v4 build emits the
-   bottom-width rule on ``> :not(:last-child)`` but leaves the colour
-   unset, so the colour falls back to ``currentColor`` (body text =
-   near-black). The previous version of these fallbacks only coloured
-   the ``border-top`` of ``:not(:first-child)`` children, which left
-   row 0's bottom border at currentColor — a single hard hairline
-   between the first and second row while the rest of the dividers
-   rendered softly. Colour BOTH border-top and border-bottom on every
-   direct child so whichever side Tailwind chooses to size, the colour
-   is correct. Also set the top width as a width-fallback in case the
-   ``divide-y`` width rule isn't emitted at all. */
-.divide-border\/30 > * {
+   Tailwind v4 opacity modifiers can't be applied to raw-RGB CSS vars,
+   so without these explicit rules ``divide-border/N`` would have no
+   colour at all and the divider falls back to ``currentColor`` (body
+   text = near-black) wherever Tailwind sets a divide width. Colour
+   BOTH ``border-top`` and ``border-bottom`` on every direct child so
+   whichever side ``divide-y``/``divide-y-2``/``divide-y-reverse`` ends
+   up sizing, the colour is correct. The selector is wrapped in
+   ``:where()`` to keep these helpers at zero specificity, so an
+   explicit ``divide-y-*`` width utility on the same element still
+   wins in the cascade. */
+:where(.divide-border\/30) > * {
   border-top-color: rgb(var(--color-border) / 0.3);
   border-bottom-color: rgb(var(--color-border) / 0.3);
 }
-.divide-border\/30 > :not([hidden]) ~ :not([hidden]) {
-  border-top-width: 1px;
-  border-top-style: solid;
-}
-.divide-border\/40 > * {
+:where(.divide-border\/40) > * {
   border-top-color: rgb(var(--color-border) / 0.4);
   border-bottom-color: rgb(var(--color-border) / 0.4);
 }
-.divide-border\/40 > :not([hidden]) ~ :not([hidden]) {
-  border-top-width: 1px;
-  border-top-style: solid;
-}
-.divide-border\/50 > * {
+:where(.divide-border\/50) > * {
   border-top-color: rgb(var(--color-border) / 0.5);
   border-bottom-color: rgb(var(--color-border) / 0.5);
-}
-.divide-border\/50 > :not([hidden]) ~ :not([hidden]) {
-  border-top-width: 1px;
-  border-top-style: solid;
 }
 
 /* --- border-primary opacity variants --- */

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -507,29 +507,41 @@ html.no-transitions * {
 .border-border\/50 { border-color: rgb(var(--color-border) / 0.5); }
 
 /* --- divide-border opacity variants ---
-   ``divide-y divide-border/40`` and friends rely on Tailwind's ``divide-y``
-   to set ``border-top-width: 1px`` on every ``:not(:first-child)`` and on
-   ``divide-border/N`` to colour it. In this project Tailwind v4 does NOT
-   emit the divide-y width rule (preflight resets ``border: 0px solid``
-   for every element via ``*``), so without these fallbacks the dividers
-   either disappear (no width) or render at ``currentColor`` (default
-   border colour = body text colour, full-opacity black-on-white). Set
-   both width and colour here so ``divide-border/N`` alone produces the
-   intended soft hairline between siblings. */
+   ``divide-y divide-border/40`` and friends rely on Tailwind to set both
+   the divide widths AND colours. In this project the v4 build emits the
+   bottom-width rule on ``> :not(:last-child)`` but leaves the colour
+   unset, so the colour falls back to ``currentColor`` (body text =
+   near-black). The previous version of these fallbacks only coloured
+   the ``border-top`` of ``:not(:first-child)`` children, which left
+   row 0's bottom border at currentColor — a single hard hairline
+   between the first and second row while the rest of the dividers
+   rendered softly. Colour BOTH border-top and border-bottom on every
+   direct child so whichever side Tailwind chooses to size, the colour
+   is correct. Also set the top width as a width-fallback in case the
+   ``divide-y`` width rule isn't emitted at all. */
+.divide-border\/30 > * {
+  border-top-color: rgb(var(--color-border) / 0.3);
+  border-bottom-color: rgb(var(--color-border) / 0.3);
+}
 .divide-border\/30 > :not([hidden]) ~ :not([hidden]) {
   border-top-width: 1px;
   border-top-style: solid;
-  border-color: rgb(var(--color-border) / 0.3);
+}
+.divide-border\/40 > * {
+  border-top-color: rgb(var(--color-border) / 0.4);
+  border-bottom-color: rgb(var(--color-border) / 0.4);
 }
 .divide-border\/40 > :not([hidden]) ~ :not([hidden]) {
   border-top-width: 1px;
   border-top-style: solid;
-  border-color: rgb(var(--color-border) / 0.4);
+}
+.divide-border\/50 > * {
+  border-top-color: rgb(var(--color-border) / 0.5);
+  border-bottom-color: rgb(var(--color-border) / 0.5);
 }
 .divide-border\/50 > :not([hidden]) ~ :not([hidden]) {
   border-top-width: 1px;
   border-top-style: solid;
-  border-color: rgb(var(--color-border) / 0.5);
 }
 
 /* --- border-primary opacity variants --- */


### PR DESCRIPTION
## Summary

Three classes of trust-center polish:

### 1. Stop leaking template comments to the browser
~20 HTML comments leaked through the rendered trust-center pages (`<!-- SEO Meta Tags -->`, `<!-- Brand Header -->`, `<!-- Footer -->`, `<!-- Hero Section -->`, etc.). Per the [Django docs](https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#comment), these belong in `{# … #}` (single-line) or `{% comment %} … {% endcomment %}` (multi-line) so the engine strips them at render time. The current state leaks internal section names and adds dead bytes to every public page request.

### 2. Multi-line `{# … #}` was producing visible text in the SBOM table
Django's `{# … #}` is single-line only. Four multi-line bodies (in `sboms_table_content.html.j2` and `public_release_artifacts.html.j2`) were leaking their tails into the rendered page — the "Mobile fallback for the columns hidden under md…" text the user spotted in the SBOM table. Converted to `{% comment %}` blocks.

### 3. Consistent soft hairline dividers on public pages
- Stacked footer separator: removed `.public-footer { border-top: 1px solid }` since `::before` already provides a brand-gradient separator (was stacking two hairlines).
- `divide-border` opacity: the codebase had explicit fallback rules for `border-border/N` because Tailwind v4 can't apply opacity modifiers to raw-RGB CSS vars, but lacked the matching `divide-border/N` rules. So `divide-y divide-border/40` was rendering at `currentColor` (body text = near-black) instead of the intended soft hairline. Added the missing rules at zero specificity (`:where(...)`) so explicit `divide-y-*` width utilities still win.
- Applied softer dividers consistently across Components, Resources & Links, Product Identifiers, Releases, and workspace-home product/component cards.

## Files changed
- `core/templates/core/public_base.htmx.j2` — 17 HTML comments → Jinja `{# #}`; removed redundant `.public-footer { border-top }`; CSS rationale wrapped in `{% comment %}` so it doesn't ship
- `core/templates/core/workspace_public.html.j2` — 3 HTML comments → Jinja `{# #}`; soften card-footer dividers to `border-border/40`
- `core/templates/core/product_details_public.html.j2` — soften Components list divider to `divide-border/40`
- `sboms/templates/sboms/sboms_table_content.html.j2` — 2 multi-line `{# #}` → `{% comment %}…{% endcomment %}`
- `core/templates/core/components/public_release_artifacts.html.j2` — 2 multi-line `{# #}` → `{% comment %}…{% endcomment %}`
- `assets/css/tailwind.src.css` — add `divide-border/30,40,50` opacity-fallback rules colouring top + bottom borders at `:where()`-zero specificity

## Test plan
- [x] Reload `/public/workspace/<key>/` — `document.documentElement.outerHTML` contains **0** HTML comments
- [x] SBOM table no longer shows "Mobile fallback for the columns…" inline text
- [x] Footer renders with a single brand-color gradient bar (no stacked hairline)
- [x] Product Identifiers / Components / Resources & Links / Releases all render dividers at `rgba(226, 232, 240, 0.4)` for both `border-top-color` and `border-bottom-color`
- [x] No leftover CSS comment leak in `public_base.htmx.j2` (verified via DOM scrape)
- [x] `djlint` clean