### PR TITLE
fix(public+auth): dark-mode visibility (logos, table headers, Tailwind variant) + CRA signature pad reload

### DIFF
--- a/sbomify/apps/compliance/js/cra-doc-signature.spec.ts
+++ b/sbomify/apps/compliance/js/cra-doc-signature.spec.ts
@@ -1,28 +1,31 @@
 import { describe, test, expect, mock } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
  * Regression coverage for the DoC signature pad zoom-on-reload bug.
  *
- * ``_fitCanvas`` (in cra-doc-signature.ts) pre-scales the canvas
- * back-buffer by ``window.devicePixelRatio`` and applies
- * ``ctx.scale(ratio, ratio)``. The restore path therefore must pass
- * the SAME ratio to ``SignaturePad.fromDataURL`` — otherwise the
- * saved PNG is drawn at the wrong size through the already-scaled
- * context and the signature renders zoomed in 2× on retina screens.
+ * Two layers:
  *
- * The contract enforced here:
- *   restore.ratio === Math.max(window.devicePixelRatio || 1, 1)
+ * 1. **Unit tests** for the ratio formula. ``_fitCanvas`` pre-scales the
+ *    canvas back-buffer by ``window.devicePixelRatio`` and applies
+ *    ``ctx.scale(ratio, ratio)`` — the restore path must pass the SAME
+ *    ratio to ``SignaturePad.fromDataURL`` or the saved PNG renders
+ *    zoomed in 2× on retina screens.
  *
- * If anyone reverts the restore to ``{ ratio: 1 }`` (the previous
- * buggy value) or otherwise breaks the relationship, these tests
- * catch it without spinning up the full Alpine + signature_pad +
- * fetch stack.
+ * 2. **Source-text guard** on ``cra-doc-signature.ts`` so the actual
+ *    call site can't silently regress back to ``{ ratio: 1 }``. Bun's
+ *    test runner doesn't have a DOM and the production factory pulls in
+ *    Alpine.js (which needs ``MutationObserver``), so a full integration
+ *    test would need a heavy jsdom/happy-dom setup. The source check is
+ *    the pragmatic alternative: it fires the moment anyone reverts the
+ *    one-line fix, with zero runtime dependencies.
  */
 
 const computeRatio = (devicePixelRatio: number | undefined): number =>
   Math.max(devicePixelRatio || 1, 1);
 
-describe('CRA DoC signature pad restore ratio', () => {
+describe('CRA DoC signature pad restore ratio (unit)', () => {
   test('matches the fitted-canvas ratio formula for retina screens', () => {
     expect(computeRatio(2)).toBe(2);
     expect(computeRatio(3)).toBe(3);
@@ -40,17 +43,13 @@ describe('CRA DoC signature pad restore ratio', () => {
     expect(computeRatio(0.75)).toBe(1);
   });
 
-  test('regression: ratio:1 hardcoding (the original bug) would mismatch on retina', () => {
-    // The bug: passing { ratio: 1 } to fromDataURL while _fitCanvas
-    // had scaled the canvas at devicePixelRatio. Document the mismatch.
-    const fitRatio = computeRatio(2); // 2× retina
+  test('regression: ratio:1 hardcoding (the original bug) mismatches on retina', () => {
+    const fitRatio = computeRatio(2);
     const buggyRestoreRatio = 1;
     expect(fitRatio).not.toBe(buggyRestoreRatio);
   });
 
   test('restore options shape passes ratio to signature_pad', () => {
-    // signature_pad.fromDataURL options must include the ratio key.
-    // This is the option shape cra-doc-signature.ts now uses.
     const fromDataURL = mock((_data: string, _options: { ratio: number }) => {});
     const ratio = computeRatio(2);
     fromDataURL('data:image/png;base64,...', { ratio });
@@ -58,5 +57,29 @@ describe('CRA DoC signature pad restore ratio', () => {
     expect(fromDataURL).toHaveBeenCalledTimes(1);
     const call = fromDataURL.mock.calls[0];
     expect(call[1]).toHaveProperty('ratio', ratio);
+  });
+});
+
+describe('CRA DoC signature pad restore ratio (source guard)', () => {
+  // Reads cra-doc-signature.ts and asserts the actual restore call uses
+  // the devicePixelRatio formula. Catches reverts to ``{ ratio: 1 }`` —
+  // i.e. exactly the bug this PR fixes — even though the test runner
+  // can't execute the Alpine + signature_pad stack.
+  const source = readFileSync(join(import.meta.dir, 'cra-doc-signature.ts'), 'utf8');
+
+  test('the restore call uses Math.max(window.devicePixelRatio || 1, 1)', () => {
+    expect(source).toContain('Math.max(window.devicePixelRatio || 1, 1)');
+  });
+
+  test('the restore call does NOT hardcode ratio: 1 (the original bug)', () => {
+    // Match any ``fromDataURL(..., { ratio: 1 })`` literal. Multi-line
+    // safe because we collapse whitespace in the test pattern.
+    const collapsed = source.replace(/\s+/g, ' ');
+    expect(collapsed).not.toMatch(/fromDataURL\([^)]*\{\s*ratio:\s*1\s*\}/);
+  });
+
+  test('the restore call invokes fromDataURL with a ratio option', () => {
+    const collapsed = source.replace(/\s+/g, ' ');
+    expect(collapsed).toMatch(/this\.pad\.fromDataURL\([^)]*\{\s*ratio\s*\}/);
   });
 });

--- a/sbomify/apps/compliance/js/cra-doc-signature.spec.ts
+++ b/sbomify/apps/compliance/js/cra-doc-signature.spec.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, mock } from 'bun:test';
+
+/**
+ * Regression coverage for the DoC signature pad zoom-on-reload bug.
+ *
+ * ``_fitCanvas`` (in cra-doc-signature.ts) pre-scales the canvas
+ * back-buffer by ``window.devicePixelRatio`` and applies
+ * ``ctx.scale(ratio, ratio)``. The restore path therefore must pass
+ * the SAME ratio to ``SignaturePad.fromDataURL`` — otherwise the
+ * saved PNG is drawn at the wrong size through the already-scaled
+ * context and the signature renders zoomed in 2× on retina screens.
+ *
+ * The contract enforced here:
+ *   restore.ratio === Math.max(window.devicePixelRatio || 1, 1)
+ *
+ * If anyone reverts the restore to ``{ ratio: 1 }`` (the previous
+ * buggy value) or otherwise breaks the relationship, these tests
+ * catch it without spinning up the full Alpine + signature_pad +
+ * fetch stack.
+ */
+
+const computeRatio = (devicePixelRatio: number | undefined): number =>
+  Math.max(devicePixelRatio || 1, 1);
+
+describe('CRA DoC signature pad restore ratio', () => {
+  test('matches the fitted-canvas ratio formula for retina screens', () => {
+    expect(computeRatio(2)).toBe(2);
+    expect(computeRatio(3)).toBe(3);
+    expect(computeRatio(1.5)).toBe(1.5);
+  });
+
+  test('falls back to 1 for non-retina and missing devicePixelRatio', () => {
+    expect(computeRatio(1)).toBe(1);
+    expect(computeRatio(undefined)).toBe(1);
+    expect(computeRatio(0)).toBe(1);
+  });
+
+  test('never drops below 1 even with sub-pixel ratios', () => {
+    expect(computeRatio(0.5)).toBe(1);
+    expect(computeRatio(0.75)).toBe(1);
+  });
+
+  test('regression: ratio:1 hardcoding (the original bug) would mismatch on retina', () => {
+    // The bug: passing { ratio: 1 } to fromDataURL while _fitCanvas
+    // had scaled the canvas at devicePixelRatio. Document the mismatch.
+    const fitRatio = computeRatio(2); // 2× retina
+    const buggyRestoreRatio = 1;
+    expect(fitRatio).not.toBe(buggyRestoreRatio);
+  });
+
+  test('restore options shape passes ratio to signature_pad', () => {
+    // signature_pad.fromDataURL options must include the ratio key.
+    // This is the option shape cra-doc-signature.ts now uses.
+    const fromDataURL = mock((_data: string, _options: { ratio: number }) => {});
+    const ratio = computeRatio(2);
+    fromDataURL('data:image/png;base64,...', { ratio });
+
+    expect(fromDataURL).toHaveBeenCalledTimes(1);
+    const call = fromDataURL.mock.calls[0];
+    expect(call[1]).toHaveProperty('ratio', ratio);
+  });
+});

--- a/sbomify/apps/compliance/js/cra-doc-signature.ts
+++ b/sbomify/apps/compliance/js/cra-doc-signature.ts
@@ -99,9 +99,15 @@ function craDocSignature() {
         this.image = data.image || '';
         this.signedAt = data.signed_at;
         this.isSigned = data.is_signed;
-        // Restore the strokes so the pad reflects the prior save.
+        // Restore the strokes so the pad reflects the prior save. The
+        // ratio must match the one ``_fitCanvas`` applied via
+        // ``ctx.scale(ratio, ratio)``; passing ``ratio: 1`` against a
+        // context that's already scaled by ``devicePixelRatio`` makes
+        // signature_pad draw the saved PNG at 2× on retina screens,
+        // producing the "zoomed in" reload bug.
         if (data.image && this.pad) {
-          this.pad.fromDataURL(data.image, { ratio: 1 });
+          const ratio = Math.max(window.devicePixelRatio || 1, 1);
+          this.pad.fromDataURL(data.image, { ratio });
         }
       } catch {
         // Network blip — leave the form empty, operator can still sign.

--- a/sbomify/apps/core/js/theme-manager.spec.ts
+++ b/sbomify/apps/core/js/theme-manager.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, mock } from 'bun:test'
 
 describe('Theme Manager', () => {
 
@@ -99,32 +99,94 @@ describe('Theme Manager', () => {
         })
     })
 
-    describe('initThemeManager public-page short-circuit', () => {
-        // public_base.htmx.j2 owns its own theme system keyed on
-        // ``data-theme="dark"|"light"`` (with its own ``public-theme``
-        // localStorage key). When that attribute is already present on
-        // <html> by the time main.ts runs ``initThemeManager``, the
-        // auth-app theme manager must early-return so it doesn't clobber
-        // the public theme (which would force a stale
-        // ``sbomify-theme`` value over the live ``public-theme`` and
-        // flip e.g. table-header backgrounds to the wrong variant set).
-        const initThemeManagerGuard = (rootHasDataTheme: boolean): { ran: boolean; reason: string } => {
-            if (rootHasDataTheme) {
-                return { ran: false, reason: 'short-circuit: public page owns theming via data-theme' }
-            }
-            return { ran: true, reason: 'auth page: applied stored theme + exposed window.themeManager' }
+    describe('initThemeManager public-page short-circuit (real module)', () => {
+        // Exercises the production initThemeManager() with mocked
+        // ``document``/``localStorage``/``window`` so the guard is
+        // covered against accidental removal. public_base.htmx.j2 owns
+        // theming on trust-center pages via ``data-theme``; the auth-app
+        // theme manager must early-return there so it doesn't clobber
+        // the public theme.
+
+        type ClassList = { add: ReturnType<typeof mock>; remove: ReturnType<typeof mock> }
+        type FakeHtml = {
+            hasAttribute: ReturnType<typeof mock>
+            classList: ClassList
+            style: { colorScheme: string }
+            attrs: Record<string, string>
+        }
+        type FakeWindow = {
+            matchMedia: ReturnType<typeof mock>
+            themeManager?: unknown
         }
 
-        test('returns without applying anything when data-theme is preset', () => {
-            const result = initThemeManagerGuard(true)
-            expect(result.ran).toBe(false)
-            expect(result.reason).toContain('short-circuit')
+        const makeFakeHtml = (attrs: Record<string, string> = {}): FakeHtml => ({
+            hasAttribute: mock((name: string) => name in attrs),
+            classList: { add: mock(() => {}), remove: mock(() => {}) },
+            style: { colorScheme: '' },
+            attrs,
         })
 
-        test('runs normally on auth pages with no data-theme attribute', () => {
-            const result = initThemeManagerGuard(false)
-            expect(result.ran).toBe(true)
-            expect(result.reason).toContain('auth page')
+        const installMocks = (fakeHtml: FakeHtml, storage: Record<string, string> = {}): FakeWindow => {
+            const fakeWindow: FakeWindow = {
+                matchMedia: mock(() => ({
+                    matches: false,
+                    addEventListener: () => {},
+                })),
+            }
+            ;(globalThis as unknown as { document: { documentElement: FakeHtml } }).document = {
+                documentElement: fakeHtml,
+            }
+            ;(globalThis as unknown as { window: FakeWindow }).window = fakeWindow
+            ;(globalThis as unknown as { localStorage: Storage }).localStorage = {
+                getItem: mock((k: string) => storage[k] ?? null),
+                setItem: mock((k: string, v: string) => {
+                    storage[k] = v
+                }),
+                removeItem: mock((k: string) => {
+                    delete storage[k]
+                }),
+                clear: mock(() => {}),
+                key: mock(() => null),
+                length: 0,
+            } as unknown as Storage
+            // requestAnimationFrame is used by applyTheme() after the
+            // class is added; we don't need the rAF body to run, just to
+            // not crash. A no-op satisfies that.
+            ;(globalThis as unknown as { requestAnimationFrame: (cb: () => void) => number }).requestAnimationFrame = (() =>
+                0) as () => number
+            return fakeWindow
+        }
+
+        const loadFreshInitThemeManager = async (): Promise<() => void> => {
+            // Force a fresh import so module-level globals re-bind to the
+            // freshly installed ``window``/``document`` mocks.
+            const path = './theme-manager'
+            const mod = (await import(`${path}?cache=${Math.random()}`)) as { initThemeManager: () => void }
+            return mod.initThemeManager
+        }
+
+        test('short-circuits when <html data-theme="dark"> is preset (public page)', async () => {
+            const fakeHtml = makeFakeHtml({ 'data-theme': 'dark' })
+            const fakeWindow = installMocks(fakeHtml, { 'sbomify-theme': 'light' })
+            const initThemeManager = await loadFreshInitThemeManager()
+
+            initThemeManager()
+
+            expect(fakeHtml.hasAttribute).toHaveBeenCalledWith('data-theme')
+            expect(fakeHtml.classList.add).not.toHaveBeenCalled()
+            expect(fakeHtml.classList.remove).not.toHaveBeenCalled()
+            expect(fakeWindow.themeManager).toBeUndefined()
+        })
+
+        test('runs normally on auth pages (no data-theme attribute)', async () => {
+            const fakeHtml = makeFakeHtml({})
+            const fakeWindow = installMocks(fakeHtml, { 'sbomify-theme': 'dark' })
+            const initThemeManager = await loadFreshInitThemeManager()
+
+            initThemeManager()
+
+            expect(fakeHtml.classList.add).toHaveBeenCalled()
+            expect(fakeWindow.themeManager).toBeDefined()
         })
     })
 })

--- a/sbomify/apps/core/js/theme-manager.spec.ts
+++ b/sbomify/apps/core/js/theme-manager.spec.ts
@@ -98,4 +98,33 @@ describe('Theme Manager', () => {
             expect(STORAGE_KEY).toBe('sbomify-theme')
         })
     })
+
+    describe('initThemeManager public-page short-circuit', () => {
+        // public_base.htmx.j2 owns its own theme system keyed on
+        // ``data-theme="dark"|"light"`` (with its own ``public-theme``
+        // localStorage key). When that attribute is already present on
+        // <html> by the time main.ts runs ``initThemeManager``, the
+        // auth-app theme manager must early-return so it doesn't clobber
+        // the public theme (which would force a stale
+        // ``sbomify-theme`` value over the live ``public-theme`` and
+        // flip e.g. table-header backgrounds to the wrong variant set).
+        const initThemeManagerGuard = (rootHasDataTheme: boolean): { ran: boolean; reason: string } => {
+            if (rootHasDataTheme) {
+                return { ran: false, reason: 'short-circuit: public page owns theming via data-theme' }
+            }
+            return { ran: true, reason: 'auth page: applied stored theme + exposed window.themeManager' }
+        }
+
+        test('returns without applying anything when data-theme is preset', () => {
+            const result = initThemeManagerGuard(true)
+            expect(result.ran).toBe(false)
+            expect(result.reason).toContain('short-circuit')
+        })
+
+        test('runs normally on auth pages with no data-theme attribute', () => {
+            const result = initThemeManagerGuard(false)
+            expect(result.ran).toBe(true)
+            expect(result.reason).toContain('auth page')
+        })
+    })
 })

--- a/sbomify/apps/core/js/theme-manager.ts
+++ b/sbomify/apps/core/js/theme-manager.ts
@@ -67,6 +67,18 @@ function setTheme(theme: Theme): void {
 }
 
 function initThemeManager(): void {
+  // Public trust-center pages run their own theme system (see
+  // ``public_base.htmx.j2``) keyed on ``data-theme="dark"|"light"`` and
+  // its own ``public-theme`` localStorage key. If that attribute is
+  // already on the root element when we boot, the auth-app theme
+  // manager must not override it — otherwise the public page applies
+  // whatever ``sbomify-theme`` the user last picked in the auth app
+  // (typically light) and the trust-center renders with the wrong
+  // Tailwind variable set.
+  if (document.documentElement.hasAttribute('data-theme')) {
+    return;
+  }
+
   // Apply stored theme immediately, skip transitions to prevent FOUC
   const storedTheme = getStoredTheme();
   applyTheme(storedTheme, true);

--- a/sbomify/apps/core/templates/core/component_item.html.j2
+++ b/sbomify/apps/core/templates/core/component_item.html.j2
@@ -51,13 +51,13 @@
                         {% if item.format == 'cyclonedx' %}
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
                                  alt="CycloneDX"
-                                 class="h-4 w-auto"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
                                  width="16"
                                  height="16">
                         {% elif item.format == 'spdx' %}
                             <img src="{% static 'img/spdx-logo.svg' %}"
                                  alt="SPDX"
-                                 class="h-4 w-auto"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
                                  width="16"
                                  height="16">
                         {% endif %}

--- a/sbomify/apps/core/templates/core/product_details_private.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_private.html.j2
@@ -153,7 +153,7 @@
                        title="Download as CycloneDX">
                         <img src="{% static 'img/cyclonedx-logo.svg' %}"
                              alt="CycloneDX"
-                             class="h-[18px] w-auto"
+                             class="h-[18px] w-auto dark:brightness-0 dark:invert"
                              width="18"
                              height="18">
                         <i class="fas fa-download"></i>
@@ -163,7 +163,7 @@
                        title="Download as SPDX">
                         <img src="{% static 'img/spdx-logo.svg' %}"
                              alt="SPDX"
-                             class="h-[18px] w-auto"
+                             class="h-[18px] w-auto dark:brightness-0 dark:invert"
                              width="18"
                              height="18">
                         <i class="fas fa-download"></i>

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -59,24 +59,20 @@
                            href="{% url 'core:sbom_download_product' product.id %}"
                            title="Download combined SBOM as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt=""
+                                 alt="CycloneDX"
                                  class="h-5 w-auto dark:brightness-0 dark:invert"
                                  height="20"
-                                 width="20"
-                                 aria-hidden="true">
-                            <span>CycloneDX</span>
+                                 width="20">
                             <i class="fas fa-download text-primary text-xs ml-1" aria-hidden="true"></i>
                         </a>
                         <a class="inline-flex items-center gap-2 min-h-10 px-4 py-2 border border-border rounded-lg text-text hover:bg-border/30 transition-colors no-underline"
                            href="{% url 'core:sbom_download_product' product.id %}?format=spdx"
                            title="Download combined SBOM as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt=""
+                                 alt="SPDX"
                                  class="h-5 w-auto dark:brightness-0 dark:invert"
                                  height="20"
-                                 width="20"
-                                 aria-hidden="true">
-                            <span>SPDX</span>
+                                 width="20">
                             <i class="fas fa-download text-primary text-xs ml-1" aria-hidden="true"></i>
                         </a>
                     </div>

--- a/sbomify/apps/core/templates/core/product_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/product_details_public.html.j2
@@ -60,7 +60,7 @@
                            title="Download combined SBOM as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
                                  alt=""
-                                 class="h-5 w-auto"
+                                 class="h-5 w-auto dark:brightness-0 dark:invert"
                                  height="20"
                                  width="20"
                                  aria-hidden="true">
@@ -72,7 +72,7 @@
                            title="Download combined SBOM as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
                                  alt=""
-                                 class="h-5 w-auto"
+                                 class="h-5 w-auto dark:brightness-0 dark:invert"
                                  height="20"
                                  width="20"
                                  aria-hidden="true">

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -257,19 +257,6 @@
                 color-scheme: dark;
             }
 
-            /* Format logos (CycloneDX / SPDX) are dark-on-light by design.
-               Render them white when the trust-center is in dark mode so
-               they don't disappear against the slate surface. This handles
-               the manual toggle case where `data-theme="dark"` is set but
-               the `.dark` class isn't (theme-manager.ts uses a different
-               state machine on auth pages). The `dark:brightness-0
-               dark:invert` Tailwind utilities on the <img> tags cover the
-               OS-level prefers-color-scheme: dark case. */
-            html[data-theme="dark"] img[src*="cyclonedx-logo"],
-            html[data-theme="dark"] img[src*="spdx-logo"] {
-                filter: brightness(0) invert(1);
-            }
-
             /* System theme - light preference */
             html:not([data-theme]) {
                 --text-primary: #0f172a;

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -247,6 +247,19 @@
                 color-scheme: dark;
             }
 
+            /* Format logos (CycloneDX / SPDX) are dark-on-light by design.
+               Render them white when the trust-center is in dark mode so
+               they don't disappear against the slate surface. This handles
+               the manual toggle case where `data-theme="dark"` is set but
+               the `.dark` class isn't (theme-manager.ts uses a different
+               state machine on auth pages). The `dark:brightness-0
+               dark:invert` Tailwind utilities on the <img> tags cover the
+               OS-level prefers-color-scheme: dark case. */
+            html[data-theme="dark"] img[src*="cyclonedx-logo"],
+            html[data-theme="dark"] img[src*="spdx-logo"] {
+                filter: brightness(0) invert(1);
+            }
+
             /* System theme - light preference */
             html:not([data-theme]) {
                 --text-primary: #0f172a;

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -18,8 +18,13 @@
             // This ensures CSS rules apply immediately without relying on @media queries
             if(isDark) {
                 html.setAttribute('data-theme','dark');
+                // tailwind.src.css uses :root as the dark default and
+                // :root.light as the light override — remove .light so the
+                // dark Tailwind variables apply.
+                html.classList.remove('light');
             } else {
                 html.setAttribute('data-theme','light');
+                html.classList.add('light');
             }
             // Also mark if using system preference for the toggle component
             if(!t || t==='system') html.setAttribute('data-theme-source','system');
@@ -1164,6 +1169,9 @@
                 const html = document.documentElement;
                 const style = html.style;
                 html.setAttribute('data-theme', isDark ? 'dark' : 'light');
+                // Mirror via .light class so the :root.light overrides in
+                // tailwind.src.css fire (or don't) correctly.
+                html.classList.toggle('light', !isDark);
                 if (isDark) {
                     style.setProperty('--color-surface', '30 41 59');
                     style.setProperty('--color-surface-elevated', '51 65 85');

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -20,11 +20,16 @@
                 html.setAttribute('data-theme','dark');
                 // tailwind.src.css uses :root as the dark default and
                 // :root.light as the light override — remove .light so the
-                // dark Tailwind variables apply.
+                // dark Tailwind variables apply. Also add .dark so the
+                // @custom-variant dark in tailwind.src.css fires for
+                // `dark:*` utilities used by other public templates
+                // (e.g. `dark:prose-invert` in doc/vdp/early-warning).
                 html.classList.remove('light');
+                html.classList.add('dark');
             } else {
                 html.setAttribute('data-theme','light');
                 html.classList.add('light');
+                html.classList.remove('dark');
             }
             // Also mark if using system preference for the toggle component
             if(!t || t==='system') html.setAttribute('data-theme-source','system');
@@ -1169,9 +1174,12 @@
                 const html = document.documentElement;
                 const style = html.style;
                 html.setAttribute('data-theme', isDark ? 'dark' : 'light');
-                // Mirror via .light class so the :root.light overrides in
-                // tailwind.src.css fire (or don't) correctly.
+                // Mirror via .light/.dark class so the :root.light overrides
+                // in tailwind.src.css fire correctly AND so the class-based
+                // `dark:*` Tailwind variant (defined via @custom-variant in
+                // tailwind.src.css) picks up the public dark theme too.
                 html.classList.toggle('light', !isDark);
+                html.classList.toggle('dark', isDark);
                 if (isDark) {
                     style.setProperty('--color-surface', '30 41 59');
                     style.setProperty('--color-surface-elevated', '51 65 85');

--- a/sbomify/apps/core/templates/core/release_details_private.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_private.html.j2
@@ -62,7 +62,7 @@
                        title="Download as CycloneDX">
                         <img src="{% static 'img/cyclonedx-logo.svg' %}"
                              alt="CycloneDX"
-                             class="h-4 w-auto"
+                             class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
                              height="16">
                         <i class="fas fa-download"></i>
@@ -72,7 +72,7 @@
                        title="Download as SPDX">
                         <img src="{% static 'img/spdx-logo.svg' %}"
                              alt="SPDX"
-                             class="h-4 w-auto"
+                             class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
                              height="16">
                         <i class="fas fa-download"></i>
@@ -140,7 +140,7 @@
                            title="Download as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
                                  alt="CycloneDX"
-                                 class="h-[18px] w-auto"
+                                 class="h-[18px] w-auto dark:brightness-0 dark:invert"
                                  width="18"
                                  height="18">
                             <i class="fas fa-download"></i>
@@ -150,7 +150,7 @@
                            title="Download as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
                                  alt="SPDX"
-                                 class="h-[18px] w-auto"
+                                 class="h-[18px] w-auto dark:brightness-0 dark:invert"
                                  width="18"
                                  height="18">
                             <i class="fas fa-download"></i>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -56,24 +56,20 @@
                        href="{% url 'api-1:download_release' release.id %}"
                        title="Download release as CycloneDX">
                         <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                             alt=""
+                             alt="CycloneDX"
                              class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
-                             height="16"
-                             aria-hidden="true">
-                        <span>CycloneDX</span>
+                             height="16">
                         <i class="fas fa-download text-xs" aria-hidden="true"></i>
                     </a>
                     <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                        href="{% url 'api-1:download_release' release.id %}?format=spdx"
                        title="Download release as SPDX">
                         <img src="{% static 'img/spdx-logo.svg' %}"
-                             alt=""
+                             alt="SPDX"
                              class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
-                             height="16"
-                             aria-hidden="true">
-                        <span>SPDX</span>
+                             height="16">
                         <i class="fas fa-download text-xs" aria-hidden="true"></i>
                     </a>
                 </div>
@@ -116,24 +112,20 @@
                            href="{% url 'api-1:download_release' release.id %}"
                            title="Download release as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt=""
+                                 alt="CycloneDX"
                                  class="h-5 w-auto dark:brightness-0 dark:invert"
                                  width="20"
-                                 height="20"
-                                 aria-hidden="true">
-                            <span>CycloneDX</span>
+                                 height="20">
                             <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                         <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                            href="{% url 'api-1:download_release' release.id %}?format=spdx"
                            title="Download release as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt=""
+                                 alt="SPDX"
                                  class="h-5 w-auto dark:brightness-0 dark:invert"
                                  width="20"
-                                 height="20"
-                                 aria-hidden="true">
-                            <span>SPDX</span>
+                                 height="20">
                             <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                     </div>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -57,7 +57,7 @@
                        title="Download release as CycloneDX">
                         <img src="{% static 'img/cyclonedx-logo.svg' %}"
                              alt=""
-                             class="h-4 w-auto"
+                             class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
                              height="16"
                              aria-hidden="true">
@@ -69,7 +69,7 @@
                        title="Download release as SPDX">
                         <img src="{% static 'img/spdx-logo.svg' %}"
                              alt=""
-                             class="h-4 w-auto"
+                             class="h-4 w-auto dark:brightness-0 dark:invert"
                              width="16"
                              height="16"
                              aria-hidden="true">
@@ -117,7 +117,7 @@
                            title="Download release as CycloneDX">
                             <img src="{% static 'img/cyclonedx-logo.svg' %}"
                                  alt=""
-                                 class="h-5 w-auto"
+                                 class="h-5 w-auto dark:brightness-0 dark:invert"
                                  width="20"
                                  height="20"
                                  aria-hidden="true">
@@ -129,7 +129,7 @@
                            title="Download release as SPDX">
                             <img src="{% static 'img/spdx-logo.svg' %}"
                                  alt=""
-                                 class="h-5 w-auto"
+                                 class="h-5 w-auto dark:brightness-0 dark:invert"
                                  width="20"
                                  height="20"
                                  aria-hidden="true">

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -9,6 +9,18 @@
 @source "../../templates/**/*.{html,html.j2,j2}";
 
 /* ============================================
+   Dark mode variant (class-based)
+   ============================================
+   Tailwind v4 ignores the v3-era ``darkMode: 'class'`` in
+   ``tailwind.config.js`` — the CSS-first variant below is the way to
+   make ``dark:*`` utilities fire from the ``.dark`` class added by
+   ``theme-manager.ts`` (and the inline FOUC script in
+   ``base.html.j2``). Without it, Tailwind defaults to
+   ``prefers-color-scheme: dark``, which means UI-toggled dark mode
+   on a light-OS browser wouldn't trigger ``dark:*`` rules. */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ============================================
    Theme Configuration
    Based on sbomify Brand Guidelines v1.0
    ============================================ */


### PR DESCRIPTION
## Summary

A bundle of related public + auth-app rendering fixes uncovered while running down a single Slack screenshot:

1. **CycloneDX / SPDX format-logo SVGs** are dark-on-light brand assets — they vanish against the slate surface on public trust-center pages in dark mode.
2. **`.tw-table th`** and divider rules that read `var(--color-background)` rendered LIGHT in dark mode on public pages, so table headers showed as `slate-50` white bands.
3. **Tailwind v4 ignored** the v3-era `darkMode: 'class'` in `tailwind.config.js` and defaulted to `prefers-color-scheme`, so the auth-app UI-toggled dark mode didn't trigger `dark:*` utilities at all on a light-OS browser.
4. **Format-logo buttons rendered "CycloneDX CycloneDX"** / "SPDX SPDX" because the SVG already contains the wordmark and the template added a duplicate `<span>` next to it.
5. **CRA DoC signature pad** rendered the saved PNG zoomed in 2× on retina screens after reload — `_fitCanvas` pre-scales the context but the restore path passed `ratio: 1`.

### Root causes + fixes

- **`@custom-variant dark (&:where(.dark, .dark *))`** added to `tailwind.src.css`. Without this declaration Tailwind v4 ignores `darkMode: 'class'` and `dark:*` utilities fire only on `prefers-color-scheme: dark`.
- **`theme-manager.ts`** short-circuits `initThemeManager()` when `<html data-theme="…">` is already set. Auth pages don't set the attribute, so the early-return is a no-op there. Public pages drive their own theme system via `data-theme` + `public-theme` localStorage.
- **`public_base.htmx.j2`** boot script + runtime toggle now toggle BOTH `.light` AND `.dark` classes alongside the `data-theme` attribute, so (a) the `:root.light` overrides in `tailwind.src.css` fire correctly and (b) the new `dark:` variant fires on public dark mode too. Templates that use `dark:prose-invert` (e.g. `compliance/doc_public.html.j2`, `compliance/vdp_public.html.j2`) now switch correctly via the trust-center UI toggle, not just OS prefs.
- **14 `<img>` tags across 7 templates** got `dark:brightness-0 dark:invert` for the logo invert.
- **6 public download buttons** had their redundant `<span>CycloneDX</span>` / `<span>SPDX</span>` removed; the label moved onto the `<img alt="…">` for accessibility (the SVG itself carries the visible wordmark).
- **`cra-doc-signature.ts`** restore path now passes `ratio: window.devicePixelRatio || 1` (matching the value `_fitCanvas` applied via `ctx.scale(ratio, ratio)`) so `signature_pad` draws the saved PNG at offsetWidth/offsetHeight CSS pixels — fits the back-buffer exactly. Before, `ratio: 1` made it draw at back-buffer dimensions through a 2×-scaled context → 4× pixel area → only the top-left quadrant of the saved signature was visible ("zoomed in" effect).

### Files changed

- `sbomify/assets/css/tailwind.src.css` (new `@custom-variant dark`)
- `sbomify/apps/core/js/theme-manager.ts` (early-return)
- `sbomify/apps/core/js/theme-manager.spec.ts` (guard test)
- `sbomify/apps/core/templates/core/public_base.htmx.j2` (boot + runtime toggle the `.light`/`.dark` classes alongside `data-theme`)
- `sbomify/apps/core/templates/core/component_item.html.j2`
- `sbomify/apps/core/templates/core/product_details_public.html.j2`
- `sbomify/apps/core/templates/core/product_details_private.html.j2`
- `sbomify/apps/core/templates/core/release_details_public.html.j2`
- `sbomify/apps/core/templates/core/release_details_private.html.j2`
- `sbomify/apps/compliance/js/cra-doc-signature.ts` (`ratio: 1` → `ratio: devicePixelRatio`)

### Local verification

| Scenario | Outcome |
| --- | --- |
| Public dark (UI toggle) | `--color-background = 15 23 42`, table headers dark slate, logos `filter: brightness(0) invert(1)` |
| Public light (UI toggle) | `--color-background = 248 250 252`, table headers light slate, logos in brand colors |
| Public OS-level dark (`prefers-color-scheme: dark`) | `cyc_filter = brightness(0) invert(1)`, page renders dark |
| Auth-app UI dark on OS=light (regression case Copilot flagged) | `cyc_filter = brightness(0) invert(1)` (was `none` before the variant fix) |
| Auth-app UI light | `cyc_filter = none` |
| Public + sbomify-theme=dark in localStorage but public-theme=light | filter `none`, logos in brand colors — auth-app theme manager early-returns |
| CRA Step 5 signature: draw diagonal corner-to-corner, save, reload | pixel sample at back-buffer center `(396, 158)` = `rgba(0,0,0,255)`; full-page screenshot shows the diagonal spanning the canvas (vs. cramped top-left quadrant before the fix) |

## Test plan

- [ ] Stage: public product page (`/public/product/<id>/`) in dark mode — table headers, dividers, and CycloneDX/SPDX download buttons all blend cleanly with the slate surface; no duplicate "CycloneDX CycloneDX" text on the buttons.
- [ ] Toggle back to light — table headers light slate, logos in brand colors.
- [ ] Repeat on `/public/release/<id>/` and public component pages.
- [ ] Auth app: toggle theme on any product/release page — the `dark:` Tailwind variant now fires from the `.dark` class regardless of OS preference.
- [ ] CRA Step 5: sign once, save, reload — restored signature spans the full canvas (not zoomed in).