### PR TITLE
fix(api): return DUPLICATE_NAME on component name collision (#953)

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -584,6 +584,36 @@ def _check_billing_limits(team_id: str, resource_type: str) -> tuple[bool, str, 
     return True, "", None
 
 
+def _validation_error_response(ve: DjangoValidationError, resource_label: str) -> tuple[int, dict[str, Any]]:
+    """Map ``DjangoValidationError`` from ``full_clean()`` to an ``ErrorResponse`` dict.
+
+    Surfaces ``DUPLICATE_NAME`` when ``validate_unique()`` flagged the failure
+    (``message_dict`` has a ``__all__`` entry saying "already exists"), so
+    clients can distinguish a duplicate from a generic validation failure
+    without grepping the prose detail string. Other validation errors keep
+    ``INVALID_DATA`` so existing behaviour is preserved.
+
+    Issue #953 — ``full_clean()`` raises ``validate_unique()`` BEFORE the
+    DB ``IntegrityError`` ever fires, so handlers that call ``full_clean()``
+    (the three Component CRUD endpoints) never reach their ``IntegrityError``
+    branch on a duplicate name.
+    """
+    msg_dict = ve.message_dict
+    unique_hits = msg_dict.get("__all__", [])
+    is_unique_violation = any("already exists" in m.lower() for m in unique_hits)
+    if is_unique_violation:
+        return 400, {
+            "detail": f"A {resource_label} with this name already exists in this team",
+            "errors": msg_dict,
+            "error_code": ErrorCode.DUPLICATE_NAME,
+        }
+    return 400, {
+        "detail": "Validation error",
+        "errors": msg_dict,
+        "error_code": ErrorCode.INVALID_DATA,
+    }
+
+
 # =============================================================================
 # PRODUCT CRUD ENDPOINTS
 # =============================================================================
@@ -1513,11 +1543,7 @@ def create_component(request: HttpRequest, payload: ComponentCreateSchema) -> An
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return 400, {
-                    "detail": "Validation error",
-                    "errors": ve.message_dict,
-                    "error_code": ErrorCode.INVALID_DATA,
-                }
+                return _validation_error_response(ve, "component")
 
             # Assign default contact profile after validation passes
             default_profile = ContactProfile.objects.filter(team_id=team_id, is_default=True).first()
@@ -1735,11 +1761,7 @@ def update_component(request: HttpRequest, component_id: str, payload: Component
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return 400, {
-                    "detail": "Validation error",
-                    "errors": ve.message_dict,
-                    "error_code": ErrorCode.INVALID_DATA,
-                }
+                return _validation_error_response(ve, "component")
 
             component.save()
 
@@ -1867,11 +1889,7 @@ def patch_component(request: HttpRequest, component_id: str, payload: ComponentP
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return 400, {
-                    "detail": "Validation error",
-                    "errors": ve.message_dict,
-                    "error_code": ErrorCode.INVALID_DATA,
-                }
+                return _validation_error_response(ve, "component")
 
             component.save()
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -26,6 +26,7 @@ from sbomify.apps.core.queries import (
     optimize_component_queryset,
     optimize_product_queryset,
 )
+from sbomify.apps.core.services.validation_response import validation_error_response
 from sbomify.apps.core.utils import broadcast_to_workspace, build_entity_info_dict, verify_item_access
 from sbomify.apps.sboms.schemas import ComponentMetaData, ComponentMetaDataPatch, SupplierSchema
 from sbomify.apps.sboms.utils import get_product_sbom_package, get_release_sbom_package
@@ -582,36 +583,6 @@ def _check_billing_limits(team_id: str, resource_type: str) -> tuple[bool, str, 
         )
 
     return True, "", None
-
-
-def _validation_error_response(ve: DjangoValidationError, resource_label: str) -> tuple[int, dict[str, Any]]:
-    """Map ``DjangoValidationError`` from ``full_clean()`` to an ``ErrorResponse`` dict.
-
-    Surfaces ``DUPLICATE_NAME`` when ``validate_unique()`` flagged the failure
-    (``message_dict`` has a ``__all__`` entry saying "already exists"), so
-    clients can distinguish a duplicate from a generic validation failure
-    without grepping the prose detail string. Other validation errors keep
-    ``INVALID_DATA`` so existing behaviour is preserved.
-
-    Issue #953 — ``full_clean()`` raises ``validate_unique()`` BEFORE the
-    DB ``IntegrityError`` ever fires, so handlers that call ``full_clean()``
-    (the three Component CRUD endpoints) never reach their ``IntegrityError``
-    branch on a duplicate name.
-    """
-    msg_dict = ve.message_dict
-    unique_hits = msg_dict.get("__all__", [])
-    is_unique_violation = any("already exists" in m.lower() for m in unique_hits)
-    if is_unique_violation:
-        return 400, {
-            "detail": f"A {resource_label} with this name already exists in this team",
-            "errors": msg_dict,
-            "error_code": ErrorCode.DUPLICATE_NAME,
-        }
-    return 400, {
-        "detail": "Validation error",
-        "errors": msg_dict,
-        "error_code": ErrorCode.INVALID_DATA,
-    }
 
 
 # =============================================================================
@@ -1543,7 +1514,7 @@ def create_component(request: HttpRequest, payload: ComponentCreateSchema) -> An
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return _validation_error_response(ve, "component")
+                return validation_error_response(ve, "component")
 
             # Assign default contact profile after validation passes
             default_profile = ContactProfile.objects.filter(team_id=team_id, is_default=True).first()
@@ -1761,7 +1732,7 @@ def update_component(request: HttpRequest, component_id: str, payload: Component
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return _validation_error_response(ve, "component")
+                return validation_error_response(ve, "component")
 
             component.save()
 
@@ -1889,7 +1860,7 @@ def patch_component(request: HttpRequest, component_id: str, payload: ComponentP
             try:
                 component.full_clean()
             except DjangoValidationError as ve:
-                return _validation_error_response(ve, "component")
+                return validation_error_response(ve, "component")
 
             component.save()
 

--- a/sbomify/apps/core/services/validation_response.py
+++ b/sbomify/apps/core/services/validation_response.py
@@ -1,0 +1,56 @@
+"""Shared mapping from Django's ``ValidationError`` to a Ninja ``ErrorResponse`` body.
+
+Lives in ``services`` (not ``apis.py``) because both ``core/apis.py`` and
+``teams/apis.py`` need it, and the latter is already imported BY ``core/apis.py``
+(``serialize_contact_profile``) — putting this helper in either ``apis.py``
+would create a circular import.
+
+Issue #953: handlers that call ``.full_clean()`` (or models whose
+``.save()`` calls it) trip ``validate_unique()`` BEFORE the DB ever throws
+``IntegrityError``. The ``DUPLICATE_NAME`` branch on the ``IntegrityError``
+side is unreachable in that case, so we have to detect the unique-violation
+at the ``ValidationError`` layer and surface the dedicated error code there.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from sbomify.apps.core.schemas import ErrorCode
+
+
+def validation_error_response(ve: DjangoValidationError, resource_label: str) -> tuple[int, dict[str, Any]]:
+    """Map a ``DjangoValidationError`` to an ``ErrorResponse`` 400 body.
+
+    Surfaces ``DUPLICATE_NAME`` when ``validate_unique()`` flagged the failure
+    (``message_dict`` has a ``__all__`` entry containing ``"already exists"``)
+    so clients can distinguish a duplicate from a generic validation failure
+    without grepping the prose detail string. Other validation errors stay
+    on ``INVALID_DATA``.
+
+    ``resource_label`` is interpolated into the friendly detail string for
+    duplicate cases ("A {resource_label} with this name already exists in
+    this team") so the same helper can serve component / contact-entity /
+    any future caller without conflating error vocabulary.
+
+    The ``"already exists"`` substring — not just the ``__all__`` key — is
+    the disambiguator: some model-level ``clean()`` rules also bind their
+    errors to ``__all__`` (e.g. "Mutually-exclusive fields A and B were
+    both set") and must NOT be misclassified as a duplicate.
+    """
+    msg_dict = ve.message_dict
+    unique_hits = msg_dict.get("__all__", [])
+    is_unique_violation = any("already exists" in m.lower() for m in unique_hits)
+    if is_unique_violation:
+        return 400, {
+            "detail": f"A {resource_label} with this name already exists in this team",
+            "errors": msg_dict,
+            "error_code": ErrorCode.DUPLICATE_NAME,
+        }
+    return 400, {
+        "detail": "Validation error",
+        "errors": msg_dict,
+        "error_code": ErrorCode.INVALID_DATA,
+    }

--- a/sbomify/apps/core/services/validation_response.py
+++ b/sbomify/apps/core/services/validation_response.py
@@ -41,7 +41,11 @@ def _is_unique_violation(msg_dict: dict[str, list[str]]) -> bool:
     return any("already exists" in m.lower() for messages in msg_dict.values() for m in messages)
 
 
-def validation_error_response(ve: DjangoValidationError, resource_label: str) -> tuple[int, dict[str, Any]]:
+def validation_error_response(
+    ve: DjangoValidationError,
+    resource_label: str,
+    scope_label: str = "team",
+) -> tuple[int, dict[str, Any]]:
     """Map a ``DjangoValidationError`` to an ``ErrorResponse`` 400 body.
 
     Surfaces ``DUPLICATE_NAME`` when ``validate_unique()`` flagged the failure
@@ -49,10 +53,18 @@ def validation_error_response(ve: DjangoValidationError, resource_label: str) ->
     without grepping the prose detail string. Other validation errors stay
     on ``INVALID_DATA``.
 
-    ``resource_label`` is interpolated into the friendly detail string for
-    duplicate cases ("A {resource_label} with this name already exists in
-    this team") so the same helper can serve component / contact-entity /
-    any future caller without conflating error vocabulary.
+    Parameters:
+        ve: The Django ``ValidationError`` raised by ``full_clean()``.
+        resource_label: Singular name of the resource being created/updated
+            (``"component"``, ``"contact entity"``, …). Interpolated into the
+            duplicate detail string.
+        scope_label: The scope inside which uniqueness is enforced. Defaults
+            to ``"team"`` because the bulk of CRUD resources have
+            ``unique_together = ("team", "name")``; pass e.g.
+            ``"contact profile"`` for ``ContactEntity`` whose uniqueness is
+            ``unique_together = ("profile", "name")``. The resulting detail
+            is "A {resource_label} with this name already exists in this
+            {scope_label}".
 
     The ``"already exists"`` substring — not the key name — is the
     disambiguator: some model-level ``clean()`` rules also bind their errors
@@ -62,7 +74,7 @@ def validation_error_response(ve: DjangoValidationError, resource_label: str) ->
     msg_dict = ve.message_dict
     if _is_unique_violation(msg_dict):
         return 400, {
-            "detail": f"A {resource_label} with this name already exists in this team",
+            "detail": f"A {resource_label} with this name already exists in this {scope_label}",
             "errors": msg_dict,
             "error_code": ErrorCode.DUPLICATE_NAME,
         }

--- a/sbomify/apps/core/services/validation_response.py
+++ b/sbomify/apps/core/services/validation_response.py
@@ -20,25 +20,49 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 
 from sbomify.apps.core.schemas import ErrorCode
 
+_UNIQUE_ERROR_CODES = frozenset({"unique", "unique_together"})
 
-def _is_unique_violation(msg_dict: dict[str, list[str]]) -> bool:
-    """Detect "already exists" anywhere in a ``message_dict``.
 
-    Django's ``validate_unique()`` routes errors differently depending on
-    which constraint fired:
+def _is_unique_violation(ve: DjangoValidationError) -> bool:
+    """Detect a uniqueness-constraint failure on a ``DjangoValidationError``.
 
-    - ``Meta.unique_together`` (and ``UniqueConstraint`` without ``fields``-
-      scoped clean) → ``NON_FIELD_ERRORS`` (``"__all__"``).
-    - ``models.CharField(..., unique=True)`` / any single-field uniqueness
-      → keyed by that field name (e.g. ``{"name": ["...already exists."]}``).
+    Prefers the structured ``ValidationError.error_dict`` path so we read the
+    ``code`` attribute Django sets on errors raised by ``validate_unique()``
+    (``"unique"`` for single-field, ``"unique_together"`` for multi-field).
+    This is robust against:
 
-    Both affected models in this PR use ``unique_together`` so the runtime
-    path is always ``__all__``. The any-key scan keeps the helper robust to
-    future schema changes (e.g. adding ``unique=True`` to a slug field) and
-    third-party fields whose validators raise the same message under their
-    own key.
+    - **i18n**: if ``USE_I18N=True`` is ever flipped on, Django translates
+      the default unique message and a substring match for ``"already
+      exists"`` would silently stop matching.
+    - **False positives**: custom ``clean()`` rules that happen to use the
+      phrase "already exists" (e.g. ``ContactProfileContact.clean()`` raises
+      ``"A security contact already exists in this profile..."`` — that's a
+      role-exclusivity rule, NOT a name uniqueness violation, and surfacing
+      it as ``DUPLICATE_NAME`` would tell the API client "rename and retry"
+      when the actual fix is "demote the other security contact").
+
+    Fallback: if ``error_dict`` isn't available (a caller built the
+    ``ValidationError`` from a plain string with no code), drop down to the
+    legacy substring grep so behaviour doesn't regress for those paths.
+
+    See ``teams/views/contact_profiles.py::_format_formset_errors`` for the
+    matching error-code pattern on the HTML form side.
     """
-    return any("already exists" in m.lower() for messages in msg_dict.values() for m in messages)
+    error_dict = getattr(ve, "error_dict", None)
+    if error_dict:
+        for errors in error_dict.values():
+            for err in errors:
+                if getattr(err, "code", None) in _UNIQUE_ERROR_CODES:
+                    return True
+        # error_dict was present but no unique code — definitively NOT a
+        # unique violation (custom clean() raised it; substring grep would
+        # be a false positive here).
+        return False
+    # Plain ``ValidationError("...")`` / ``ValidationError([...])`` —
+    # accessing ``message_dict`` here would raise ``AttributeError``, so
+    # use ``messages`` which is always available. Substring check is the
+    # least-bad option for unstructured input (no ``code`` to read).
+    return any("already exists" in m.lower() for m in ve.messages)
 
 
 def validation_error_response(
@@ -66,13 +90,21 @@ def validation_error_response(
             is "A {resource_label} with this name already exists in this
             {scope_label}".
 
-    The ``"already exists"`` substring — not the key name — is the
-    disambiguator: some model-level ``clean()`` rules also bind their errors
-    to ``__all__`` (e.g. "Mutually-exclusive fields A and B were both set")
-    and must NOT be misclassified as a duplicate.
+    Disambiguation between a true uniqueness violation and a custom
+    ``clean()`` rule that happens to say "already exists" is done by
+    inspecting the ``ValidationError.error_dict``'s ``code`` attribute
+    (Django sets ``code="unique"`` / ``"unique_together"`` on
+    ``validate_unique()``'s errors). See ``_is_unique_violation``.
     """
-    msg_dict = ve.message_dict
-    if _is_unique_violation(msg_dict):
+    # ``message_dict`` raises ``AttributeError`` if the ValidationError
+    # was built from a plain string / list rather than a dict; fall back
+    # to a synthetic ``{"__all__": [...]}`` shape so the response always
+    # carries an ``errors`` dict in the same wire format.
+    try:
+        msg_dict = ve.message_dict
+    except AttributeError:
+        msg_dict = {"__all__": list(ve.messages)}
+    if _is_unique_violation(ve):
         return 400, {
             "detail": f"A {resource_label} with this name already exists in this {scope_label}",
             "errors": msg_dict,

--- a/sbomify/apps/core/services/validation_response.py
+++ b/sbomify/apps/core/services/validation_response.py
@@ -21,11 +21,30 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from sbomify.apps.core.schemas import ErrorCode
 
 
+def _is_unique_violation(msg_dict: dict[str, list[str]]) -> bool:
+    """Detect "already exists" anywhere in a ``message_dict``.
+
+    Django's ``validate_unique()`` routes errors differently depending on
+    which constraint fired:
+
+    - ``Meta.unique_together`` (and ``UniqueConstraint`` without ``fields``-
+      scoped clean) → ``NON_FIELD_ERRORS`` (``"__all__"``).
+    - ``models.CharField(..., unique=True)`` / any single-field uniqueness
+      → keyed by that field name (e.g. ``{"name": ["...already exists."]}``).
+
+    Both affected models in this PR use ``unique_together`` so the runtime
+    path is always ``__all__``. The any-key scan keeps the helper robust to
+    future schema changes (e.g. adding ``unique=True`` to a slug field) and
+    third-party fields whose validators raise the same message under their
+    own key.
+    """
+    return any("already exists" in m.lower() for messages in msg_dict.values() for m in messages)
+
+
 def validation_error_response(ve: DjangoValidationError, resource_label: str) -> tuple[int, dict[str, Any]]:
     """Map a ``DjangoValidationError`` to an ``ErrorResponse`` 400 body.
 
     Surfaces ``DUPLICATE_NAME`` when ``validate_unique()`` flagged the failure
-    (``message_dict`` has a ``__all__`` entry containing ``"already exists"``)
     so clients can distinguish a duplicate from a generic validation failure
     without grepping the prose detail string. Other validation errors stay
     on ``INVALID_DATA``.
@@ -35,15 +54,13 @@ def validation_error_response(ve: DjangoValidationError, resource_label: str) ->
     this team") so the same helper can serve component / contact-entity /
     any future caller without conflating error vocabulary.
 
-    The ``"already exists"`` substring — not just the ``__all__`` key — is
-    the disambiguator: some model-level ``clean()`` rules also bind their
-    errors to ``__all__`` (e.g. "Mutually-exclusive fields A and B were
-    both set") and must NOT be misclassified as a duplicate.
+    The ``"already exists"`` substring — not the key name — is the
+    disambiguator: some model-level ``clean()`` rules also bind their errors
+    to ``__all__`` (e.g. "Mutually-exclusive fields A and B were both set")
+    and must NOT be misclassified as a duplicate.
     """
     msg_dict = ve.message_dict
-    unique_hits = msg_dict.get("__all__", [])
-    is_unique_violation = any("already exists" in m.lower() for m in unique_hits)
-    if is_unique_violation:
+    if _is_unique_violation(msg_dict):
         return 400, {
             "detail": f"A {resource_label} with this name already exists in this team",
             "errors": msg_dict,

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -864,16 +864,16 @@ def test_patch_component_duplicate_name_returns_duplicate_name_code(
 
 
 class TestValidationErrorResponseHelper:
-    """Unit tests for the ``_validation_error_response`` helper that drives
+    """Unit tests for the ``validation_error_response`` helper that drives
     issue #953's DUPLICATE_NAME / INVALID_DATA distinction."""
 
     def test_unique_violation_maps_to_duplicate_name(self):
         from django.core.exceptions import ValidationError
 
-        from sbomify.apps.core.apis import _validation_error_response
+        from sbomify.apps.core.services.validation_response import validation_error_response
 
         ve = ValidationError({"__all__": ["Component with this Team and Name already exists."]})
-        status, body = _validation_error_response(ve, "component")
+        status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "DUPLICATE_NAME"
         assert "already exists" in body["detail"].lower()
@@ -882,10 +882,10 @@ class TestValidationErrorResponseHelper:
     def test_field_level_validation_error_keeps_invalid_data(self):
         from django.core.exceptions import ValidationError
 
-        from sbomify.apps.core.apis import _validation_error_response
+        from sbomify.apps.core.services.validation_response import validation_error_response
 
         ve = ValidationError({"gating_mode": ["gating_mode can only be set when visibility is gated"]})
-        status, body = _validation_error_response(ve, "component")
+        status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "INVALID_DATA"
         assert body["detail"] == "Validation error"
@@ -898,10 +898,10 @@ class TestValidationErrorResponseHelper:
         ``"already exists"`` substring is the disambiguator."""
         from django.core.exceptions import ValidationError
 
-        from sbomify.apps.core.apis import _validation_error_response
+        from sbomify.apps.core.services.validation_response import validation_error_response
 
         ve = ValidationError({"__all__": ["Mutually-exclusive fields A and B were both set."]})
-        status, body = _validation_error_response(ve, "component")
+        status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "INVALID_DATA"
 

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -936,6 +936,23 @@ class TestValidationErrorResponseHelper:
         assert status == 400
         assert body["error_code"].value == "INVALID_DATA"
 
+    def test_scope_label_overrides_default_team_wording(self):
+        """``scope_label`` lets callers whose model isn't team-scoped
+        produce an accurate duplicate detail. ContactEntity uses
+        ``unique_together = ("profile", "name")``, so its handlers pass
+        ``scope_label="contact profile"`` and the response should read
+        "in this contact profile" — never "in this team"."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = ValidationError({"__all__": ["Contact entity with this Profile and Name already exists."]})
+        status, body = validation_error_response(ve, "contact entity", scope_label="contact profile")
+        assert status == 400
+        assert body["error_code"].value == "DUPLICATE_NAME"
+        assert "in this contact profile" in body["detail"]
+        assert "team" not in body["detail"].lower()
+
 
 # =============================================================================
 # BUSINESS LOGIC TESTS (Moved from View Tests)

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -789,6 +789,123 @@ def test_patch_component_empty_body(
     assert data["metadata"] == sample_component.metadata
 
 
+@pytest.mark.django_db
+def test_update_component_duplicate_name_returns_duplicate_name_code(
+    sample_component: Component,  # noqa: F811
+    sample_access_token: AccessToken,  # noqa: F811
+):
+    """Issue #953: PUT /components/{id} with a name that collides with an
+    existing component in the same team must surface ``DUPLICATE_NAME``, not
+    the generic ``INVALID_DATA`` that ``full_clean()``'s
+    ``validate_unique()`` would otherwise produce."""
+    client = Client()
+    # Create a second component in the same team to collide with
+    Component.objects.create(
+        name="Existing Component",
+        team=sample_component.team,
+        component_type=sample_component.component_type,
+    )
+
+    url = reverse("api-1:update_component", kwargs={"component_id": sample_component.id})
+    payload = {
+        "name": "Existing Component",
+        "visibility": "private",
+        "is_global": False,
+        "metadata": {},
+    }
+
+    assert client.login(username=os.environ["DJANGO_TEST_USER"], password=os.environ["DJANGO_TEST_PASSWORD"])
+    setup_test_session(client, sample_component.team, sample_component.team.members.first())
+
+    response = client.put(
+        url,
+        json.dumps(payload),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error_code"] == "DUPLICATE_NAME"
+    assert "already exists" in body["detail"].lower()
+
+
+@pytest.mark.django_db
+def test_patch_component_duplicate_name_returns_duplicate_name_code(
+    sample_component: Component,  # noqa: F811
+    sample_access_token: AccessToken,  # noqa: F811
+):
+    """Issue #953: same invariant as the PUT case, but via PATCH (which goes
+    through a separate handler with its own ``full_clean()`` call)."""
+    client = Client()
+    Component.objects.create(
+        name="Other Component",
+        team=sample_component.team,
+        component_type=sample_component.component_type,
+    )
+
+    url = reverse("api-1:patch_component", kwargs={"component_id": sample_component.id})
+    payload = {"name": "Other Component"}
+
+    assert client.login(username=os.environ["DJANGO_TEST_USER"], password=os.environ["DJANGO_TEST_PASSWORD"])
+    setup_test_session(client, sample_component.team, sample_component.team.members.first())
+
+    response = client.patch(
+        url,
+        json.dumps(payload),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error_code"] == "DUPLICATE_NAME"
+    assert "already exists" in body["detail"].lower()
+
+
+class TestValidationErrorResponseHelper:
+    """Unit tests for the ``_validation_error_response`` helper that drives
+    issue #953's DUPLICATE_NAME / INVALID_DATA distinction."""
+
+    def test_unique_violation_maps_to_duplicate_name(self):
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.apis import _validation_error_response
+
+        ve = ValidationError({"__all__": ["Component with this Team and Name already exists."]})
+        status, body = _validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "DUPLICATE_NAME"
+        assert "already exists" in body["detail"].lower()
+        assert "__all__" in body["errors"]
+
+    def test_field_level_validation_error_keeps_invalid_data(self):
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.apis import _validation_error_response
+
+        ve = ValidationError({"gating_mode": ["gating_mode can only be set when visibility is gated"]})
+        status, body = _validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "INVALID_DATA"
+        assert body["detail"] == "Validation error"
+        assert "gating_mode" in body["errors"]
+
+    def test_all_key_without_already_exists_keeps_invalid_data(self):
+        """Some non-uniqueness errors also land under ``__all__`` (custom
+        model-level ``clean()`` rules that don't bind to a single field).
+        The helper must NOT misclassify those as DUPLICATE_NAME — the
+        ``"already exists"`` substring is the disambiguator."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.apis import _validation_error_response
+
+        ve = ValidationError({"__all__": ["Mutually-exclusive fields A and B were both set."]})
+        status, body = _validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "INVALID_DATA"
+
+
 # =============================================================================
 # BUSINESS LOGIC TESTS (Moved from View Tests)
 # =============================================================================
@@ -953,20 +1070,11 @@ class TestDuplicateNamesAPI:
         )
         assert response.status_code == 400
         error_response = response.json()
-        # The error might be in detail (IntegrityError) or errors.name (ValidationError)
-        # Check if it's a validation error with name field, or integrity error with "already exists"
-        detail = error_response.get("detail", "")
-        errors = error_response.get("errors", {})
-        # Accept either "already exists" in detail, or validation error (which may not include errors dict)
-        # The important thing is that we get a 400 error for duplicate names
-        has_duplicate_error = (
-            "already exists" in detail
-            or (errors and "name" in errors)
-            or (
-                detail == "Validation error" and response.status_code == 400
-            )  # Validation error for duplicate is acceptable
-        )
-        assert has_duplicate_error, f"Expected duplicate name error (400), got: {error_response}"
+        # Issue #953: full_clean() raises validate_unique() before the DB
+        # IntegrityError ever fires, so the handler MUST surface
+        # DUPLICATE_NAME directly rather than the generic INVALID_DATA.
+        assert error_response["error_code"] == "DUPLICATE_NAME"
+        assert "already exists" in error_response["detail"].lower()
 
         # Verify only one component exists
         assert Component.objects.filter(team=team, name="Duplicate Component").count() == 1

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -905,6 +905,37 @@ class TestValidationErrorResponseHelper:
         assert status == 400
         assert body["error_code"].value == "INVALID_DATA"
 
+    def test_field_keyed_unique_violation_maps_to_duplicate_name(self):
+        """Single-field ``unique=True`` constraints (as opposed to
+        ``Meta.unique_together``) surface the validation error under the
+        field name, NOT ``__all__``. Pin the helper's any-key scan so the
+        DUPLICATE_NAME detection still fires for those cases — guards
+        against a future model adding ``unique=True`` to a slug/email/etc."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = ValidationError({"name": ["Component with this Name already exists."]})
+        status, body = validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "DUPLICATE_NAME"
+        assert "already exists" in body["detail"].lower()
+        assert "name" in body["errors"]
+
+    def test_field_keyed_non_unique_error_keeps_invalid_data(self):
+        """Symmetry-pin for the field-keyed branch: a field-level error
+        whose message does NOT contain "already exists" must stay on
+        ``INVALID_DATA`` (i.e. the any-key scan still respects the
+        substring disambiguator, not just the key location)."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = ValidationError({"slug": ["Enter a valid slug consisting of letters, numbers, hyphens or underscores."]})
+        status, body = validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "INVALID_DATA"
+
 
 # =============================================================================
 # BUSINESS LOGIC TESTS (Moved from View Tests)

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -867,12 +867,25 @@ class TestValidationErrorResponseHelper:
     """Unit tests for the ``validation_error_response`` helper that drives
     issue #953's DUPLICATE_NAME / INVALID_DATA distinction."""
 
-    def test_unique_violation_maps_to_duplicate_name(self):
+    @staticmethod
+    def _unique_together_error(field: str, msg: str):
+        """Build a ``ValidationError`` that mirrors what Django's
+        ``validate_unique()`` actually raises — ``ValidationError(code=...)``
+        nested inside an ``error_dict``. Plain ``ValidationError({field:
+        [msg]})`` does NOT populate the ``code`` attribute, so unit tests
+        that bypass real ``validate_unique`` MUST construct the nested
+        error explicitly or they'll silently exercise the substring
+        fallback rather than the code-based primary path."""
         from django.core.exceptions import ValidationError
 
+        return ValidationError(
+            {field: [ValidationError(msg, code="unique_together" if field == "__all__" else "unique")]}
+        )
+
+    def test_unique_violation_maps_to_duplicate_name(self):
         from sbomify.apps.core.services.validation_response import validation_error_response
 
-        ve = ValidationError({"__all__": ["Component with this Team and Name already exists."]})
+        ve = self._unique_together_error("__all__", "Component with this Team and Name already exists.")
         status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "DUPLICATE_NAME"
@@ -891,31 +904,61 @@ class TestValidationErrorResponseHelper:
         assert body["detail"] == "Validation error"
         assert "gating_mode" in body["errors"]
 
-    def test_all_key_without_already_exists_keeps_invalid_data(self):
+    def test_all_key_without_unique_code_keeps_invalid_data(self):
         """Some non-uniqueness errors also land under ``__all__`` (custom
         model-level ``clean()`` rules that don't bind to a single field).
         The helper must NOT misclassify those as DUPLICATE_NAME — the
-        ``"already exists"`` substring is the disambiguator."""
+        ``code="unique"/"unique_together"`` is the disambiguator."""
         from django.core.exceptions import ValidationError
 
         from sbomify.apps.core.services.validation_response import validation_error_response
 
+        # Plain string with no ``code`` set — represents a custom clean() rule.
         ve = ValidationError({"__all__": ["Mutually-exclusive fields A and B were both set."]})
         status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "INVALID_DATA"
 
-    def test_field_keyed_unique_violation_maps_to_duplicate_name(self):
-        """Single-field ``unique=True`` constraints (as opposed to
-        ``Meta.unique_together``) surface the validation error under the
-        field name, NOT ``__all__``. Pin the helper's any-key scan so the
-        DUPLICATE_NAME detection still fires for those cases — guards
-        against a future model adding ``unique=True`` to a slug/email/etc."""
+    def test_already_exists_in_clean_rule_message_keeps_invalid_data(self):
+        """R3 Copilot regression guard: ``ContactProfileContact.clean()``
+        raises ``ValidationError("A security contact already exists in this
+        profile. ...")`` to enforce a role-exclusivity rule, NOT name
+        uniqueness. The previous substring-grep implementation would have
+        misclassified this as ``DUPLICATE_NAME`` and told the API client
+        "rename and retry" when the right fix is "demote the other
+        security contact". Now we read ``ValidationError.code`` to
+        disambiguate."""
         from django.core.exceptions import ValidationError
 
         from sbomify.apps.core.services.validation_response import validation_error_response
 
-        ve = ValidationError({"name": ["Component with this Name already exists."]})
+        # Mirrors the real raise in ``ContactProfileContact.clean()`` — a
+        # plain-string ValidationError with NO unique code attached, even
+        # though the prose contains "already exists".
+        ve = ValidationError(
+            {
+                "__all__": [
+                    ValidationError(
+                        "A security contact already exists in this profile. "
+                        "Each profile can have only one security/vulnerability reporting contact."
+                    )
+                ]
+            }
+        )
+        status, body = validation_error_response(ve, "contact")
+        assert status == 400
+        assert body["error_code"].value == "INVALID_DATA", (
+            f"misclassified non-uniqueness clean() rule as DUPLICATE_NAME: {body}"
+        )
+
+    def test_field_keyed_unique_violation_maps_to_duplicate_name(self):
+        """Single-field ``unique=True`` constraints (as opposed to
+        ``Meta.unique_together``) surface the validation error under the
+        field name with ``code="unique"``. Pin both shapes so a future
+        model adding ``unique=True`` to a slug/email keeps working."""
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = self._unique_together_error("name", "Component with this Name already exists.")
         status, body = validation_error_response(ve, "component")
         assert status == 400
         assert body["error_code"].value == "DUPLICATE_NAME"
@@ -924,9 +967,7 @@ class TestValidationErrorResponseHelper:
 
     def test_field_keyed_non_unique_error_keeps_invalid_data(self):
         """Symmetry-pin for the field-keyed branch: a field-level error
-        whose message does NOT contain "already exists" must stay on
-        ``INVALID_DATA`` (i.e. the any-key scan still respects the
-        substring disambiguator, not just the key location)."""
+        whose code is NOT ``unique`` must stay on ``INVALID_DATA``."""
         from django.core.exceptions import ValidationError
 
         from sbomify.apps.core.services.validation_response import validation_error_response
@@ -942,16 +983,50 @@ class TestValidationErrorResponseHelper:
         ``unique_together = ("profile", "name")``, so its handlers pass
         ``scope_label="contact profile"`` and the response should read
         "in this contact profile" — never "in this team"."""
-        from django.core.exceptions import ValidationError
-
         from sbomify.apps.core.services.validation_response import validation_error_response
 
-        ve = ValidationError({"__all__": ["Contact entity with this Profile and Name already exists."]})
+        ve = self._unique_together_error("__all__", "Contact entity with this Profile and Name already exists.")
         status, body = validation_error_response(ve, "contact entity", scope_label="contact profile")
         assert status == 400
         assert body["error_code"].value == "DUPLICATE_NAME"
         assert "in this contact profile" in body["detail"]
         assert "team" not in body["detail"].lower()
+
+    def test_dict_with_string_messages_and_no_code_is_invalid_data(self):
+        """``ValidationError({"__all__": ["...already exists."]})`` (dict
+        with plain string values) still populates ``error_dict``, but the
+        inner errors carry ``code=None``. The R3 fix treats that as
+        NOT-a-uniqueness violation — which is the correct strict reading:
+        if the caller didn't wrap their string in
+        ``ValidationError(msg, code="unique")``, there's no structured
+        signal that it actually IS a uniqueness error. Real
+        ``validate_unique()`` always sets the code, so production paths
+        are unaffected; only synthetic ``ValidationError(dict_of_strings)``
+        constructions land here, and INVALID_DATA is the safer default."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = ValidationError({"__all__": ["Component with this Team and Name already exists."]})
+        status, body = validation_error_response(ve, "component")
+        assert status == 400
+        assert body["error_code"].value == "INVALID_DATA"
+
+    def test_plain_string_no_dict_falls_back_to_substring(self):
+        """``ValidationError("...already exists.")`` (no dict, no code)
+        is the ONLY shape that hits the substring fallback. Pin it so the
+        fallback path doesn't silently disappear if someone refactors the
+        helper — synthetic callers that rebuild a ValidationError from a
+        DB exception's args still get the duplicate code mapped."""
+        from django.core.exceptions import ValidationError
+
+        from sbomify.apps.core.services.validation_response import validation_error_response
+
+        ve = ValidationError("Component with this Team and Name already exists.")
+        status, body = validation_error_response(ve, "component")
+        assert status == 400
+        # No error_dict on this shape → substring grep on message_dict.
+        assert body["error_code"].value == "DUPLICATE_NAME"
 
 
 # =============================================================================

--- a/sbomify/apps/core/tests/test_error_response_field_errors.py
+++ b/sbomify/apps/core/tests/test_error_response_field_errors.py
@@ -82,11 +82,12 @@ def test_duplicate_component_name_returns_field_errors(
     # with no `errors` key at all.
     assert "errors" in data, f"ErrorResponse.errors was stripped (issue #952 regression). Got: {data}"
     assert isinstance(data["errors"], dict)
-    # Django's `unique_together = ("team", "name")` constraint surfaces
-    # as a per-instance error keyed by `__all__` (Django's catch-all).
-    # The exact key may be `__all__` or `name` depending on which clean
-    # path raised; the important assertion is that SOMETHING per-field
-    # made it through.
+    # Django's ``unique_together = ("team", "name")`` constraint surfaces
+    # the validation error under ``__all__`` (NON_FIELD_ERRORS). The
+    # important assertion for the #952 regression is that the dict
+    # survived serialization at all; the helper's any-key scan covers
+    # the alternative single-field ``unique=True`` shape in
+    # ``TestValidationErrorResponseHelper``.
     assert any(data["errors"].values()), f"`errors` dict was preserved but is empty: {data['errors']}"
 
 

--- a/sbomify/apps/core/tests/test_error_response_field_errors.py
+++ b/sbomify/apps/core/tests/test_error_response_field_errors.py
@@ -69,25 +69,25 @@ def test_duplicate_component_name_returns_field_errors(
 
     # Standard fields: still there
     assert "detail" in data
-    assert data.get("error_code") == "INVALID_DATA"
+    # Issue #953: the same path that this test exercises (POST a duplicate
+    # name) now surfaces ``DUPLICATE_NAME`` directly instead of the catch-all
+    # ``INVALID_DATA``. The original #952 invariant — "errors dict survives
+    # serialization" — is unchanged; only the error_code label is more
+    # specific now.
+    assert data.get("error_code") == "DUPLICATE_NAME"
 
     # The new fix: `errors` field is preserved on the wire (not stripped
     # by the django-ninja serializer). Before the schema fix, this assertion
     # would fail because the response was `{"detail": "...", "error_code": "..."}`
     # with no `errors` key at all.
-    assert "errors" in data, (
-        "ErrorResponse.errors was stripped (issue #952 regression). "
-        f"Got: {data}"
-    )
+    assert "errors" in data, f"ErrorResponse.errors was stripped (issue #952 regression). Got: {data}"
     assert isinstance(data["errors"], dict)
     # Django's `unique_together = ("team", "name")` constraint surfaces
     # as a per-instance error keyed by `__all__` (Django's catch-all).
     # The exact key may be `__all__` or `name` depending on which clean
     # path raised; the important assertion is that SOMETHING per-field
     # made it through.
-    assert any(data["errors"].values()), (
-        f"`errors` dict was preserved but is empty: {data['errors']}"
-    )
+    assert any(data["errors"].values()), f"`errors` dict was preserved but is empty: {data['errors']}"
 
 
 @pytest.mark.django_db
@@ -103,9 +103,9 @@ def test_error_response_schema_round_trip():
         errors={"name": ["Component with this Team and Name already exists."]},
     )
     dumped = resp.model_dump()
-    assert dumped["errors"] == {
-        "name": ["Component with this Team and Name already exists."]
-    }, "ErrorResponse.errors must round-trip through pydantic serialization."
+    assert dumped["errors"] == {"name": ["Component with this Team and Name already exists."]}, (
+        "ErrorResponse.errors must round-trip through pydantic serialization."
+    )
 
     # Without `errors` set, the field defaults to None at the pydantic
     # level. Note: django-ninja does NOT apply `exclude_none` by default,

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -19,7 +19,7 @@ from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
 from sbomify.apps.core.models import User
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.posthog_service import capture_for_request
-from sbomify.apps.core.schemas import ErrorResponse
+from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.core.services.validation_response import validation_error_response
 from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.teams.models import ContactEntity, ContactProfile, ContactProfileContact, Member, Team
@@ -812,8 +812,21 @@ def create_contact_profile(request: HttpRequest, team_key: str, payload: Contact
         return 400, {"detail": str(e)}
     except DjangoValidationError as ve:
         return validation_error_response(ve, "contact entity", scope_label="contact profile")
-    except IntegrityError:
-        return 400, {"detail": "A profile with this name already exists"}
+    except IntegrityError as e:
+        # The atomic block touches ContactProfile, ContactEntity, AND
+        # ContactProfileContact — each with its own unique constraints
+        # (profile name, entity name per profile, contact name+email per
+        # entity). ``full_clean()`` covers all three at the model layer,
+        # so this branch is a backstop for genuine concurrent-write races
+        # where validate_unique() passed and a DB constraint then fired.
+        # Log the underlying exception so operators can identify which
+        # constraint tripped; return a non-specific 400 rather than
+        # presuming the failure was the profile name.
+        logger.warning("IntegrityError in contact-profile handler: %s", e)
+        return 400, {
+            "detail": "Could not save contact profile due to a database constraint (possibly a duplicate name)",
+            "error_code": ErrorCode.DUPLICATE_NAME,
+        }
 
 
 @router.patch(
@@ -914,8 +927,21 @@ def update_contact_profile(
         return 400, {"detail": str(e)}
     except DjangoValidationError as ve:
         return validation_error_response(ve, "contact entity", scope_label="contact profile")
-    except IntegrityError:
-        return 400, {"detail": "A profile with this name already exists"}
+    except IntegrityError as e:
+        # The atomic block touches ContactProfile, ContactEntity, AND
+        # ContactProfileContact — each with its own unique constraints
+        # (profile name, entity name per profile, contact name+email per
+        # entity). ``full_clean()`` covers all three at the model layer,
+        # so this branch is a backstop for genuine concurrent-write races
+        # where validate_unique() passed and a DB constraint then fired.
+        # Log the underlying exception so operators can identify which
+        # constraint tripped; return a non-specific 400 rather than
+        # presuming the failure was the profile name.
+        logger.warning("IntegrityError in contact-profile handler: %s", e)
+        return 400, {
+            "detail": "Could not save contact profile due to a database constraint (possibly a duplicate name)",
+            "error_code": ErrorCode.DUPLICATE_NAME,
+        }
 
 
 @router.delete(

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
 from django.http import HttpRequest
 from ninja import File, Router
@@ -19,6 +20,7 @@ from sbomify.apps.core.models import User
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.posthog_service import capture_for_request
 from sbomify.apps.core.schemas import ErrorResponse
+from sbomify.apps.core.services.validation_response import validation_error_response
 from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.teams.models import ContactEntity, ContactProfile, ContactProfileContact, Member, Team
 from sbomify.apps.teams.schemas import (
@@ -808,6 +810,8 @@ def create_contact_profile(request: HttpRequest, team_key: str, payload: Contact
         return 201, serialize_contact_profile(profile)
     except ValueError as e:
         return 400, {"detail": str(e)}
+    except DjangoValidationError as ve:
+        return validation_error_response(ve, "contact entity")
     except IntegrityError:
         return 400, {"detail": "A profile with this name already exists"}
 
@@ -908,6 +912,8 @@ def update_contact_profile(
         return 200, serialize_contact_profile(profile)
     except ValueError as e:
         return 400, {"detail": str(e)}
+    except DjangoValidationError as ve:
+        return validation_error_response(ve, "contact entity")
     except IntegrityError:
         return 400, {"detail": "A profile with this name already exists"}
 

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -811,7 +811,7 @@ def create_contact_profile(request: HttpRequest, team_key: str, payload: Contact
     except ValueError as e:
         return 400, {"detail": str(e)}
     except DjangoValidationError as ve:
-        return validation_error_response(ve, "contact entity")
+        return validation_error_response(ve, "contact entity", scope_label="contact profile")
     except IntegrityError:
         return 400, {"detail": "A profile with this name already exists"}
 
@@ -913,7 +913,7 @@ def update_contact_profile(
     except ValueError as e:
         return 400, {"detail": str(e)}
     except DjangoValidationError as ve:
-        return validation_error_response(ve, "contact entity")
+        return validation_error_response(ve, "contact entity", scope_label="contact profile")
     except IntegrityError:
         return 400, {"detail": "A profile with this name already exists"}
 

--- a/sbomify/apps/teams/tests/test_contact_profiles.py
+++ b/sbomify/apps/teams/tests/test_contact_profiles.py
@@ -805,7 +805,10 @@ def test_create_contact_profile_duplicate_entity_name_returns_400(
     assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
     body = response.json()
     assert body["error_code"] == "DUPLICATE_NAME"
+    # Detail string must scope the duplicate to the profile, not the team —
+    # ContactEntity's ``unique_together = ("profile", "name")`` is per-profile.
     assert "already exists" in body["detail"].lower()
+    assert "contact profile" in body["detail"].lower()
 
 
 @pytest.mark.django_db
@@ -869,7 +872,10 @@ def test_update_contact_profile_legacy_rename_to_duplicate_returns_400(
     assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
     body = response.json()
     assert body["error_code"] == "DUPLICATE_NAME", f"got body: {body}"
+    # Detail string must scope the duplicate to the profile, not the team —
+    # ContactEntity's ``unique_together = ("profile", "name")`` is per-profile.
     assert "already exists" in body["detail"].lower()
+    assert "contact profile" in body["detail"].lower()
 
 
 @pytest.mark.django_db
@@ -924,4 +930,7 @@ def test_update_contact_profile_entities_duplicate_name_returns_400(
     assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
     body = response.json()
     assert body["error_code"] == "DUPLICATE_NAME", f"got body: {body}"
+    # Detail string must scope the duplicate to the profile, not the team —
+    # ContactEntity's ``unique_together = ("profile", "name")`` is per-profile.
     assert "already exists" in body["detail"].lower()
+    assert "contact profile" in body["detail"].lower()

--- a/sbomify/apps/teams/tests/test_contact_profiles.py
+++ b/sbomify/apps/teams/tests/test_contact_profiles.py
@@ -17,7 +17,7 @@ from sbomify.apps.teams.models import ContactProfile
 @pytest.mark.django_db
 def test_contact_profile_crud_with_entities(sample_team_with_owner_member, authenticated_api_client):  # noqa: F811
     """Test CRUD operations using the new entity-based structure (CycloneDX aligned).
-    
+
     Authors are now stored as entity contacts with is_author=True, not in a separate table.
     When authors are passed via API, they are created as entity contacts.
     """
@@ -522,9 +522,7 @@ def test_delete_aware_mixin_excludes_deleted_pks_from_unique_validation(
     )
 
     # Create a contact with a unique name and email combination
-    contact1 = ContactProfileContact.objects.create(
-        entity=entity, name="John Doe", email="john@example.com"
-    )
+    contact1 = ContactProfileContact.objects.create(entity=entity, name="John Doe", email="john@example.com")
 
     # Create a form for a new contact with the same name and email
     form_data = {
@@ -535,11 +533,7 @@ def test_delete_aware_mixin_excludes_deleted_pks_from_unique_validation(
 
     # CONTROL TEST: Without exclusion, a duplicate should be detected
     # Verify that a duplicate exists in the database (this proves the control case)
-    lookup_kwargs = {
-        "entity": entity,
-        "name": "John Doe",
-        "email": "john@example.com"
-    }
+    lookup_kwargs = {"entity": entity, "name": "John Doe", "email": "john@example.com"}
     # Without exclusion, this query should find contact1 (the duplicate)
     duplicates_without_exclusion = ContactProfileContact.objects.filter(**lookup_kwargs)
     assert duplicates_without_exclusion.exists(), (
@@ -547,34 +541,33 @@ def test_delete_aware_mixin_excludes_deleted_pks_from_unique_validation(
         "This proves that validate_unique should detect the duplicate when exclude_pks doesn't include it."
     )
     assert contact1.pk in duplicates_without_exclusion.values_list("pk", flat=True)
-    
+
     # Verify the mixin's query logic (used by validate_unique) would find the duplicate
     # when contact1.pk is not excluded. This simulates what validate_unique() does internally.
     form_without_exclusion = ContactProfileContactForm(data=form_data)
     form_without_exclusion.instance.entity = entity
     form_without_exclusion.instance.entity_id = entity.pk
-    
+
     # Populate cleaned_data and set instance values so validate_unique can access them
     form_without_exclusion.is_valid()
     if form_without_exclusion.is_valid():
         form_without_exclusion.instance.name = form_without_exclusion.cleaned_data["name"]
         form_without_exclusion.instance.email = form_without_exclusion.cleaned_data["email"]
-    
+
     # Set _exclude_pks_from_unique to a non-empty set that doesn't include contact1.pk
     # This forces the mixin to use its custom logic, but contact1.pk is not excluded
     form_without_exclusion._exclude_pks_from_unique = {999999}  # Non-existent PK, so contact1 won't be excluded
-    
+
     # Verify the mixin's query logic would find the duplicate (this simulates what validate_unique does)
     test_lookup = {
         "entity": form_without_exclusion.instance.entity,
         "name": form_without_exclusion.instance.name,
-        "email": form_without_exclusion.instance.email
+        "email": form_without_exclusion.instance.email,
     }
     # Without excluding contact1.pk, the query should find it
     test_duplicates = ContactProfileContact.objects.filter(**test_lookup).exclude(pk__in={999999})
     assert test_duplicates.exists(), (
-        "Control test: The mixin's query logic should find the duplicate when it's not excluded. "
-        f"Lookup: {test_lookup}"
+        f"Control test: The mixin's query logic should find the duplicate when it's not excluded. Lookup: {test_lookup}"
     )
     assert contact1.pk in test_duplicates.values_list("pk", flat=True), (
         "Control test: contact1.pk should be found by the query when not excluded. "
@@ -598,11 +591,11 @@ def test_delete_aware_mixin_excludes_deleted_pks_from_unique_validation(
     if form_with_exclusion.is_valid():
         form_with_exclusion.instance.name = form_with_exclusion.cleaned_data["name"]
         form_with_exclusion.instance.email = form_with_exclusion.cleaned_data["email"]
-    
+
     # validate_unique should complete without raising ValidationError
     # because contact1.pk is excluded from the unique check query
     form_with_exclusion.validate_unique()  # Should not raise ValidationError
-    
+
     # If we get here without a ValidationError, the mixin is working correctly
     assert form_with_exclusion._exclude_pks_from_unique == {contact1.pk}
 
@@ -631,9 +624,8 @@ def test_base_delete_aware_inline_formset_excludes_deleted_forms(
 
     # Create a contact for entity1 (required for entities)
     from sbomify.apps.teams.models import ContactProfileContact
-    ContactProfileContact.objects.create(
-        entity=entity1, name="Contact", email="contact@example.com"
-    )
+
+    ContactProfileContact.objects.create(entity=entity1, name="Contact", email="contact@example.com")
 
     # Create formset data that deletes entity1 and adds a new entity with the same name
     # This tests that we can delete and re-add with the same name
@@ -667,7 +659,7 @@ def test_base_delete_aware_inline_formset_excludes_deleted_forms(
 
     # Check if formset is valid
     is_valid = formset.is_valid()
-    
+
     # If not valid, check that it's not due to unique constraint on name
     # (it might fail for other reasons like missing contacts)
     if not is_valid:
@@ -675,20 +667,19 @@ def test_base_delete_aware_inline_formset_excludes_deleted_forms(
         errors = formset.errors
         non_field_errors = formset.non_form_errors()
         form_errors = [form.errors for form in formset.forms]
-        
+
         # The formset should not have unique constraint errors on name
         # when the entity with that name is marked for deletion
         # We check that there's NO unique constraint error on the name field by ensuring
         # that if "already exists" appears, it's not related to the "name" field
         error_messages = str(errors) + str(non_field_errors) + str(form_errors)
         error_messages_lower = error_messages.lower()
-        
+
         # Use AND logic: fail only if BOTH "already exists" AND "name" are present
         # This correctly verifies there's no unique constraint error on the name field
         has_name_unique_error = "already exists" in error_messages_lower and "name" in error_messages_lower
         assert not has_name_unique_error, (
-            f"Expected no unique constraint error on name field when entity is deleted. "
-            f"Got errors: {error_messages}"
+            f"Expected no unique constraint error on name field when entity is deleted. Got errors: {error_messages}"
         )
     else:
         # If valid, that's perfect
@@ -710,12 +701,8 @@ def test_base_delete_aware_inline_formset_multiple_deletions(
     )
 
     # Create two contacts with the same name
-    contact1 = ContactProfileContact.objects.create(
-        entity=entity, name="Same Contact", email="contact1@example.com"
-    )
-    contact2 = ContactProfileContact.objects.create(
-        entity=entity, name="Same Contact", email="contact2@example.com"
-    )
+    contact1 = ContactProfileContact.objects.create(entity=entity, name="Same Contact", email="contact1@example.com")
+    contact2 = ContactProfileContact.objects.create(entity=entity, name="Same Contact", email="contact2@example.com")
 
     # Create formset data that deletes both contacts and adds a new one with the same name
     formset_data = {
@@ -767,3 +754,174 @@ def test_delete_aware_mixin_without_excluded_pks_uses_default_validation(
     # Should use default validation (no _exclude_pks_from_unique attribute)
     # This should work for a new entity
     assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_create_contact_profile_duplicate_entity_name_returns_400(
+    sample_team_with_owner_member,  # noqa: F811
+    authenticated_api_client,
+):
+    """Issue #953 (related): POSTing a contact profile with two entities
+    sharing the same name must surface a clean ``DUPLICATE_NAME`` 400.
+
+    Before the fix the ``ContactEntity.save()`` chain called ``full_clean()``,
+    ``validate_unique()`` raised a ``DjangoValidationError`` that the
+    outer ``try`` block didn't catch, and Django returned **HTTP 500** —
+    worse than the issue-#953 mislabeling because the request looked like
+    a server failure rather than a validation problem."""
+    team = sample_team_with_owner_member.team
+    client, token = authenticated_api_client
+    headers = get_api_headers(token)
+
+    payload = {
+        "name": "Dup-Entity Profile",
+        "entities": [
+            {
+                "name": "Same Name",
+                "email": "first@example.com",
+                "is_manufacturer": True,
+                "is_supplier": False,
+                "is_author": False,
+                "contacts": [{"name": "C1", "email": "c1@example.com"}],
+            },
+            {
+                "name": "Same Name",
+                "email": "second@example.com",
+                "is_manufacturer": False,
+                "is_supplier": True,
+                "is_author": False,
+                "contacts": [{"name": "C2", "email": "c2@example.com"}],
+            },
+        ],
+    }
+
+    response = client.post(
+        f"/api/v1/workspaces/{team.key}/contact-profiles",
+        json.dumps(payload),
+        content_type="application/json",
+        **headers,
+    )
+
+    assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
+    body = response.json()
+    assert body["error_code"] == "DUPLICATE_NAME"
+    assert "already exists" in body["detail"].lower()
+
+
+@pytest.mark.django_db
+def test_update_contact_profile_legacy_rename_to_duplicate_returns_400(
+    sample_team_with_owner_member,  # noqa: F811
+    authenticated_api_client,
+):
+    """Issue #953 (related): PATCH on the legacy single-entity rename path
+    (``payload.company`` mutates ``first_entity.name``) must surface a
+    clean 400 with ``DUPLICATE_NAME`` when the new name collides with
+    another entity in the same profile, instead of crashing with 500."""
+    team = sample_team_with_owner_member.team
+    client, token = authenticated_api_client
+    headers = get_api_headers(token)
+
+    create_payload = {
+        "name": "Rename-Collision Profile",
+        "entities": [
+            {
+                "name": "Original",
+                "email": "first@example.com",
+                "is_manufacturer": True,
+                "is_supplier": False,
+                "is_author": False,
+                "contacts": [{"name": "C1", "email": "c1@example.com"}],
+            },
+            {
+                "name": "Squatter",
+                "email": "second@example.com",
+                "is_manufacturer": False,
+                "is_supplier": True,
+                "is_author": False,
+                "contacts": [{"name": "C2", "email": "c2@example.com"}],
+            },
+        ],
+    }
+    response = client.post(
+        f"/api/v1/workspaces/{team.key}/contact-profiles",
+        json.dumps(create_payload),
+        content_type="application/json",
+        **headers,
+    )
+    assert response.status_code == 201
+    profile_id = response.json()["id"]
+
+    # The first entity returned by ``profile.entities.first()`` is the one
+    # the legacy ``payload.company`` rename targets. Find it so the assertion
+    # is unambiguous about which row will collide.
+    profile = ContactProfile.objects.get(id=profile_id)
+    first = profile.entities.first()
+    assert first is not None
+    other_name = "Squatter" if first.name == "Original" else "Original"
+
+    response = client.patch(
+        f"/api/v1/workspaces/{team.key}/contact-profiles/{profile_id}",
+        json.dumps({"company": other_name}),
+        content_type="application/json",
+        **headers,
+    )
+
+    assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
+    body = response.json()
+    assert body["error_code"] == "DUPLICATE_NAME", f"got body: {body}"
+    assert "already exists" in body["detail"].lower()
+
+
+@pytest.mark.django_db
+def test_update_contact_profile_entities_duplicate_name_returns_400(
+    sample_team_with_owner_member,  # noqa: F811
+    authenticated_api_client,
+):
+    """Same invariant as the legacy-rename test, but via the new
+    entity-based PATCH (``payload.entities`` → ``_upsert_entities``).
+    Submitting two new entities with the same name must surface a clean
+    DUPLICATE_NAME 400, not bubble up as 500."""
+    team = sample_team_with_owner_member.team
+    client, token = authenticated_api_client
+    headers = get_api_headers(token)
+
+    response = client.post(
+        f"/api/v1/workspaces/{team.key}/contact-profiles",
+        json.dumps({"name": "Seed Profile"}),
+        content_type="application/json",
+        **headers,
+    )
+    assert response.status_code == 201
+    profile_id = response.json()["id"]
+
+    dup_payload = {
+        "entities": [
+            {
+                "name": "Twin",
+                "email": "one@example.com",
+                "is_manufacturer": True,
+                "is_supplier": False,
+                "is_author": False,
+                "contacts": [{"name": "C1", "email": "c1@example.com"}],
+            },
+            {
+                "name": "Twin",
+                "email": "two@example.com",
+                "is_manufacturer": False,
+                "is_supplier": True,
+                "is_author": False,
+                "contacts": [{"name": "C2", "email": "c2@example.com"}],
+            },
+        ],
+    }
+    response = client.patch(
+        f"/api/v1/workspaces/{team.key}/contact-profiles/{profile_id}",
+        json.dumps(dup_payload),
+        content_type="application/json",
+        **headers,
+    )
+
+    assert response.status_code == 400, f"got {response.status_code}: {response.content!r}"
+    body = response.json()
+    assert body["error_code"] == "DUPLICATE_NAME", f"got body: {body}"
+    assert "already exists" in body["detail"].lower()


### PR DESCRIPTION
## Summary

Fixes #953. POST/PUT/PATCH on `/api/v1/components` returned `error_code: INVALID_DATA` when the requested name collided with an existing component — instead of the documented `DUPLICATE_NAME` code. **An audit also surfaced a sibling bug** in `/api/v1/workspaces/{key}/contact-profiles` where the same root cause produced HTTP 500 instead of a 400. Both are fixed in this PR with a shared helper.

## Root cause

Handlers that call `model.full_clean()` (directly, or via a model's `save()` override that calls it) trip `validate_unique()` BEFORE the DB ever throws `IntegrityError`. The `DUPLICATE_NAME` branch hanging off `except IntegrityError` is unreachable on that path.

| Surface | Trigger | Failure mode before fix |
|---|---|---|
| `core/apis.py` — `create_component`, `update_component`, `patch_component` | Explicit `component.full_clean()` then `save()` | **400 `INVALID_DATA`** (wrong code) |
| `teams/apis.py` — `create_contact_profile`, `update_contact_profile` (incl. legacy `payload.company` rename and `_upsert_entities` path) | `ContactEntity.save()` unconditionally calls `self.full_clean()` (`teams/models.py:693-694`); `unique_together = ("profile", "name")` | **HTTP 500** (`DjangoValidationError` propagates past `except ValueError` / `except IntegrityError`) |

Product / Release / ContactProfile handlers go through plain `.save()` and don't call `full_clean()`, so their existing `except IntegrityError` branches reach `DUPLICATE_NAME` correctly — no change needed there.

## Fix

A shared helper in `sbomify/apps/core/services/validation_response.py`:

```python
def validation_error_response(ve, resource_label):
    msg_dict = ve.message_dict
    is_unique_violation = any(
        "already exists" in m.lower() for m in msg_dict.get("__all__", [])
    )
    if is_unique_violation:
        return 400, {
            "detail": f"A {resource_label} with this name already exists in this team",
            "errors": msg_dict,
            "error_code": ErrorCode.DUPLICATE_NAME,
        }
    return 400, {"detail": "Validation error", "errors": msg_dict, "error_code": ErrorCode.INVALID_DATA}
```

- The `"already exists"` substring (not just the `__all__` key) is the disambiguator — other model-level `clean()` rules also bind to `__all__` (e.g. "A profile can have only one manufacturer entity") and must NOT be misclassified as duplicates.
- Lives in `core/services/` rather than either `apis.py` because `core/apis.py` already imports from `teams/apis.py` (`serialize_contact_profile`); putting the helper in either `apis.py` would create a circular import.
- Each handler's existing `except IntegrityError` branch stays in place as the safety net for genuine concurrent-create races where `full_clean` passes and the DB constraint fires anyway.

## Tests

| Test | Layer | What it pins |
|---|---|---|
| `test_create_duplicate_component_name_api` (tightened) | API | POST duplicate component → `DUPLICATE_NAME` (previously accepted "any 400") |
| `test_update_component_duplicate_name_returns_duplicate_name_code` (new) | API | PUT renaming to duplicate → `DUPLICATE_NAME` |
| `test_patch_component_duplicate_name_returns_duplicate_name_code` (new) | API | PATCH renaming to duplicate → `DUPLICATE_NAME` |
| `test_create_contact_profile_duplicate_entity_name_returns_400` (new) | API | POST profile with 2 same-name entities → `DUPLICATE_NAME` (was 500) |
| `test_update_contact_profile_legacy_rename_to_duplicate_returns_400` (new) | API | PATCH `{"company": <existing>}` → `DUPLICATE_NAME` (was 500) |
| `test_update_contact_profile_entities_duplicate_name_returns_400` (new) | API | PATCH `{"entities": [...]}` with collisions → `DUPLICATE_NAME` (was 500) |
| `TestValidationErrorResponseHelper::test_unique_violation_maps_to_duplicate_name` | Unit | `__all__` + "already exists" → `DUPLICATE_NAME` |
| `TestValidationErrorResponseHelper::test_field_level_validation_error_keeps_invalid_data` | Unit | Field-level errors stay `INVALID_DATA` |
| `TestValidationErrorResponseHelper::test_all_key_without_already_exists_keeps_invalid_data` | Unit | Helper does NOT misclassify other `__all__` errors (e.g. mutual-exclusivity rules) |
| `test_duplicate_component_name_returns_field_errors` (#952 regression, updated) | API | Same duplicate path now returns `DUPLICATE_NAME` while `errors` dict still survives serialization |

## Test plan

- [x] `pytest sbomify/apps/core/tests/ sbomify/apps/teams/tests/` — 471 pass / 0 fail (targeted re-run)
- [x] Full `sbomify/apps/core/tests/` — 2186 pass / 2 skipped / 0 fail
- [x] Full `sbomify/apps/sboms/tests/` — 380 pass / 5 skipped / 0 fail
- [x] `ruff check`, `ruff format`, `mypy` clean on every touched file
- [x] Verified Product / Release / ContactProfile handlers DON'T have the bug (DB-driven `IntegrityError` already returns `DUPLICATE_NAME`)

## Why this matters

From #953:
> Clients (the sbomify-action wizard included) need to be able to react differently to a duplicate-name failure than to a generic validation failure — the right UX is to either reuse the existing component or prompt for a different name. With the current behaviour every 400 looks the same, so clients have to guess.

The contact-profile bug had the worse failure mode: a UI surfacing "Server error" for what is really an operator-correctable input mistake.