### PR TITLE
fix(oidc): accept string repository_id/owner_id claims from GitHub

### DIFF
--- a/sbomify/apps/oidc/services.py
+++ b/sbomify/apps/oidc/services.py
@@ -68,6 +68,32 @@ _BOT_EMAIL_DOMAIN = "sbomify.local"
 _BOT_ROLE = "bot"
 
 
+def _coerce_repo_int_claim(value: Any) -> int | None:
+    """Return ``value`` as an ``int`` iff it's a numeric ``str`` or ``int``.
+
+    GitHub's OIDC tokens encode ``repository_id`` / ``repository_owner_id``
+    as JSON strings, but our test factory (and conceivably other OIDC
+    providers) may use ints. Accept both; reject ``None``, ``bool``,
+    floats, non-numeric strings, and any other type by returning ``None``
+    — the caller maps that to 401.
+
+    ``bool`` deserves the explicit reject: in Python ``isinstance(True,
+    int)`` is True and ``int(True) == 1``, so without the guard a
+    forged token shipping ``"repository_id": true`` would silently
+    coerce to 1.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
 def _bot_username(binding_id: str) -> str:
     return f"{BOT_USERNAME_PREFIX}{binding_id}"
 
@@ -351,9 +377,26 @@ def exchange_github_oidc_token(*, component_id: str, oidc_token: str) -> Service
         logger.warning("OIDC exchange: unexpected verification error: %s", exc)
         return ServiceResult.failure("invalid OIDC token", status_code=401)
 
-    repository_owner_id = claims.get("repository_owner_id")
-    repository_id = claims.get("repository_id")
-    if not isinstance(repository_owner_id, int) or not isinstance(repository_id, int):
+    # GitHub Actions OIDC tokens ship every numeric identifier as a JSON
+    # *string* (``"repository_id": "74"``, ``"repository_owner_id": "65"``,
+    # ``"actor_id": "12"`` …) — see the ``Example subject claims`` table
+    # in GitHub's OIDC hardening docs. A naive ``isinstance(..., int)``
+    # check therefore rejects every real-world token. Coerce defensively:
+    # accept ``str`` and ``int`` (some OIDC providers — and our own tests
+    # — encode as int), reject everything else including ``bool`` (which
+    # would otherwise pass ``int()`` because ``bool`` is an ``int``
+    # subclass in Python).
+    raw_owner_id = claims.get("repository_owner_id")
+    raw_repo_id = claims.get("repository_id")
+    repository_owner_id = _coerce_repo_int_claim(raw_owner_id)
+    repository_id = _coerce_repo_int_claim(raw_repo_id)
+    if repository_owner_id is None or repository_id is None:
+        logger.info(
+            "OIDC exchange: token missing/invalid repo id claims "
+            "(repository_owner_id=%r repository_id=%r)",
+            raw_owner_id,
+            raw_repo_id,
+        )
         return ServiceResult.failure("invalid OIDC token", status_code=401)
 
     binding = (

--- a/sbomify/apps/oidc/services.py
+++ b/sbomify/apps/oidc/services.py
@@ -68,29 +68,55 @@ _BOT_EMAIL_DOMAIN = "sbomify.local"
 _BOT_ROLE = "bot"
 
 
+# PostgreSQL ``bigint`` (the underlying type of ``OIDCBinding.repository_id``
+# and ``repository_owner_id``) is signed 64-bit. A coerced Python int that
+# exceeds this range would survive ``int()`` (Python ints are unbounded) but
+# raise ``DataError`` from psycopg when handed to ``filter()`` below — a 500
+# instead of the documented 401. Cap to the positive side: GitHub IDs are
+# always positive 32-bit integers in practice, but pinning to int64 keeps the
+# bound aligned with the database column.
+_MAX_REPO_INT_CLAIM = 2**63 - 1
+
+
 def _coerce_repo_int_claim(value: Any) -> int | None:
-    """Return ``value`` as an ``int`` iff it's a numeric ``str`` or ``int``.
+    """Return ``value`` as an ``int`` iff it's a non-negative bigint-sized
+    integer expressed exactly the way GitHub emits it (an ASCII-decimal
+    string), or a Python ``int`` of the same magnitude.
 
     GitHub's OIDC tokens encode ``repository_id`` / ``repository_owner_id``
-    as JSON strings, but our test factory (and conceivably other OIDC
-    providers) may use ints. Accept both; reject ``None``, ``bool``,
-    floats, non-numeric strings, and any other type by returning ``None``
-    — the caller maps that to 401.
+    as JSON strings — ``"74"``, ``"65"``, … — so the str branch is the
+    primary path. ``int`` is also accepted because our test factory (and
+    conceivably other OIDC providers) may encode them as JSON numbers.
 
-    ``bool`` deserves the explicit reject: in Python ``isinstance(True,
-    int)`` is True and ``int(True) == 1``, so without the guard a
-    forged token shipping ``"repository_id": true`` would silently
-    coerce to 1.
+    Rejected (returns ``None`` → caller maps to 401):
+
+    * ``None``, ``bool``, ``float``, ``list``, ``dict`` — wrong JSON type.
+      ``bool`` is called out explicitly because in Python ``isinstance(True,
+      int)`` is ``True`` and would otherwise let a forged ``"…": true``
+      claim through as the integer ``1``.
+    * Strings with whitespace, sign prefixes (``"+74"``, ``"-74"``), PEP-515
+      underscore separators (``"7_4"``), or non-ASCII decimal digits
+      (``"١٢٣"`` etc.) — Python's ``int()`` accepts all of
+      these but GitHub never emits any of them, so accepting them only
+      widens the input surface for forged tokens.
+    * Negative integers — GitHub IDs are always positive.
+    * Integers ``> 2**63 - 1`` — would overflow PostgreSQL ``bigint`` when
+      handed to ``OIDCBinding.objects.filter(repository_id=…)`` and raise
+      a 500 instead of a clean 401.
     """
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
-        return value
+        return value if 0 <= value <= _MAX_REPO_INT_CLAIM else None
     if isinstance(value, str):
-        try:
-            return int(value)
-        except ValueError:
+        # ``isascii() and isdigit()`` admits only ``"0"`` … ``"9"`` —
+        # rejects ``"١"``-style Unicode digits, leading ``+``/``-``,
+        # whitespace, and PEP 515 underscores. Also rejects the empty
+        # string. Matches GitHub's wire format exactly.
+        if not (value.isascii() and value.isdigit()):
             return None
+        coerced = int(value)
+        return coerced if coerced <= _MAX_REPO_INT_CLAIM else None
     return None
 
 

--- a/sbomify/apps/oidc/services.py
+++ b/sbomify/apps/oidc/services.py
@@ -418,8 +418,7 @@ def exchange_github_oidc_token(*, component_id: str, oidc_token: str) -> Service
     repository_id = _coerce_repo_int_claim(raw_repo_id)
     if repository_owner_id is None or repository_id is None:
         logger.info(
-            "OIDC exchange: token missing/invalid repo id claims "
-            "(repository_owner_id=%r repository_id=%r)",
+            "OIDC exchange: token missing/invalid repo id claims (repository_owner_id=%r repository_id=%r)",
             raw_owner_id,
             raw_repo_id,
         )

--- a/sbomify/apps/oidc/tests/conftest.py
+++ b/sbomify/apps/oidc/tests/conftest.py
@@ -70,6 +70,12 @@ def github_claims_factory(rsa_keypair: dict[str, Any]):
             "sub": "repo:acme/widget:ref:refs/heads/main",
             "repository": "acme/widget",
             "repository_owner": "acme",
+            # GitHub Actions encodes every numeric identifier in the JWT
+            # as a JSON *string* (see GitHub's OIDC hardening docs); using
+            # strings here keeps the fixture aligned with real tokens and
+            # exercises the production string→int coerce path.
+            "repository_id": "12345",
+            "repository_owner_id": "67890",
             "ref": "refs/heads/main",
             "workflow_ref": "acme/widget/.github/workflows/publish.yml@refs/heads/main",
             "actor": "octocat",

--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -288,6 +288,67 @@ class TestTokenRejection:
         )
         assert response.status_code == 401
 
+    @pytest.mark.django_db
+    def test_string_repository_id_claims_succeed(
+        self, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        """Real GitHub tokens encode ``repository_id`` and
+        ``repository_owner_id`` as JSON strings (``"74"``, not ``74``).
+
+        Regression for the production 401-loop where every exchange was
+        rejected because the service-layer typecheck required Python
+        ``int`` — see services._coerce_repo_int_claim.
+        """
+        token = github_claims_factory(repository_owner_id="67890", repository_id="12345")
+        client = Client()
+        response = client.post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200, response.content
+
+    @pytest.mark.django_db
+    def test_non_numeric_string_repository_id_401(
+        self, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        """A non-numeric string in ``repository_id`` must still 401.
+
+        Accepting strings (to mirror GitHub) shouldn't open the door to
+        forged tokens with arbitrary payloads in the ID claim.
+        """
+        token = github_claims_factory(repository_owner_id="67890", repository_id="not-a-number")
+        client = Client()
+        response = client.post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "invalid OIDC token"
+
+    @pytest.mark.django_db
+    def test_bool_repository_id_claim_rejected(
+        self, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        """``bool`` is an ``int`` subclass in Python — ``int(True) == 1``.
+
+        Without an explicit reject, a forged token with
+        ``"repository_id": true`` would silently coerce to ``1`` and
+        attempt a binding lookup. Belt-and-suspenders: reject explicitly.
+        """
+        token = github_claims_factory(repository_owner_id=True, repository_id=True)
+        client = Client()
+        response = client.post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401
+
 
 class TestBindingMismatch:
     @pytest.mark.django_db

--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -349,6 +349,64 @@ class TestTokenRejection:
         )
         assert response.status_code == 401
 
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "  12345  ",  # whitespace
+            "+12345",  # positive sign
+            "-12345",  # negative
+            "1_2345",  # PEP 515 underscore separator
+            "12345.0",  # decimal
+            "0x3039",  # hex
+            "١٢٣٤٥",  # Arabic-Indic digits (decimal, but non-ASCII)
+            "",  # empty
+        ],
+    )
+    def test_non_canonical_string_repository_id_401(
+        self, github_claims_factory, mock_github_jwks, github_binding, component, bad_value
+    ) -> None:
+        """GitHub emits ASCII-decimal-only strings; everything else 401.
+
+        Python's ``int()`` is permissive (accepts whitespace, signs,
+        PEP 515 underscores, and Unicode decimal digits) — the helper
+        deliberately tightens to ``value.isascii() and value.isdigit()``
+        to mirror GitHub's wire format exactly. Regression for
+        defense-in-depth finding on the OIDC PR.
+        """
+        token = github_claims_factory(repository_owner_id="67890", repository_id=bad_value)
+        client = Client()
+        response = client.post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401, response.content
+
+    @pytest.mark.django_db
+    def test_repository_id_overflowing_bigint_401(
+        self, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        """A value > 2**63-1 must 401, not 500.
+
+        Python ints are unbounded, but ``OIDCBinding.repository_id`` is
+        a PostgreSQL ``bigint``. Without the range check, the
+        downstream ``filter(repository_id=<huge>)`` would raise
+        ``DataError`` and propagate as an unhandled 500 — violating
+        the documented 401-only-for-bad-token error contract.
+        """
+        too_big = str(2**63)  # one over int64 max
+        token = github_claims_factory(repository_owner_id="67890", repository_id=too_big)
+        client = Client()
+        response = client.post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401, response.content
+
 
 class TestBindingMismatch:
     @pytest.mark.django_db

--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -133,9 +133,7 @@ class TestSuccessfulExchange:
         ``binding.last_used_at`` — only successful exchanges count.
         """
         assert github_binding.last_used_at is None
-        token = github_claims_factory(
-            repository="evil/forge", repository_owner_id=11111, repository_id=22222
-        )
+        token = github_claims_factory(repository="evil/forge", repository_owner_id=11111, repository_id=22222)
         client = Client()
         response = client.post(
             EXCHANGE_URL,
@@ -146,8 +144,7 @@ class TestSuccessfulExchange:
         assert response.status_code == 403
         github_binding.refresh_from_db()
         assert github_binding.last_used_at is None, (
-            "Refused-token exchange must NOT bump last_used_at — the "
-            "timestamp is a 'last legitimate use' indicator."
+            "Refused-token exchange must NOT bump last_used_at — the timestamp is a 'last legitimate use' indicator."
         )
 
 
@@ -499,9 +496,7 @@ class TestRateLimit:
 
 class TestInfrastructureFailures:
     @pytest.mark.django_db
-    def test_jwks_unavailable_503(
-        self, github_claims_factory, github_binding, component, mocker, rsa_keypair
-    ) -> None:
+    def test_jwks_unavailable_503(self, github_claims_factory, github_binding, component, mocker, rsa_keypair) -> None:
         """GitHub's JWKS endpoint being down must NOT be conflated with a bad
         token — return 503 so CI doesn't retry-loop a real config error.
         """


### PR DESCRIPTION
## Summary

Real GitHub Actions OIDC tokens ship every numeric identifier as a JSON **string** (`"repository_id": "74"`, `"repository_owner_id": "65"`, `"actor_id": "12"` — see the [example subject claims](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) table). Our service-layer check in `services.exchange_github_oidc_token` required Python `int`, so every real exchange bounced 401.

## Symptom

Every `Generate SBOMs` job in [sbomify-action CI](https://github.com/sbomify/sbomify-action/actions/runs/26514649882) has failed since OIDC trusted publishing rolled out:

```
ERROR    OIDC trusted publishing failed: sbomify rejected the GitHub OIDC token
         (401). The token signature, audience, or expiry did not validate.
         Detail: invalid OIDC token
```

Backend (`stage.sbomify.com`) logs only show Django's generic `WARNING:Unauthorized: /api/v1/auth/oidc/github/exchange` — the existing INFO log lines inside `exchange_github_oidc_token` never fire because the rejection happens **after** PyJWT verification (signature/iss/aud/exp all pass) and **before** the binding lookup. Caddy access logs show clean 32-byte POSTs returning a 68-byte 401 body, matching `{"detail":"invalid OIDC token"}` exactly.

## Why tests didn't catch this

The `github_claims_factory` fixture in `tests/conftest.py` builds JWTs from a Python `dict` — `int` → JSON number → `int` on decode — and every success-path test passes `repository_owner_id=67890, repository_id=12345` as Python `int`s. PyJWT preserves the type round-trip, so the typecheck happened to pass. Real GitHub tokens have JSON strings, which decode to Python `str`, fail `isinstance(..., int)`, and 401.

The existing `test_missing_repository_id_claims_401` covered the `None` case and asserted 401 — which masked the bug because the string case also returns 401, just for the wrong reason.

## Changes

* **`sbomify/apps/oidc/services.py`**
  * New `_coerce_repo_int_claim` helper: accepts `int` or numeric `str`, returns `int | None`. Rejects:
    * `bool` explicitly — `isinstance(True, int)` is True and `int(True) == 1`; without the guard a forged token with `"repository_id": true` would silently coerce to `1` and attempt a binding lookup.
    * floats, non-numeric strings, any other type.
  * `exchange_github_oidc_token` uses the helper and now `logger.info`s when the repo-id claims are missing/invalid — gives operators the same visibility the verifier-rejection paths already had.

* **`sbomify/apps/oidc/tests/conftest.py`**
  * `github_claims_factory` defaults `repository_id` and `repository_owner_id` to JSON strings, mirroring real GitHub tokens. Every success-path test now exercises the string→int coerce path.

* **`sbomify/apps/oidc/tests/test_apis.py`**
  * New regressions in `TestTokenRejection`:
    * `test_string_repository_id_claims_succeed` — explicit pin that string IDs work.
    * `test_non_numeric_string_repository_id_401` — accepting strings doesn't open the door to arbitrary payloads.
    * `test_bool_repository_id_claim_rejected` — `int(True) == 1` doesn't accidentally let forged `true` claims through.

## Test plan

- [ ] CI green on this PR (couldn't run the docker test stack locally — `172.25.0.0/16` was already taken by a parallel worktree's testnet)
- [ ] After merge + deploy to stage, retry the sbomify-action master run and confirm 200 from `/api/v1/auth/oidc/github/exchange`
- [ ] Confirm `OIDC exchange: issued token for binding=... component=...` INFO log appears in `sbomify-backend` logs

## Security notes

No widening of trust:
* PyJWT still does the full signature/iss/aud/exp verification before this code runs.
* `bool` is explicitly rejected to prevent silent `True → 1` coercion.
* Non-numeric strings 401 just like before.
* The added INFO log uses `%r` on the raw claim value — same approach as the existing repository-claim log a few lines below, so we don't leak un-quoted attacker-controlled content into log aggregators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)