### PR TITLE
fix(docker): ship WeasyPrint runtime libs in distroless prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ ARG COSIGN_VERSION=v3.0.6
 # IMPORTANT: This image must provide the same Python minor version as PYTHON_VERSION above.
 # To update: docker pull cgr.dev/chainguard/python:latest && docker inspect --format '{{index .RepoDigests 0}}'
 ARG CHAINGUARD_PYTHON_IMAGE=cgr.dev/chainguard/python@sha256:af9f881767681598970f2d4316ffe1f42abcb0413282b555bf7ce9b0774a7c79
-# Chainguard Wolfi base for the weasyprint-libs builder stage, pinned by digest
-# so the .so files copied into the distroless prod image stay reproducible.
+# Chainguard Wolfi base for the weasyprint-libs builder stage, pinned by
+# digest so the builder image itself is reproducible. The actual .so
+# versions still come from `apk add` against the live Wolfi repo at build
+# time — Wolfi ships no repo-snapshot mechanism, but its package updates
+# are ABI-stable security patches, so the copied libraries stay binary-
+# compatible across rebuilds. Bump the digest below when you want to pick
+# up newer patches.
 # To update: docker pull cgr.dev/chainguard/wolfi-base:latest && docker inspect --format '{{index .RepoDigests 0}}'
 ARG CHAINGUARD_WOLFI_BASE_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:0cff4df29a6597173dc8b813787318150141eb96ac783dc3ff4f5ff52c49a1e2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -335,8 +335,10 @@ RUN apk add --no-cache \
 #
 # Font selection: Liberation Sans is the metric-compatible Arial / Helvetica
 # substitute (the families the body CSS asks for) — fontconfig resolves the
-# CSS request to it. The 4 weights shipped were picked by auditing the actual
+# CSS request to it. The 4 .ttf files shipped (LiberationSans Regular + Bold
+# + Italic, plus LiberationMono Regular) were picked by auditing the actual
 # HTML the markdown renderer produces against every CRA document kind:
+#   - body text: present everywhere → ship Sans Regular.
 #   - <strong> tags: present in all 4 docs (3-19 each) → ship Sans Bold.
 #   - <em> tags: present in all 4 docs (1-18 each) → ship Sans Italic.
 #   - <strong><em> nested: 0 across all docs → SansBoldItalic skipped;
@@ -344,8 +346,8 @@ RUN apk add --no-cache \
 #     future template introduces ***foo***.
 #   - <code> tags: present only in the DoC (10 each), never bolded or
 #     italicized → ship LiberationMono-Regular only.
-# LiberationSerif is unused; LiberationMono Bold / Italic / BoldItalic are
-# unused; SansBoldItalic is unused.
+# Skipped weights: LiberationSans-BoldItalic, all 4 LiberationSerif weights,
+# and LiberationMono Bold / Italic / BoldItalic.
 # fontconfig setup (/etc/fonts + /usr/share/fontconfig) ships verbatim
 # because the per-family conf snippets are small (~370 KB combined) and
 # trimming them would require auditing every snippet.

--- a/Dockerfile
+++ b/Dockerfile
@@ -324,6 +324,44 @@ RUN apk add --no-cache \
         glib \
         font-liberation
 
+# Stage just the .so files WeasyPrint actually dlopen()s plus their transitive
+# deps (verified with ld-linux --list against libpango / libpangoft2 / libharfbuzz
+# / libfreetype / libfontconfig / libopenjp2 / libjpeg) and the Liberation Sans
+# weights + Liberation Mono Regular the print CSS targets. Copying these
+# specific files instead of /usr/lib + /usr/share/fonts wholesale shrinks the
+# runtime payload from ~46 MB to ~18 MB. libc / libm / libffi / ld-linux are
+# already in the prod image — re-copying them would risk a glibc skew, so
+# they're intentionally omitted.
+#
+# Font selection: Liberation Sans is the metric-compatible Arial / Helvetica
+# substitute (the families the body CSS asks for) — fontconfig resolves the
+# CSS request to it. Liberation Mono Regular is the lone monospace weight
+# because the print CSS doesn't bold or italicize <code>; fontconfig synths
+# bold / italic on the rare nested case. LiberationSerif and LiberationMono
+# Bold / Italic / BoldItalic are unused.
+# fontconfig setup (/etc/fonts + /usr/share/fontconfig) ships verbatim
+# because the per-family conf snippets are small (~370 KB combined) and
+# trimming them would require auditing every snippet.
+RUN mkdir -p /staged/usr/lib /staged/usr/share/fonts/font-liberation \
+             /staged/usr/share/fontconfig /staged/etc/fonts && \
+    cd /usr/lib && cp -a \
+        libpango-1.0.so* libpangoft2-1.0.so* \
+        libharfbuzz.so* \
+        libfreetype.so* \
+        libfontconfig.so* \
+        libopenjp2.so* libjpeg.so* \
+        libbrotlicommon.so* libbrotlidec.so* \
+        libbz2.so* libexpat.so* libfribidi.so* libgraphite2.so* \
+        libgio-2.0.so* libglib-2.0.so* libgmodule-2.0.so* libgobject-2.0.so* \
+        libpcre2-8.so* libpng16.so* libz.so* \
+        libblkid.so* libmount.so* libselinux.so* \
+        /staged/usr/lib/ && \
+    cp -a /usr/share/fonts/font-liberation/LiberationSans-*.ttf \
+          /usr/share/fonts/font-liberation/LiberationMono-Regular.ttf \
+          /staged/usr/share/fonts/font-liberation/ && \
+    cp -a /usr/share/fontconfig/. /staged/usr/share/fontconfig/ && \
+    cp -a /etc/fonts/. /staged/etc/fonts/
+
 ### Stage 7: Python Application for Production (python-app-prod)
 # Uses Chainguard distroless Python — no shell, no apt, no pip, no uv at runtime.
 # This reduces CVEs significantly and shrinks the image by ~50%.
@@ -365,14 +403,9 @@ COPY --from=collectstatic /code /code
 COPY --from=binary-downloader /usr/local/bin/osv-scanner /usr/local/bin/osv-scanner
 COPY --from=binary-downloader /usr/local/bin/cosign /usr/local/bin/cosign
 
-# Copy WeasyPrint's runtime libraries and font setup from the Wolfi stage.
-# /usr/lib carries pango/harfbuzz/openjpeg/jpeg/freetype/fontconfig/glib .so
-# files. /etc/fonts + /usr/share/fontconfig + /usr/share/fonts carry the
-# font config tree and Liberation fonts WeasyPrint queries via fontconfig.
-COPY --from=weasyprint-libs /usr/lib/ /usr/lib/
-COPY --from=weasyprint-libs /etc/fonts/ /etc/fonts/
-COPY --from=weasyprint-libs /usr/share/fontconfig/ /usr/share/fontconfig/
-COPY --from=weasyprint-libs /usr/share/fonts/ /usr/share/fonts/
+# Copy the slimmed /staged tree (pre-filtered to WeasyPrint's actual .so
+# closure plus the Liberation Sans / Mono fonts the print CSS references).
+COPY --from=weasyprint-libs /staged/ /
 
 # Copy pre-created runtime directories with nonroot ownership (UID 65532)
 COPY --from=collectstatic /staged-dirs/var/lib/dramatiq-prometheus /var/lib/dramatiq-prometheus

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ARG COSIGN_VERSION=v3.0.6
 # IMPORTANT: This image must provide the same Python minor version as PYTHON_VERSION above.
 # To update: docker pull cgr.dev/chainguard/python:latest && docker inspect --format '{{index .RepoDigests 0}}'
 ARG CHAINGUARD_PYTHON_IMAGE=cgr.dev/chainguard/python@sha256:af9f881767681598970f2d4316ffe1f42abcb0413282b555bf7ce9b0774a7c79
+# Chainguard Wolfi base for the weasyprint-libs builder stage, pinned by digest
+# so the .so files copied into the distroless prod image stay reproducible.
+# To update: docker pull cgr.dev/chainguard/wolfi-base:latest && docker inspect --format '{{index .RepoDigests 0}}'
+ARG CHAINGUARD_WOLFI_BASE_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:0cff4df29a6597173dc8b813787318150141eb96ac783dc3ff4f5ff52c49a1e2
 
 # Build metadata arguments (passed from CI/CD)
 ARG BUILD_DATE=""
@@ -303,7 +307,8 @@ RUN mkdir -p /code/staticfiles && \
 # Fonts (font-liberation + fontconfig) are required because WeasyPrint
 # asks fontconfig for fallbacks at render time; without a font, text
 # glyphs render as boxes instead of the chosen Helvetica/Arial fallback.
-FROM cgr.dev/chainguard/wolfi-base:latest AS weasyprint-libs
+ARG CHAINGUARD_WOLFI_BASE_IMAGE
+FROM ${CHAINGUARD_WOLFI_BASE_IMAGE} AS weasyprint-libs
 # font-liberation is a metric-compatible drop-in for Arial / Helvetica /
 # Times New Roman / Courier (the families the print CSS targets) at
 # ~3 MB. font-noto's full multi-script set is ~470 MB — needlessly

--- a/Dockerfile
+++ b/Dockerfile
@@ -335,10 +335,17 @@ RUN apk add --no-cache \
 #
 # Font selection: Liberation Sans is the metric-compatible Arial / Helvetica
 # substitute (the families the body CSS asks for) — fontconfig resolves the
-# CSS request to it. Liberation Mono Regular is the lone monospace weight
-# because the print CSS doesn't bold or italicize <code>; fontconfig synths
-# bold / italic on the rare nested case. LiberationSerif and LiberationMono
-# Bold / Italic / BoldItalic are unused.
+# CSS request to it. The 4 weights shipped were picked by auditing the actual
+# HTML the markdown renderer produces against every CRA document kind:
+#   - <strong> tags: present in all 4 docs (3-19 each) → ship Sans Bold.
+#   - <em> tags: present in all 4 docs (1-18 each) → ship Sans Italic.
+#   - <strong><em> nested: 0 across all docs → SansBoldItalic skipped;
+#     fontconfig synthesizes acceptable bold-italic from Italic / Bold if a
+#     future template introduces ***foo***.
+#   - <code> tags: present only in the DoC (10 each), never bolded or
+#     italicized → ship LiberationMono-Regular only.
+# LiberationSerif is unused; LiberationMono Bold / Italic / BoldItalic are
+# unused; SansBoldItalic is unused.
 # fontconfig setup (/etc/fonts + /usr/share/fontconfig) ships verbatim
 # because the per-family conf snippets are small (~370 KB combined) and
 # trimming them would require auditing every snippet.
@@ -356,7 +363,9 @@ RUN mkdir -p /staged/usr/lib /staged/usr/share/fonts/font-liberation \
         libpcre2-8.so* libpng16.so* libz.so* \
         libblkid.so* libmount.so* libselinux.so* \
         /staged/usr/lib/ && \
-    cp -a /usr/share/fonts/font-liberation/LiberationSans-*.ttf \
+    cp -a /usr/share/fonts/font-liberation/LiberationSans-Regular.ttf \
+          /usr/share/fonts/font-liberation/LiberationSans-Bold.ttf \
+          /usr/share/fonts/font-liberation/LiberationSans-Italic.ttf \
           /usr/share/fonts/font-liberation/LiberationMono-Regular.ttf \
           /staged/usr/share/fonts/font-liberation/ && \
     cp -a /usr/share/fontconfig/. /staged/usr/share/fontconfig/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -289,6 +289,36 @@ RUN mkdir -p /code/staticfiles && \
     mkdir -p /staged-dirs/var/lib/dramatiq-prometheus /staged-dirs/tmp/.cache && \
     chown -R 65532:65532 /staged-dirs/var /staged-dirs/tmp
 
+### Stage 7b: Stage WeasyPrint runtime libraries from Wolfi
+# WeasyPrint dlopen()s Pango / HarfBuzz / OpenJPEG / libjpeg / FreeType /
+# fontconfig / glib at write_pdf() time, NOT at import time. The Chainguard
+# distroless prod image (Stage 7) does not ship these libs, so PDF rendering
+# fails at runtime with "PDF rendering is unavailable" even though the
+# WeasyPrint Python package itself imports cleanly. We install the libs in
+# a Wolfi-based builder stage and COPY them into the distroless image.
+#
+# Wolfi-base shares the same glibc as cgr.dev/chainguard/python (both are
+# built on Wolfi-glibc), so .so files copied across stages are ABI-safe —
+# unlike copying libs from a Debian builder, which would risk glibc skew.
+# Fonts (font-liberation + fontconfig) are required because WeasyPrint
+# asks fontconfig for fallbacks at render time; without a font, text
+# glyphs render as boxes instead of the chosen Helvetica/Arial fallback.
+FROM cgr.dev/chainguard/wolfi-base:latest AS weasyprint-libs
+# font-liberation is a metric-compatible drop-in for Arial / Helvetica /
+# Times New Roman / Courier (the families the print CSS targets) at
+# ~3 MB. font-noto's full multi-script set is ~470 MB — needlessly
+# bloats the prod image since the DoC is Latin / Latin-extended /
+# Cyrillic / Greek only and Liberation covers all four.
+RUN apk add --no-cache \
+        pango \
+        harfbuzz \
+        openjpeg \
+        libjpeg-turbo \
+        fontconfig \
+        freetype \
+        glib \
+        font-liberation
+
 ### Stage 7: Python Application for Production (python-app-prod)
 # Uses Chainguard distroless Python — no shell, no apt, no pip, no uv at runtime.
 # This reduces CVEs significantly and shrinks the image by ~50%.
@@ -329,6 +359,15 @@ COPY --from=collectstatic /code /code
 # Copy the osv-scanner and cosign binaries from the binary-downloader stage
 COPY --from=binary-downloader /usr/local/bin/osv-scanner /usr/local/bin/osv-scanner
 COPY --from=binary-downloader /usr/local/bin/cosign /usr/local/bin/cosign
+
+# Copy WeasyPrint's runtime libraries and font setup from the Wolfi stage.
+# /usr/lib carries pango/harfbuzz/openjpeg/jpeg/freetype/fontconfig/glib .so
+# files. /etc/fonts + /usr/share/fontconfig + /usr/share/fonts carry the
+# font config tree and Liberation fonts WeasyPrint queries via fontconfig.
+COPY --from=weasyprint-libs /usr/lib/ /usr/lib/
+COPY --from=weasyprint-libs /etc/fonts/ /etc/fonts/
+COPY --from=weasyprint-libs /usr/share/fontconfig/ /usr/share/fontconfig/
+COPY --from=weasyprint-libs /usr/share/fonts/ /usr/share/fonts/
 
 # Copy pre-created runtime directories with nonroot ownership (UID 65532)
 COPY --from=collectstatic /staged-dirs/var/lib/dramatiq-prometheus /var/lib/dramatiq-prometheus


### PR DESCRIPTION
## Summary

CRA Step 5 document downloads return `PDF rendering is unavailable on this server` on stage and prod, forcing operators to hand-author the PDF. The bug landed with the Chainguard distroless migration (`2bb5f3e7`) and fires for every per-document download tile on Step 5.

### Root cause

WeasyPrint `dlopen()`s Pango, HarfBuzz, OpenJPEG, libjpeg, FreeType, fontconfig, and glib at `write_pdf()` time — not at import time. The distroless prod image (`cgr.dev/chainguard/python`) ships none of those shared libraries. The Python package imports cleanly, `write_pdf()` raises `OSError`, `markdown_to_pdf` swallows it and returns `None`, and the API responds with HTTP 503.

### Fix

- New Stage 7b (`weasyprint-libs`) built on `cgr.dev/chainguard/wolfi-base`, pinned by digest via a `CHAINGUARD_WOLFI_BASE_IMAGE` ARG mirroring the existing `CHAINGUARD_PYTHON_IMAGE` pattern.
- `apk add`s the runtime libs plus `font-liberation`, then runs a `cp -a` allowlist into a `/staged` tree containing only what's needed.
- One `COPY --from=weasyprint-libs /staged/ /` carries the slim payload into the distroless prod image. Wolfi-base and `chainguard/python` share glibc so the libraries are ABI-safe — copying from a Debian builder would risk a glibc skew.

### Allowlist

`.so` closure verified with `ld-linux --list` against every lib WeasyPrint loads (`libpango`, `libpangoft2`, `libharfbuzz`, `libfreetype`, `libfontconfig`, `libopenjp2`, `libjpeg`) and their transitive deps. `libc`, `libm`, `libffi`, `ld-linux` are intentionally not staged because the distroless prod image already ships them — overwriting risks a glibc skew.

Fonts picked by auditing the actual HTML the markdown renderer produces across every CRA document kind:

| HTML tag | Occurrences | Ship |
| --- | --- | --- |
| `<strong>` | 3–19 per doc, all 4 docs | LiberationSans-Bold |
| `<em>` | 1–18 per doc, all 4 docs | LiberationSans-Italic |
| `<strong><em>` nested | 0 across all docs | _skipped_ (fontconfig synthesizes) |
| `<code>` | 10, DoC only, never bold/italic | LiberationMono-Regular |
| body text | everywhere | LiberationSans-Regular |

LiberationSerif, LiberationMono Bold/Italic/BoldItalic, and LiberationSans BoldItalic are unused and not shipped.

### Image size

| Stage | Total | Delta vs baseline |
| --- | --- | --- |
| Baseline (no fix) | 947 MB | — |
| Wholesale `/usr/lib` + full `font-noto` (original draft) | 1.69 GB | +744 MB |
| Wholesale `/usr/lib` + `font-liberation` | 1.01 GB | +63 MB |
| **Slim allowlist + 4 audited fonts (this PR)** | **972 MB** | **+25 MB** |

### Local verification

- Built `python-app-prod` locally and ran the live Django shell against the slim image, rendering all four document kinds from CRA assessment `RDDE57t7OgMb`: DoC 37 KB, User Instructions 14 KB, Risk Assessment 19 KB, Decommissioning Guide 16 KB — every one a valid `%PDF-`.
- Visual inspection of the rendered DoC pages 2 & 3 shows body, headings, **bold**, *italic*, `inline code`, and the embedded canvas-PNG signature all render identically to the wholesale variant.
- International glyph coverage smoke-tested: Greek (`αβγ`), accented Latin (`Größe`, `Voix ambiguë`), and Polish (`Łódź`).

## Test plan

- [x] CI `docker-build` job passes.
- [x] `sbomify/apps/compliance/tests/test_pdf_service.py` still passes (12 / 12, dev image, unchanged).
- [ ] On stage Step 5: each document download tile returns a real PDF, not the 503 banner.
- [ ] Signature image is visible inside the rendered DoC PDF.