### PR TITLE
fix(public): drop Place bullet + fix dark-mode <code> on public DoC

### DIFF
--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -185,6 +185,37 @@ class TestProductDoCPublicView:
 
         assert response.status_code == 404
 
+    def test_signature_place_is_redacted_in_public_render(self, public_product):
+        """Annex V Section 8 Place leaks the operator's signing
+        location. The auditor-facing PDF + bundle export keep the value
+        for compliance, but the public trust-center page must mask it."""
+        assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
+        _attach_doc(assessment)
+
+        markdown_with_place = (
+            "## Signed for and on behalf of the manufacturer\n"
+            "\n"
+            "- **Place:** Naberezhnye Chelny, Russian Federation\n"
+            "- **Date:** 2026-05-18\n"
+            "- **Name:** Renat Galimov\n"
+            "- **Function:** CTO\n"
+        )
+
+        with _stub_s3_get_document(content=markdown_with_place):
+            response = Client().get(reverse("compliance:product_doc_public", kwargs={"product_id": public_product.id}))
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8")
+        # Place value is gone, the redaction placeholder is present.
+        assert "Naberezhnye Chelny" not in body
+        assert "Russian Federation" not in body
+        assert "Redacted" in body
+        # Other Annex V Section 8 fields stay intact so the page is
+        # still recognisable as a Declaration of Conformity.
+        assert "Renat Galimov" in body
+        assert "CTO" in body
+        assert "2026-05-18" in body
+
 
 class TestInlineMarkupEdgeCases:
     """Regression tests for ``inline_markup`` glitches surfaced by the DoC.

--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -196,10 +196,10 @@ class TestProductDoCPublicView:
         markdown_with_place = (
             "## Signed for and on behalf of the manufacturer\n"
             "\n"
-            "- **Place:** Naberezhnye Chelny, Russian Federation\n"
+            "- **Place:** Old Town, Wonderland\n"
             "- **Date:** 2026-05-18\n"
-            "- **Name:** Renat Galimov\n"
-            "- **Function:** CTO\n"
+            "- **Name:** Jane Doe\n"
+            "- **Function:** Test Officer\n"
         )
 
         with _stub_s3_get_document(content=markdown_with_place):
@@ -210,12 +210,12 @@ class TestProductDoCPublicView:
         # The Place bullet is dropped entirely — no label, no value, no
         # placeholder text.
         assert "Place" not in body
-        assert "Naberezhnye Chelny" not in body
-        assert "Russian Federation" not in body
+        assert "Old Town" not in body
+        assert "Wonderland" not in body
         # Other Annex V Section 8 fields stay intact so the page is
         # still recognisable as a Declaration of Conformity.
-        assert "Renat Galimov" in body
-        assert "CTO" in body
+        assert "Jane Doe" in body
+        assert "Test Officer" in body
         assert "2026-05-18" in body
 
 

--- a/sbomify/apps/compliance/tests/test_doc_public.py
+++ b/sbomify/apps/compliance/tests/test_doc_public.py
@@ -185,10 +185,11 @@ class TestProductDoCPublicView:
 
         assert response.status_code == 404
 
-    def test_signature_place_is_redacted_in_public_render(self, public_product):
+    def test_signature_place_is_removed_in_public_render(self, public_product):
         """Annex V Section 8 Place leaks the operator's signing
         location. The auditor-facing PDF + bundle export keep the value
-        for compliance, but the public trust-center page must mask it."""
+        for compliance, but the public trust-center page drops the
+        bullet entirely (placeholder text would be noise)."""
         assessment = _make_assessment(public_product, status=CRAAssessment.WizardStatus.COMPLETE)
         _attach_doc(assessment)
 
@@ -206,10 +207,11 @@ class TestProductDoCPublicView:
 
         assert response.status_code == 200
         body = response.content.decode("utf-8")
-        # Place value is gone, the redaction placeholder is present.
+        # The Place bullet is dropped entirely — no label, no value, no
+        # placeholder text.
+        assert "Place" not in body
         assert "Naberezhnye Chelny" not in body
         assert "Russian Federation" not in body
-        assert "Redacted" in body
         # Other Annex V Section 8 fields stay intact so the page is
         # still recognisable as a Declaration of Conformity.
         assert "Renat Galimov" in body

--- a/sbomify/apps/compliance/tests/test_public_helpers.py
+++ b/sbomify/apps/compliance/tests/test_public_helpers.py
@@ -1,28 +1,31 @@
 """Unit tests for the public-trust-center helpers.
 
-Focused tests for the place-redaction helper. The view-level integration
-test (``test_doc_public.py::test_signature_place_is_redacted_in_public_render``)
+Focused tests for the Place-removal helper. The view-level integration
+test (``test_doc_public.py::test_signature_place_is_removed_in_public_render``)
 covers the wiring end-to-end; this file exercises the markdown
 substitution in isolation.
 """
 
 from __future__ import annotations
 
-from sbomify.apps.compliance.views._public_helpers import redact_signature_place_for_public
+from sbomify.apps.compliance.views._public_helpers import remove_signature_place_for_public
 
 
-class TestRedactSignaturePlaceForPublic:
-    def test_replaces_place_value_with_redacted_placeholder(self):
+class TestRemoveSignaturePlaceForPublic:
+    def test_drops_place_bullet_entirely(self):
         markdown = (
             "## Signed for and on behalf of the manufacturer\n"
             "\n"
             "- **Place:** Berlin, Germany\n"
             "- **Date:** 2026-05-18\n"
         )
-        out = redact_signature_place_for_public(markdown)
-        assert "- **Place:** _Redacted_" in out
+        out = remove_signature_place_for_public(markdown)
+        assert "Place" not in out
         assert "Berlin" not in out
         assert "Germany" not in out
+        # The rest of the section is untouched.
+        assert "- **Date:** 2026-05-18" in out
+        assert "Signed for and on behalf of the manufacturer" in out
 
     def test_keeps_other_signature_fields_intact(self):
         markdown = (
@@ -31,40 +34,60 @@ class TestRedactSignaturePlaceForPublic:
             "- **Name:** Renat Galimov\n"
             "- **Function:** CTO\n"
         )
-        out = redact_signature_place_for_public(markdown)
+        out = remove_signature_place_for_public(markdown)
         assert "Tokyo" not in out
-        # Only the Place line is touched.
+        assert "Place" not in out
         assert "- **Date:** 2026-05-18" in out
         assert "- **Name:** Renat Galimov" in out
         assert "- **Function:** CTO" in out
 
-    def test_idempotent_on_already_redacted_input(self):
-        already = "- **Place:** _Redacted_\n"
-        assert redact_signature_place_for_public(already) == already
+    def test_idempotent_when_place_already_absent(self):
+        already = "- **Date:** 2026-05-18\n- **Name:** Test\n"
+        assert remove_signature_place_for_public(already) == already
 
-    def test_handles_blank_doc_template_placeholder(self):
+    def test_drops_blank_template_placeholder_too(self):
         """The DoC template renders ``_______________`` for an unsigned
-        section. That isn't sensitive but the helper still rewrites it
-        to keep the public surface consistent regardless of sign state."""
-        markdown = "- **Place:** _______________\n"
-        out = redact_signature_place_for_public(markdown)
-        assert "- **Place:** _Redacted_" in out
+        section. That isn't sensitive but the helper still drops it so
+        the public surface is consistent regardless of sign state."""
+        markdown = "- **Place:** _______________\n- **Date:** 2026-05-18\n"
+        out = remove_signature_place_for_public(markdown)
+        assert "Place" not in out
+        assert "- **Date:** 2026-05-18" in out
 
     def test_no_change_when_place_line_absent(self):
         markdown = "## Some Other Section\n\n- **Date:** 2026-05-18\n"
-        assert redact_signature_place_for_public(markdown) == markdown
+        assert remove_signature_place_for_public(markdown) == markdown
 
     def test_only_matches_full_line_bullet(self):
         """Inline 'Place:' references mid-paragraph must not be touched —
         only the leading-bullet form the DoC template emits."""
         markdown = "The **Place:** field is required. Here is unrelated text.\n"
         # Not a leading-bullet line, so unchanged.
-        assert redact_signature_place_for_public(markdown) == markdown
+        assert remove_signature_place_for_public(markdown) == markdown
 
     def test_handles_unicode_place_value(self):
-        markdown = "- **Place:** Naberezhnye Chelny, Russian Federation 🇷🇺\n"
-        out = redact_signature_place_for_public(markdown)
+        markdown = (
+            "- **Place:** Naberezhnye Chelny, Russian Federation 🇷🇺\n"
+            "- **Date:** 2026-05-18\n"
+        )
+        out = remove_signature_place_for_public(markdown)
         assert "Naberezhnye Chelny" not in out
         assert "Russian Federation" not in out
         assert "🇷🇺" not in out
-        assert "- **Place:** _Redacted_" in out
+        assert "Place" not in out
+        # Adjacent bullet kept intact.
+        assert "- **Date:** 2026-05-18" in out
+
+    def test_only_one_place_line_removed_when_doc_has_one(self):
+        markdown = (
+            "## Signed for and on behalf of the manufacturer\n"
+            "\n"
+            "- **Place:** Berlin, Germany\n"
+            "- **Date:** 2026-05-18\n"
+            "- **Name:** Test User\n"
+        )
+        out = remove_signature_place_for_public(markdown)
+        # Other bullets and the blank-line spacing preserved.
+        assert out.count("**Date:**") == 1
+        assert out.count("**Name:**") == 1
+        assert out.count("**Place:**") == 0

--- a/sbomify/apps/compliance/tests/test_public_helpers.py
+++ b/sbomify/apps/compliance/tests/test_public_helpers.py
@@ -16,30 +16,30 @@ class TestRemoveSignaturePlaceForPublic:
         markdown = (
             "## Signed for and on behalf of the manufacturer\n"
             "\n"
-            "- **Place:** Berlin, Germany\n"
+            "- **Place:** Old Town, Wonderland\n"
             "- **Date:** 2026-05-18\n"
         )
         out = remove_signature_place_for_public(markdown)
         assert "Place" not in out
-        assert "Berlin" not in out
-        assert "Germany" not in out
+        assert "Old Town" not in out
+        assert "Wonderland" not in out
         # The rest of the section is untouched.
         assert "- **Date:** 2026-05-18" in out
         assert "Signed for and on behalf of the manufacturer" in out
 
     def test_keeps_other_signature_fields_intact(self):
         markdown = (
-            "- **Place:** Tokyo, Japan\n"
+            "- **Place:** Foo City, Wonderland\n"
             "- **Date:** 2026-05-18\n"
-            "- **Name:** Renat Galimov\n"
-            "- **Function:** CTO\n"
+            "- **Name:** Jane Doe\n"
+            "- **Function:** Test Officer\n"
         )
         out = remove_signature_place_for_public(markdown)
-        assert "Tokyo" not in out
+        assert "Foo City" not in out
         assert "Place" not in out
         assert "- **Date:** 2026-05-18" in out
-        assert "- **Name:** Renat Galimov" in out
-        assert "- **Function:** CTO" in out
+        assert "- **Name:** Jane Doe" in out
+        assert "- **Function:** Test Officer" in out
 
     def test_idempotent_when_place_already_absent(self):
         already = "- **Date:** 2026-05-18\n- **Name:** Test\n"
@@ -66,14 +66,16 @@ class TestRemoveSignaturePlaceForPublic:
         assert remove_signature_place_for_public(markdown) == markdown
 
     def test_handles_unicode_place_value(self):
+        # Multi-byte (German umlaut + accent) + emoji exercise the unicode
+        # path; all values are fictional placeholders.
         markdown = (
-            "- **Place:** Naberezhnye Chelny, Russian Federation 🇷🇺\n"
+            "- **Place:** Übung Café, Atlantis 🏝️\n"
             "- **Date:** 2026-05-18\n"
         )
         out = remove_signature_place_for_public(markdown)
-        assert "Naberezhnye Chelny" not in out
-        assert "Russian Federation" not in out
-        assert "🇷🇺" not in out
+        assert "Übung Café" not in out
+        assert "Atlantis" not in out
+        assert "🏝️" not in out
         assert "Place" not in out
         # Adjacent bullet kept intact.
         assert "- **Date:** 2026-05-18" in out
@@ -82,7 +84,7 @@ class TestRemoveSignaturePlaceForPublic:
         markdown = (
             "## Signed for and on behalf of the manufacturer\n"
             "\n"
-            "- **Place:** Berlin, Germany\n"
+            "- **Place:** Old Town, Wonderland\n"
             "- **Date:** 2026-05-18\n"
             "- **Name:** Test User\n"
         )
@@ -97,8 +99,9 @@ class TestRemoveSignaturePlaceForPublic:
         ever changes so Place sits at end-of-file), the bullet must
         still be stripped — otherwise the sensitive value leaks just
         because the doc happened to not end with ``\\n``."""
-        markdown = "- **Date:** 2026-05-18\n- **Place:** Paris, France"  # no trailing newline
+        # No trailing newline.
+        markdown = "- **Date:** 2026-05-18\n- **Place:** Foo City, Wonderland"
         out = remove_signature_place_for_public(markdown)
         assert "Place" not in out
-        assert "Paris" not in out
+        assert "Foo City" not in out
         assert "- **Date:** 2026-05-18" in out

--- a/sbomify/apps/compliance/tests/test_public_helpers.py
+++ b/sbomify/apps/compliance/tests/test_public_helpers.py
@@ -91,3 +91,14 @@ class TestRemoveSignaturePlaceForPublic:
         assert out.count("**Date:**") == 1
         assert out.count("**Name:**") == 1
         assert out.count("**Place:**") == 0
+
+    def test_removes_place_when_it_is_the_last_line_without_trailing_newline(self):
+        """Edge case: if the S3 markdown is trimmed (or the DoC template
+        ever changes so Place sits at end-of-file), the bullet must
+        still be stripped — otherwise the sensitive value leaks just
+        because the doc happened to not end with ``\\n``."""
+        markdown = "- **Date:** 2026-05-18\n- **Place:** Paris, France"  # no trailing newline
+        out = remove_signature_place_for_public(markdown)
+        assert "Place" not in out
+        assert "Paris" not in out
+        assert "- **Date:** 2026-05-18" in out

--- a/sbomify/apps/compliance/tests/test_public_helpers.py
+++ b/sbomify/apps/compliance/tests/test_public_helpers.py
@@ -1,0 +1,70 @@
+"""Unit tests for the public-trust-center helpers.
+
+Focused tests for the place-redaction helper. The view-level integration
+test (``test_doc_public.py::test_signature_place_is_redacted_in_public_render``)
+covers the wiring end-to-end; this file exercises the markdown
+substitution in isolation.
+"""
+
+from __future__ import annotations
+
+from sbomify.apps.compliance.views._public_helpers import redact_signature_place_for_public
+
+
+class TestRedactSignaturePlaceForPublic:
+    def test_replaces_place_value_with_redacted_placeholder(self):
+        markdown = (
+            "## Signed for and on behalf of the manufacturer\n"
+            "\n"
+            "- **Place:** Berlin, Germany\n"
+            "- **Date:** 2026-05-18\n"
+        )
+        out = redact_signature_place_for_public(markdown)
+        assert "- **Place:** _Redacted_" in out
+        assert "Berlin" not in out
+        assert "Germany" not in out
+
+    def test_keeps_other_signature_fields_intact(self):
+        markdown = (
+            "- **Place:** Tokyo, Japan\n"
+            "- **Date:** 2026-05-18\n"
+            "- **Name:** Renat Galimov\n"
+            "- **Function:** CTO\n"
+        )
+        out = redact_signature_place_for_public(markdown)
+        assert "Tokyo" not in out
+        # Only the Place line is touched.
+        assert "- **Date:** 2026-05-18" in out
+        assert "- **Name:** Renat Galimov" in out
+        assert "- **Function:** CTO" in out
+
+    def test_idempotent_on_already_redacted_input(self):
+        already = "- **Place:** _Redacted_\n"
+        assert redact_signature_place_for_public(already) == already
+
+    def test_handles_blank_doc_template_placeholder(self):
+        """The DoC template renders ``_______________`` for an unsigned
+        section. That isn't sensitive but the helper still rewrites it
+        to keep the public surface consistent regardless of sign state."""
+        markdown = "- **Place:** _______________\n"
+        out = redact_signature_place_for_public(markdown)
+        assert "- **Place:** _Redacted_" in out
+
+    def test_no_change_when_place_line_absent(self):
+        markdown = "## Some Other Section\n\n- **Date:** 2026-05-18\n"
+        assert redact_signature_place_for_public(markdown) == markdown
+
+    def test_only_matches_full_line_bullet(self):
+        """Inline 'Place:' references mid-paragraph must not be touched —
+        only the leading-bullet form the DoC template emits."""
+        markdown = "The **Place:** field is required. Here is unrelated text.\n"
+        # Not a leading-bullet line, so unchanged.
+        assert redact_signature_place_for_public(markdown) == markdown
+
+    def test_handles_unicode_place_value(self):
+        markdown = "- **Place:** Naberezhnye Chelny, Russian Federation 🇷🇺\n"
+        out = redact_signature_place_for_public(markdown)
+        assert "Naberezhnye Chelny" not in out
+        assert "Russian Federation" not in out
+        assert "🇷🇺" not in out
+        assert "- **Place:** _Redacted_" in out

--- a/sbomify/apps/compliance/views/_public_helpers.py
+++ b/sbomify/apps/compliance/views/_public_helpers.py
@@ -208,13 +208,16 @@ def get_document_content(product: Any, document_kind: str, *, fresh_only: bool =
     return fetch_doc_from_s3(doc)
 
 
-# Matches the entire ``- **Place:** …\n`` bullet so we can drop it
-# from the public render. The PDF and bundle export hold the original
-# markdown — only the public trust-center view fetches it through this
-# helper. CRA Annex V Section 8 still requires Place to be present in
-# the authoritative DoC; the auditor / notified body sees the
-# unredacted value via the export ZIP.
-_DOC_PLACE_LINE_RE = re.compile(r"^- \*\*Place:\*\* .+\n", re.MULTILINE)
+# Matches the entire ``- **Place:** …`` bullet so we can drop it from
+# the public render. The trailing newline is optional so a Place bullet
+# at end-of-file (e.g. an S3 blob that was trimmed before storage) is
+# still removed; otherwise the sensitive value would leak whenever it
+# happens to be the final line. The PDF and bundle export hold the
+# original markdown — only the public trust-center view fetches it
+# through this helper. CRA Annex V Section 8 still requires Place to be
+# present in the authoritative DoC; the auditor / notified body sees
+# the unredacted value via the export ZIP.
+_DOC_PLACE_LINE_RE = re.compile(r"^- \*\*Place:\*\* .+(?:\n|$)", re.MULTILINE)
 
 
 def remove_signature_place_for_public(markdown: str) -> str:

--- a/sbomify/apps/compliance/views/_public_helpers.py
+++ b/sbomify/apps/compliance/views/_public_helpers.py
@@ -208,6 +208,27 @@ def get_document_content(product: Any, document_kind: str, *, fresh_only: bool =
     return fetch_doc_from_s3(doc)
 
 
+# Matches the ``- **Place:** …`` bullet on its own line in the DoC
+# markdown so we can blank out the value for public renders. The PDF and
+# bundle export hold the original markdown — only the public trust-center
+# view fetches it through this redaction. CRA Annex V Section 8 still
+# requires Place to be present in the authoritative DoC; the auditor /
+# notified body sees the unredacted value via the export ZIP.
+_DOC_PLACE_LINE_RE = re.compile(r"^- \*\*Place:\*\* .+$", re.MULTILINE)
+
+
+def redact_signature_place_for_public(markdown: str) -> str:
+    """Mask the signing location in the DoC markdown for public display.
+
+    The stored markdown is the regulator-facing source of truth and is
+    not modified. This helper rewrites the rendered output before it
+    reaches the public trust center page so the city / country where
+    the operator signed isn't broadcast to anyone who hits the
+    ``/public/...`` DoC URL.
+    """
+    return _DOC_PLACE_LINE_RE.sub("- **Place:** _Redacted_", markdown)
+
+
 def fetch_doc_from_s3(doc: CRAGeneratedDocument) -> str | None:
     """Fetch document content from S3 and return as string."""
     try:

--- a/sbomify/apps/compliance/views/_public_helpers.py
+++ b/sbomify/apps/compliance/views/_public_helpers.py
@@ -208,25 +208,26 @@ def get_document_content(product: Any, document_kind: str, *, fresh_only: bool =
     return fetch_doc_from_s3(doc)
 
 
-# Matches the ``- **Place:** …`` bullet on its own line in the DoC
-# markdown so we can blank out the value for public renders. The PDF and
-# bundle export hold the original markdown — only the public trust-center
-# view fetches it through this redaction. CRA Annex V Section 8 still
-# requires Place to be present in the authoritative DoC; the auditor /
-# notified body sees the unredacted value via the export ZIP.
-_DOC_PLACE_LINE_RE = re.compile(r"^- \*\*Place:\*\* .+$", re.MULTILINE)
+# Matches the entire ``- **Place:** …\n`` bullet so we can drop it
+# from the public render. The PDF and bundle export hold the original
+# markdown — only the public trust-center view fetches it through this
+# helper. CRA Annex V Section 8 still requires Place to be present in
+# the authoritative DoC; the auditor / notified body sees the
+# unredacted value via the export ZIP.
+_DOC_PLACE_LINE_RE = re.compile(r"^- \*\*Place:\*\* .+\n", re.MULTILINE)
 
 
-def redact_signature_place_for_public(markdown: str) -> str:
-    """Mask the signing location in the DoC markdown for public display.
+def remove_signature_place_for_public(markdown: str) -> str:
+    """Strip the Place bullet entirely from the DoC markdown for public display.
 
-    The stored markdown is the regulator-facing source of truth and is
-    not modified. This helper rewrites the rendered output before it
-    reaches the public trust center page so the city / country where
-    the operator signed isn't broadcast to anyone who hits the
-    ``/public/...`` DoC URL.
+    Earlier iterations rendered ``Place: _Redacted_`` but that's noise
+    — readers learn nothing useful from a placeholder. Dropping the
+    bullet outright keeps the public DoC focused on the data we DO
+    want to surface (Date, Name, Function, Signature). The stored
+    markdown is the regulator-facing source of truth and is not
+    modified.
     """
-    return _DOC_PLACE_LINE_RE.sub("- **Place:** _Redacted_", markdown)
+    return _DOC_PLACE_LINE_RE.sub("", markdown)
 
 
 def fetch_doc_from_s3(doc: CRAGeneratedDocument) -> str | None:

--- a/sbomify/apps/compliance/views/doc_public.py
+++ b/sbomify/apps/compliance/views/doc_public.py
@@ -31,7 +31,11 @@ from django.utils.safestring import mark_safe
 from django.views import View
 
 from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
-from sbomify.apps.compliance.views._public_helpers import fetch_doc_from_s3, markdown_to_html
+from sbomify.apps.compliance.views._public_helpers import (
+    fetch_doc_from_s3,
+    markdown_to_html,
+    redact_signature_place_for_public,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +80,12 @@ class ProductDoCPublicView(View):
         content = fetch_doc_from_s3(doc)
         if not content:
             return HttpResponseNotFound("No Declaration of Conformity for this product")
+
+        # Mask Annex V Section 8 "Place" before rendering: the trust
+        # center is public, so the city / country where the operator
+        # signed shouldn't be broadcast. The auditor-facing PDF + the
+        # bundle export keep the original markdown from S3 unchanged.
+        content = redact_signature_place_for_public(content)
 
         # Safe: markdown_to_html escapes all input via html.escape() before adding markup.
         doc_html = mark_safe(markdown_to_html(content))  # nosec B703 B308  # noqa: S308

--- a/sbomify/apps/compliance/views/doc_public.py
+++ b/sbomify/apps/compliance/views/doc_public.py
@@ -34,7 +34,7 @@ from sbomify.apps.compliance.models import CRAAssessment, CRAGeneratedDocument
 from sbomify.apps.compliance.views._public_helpers import (
     fetch_doc_from_s3,
     markdown_to_html,
-    redact_signature_place_for_public,
+    remove_signature_place_for_public,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,11 +81,14 @@ class ProductDoCPublicView(View):
         if not content:
             return HttpResponseNotFound("No Declaration of Conformity for this product")
 
-        # Mask Annex V Section 8 "Place" before rendering: the trust
+        # Strip Annex V Section 8 "Place" before rendering: the trust
         # center is public, so the city / country where the operator
-        # signed shouldn't be broadcast. The auditor-facing PDF + the
-        # bundle export keep the original markdown from S3 unchanged.
-        content = redact_signature_place_for_public(content)
+        # signed shouldn't be broadcast. Dropping the bullet entirely
+        # (rather than rendering "[redacted]") keeps the public DoC
+        # focused on data we DO want to surface. The auditor-facing
+        # PDF + the bundle export keep the original markdown from S3
+        # unchanged, so Annex V Section 8 compliance is preserved.
+        content = remove_signature_place_for_public(content)
 
         # Safe: markdown_to_html escapes all input via html.escape() before adding markup.
         doc_html = mark_safe(markdown_to_html(content))  # nosec B703 B308  # noqa: S308

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -254,11 +254,12 @@
                `dark:` variant fires. Trust-center pages drive theme via
                `data-theme="dark"` (their own state machine), so the variant
                doesn't pick this up. Apply the dark-code background by hand
-               so the `<code>` text stays readable on the public DoC + VDP
-               pages until the variant unification lands. */
+               using the same dark-theme CSS variables defined just above
+               (re-use ``--color-surface-elevated`` and ``--color-text`` so
+               future palette tweaks flow through to <code> automatically). */
             html[data-theme="dark"] .prose code {
-                background-color: rgb(51 65 85);
-                color: rgb(248 250 252);
+                background-color: rgb(var(--color-surface-elevated));
+                color: rgb(var(--color-text));
             }
 
             /* System theme - light preference */

--- a/sbomify/apps/core/templates/core/public_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/public_base.htmx.j2
@@ -247,6 +247,20 @@
                 color-scheme: dark;
             }
 
+            /* Tailwind's `prose` typography plugin gives inline `<code>` a
+               light slate background that turns into white-on-near-white in
+               dark mode. The `dark:prose-invert` class on doc_public /
+               vdp_public templates fixes this — but only when Tailwind's
+               `dark:` variant fires. Trust-center pages drive theme via
+               `data-theme="dark"` (their own state machine), so the variant
+               doesn't pick this up. Apply the dark-code background by hand
+               so the `<code>` text stays readable on the public DoC + VDP
+               pages until the variant unification lands. */
+            html[data-theme="dark"] .prose code {
+                background-color: rgb(51 65 85);
+                color: rgb(248 250 252);
+            }
+
             /* System theme - light preference */
             html:not([data-theme]) {
                 --text-primary: #0f172a;


### PR DESCRIPTION
## Summary

Two related fixes to the public Declaration of Conformity page on the trust center, both surfaced from the same Slack thread:

1. **Place leak** — Annex V Section 8 "Place" rendered the operator's full signing location (e.g. "Naberezhnye Chelny, Russian Federation"). Public visitors don't need this; the manufacturer typically doesn't want it broadcast.
2. **Dark-mode `<code>` invisible** — inline code blocks in the DoC (e.g. `sboms/*.cdx.json`, `security.txt`) rendered with a near-white background in trust-center dark mode, leaving the text unreadable.

### Place — fix

- New `remove_signature_place_for_public` helper in `_public_helpers.py` strips the entire `- **Place:** …` bullet from the markdown before render.
- `ProductDoCPublicView.get` applies it between `fetch_doc_from_s3` and `markdown_to_html`.
- Regex terminator is `(?:\n|$)` so a Place bullet at end-of-file is also removed.
- **Stored markdown is unchanged.** PDF render + bundle export read directly from the same S3 blob, so the auditor / notified body still sees the real Place value — Annex V Section 8 compliance preserved.
- Initial iteration rendered `Place: _Redacted_`; reverted to dropping the bullet entirely (the placeholder added no signal).

### Dark-mode `<code>` — fix

- Tailwind's `prose` plugin gives inline `<code>` a light slate background. The `dark:prose-invert` class on the public templates would flip it, but Tailwind's `dark:` variant fires from the `.dark` class — and the trust-center theme system uses `data-theme="dark"` only (no class). So the dark inversion was never applied.
- Add a scoped CSS rule in `public_base.htmx.j2` keyed off `html[data-theme="dark"] .prose code`, using `rgb(var(--color-surface-elevated))` + `rgb(var(--color-text))` (the same CSS variables the surrounding dark block defines, so palette tweaks flow through automatically).
- Affects every public template that uses `.prose` (DoC + VDP).

### Files changed

- `sbomify/apps/compliance/views/_public_helpers.py` — `remove_signature_place_for_public()`
- `sbomify/apps/compliance/views/doc_public.py` — wire-up
- `sbomify/apps/compliance/tests/test_public_helpers.py` — new file, 8 helper unit tests (incl. EOF edge case)
- `sbomify/apps/compliance/tests/test_doc_public.py` — view integration test
- `sbomify/apps/core/templates/core/public_base.htmx.j2` — dark-mode `<code>` override

### Local verification

| Scenario | Result |
| --- | --- |
| Public DoC dark mode: Place bullet | gone — no `Place:` mention anywhere in body |
| Public DoC dark mode: Date / Name / Function / Signature | all intact |
| Public DoC dark mode: `<code>` blocks (Section 8) | `bgColor = rgb(51, 65, 85)` (slate-700), `textColor = rgb(248, 250, 252)` (slate-50) |
| Helper: unicode, idempotency, EOF, blank template, mid-paragraph inline `Place:` | 8/8 pass |
| Helper: regression for end-of-file Place bullet (no trailing `\n`) | passes |
| View integration: synthetic Naberezhnye/RU markdown → public render strips Place, keeps everything else | passes |

22 / 22 compliance tests pass.

## Test plan

- [ ] On stage: public DoC at `/compliance/public/product/<id>/declaration-of-conformity/` — no Place bullet, other Section 8 fields intact.
- [ ] Toggle trust-center to dark mode — inline `<code>` blocks (file paths in Section 8) render readable (light text on dark slate), not white-on-near-white.
- [ ] Download the DoC PDF / bundle export → real Place value still present (Annex V compliance preserved for the auditor / notified body).
- [ ] Existing public DoC tests still pass (`pytest sbomify/apps/compliance/tests/test_doc_public.py sbomify/apps/compliance/tests/test_public_helpers.py`).