### PR TITLE
docs(screencasts): drop stale 'projects' reference from release_creation

### DIFF
--- a/screencasts/release_creation.py
+++ b/screencasts/release_creation.py
@@ -5,7 +5,7 @@ create a new release → fill details → navigate to the new release →
 add artifacts via the Add Artifact modal.
 
 Prerequisite: uses the pied_piper_with_sboms ORM fixture which creates the full
-Pied Piper hierarchy (product, projects, components) with CycloneDX SBOMs.
+Pied Piper hierarchy (product with components) with CycloneDX SBOMs.
 The SBOM creation signal auto-creates a "latest" Release on the product.
 """
 


### PR DESCRIPTION
## Summary
- Projects were removed from the domain model, but `screencasts/release_creation.py` still described the Pied Piper fixture as "(product, projects, components)".
- The underlying `pied_piper_product` fixture in `screencasts/conftest.py` creates components attached directly to the product — no Project layer.
- Updated the docstring to match reality. No other screencast referenced Projects.

## Test plan
- [ ] Docstring-only change; no runtime impact on screencast recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)