### PR TITLE
fix(compliance): replace 404 BSI guidance URLs with published page

### DIFF
--- a/sbomify/apps/compliance/services/sbom_compliance_service.py
+++ b/sbomify/apps/compliance/services/sbom_compliance_service.py
@@ -78,14 +78,16 @@ _BSI_REMEDIATION_TYPE: dict[str, str] = {
 # Default guidance URL for BSI findings without a more specific override.
 _BSI_DEFAULT_GUIDANCE_URL = "https://sbomify.com/compliance/"
 
-# Anchored BSI TR-03183-2 page used by per-finding overrides. Pulled into a
-# constant so the override dict has a single source of truth and can be
-# swapped to a per-finding URL when more specific pages ship.
-_BSI_TR03183_FORMAT_REQUIREMENTS_URL = "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4"
+# BSI TR-03183-2 guidance page. The ``#format-requirements-4`` anchor is the
+# best landing for ``sbom-format`` and is acceptable for ``attestation-check``
+# (the BSI page is the standard reference for both; no separate attestation
+# anchor exists yet). Swap individual overrides to per-finding constants once
+# more specific pages (e.g. ``/compliance/attestations/``) ship.
+_BSI_TR03183_GUIDANCE_URL = "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4"
 
 _BSI_GUIDANCE_URL_OVERRIDES: dict[str, str] = {
-    "bsi-tr03183:sbom-format": _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
-    "bsi-tr03183:attestation-check": _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
+    "bsi-tr03183:sbom-format": _BSI_TR03183_GUIDANCE_URL,
+    "bsi-tr03183:attestation-check": _BSI_TR03183_GUIDANCE_URL,
 }
 
 # Plain-English "why is this failing and what do I do about it" sentence

--- a/sbomify/apps/compliance/services/sbom_compliance_service.py
+++ b/sbomify/apps/compliance/services/sbom_compliance_service.py
@@ -76,11 +76,16 @@ _BSI_REMEDIATION_TYPE: dict[str, str] = {
 }
 
 # Default guidance URL for BSI findings without a more specific override.
-_SBOMIFY_ACTION_ENRICHMENT_URL = "https://sbomify.com/compliance/"
+_BSI_DEFAULT_GUIDANCE_URL = "https://sbomify.com/compliance/"
+
+# Anchored BSI TR-03183-2 page used by per-finding overrides. Pulled into a
+# constant so the override dict has a single source of truth and can be
+# swapped to a per-finding URL when more specific pages ship.
+_BSI_TR03183_FORMAT_REQUIREMENTS_URL = "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4"
 
 _BSI_GUIDANCE_URL_OVERRIDES: dict[str, str] = {
-    "bsi-tr03183:sbom-format": "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4",
-    "bsi-tr03183:attestation-check": "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4",
+    "bsi-tr03183:sbom-format": _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
+    "bsi-tr03183:attestation-check": _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
 }
 
 # Plain-English "why is this failing and what do I do about it" sentence
@@ -210,9 +215,9 @@ def _classify_bsi_finding(finding_id: object) -> tuple[str, str, str]:
     the remediation from the BSI plugin's schema-oriented text.
     """
     if not isinstance(finding_id, str):
-        return "operator_action", _SBOMIFY_ACTION_ENRICHMENT_URL, _UNKNOWN_FINDING_SUMMARY
+        return "operator_action", _BSI_DEFAULT_GUIDANCE_URL, _UNKNOWN_FINDING_SUMMARY
     remediation_type = _BSI_REMEDIATION_TYPE.get(finding_id, "operator_action")
-    guidance_url = _BSI_GUIDANCE_URL_OVERRIDES.get(finding_id, _SBOMIFY_ACTION_ENRICHMENT_URL)
+    guidance_url = _BSI_GUIDANCE_URL_OVERRIDES.get(finding_id, _BSI_DEFAULT_GUIDANCE_URL)
     human_summary = _BSI_HUMAN_SUMMARY.get(finding_id, _UNKNOWN_FINDING_SUMMARY)
     return remediation_type, guidance_url, human_summary
 

--- a/sbomify/apps/compliance/services/sbom_compliance_service.py
+++ b/sbomify/apps/compliance/services/sbom_compliance_service.py
@@ -201,11 +201,11 @@ def _classify_bsi_finding(finding_id: object) -> tuple[str, str, str]:
     finding in the scan. Coerce to the fail-closed default instead.
 
     Unknown or non-string finding ids fall back to ``operator_action``
-    + the enrichment URL + a generic summary — the conservative
-    default keeps the wizard gate strict when the BSI plugin gains a
-    new check that this classifier hasn't been updated for yet, or
-    when upstream emits a malformed id that the ``_build_bsi_assessment_dict``
-    coercion didn't catch.
+    + ``_BSI_DEFAULT_GUIDANCE_URL`` + a generic summary — the
+    conservative default keeps the wizard gate strict when the BSI
+    plugin gains a new check that this classifier hasn't been updated
+    for yet, or when upstream emits a malformed id that the
+    ``_build_bsi_assessment_dict`` coercion didn't catch.
 
     The ``human_summary`` is a one-line operator-facing sentence
     (issue #907) explaining in plain English why this check fails

--- a/sbomify/apps/compliance/services/sbom_compliance_service.py
+++ b/sbomify/apps/compliance/services/sbom_compliance_service.py
@@ -75,9 +75,8 @@ _BSI_REMEDIATION_TYPE: dict[str, str] = {
     "bsi-tr03183:attestation-check": "operator_action",
 }
 
-# Default BSI TR-03183-2 guidance URL. Overridable per-finding below
-# when a more specific anchor on the same page is appropriate.
-_SBOMIFY_ACTION_ENRICHMENT_URL = "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4"
+# Default guidance URL for BSI findings without a more specific override.
+_SBOMIFY_ACTION_ENRICHMENT_URL = "https://sbomify.com/compliance/"
 
 _BSI_GUIDANCE_URL_OVERRIDES: dict[str, str] = {
     "bsi-tr03183:sbom-format": "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4",

--- a/sbomify/apps/compliance/services/sbom_compliance_service.py
+++ b/sbomify/apps/compliance/services/sbom_compliance_service.py
@@ -75,16 +75,13 @@ _BSI_REMEDIATION_TYPE: dict[str, str] = {
     "bsi-tr03183:attestation-check": "operator_action",
 }
 
-# Single source of truth for the sbomify-action enrichment docs so
-# every guidance link points at the same page. Overridable per-
-# finding via ``_BSI_GUIDANCE_URL_OVERRIDES`` below.
-_SBOMIFY_ACTION_ENRICHMENT_URL = "https://sbomify.com/docs/sbomify-action/enrichment"
+# Default BSI TR-03183-2 guidance URL. Overridable per-finding below
+# when a more specific anchor on the same page is appropriate.
+_SBOMIFY_ACTION_ENRICHMENT_URL = "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4"
 
-# Per-finding doc links when the default URL isn't the right target
-# (e.g. CycloneDX / SPDX schema reference for format issues).
 _BSI_GUIDANCE_URL_OVERRIDES: dict[str, str] = {
-    "bsi-tr03183:sbom-format": "https://sbomify.com/docs/sbom-format",
-    "bsi-tr03183:attestation-check": "https://sbomify.com/docs/attestations",
+    "bsi-tr03183:sbom-format": "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4",
+    "bsi-tr03183:attestation-check": "https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4",
 }
 
 # Plain-English "why is this failing and what do I do about it" sentence

--- a/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
+++ b/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
@@ -242,7 +242,7 @@ class TestClassifyBsiFinding:
         TR-03183-2 page rather than the generic /compliance/ index."""
         from sbomify.apps.compliance.services.sbom_compliance_service import (
             _BSI_DEFAULT_GUIDANCE_URL,
-            _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
+            _BSI_TR03183_GUIDANCE_URL,
             _classify_bsi_finding,
         )
 
@@ -250,8 +250,8 @@ class TestClassifyBsiFinding:
         _, url_format, _ = _classify_bsi_finding("bsi-tr03183:sbom-format")
         _, url_attest, _ = _classify_bsi_finding("bsi-tr03183:attestation-check")
         assert url_default == _BSI_DEFAULT_GUIDANCE_URL
-        assert url_format == _BSI_TR03183_FORMAT_REQUIREMENTS_URL
-        assert url_attest == _BSI_TR03183_FORMAT_REQUIREMENTS_URL
+        assert url_format == _BSI_TR03183_GUIDANCE_URL
+        assert url_attest == _BSI_TR03183_GUIDANCE_URL
         assert url_format != url_default
         assert url_attest != url_default
 

--- a/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
+++ b/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
@@ -238,7 +238,7 @@ class TestClassifyBsiFinding:
         assert "Unclassified" in human_summary
 
     def test_attestation_check_gets_overridden_guidance_url(self):
-        """Overrides point operator-action fixes at the anchored BSI
+        """Overrides point operator-action fixes to the anchored BSI
         TR-03183-2 page rather than the generic /compliance/ index."""
         from sbomify.apps.compliance.services.sbom_compliance_service import (
             _BSI_DEFAULT_GUIDANCE_URL,

--- a/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
+++ b/sbomify/apps/compliance/tests/test_sbom_compliance_service.py
@@ -238,16 +238,22 @@ class TestClassifyBsiFinding:
         assert "Unclassified" in human_summary
 
     def test_attestation_check_gets_overridden_guidance_url(self):
-        """Overrides point operator-action fixes at dedicated docs
-        rather than the generic sbomify-action enrichment page."""
-        from sbomify.apps.compliance.services.sbom_compliance_service import _classify_bsi_finding
+        """Overrides point operator-action fixes at the anchored BSI
+        TR-03183-2 page rather than the generic /compliance/ index."""
+        from sbomify.apps.compliance.services.sbom_compliance_service import (
+            _BSI_DEFAULT_GUIDANCE_URL,
+            _BSI_TR03183_FORMAT_REQUIREMENTS_URL,
+            _classify_bsi_finding,
+        )
 
         _, url_default, _ = _classify_bsi_finding("bsi-tr03183:sbom-creator")
         _, url_format, _ = _classify_bsi_finding("bsi-tr03183:sbom-format")
         _, url_attest, _ = _classify_bsi_finding("bsi-tr03183:attestation-check")
-        assert "enrichment" in url_default
-        assert "sbom-format" in url_format
-        assert "attestations" in url_attest
+        assert url_default == _BSI_DEFAULT_GUIDANCE_URL
+        assert url_format == _BSI_TR03183_FORMAT_REQUIREMENTS_URL
+        assert url_attest == _BSI_TR03183_FORMAT_REQUIREMENTS_URL
+        assert url_format != url_default
+        assert url_attest != url_default
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

The BSI TR-03183-2 finding "See docs" links in the CRA Step 2 wizard pointed at three `/docs/*` URLs that all return 404. sbomify.com publishes compliance documentation under `/compliance/`, not `/docs/`.

### URLs re-pointed

| Finding key | Old (404) | New (200) |
| --- | --- | --- |
| Default fallback (`_SBOMIFY_ACTION_ENRICHMENT_URL`) | `/docs/sbomify-action/enrichment` | `/compliance/` (index) |
| `bsi-tr03183:sbom-format` | `/docs/sbom-format` | `/compliance/bsi-tr-03183/#format-requirements-4` |
| `bsi-tr03183:attestation-check` | `/docs/attestations` | `/compliance/bsi-tr-03183/#format-requirements-4` |

The BSI page anchor (`#format-requirements-4`) is the verified id on the published page — it matches the "Format requirements (§4)" section heading. (`#format-requirements` without the section-number suffix is not a real anchor and would silently scroll to top.)

### Files changed

- `sbomify/apps/compliance/services/sbom_compliance_service.py`

## Test plan

- [x] `https://sbomify.com/compliance/` resolves (compliance index).
- [x] `https://sbomify.com/compliance/bsi-tr-03183/#format-requirements-4` resolves and scrolls to "Format requirements (§4)".
- [ ] CRA Step 2 wizard: fail the BSI gate and click "See docs" on each finding type — every link should land on a real page.
- [ ] `pytest sbomify/apps/compliance/tests/` still passes.