### PR TITLE
fix(compliance): make CRA doc templates render correctly in all markdown viewers

### DIFF
--- a/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
+++ b/sbomify/apps/compliance/document_templates/declaration_of_conformity.md.dtl
@@ -66,11 +66,11 @@ The object of the declaration described above is in conformity with Regulation (
 
 The following artefacts accompanying this declaration demonstrate conformity:
 
-- `sboms/*.cdx.json` — Software Bill of Materials in CycloneDX format (*Annex I Part II(1)*)
-- `documents/vulnerability-disclosure-policy.md` — Coordinated Vulnerability Disclosure policy (*Annex I Part II(5)-(6)*)
-- `documents/risk-assessment.md` — Cybersecurity risk assessment (*Annex VII §3*)
-- `documents/user-instructions.md` — User information and instructions (*Annex II*)
-- `documents/secure-decommissioning.md` — Secure decommissioning procedure (*Annex I Part I §13*)
+- `sboms/*.cdx.json` — Software Bill of Materials in CycloneDX format (_Annex I Part II(1)_)
+- `documents/vulnerability-disclosure-policy.md` — Coordinated Vulnerability Disclosure policy (_Annex I Part II(5)-(6)_)
+- `documents/risk-assessment.md` — Cybersecurity risk assessment (_Annex VII §3_)
+- `documents/user-instructions.md` — User information and instructions (_Annex II_)
+- `documents/secure-decommissioning.md` — Secure decommissioning procedure (_Annex I Part I §13_)
 - `security.txt` — RFC 9116 machine-readable security contact
 - `article-14/*.md` — Article 14 notification templates (active from 2026-09-11)
 - `oscal/*.json` — OSCAL catalog and assessment-results for the 21 CRA Annex I controls
@@ -89,4 +89,4 @@ The following artefacts accompanying this declaration demonstrate conformity:
 
 ***
 
-*This declaration is drawn up in accordance with CRA Article 28 and Annex V.*
+This declaration is drawn up in accordance with CRA Article 28 and Annex V.

--- a/sbomify/apps/compliance/document_templates/decommissioning_guide.md.dtl
+++ b/sbomify/apps/compliance/document_templates/decommissioning_guide.md.dtl
@@ -45,4 +45,4 @@ This guide provides instructions for securely decommissioning {{ product_name }}
 - Update asset inventory records
 
 ---
-*This guide addresses CRA Annex I, Part I, Section 13: "enable users to securely and easily remove on a permanent basis all data and settings."*
+This guide addresses CRA Annex I, Part I, Section 13: "enable users to securely and easily remove on a permanent basis all data and settings."

--- a/sbomify/apps/compliance/document_templates/early_warning.md.dtl
+++ b/sbomify/apps/compliance/document_templates/early_warning.md.dtl
@@ -36,5 +36,5 @@
 {% endif %}
 
 ---
-*Submit via ENISA Single Reporting Platform (SRP) to the designated CSIRT and ENISA simultaneously.*
-*This notification must be submitted within 24 hours of becoming aware of the vulnerability or incident.*
+> Submit via ENISA Single Reporting Platform (SRP) to the designated CSIRT and ENISA simultaneously.
+> This notification must be submitted within 24 hours of becoming aware of the vulnerability or incident.

--- a/sbomify/apps/compliance/document_templates/final_report.md.dtl
+++ b/sbomify/apps/compliance/document_templates/final_report.md.dtl
@@ -40,6 +40,6 @@
 {% endif %}
 
 ---
-*Submit via ENISA Single Reporting Platform (SRP).*
-*Vulnerability reports: submit within 14 days after corrective measure is available.*
-*Incident reports: submit within 1 month after the incident notification.*
+> Submit via ENISA Single Reporting Platform (SRP).
+> Vulnerability reports: submit within 14 days after corrective measure is available.
+> Incident reports: submit within 1 month after the incident notification.

--- a/sbomify/apps/compliance/document_templates/full_notification.md.dtl
+++ b/sbomify/apps/compliance/document_templates/full_notification.md.dtl
@@ -46,5 +46,5 @@
 {% endif %}
 
 ---
-*Submit via ENISA Single Reporting Platform (SRP).*
-*This notification must be submitted within 72 hours of becoming aware of the vulnerability or incident.*
+> Submit via ENISA Single Reporting Platform (SRP).
+> This notification must be submitted within 72 hours of becoming aware of the vulnerability or incident.

--- a/sbomify/apps/compliance/document_templates/risk_assessment.md.dtl
+++ b/sbomify/apps/compliance/document_templates/risk_assessment.md.dtl
@@ -18,33 +18,33 @@ This assessment evaluates the cybersecurity risks associated with {{ product_nam
 
 ### 2.1 Security by Design (Annex I, Part I — risk-based per CRA Art 13(4))
 
-| Control | Status | Notes | Justification |
-|---------|--------|-------|---------------|
-{% for finding in sd_findings %}| {{ finding.title }} | {{ finding.status }} | {{ finding.notes }} | {{ finding.justification }} |
+{% for finding in sd_findings %}- **{{ finding.title }}** — _{{ finding.status }}_{% if finding.notes %}
+  {{ finding.notes }}{% endif %}{% if finding.justification %}
+  Justification: {{ finding.justification }}{% endif %}
 {% endfor %}
 ### 2.2 Data Protection (Annex I, Part I — risk-based per CRA Art 13(4))
 
-| Control | Status | Notes | Justification |
-|---------|--------|-------|---------------|
-{% for finding in dp_findings %}| {{ finding.title }} | {{ finding.status }} | {{ finding.notes }} | {{ finding.justification }} |
+{% for finding in dp_findings %}- **{{ finding.title }}** — _{{ finding.status }}_{% if finding.notes %}
+  {{ finding.notes }}{% endif %}{% if finding.justification %}
+  Justification: {{ finding.justification }}{% endif %}
 {% endfor %}
 ### 2.3 Availability & Resilience (Annex I, Part I — risk-based per CRA Art 13(4))
 
-| Control | Status | Notes | Justification |
-|---------|--------|-------|---------------|
-{% for finding in av_findings %}| {{ finding.title }} | {{ finding.status }} | {{ finding.notes }} | {{ finding.justification }} |
+{% for finding in av_findings %}- **{{ finding.title }}** — _{{ finding.status }}_{% if finding.notes %}
+  {{ finding.notes }}{% endif %}{% if finding.justification %}
+  Justification: {{ finding.justification }}{% endif %}
 {% endfor %}
 ### 2.4 Monitoring & Logging (Annex I, Part I — risk-based per CRA Art 13(4))
 
-| Control | Status | Notes | Justification |
-|---------|--------|-------|---------------|
-{% for finding in mn_findings %}| {{ finding.title }} | {{ finding.status }} | {{ finding.notes }} | {{ finding.justification }} |
+{% for finding in mn_findings %}- **{{ finding.title }}** — _{{ finding.status }}_{% if finding.notes %}
+  {{ finding.notes }}{% endif %}{% if finding.justification %}
+  Justification: {{ finding.justification }}{% endif %}
 {% endfor %}
 ### 2.5 Vulnerability Handling (Annex I, Part II — always mandatory per CRA Art 13(4))
 
-| Control | Status | Notes |
-|---------|--------|-------|
-{% for finding in vh_findings %}| {{ finding.title }} | {{ finding.status }} | {{ finding.notes }} |
+{% for finding in vh_findings %}- **{{ finding.title }}** — _{{ finding.status }}_{% if finding.notes %}
+  {{ finding.notes }}{% endif %}{% if finding.justification %}
+  Justification: {{ finding.justification }}{% endif %}
 {% endfor %}
 ## 3. Summary
 
@@ -58,6 +58,5 @@ This assessment evaluates the cybersecurity risks associated with {{ product_nam
 
 {% if support_period_end %}**Support until:** {{ support_period_end }}
 {% else %}**Support period:** [To be determined]
-{% endif %}
----
-*This risk assessment is prepared in accordance with CRA Annex VII, Section 3.*
+{% endif %}---
+This risk assessment is prepared in accordance with CRA Annex VII, Section 3.

--- a/sbomify/apps/compliance/document_templates/user_instructions.md.dtl
+++ b/sbomify/apps/compliance/document_templates/user_instructions.md.dtl
@@ -66,4 +66,4 @@ Vulnerability disclosure policy: {{ vdp_url }}
 {% endif %}
 
 ---
-*This document is provided in accordance with CRA Annex II user information requirements.*
+This document is provided in accordance with CRA Annex II user information requirements.

--- a/sbomify/apps/compliance/document_templates/vdp.md.dtl
+++ b/sbomify/apps/compliance/document_templates/vdp.md.dtl
@@ -61,4 +61,4 @@ We ask reporters to:
 We acknowledge security researchers who report valid vulnerabilities in accordance with this policy.
 
 ---
-*This policy aligns with CRA Annex I, Part II, Sections 5-6 requirements for coordinated vulnerability disclosure.*
+This policy aligns with CRA Annex I, Part II, Sections 5-6 requirements for coordinated vulnerability disclosure.

--- a/sbomify/apps/compliance/services/export_service.py
+++ b/sbomify/apps/compliance/services/export_service.py
@@ -159,7 +159,16 @@ def _integrity_readme(manifest_sha256: str) -> str:
 
 
 def _article_14_reporting_readme() -> str:
-    """Article 14 deadlines + ENISA Single Reporting Platform pointers."""
+    """Article 14 deadlines + ENISA Single Reporting Platform pointers.
+
+    Uses a bullet list (not a pipe table) for the deadlines so it
+    renders consistently in every markdown engine the bundle might be
+    viewed in — GitHub, CommonMark-only static-site generators, and
+    plain-text viewers like Apple Preview's markdown-to-PDF converter
+    all render bullets identically; pipe tables are a GFM extension
+    that several common viewers degrade to literal `|`-separated text
+    runs with blank gaps between rows.
+    """
     return (
         "# CRA Article 14 — Reporting Obligations\n\n"
         "Article 14 of Regulation (EU) 2024/2847 requires manufacturers to "
@@ -168,16 +177,18 @@ def _article_14_reporting_readme() -> str:
         "reporting obligations apply from 2026-09-11**; until then, "
         "submissions are voluntary.\n\n"
         "## Deadlines\n\n"
-        "| Deadline | Requirement | Template |\n"
-        "| --- | --- | --- |\n"
-        "| ≤24 h | Early warning: what, affected Member States, malicious?"
-        " | `early-warning-template.md` |\n"
-        "| ≤72 h | Vulnerability / incident notification with corrective"
-        " measures taken | `vulnerability-notification-template.md` |\n"
-        "| ≤14 d | Final report (vulnerability — after corrective measure"
-        " applied) | `final-report-template.md` |\n"
-        "| ≤1 mo | Final report (severe incident)"
-        " | `final-report-template.md` |\n\n"
+        "- **≤24 hours — Early warning.** What happened, which Member "
+        "States are affected, and whether the incident is suspected to "
+        "be malicious. Template: `early-warning-template.md`.\n"
+        "- **≤72 hours — Vulnerability / incident notification.** "
+        "Vulnerability or incident notification with the corrective "
+        "measures taken so far. Template: "
+        "`vulnerability-notification-template.md`.\n"
+        "- **≤14 days — Final vulnerability report.** Final report once "
+        "the corrective measure has been applied. Template: "
+        "`final-report-template.md`.\n"
+        "- **≤1 month — Final incident report.** Final report for severe "
+        "incidents. Template: `final-report-template.md`.\n\n"
         "## Submission channel\n\n"
         "Article 16 designates ENISA to operate the Single Reporting Platform "
         "(SRP). The SRP consumes the notifications above and routes them to "

--- a/sbomify/apps/compliance/tests/test_export_service.py
+++ b/sbomify/apps/compliance/tests/test_export_service.py
@@ -397,8 +397,11 @@ class TestBuildExportPackage:
             assert "ENISA" in content
             assert "Article 14" in content
             assert "digital-strategy.ec.europa.eu/en/policies/cra-reporting" in content
-            # Deadlines table — all four rows present.
-            for deadline in ("≤24 h", "≤72 h", "≤14 d", "≤1 mo"):
+            # Deadlines list — all four bullets present. (Spelled-out
+            # forms because the source uses bullets, not a pipe table,
+            # so non-GFM renderers like Apple Preview's md→PDF render
+            # the list as bullets instead of literal ``|``-separated text.)
+            for deadline in ("≤24 hours", "≤72 hours", "≤14 days", "≤1 month"):
                 assert deadline in content
 
     @patch("sbomify.apps.compliance.services.export_service.S3Client")
@@ -788,8 +791,25 @@ class TestExportHelpers:
     def test_article_14_reporting_readme_contains_all_deadlines(self):
         """Readme enumerates all four Article 14 deadlines."""
         content = _article_14_reporting_readme()
-        for token in ("≤24 h", "≤72 h", "≤14 d", "≤1 mo", "2026-09-11", "ENISA"):
+        for token in ("≤24 hours", "≤72 hours", "≤14 days", "≤1 month", "2026-09-11", "ENISA"):
             assert token in content
+
+    def test_article_14_reporting_readme_uses_bullets_not_pipe_table(self):
+        """Regression: the deadlines list MUST be a bullet list, not a
+        pipe table. Non-GFM markdown renderers (Apple Preview's
+        markdown-to-PDF converter, CommonMark-only static site
+        generators) render pipe tables as literal text runs with
+        blank gaps between rows. Bullets render consistently
+        everywhere.
+        """
+        content = _article_14_reporting_readme()
+        # No pipe-table separator line — the canonical "|---|---|---|"
+        # row that GFM uses to delimit the header from the body.
+        assert "| --- |" not in content
+        assert "|---|" not in content
+        # Each deadline is a top-level bullet.
+        for marker in ("- **≤24 hours", "- **≤72 hours", "- **≤14 days", "- **≤1 month"):
+            assert marker in content
 
     def test_article_14_readme_references_ec_portal(self):
         """Readme points operators at the EC CRA reporting page."""


### PR DESCRIPTION
## Summary

CRA-bundle generated docs used markdown features that don't survive every renderer (GFM pipe tables + single-asterisk italic). Apple Preview's md→PDF and several CommonMark-only static-site generators render those features as literal text, which leaked into a customer-facing PDF (`README_REPORTING.pdf` — the Article 14 reporting deadlines doc).

Two related fixes, both touching only doc-templating files. No behaviour change in the wizard, the export pipeline, or the manifest.

### 1. Pipe tables → bullet lists

- **`_article_14_reporting_readme()`** in `services/export_service.py` — the deadlines table (4 rows) became a bullet list with bolded deadlines + inline template names. The README in the export ZIP now renders correctly in any markdown viewer.
- **`risk_assessment.md.dtl`** — five per-section control tables (`Security by Design`, `Data Protection`, `Availability & Resilience`, `Monitoring & Logging`, `Vulnerability Handling`) became per-finding bullet loops with the same fields (`**title** — _status_`, plus optional notes and justification continuation lines).

### 2. Single-asterisk italic markers stripped

Across all 8 dtl document templates plus `declaration_of_conformity`, `*…*` italic wrappers were either:

- **Removed** for footer attribution lines (`*This X is prepared in accordance with…*` → plain text under the closing `---`). Affected: `declaration_of_conformity`, `risk_assessment`, `decommissioning_guide`, `user_instructions`, `vdp`.
- **Replaced with `> ` blockquote** for Article 14 submission instructions (`*Submit via ENISA…*`, `*Vulnerability reports: submit within 14 days…*`). Affected: `early_warning`, `full_notification`, `final_report`.
- **Replaced with `_…_`** for inline Annex references in `declaration_of_conformity` (5 instances like `(*Annex I Part II(1)*)` → `(_Annex I Part II(1)_)`).

Underscore italic and blockquote are pure CommonMark and don't conflict with the `*`-as-list-marker handling that some viewers stumble over.

### 3. Tests

- Updated `test_bundle_contains_article_14_reporting_readme` and `test_article_14_reporting_readme_contains_all_deadlines` — assertions changed from the shorthand `≤24 h` to the spelled-out `≤24 hours` (matches the new bullet phrasing).
- Added a new regression `test_article_14_reporting_readme_uses_bullets_not_pipe_table` that fails if the pipe-table syntax is ever reintroduced (asserts no `| --- |` separator + every deadline appears as a `- **≤…` bullet).

## Test plan

- [x] `pytest sbomify/apps/compliance/tests/test_export_service.py sbomify/apps/compliance/tests/test_document_generation.py` — 221 pass on this branch against current master
- [x] Generated all 9 docs against a real assessment (`qOUYTLsDaNFP`) via the live `/api/v1/compliance/cra/<id>/generate/<kind>` API and rendered them to HTML — no literal `|`-cells or stray `*` anywhere
- [x] Re-rendered the original `README_REPORTING.md` in a browser preview — now bullet-formatted (the issue from the original PDF screenshot is fixed)

## Why a separate PR

The fixes were authored against `feat/cra-remaining-work` (PR #914), but that branch is 326 commits behind master and has its own scope (EN 18031 opt-in + BSI waivers). Lifting these two small commits onto a fresh branch off master so they can land independently without waiting for the larger feature PR to catch up.