### PR TITLE
fix(authz): enforce membership on branding read and redact private product names

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3651,6 +3651,11 @@ def list_sbom_releases(request: HttpRequest, sbom_id: str, page: int = Query(1),
         if not verify_item_access(request, sbom.component, ["guest", "owner", "admin"]):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
+    # Whether the requester is a member of the SBOM's workspace. Non-members may
+    # reach this endpoint when the component is public/gated, so private product
+    # names and IDs must be withheld from them to avoid leaking private products.
+    has_workspace_access = verify_item_access(request, sbom.component, ["guest", "owner", "admin"])
+
     # Get all releases containing this SBOM
     release_artifacts_queryset = (
         ReleaseArtifact.objects.filter(sbom=sbom)
@@ -3661,19 +3666,22 @@ def list_sbom_releases(request: HttpRequest, sbom_id: str, page: int = Query(1),
     # Apply pagination
     paginated_artifacts, pagination_meta = _paginate_queryset(release_artifacts_queryset, page, page_size)
 
-    items = [
-        {
-            "id": str(artifact.release.id),
-            "name": artifact.release.name,
-            "description": artifact.release.description,
-            "is_prerelease": artifact.release.is_prerelease,
-            "is_latest": artifact.release.is_latest,
-            "product_id": str(artifact.release.product.id),
-            "product_name": artifact.release.product.name,
-            "is_public": artifact.release.product.is_public,
-        }
-        for artifact in paginated_artifacts
-    ]
+    items = []
+    for artifact in paginated_artifacts:
+        product = artifact.release.product
+        reveal_product = product.is_public or has_workspace_access
+        items.append(
+            {
+                "id": str(artifact.release.id),
+                "name": artifact.release.name,
+                "description": artifact.release.description,
+                "is_prerelease": artifact.release.is_prerelease,
+                "is_latest": artifact.release.is_latest,
+                "product_id": str(product.id) if reveal_product else "",
+                "product_name": product.name if reveal_product else "",
+                "is_public": product.is_public,
+            }
+        )
 
     return {"items": items, "pagination": pagination_meta}
 

--- a/sbomify/apps/core/tests/test_sbom_tagging.py
+++ b/sbomify/apps/core/tests/test_sbom_tagging.py
@@ -113,6 +113,40 @@ class TestSBOMTaggingAPI(AuthenticationTestMixin):
         response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
         assert response.status_code == 200
 
+    def test_list_sbom_releases_redacts_private_product_for_non_members(self):
+        """Gated SBOMs are publicly listable, but private product names/IDs must not leak."""
+        client = Client()
+
+        # Component is publicly viewable (gated), but its release lives in a PRIVATE product.
+        self.component1.visibility = Component.Visibility.GATED
+        self.component1.save()
+        assert self.product1.is_public is False
+        ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
+
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases")
+        assert response.status_code == 200
+        item = json.loads(response.content)["items"][0]
+        assert item["id"] == str(self.release1.id)
+        assert item["is_public"] is False
+        # Private product name and id are withheld from non-members.
+        assert item["product_name"] == ""
+        assert item["product_id"] == ""
+
+    def test_list_sbom_releases_shows_private_product_to_members(self, authenticated_api_client):
+        """Workspace members still see private product names/IDs on gated SBOM releases."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
+        self.component1.visibility = Component.Visibility.GATED
+        self.component1.save()
+        ReleaseArtifact.objects.create(release=self.release1, sbom=self.sbom1_cdx)
+
+        response = client.get(f"/api/v1/sboms/{self.sbom1_cdx.id}/releases", **headers)
+        assert response.status_code == 200
+        item = json.loads(response.content)["items"][0]
+        assert item["product_name"] == "Test Product 1"
+        assert item["product_id"] == str(self.product1.id)
+
     def test_add_sbom_to_releases_new(self, authenticated_api_client):
         """Test adding an SBOM to releases (new case)."""
         client, access_token = authenticated_api_client

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -126,7 +126,10 @@ def _normalize_branding_payload(branding: dict[str, Any] | None) -> dict[str, An
     return data
 
 
-@router.get("/{team_key}/branding", response={200: BrandingInfoWithUrls, 400: ErrorResponse, 404: ErrorResponse})
+@router.get(
+    "/{team_key}/branding",
+    response={200: BrandingInfoWithUrls, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
+)
 def get_team_branding(request: HttpRequest, team_key: str) -> tuple[int, Any]:
     """Get workspace branding information.
 
@@ -141,6 +144,11 @@ def get_team_branding(request: HttpRequest, team_key: str) -> tuple[int, Any]:
         team = Team.objects.get(pk=team_id)
     except Team.DoesNotExist:
         return 404, {"detail": "Workspace not found"}
+
+    user = cast(User, request.user)
+    if not Member.objects.filter(user=user, team=team).exists():
+        logger.warning(f"User {user.username} is not a member of team {team_key}")
+        return 403, {"detail": "Forbidden"}
 
     branding_data = _normalize_branding_payload(team.branding_info)
     branding_info = BrandingInfo(**branding_data)

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -1290,6 +1290,21 @@ def test_team_branding_atomic_upload(sample_team_with_owner_member: Member, mock
 
 
 @pytest.mark.django_db
+def test_team_branding_api_rejects_non_member(
+    sample_team_with_owner_member: Member,  # noqa: F811
+    guest_user,  # noqa: F811
+):
+    """A user who is not a member of the workspace cannot read its branding (BOLA regression)."""
+    team = sample_team_with_owner_member.team
+    client = Client()
+    assert client.login(username="guest", password="guest")  # nosec B106
+
+    response = client.get(f"/api/v1/workspaces/{team.key}/branding")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Forbidden"
+
+
+@pytest.mark.django_db
 def test_team_branding_api_permissions(sample_team_with_guest_member: Member):  # noqa: F811
     client = Client()
 


### PR DESCRIPTION
## Summary

Fixes two missing-authorization issues surfaced by a security report (CWE-862 / OWASP API1:2023 BOLA).

### 1. BOLA on `GET /api/v1/workspaces/{team_key}/branding`
The endpoint required authentication but performed **no authorization** — any authenticated user could read any workspace's branding by knowing or enumerating its key. Branding includes `company_nda_document_id` and `trust_center_description`. The write handlers (`PATCH`/`PUT`/`POST`) already gate on owner role; only the read handler was unguarded.

For public workspaces most branding is already exposed via the server-rendered Trust Center, so the genuine incremental leak is for **private** workspaces (whose public page returns 404). Keys derive deterministically from the integer PK, making them enumerable.

**Fix:** require workspace membership (any role) before returning branding, preserving the existing guest-read behavior. Returns `403` otherwise.

### 2. Private product name leak on `GET /api/v1/sboms/{sbom_id}/releases`
This endpoint is intentionally publicly listable for `PUBLIC`/`GATED` components, but it returned `product_name`/`product_id` for **every** release containing the SBOM regardless of the product's visibility — leaking private product names to unauthenticated callers who know a gated `sbom_id`.

**Fix:** redact `product_name`/`product_id` for private products unless the requester is a workspace member. `is_public` is retained so callers still know the product is private.

## Tests
- `test_team_branding_api_rejects_non_member` — non-member gets `403`.
- `test_list_sbom_releases_redacts_private_product_for_non_members` — unauthenticated caller sees empty `product_name`/`product_id` for a private product.
- `test_list_sbom_releases_shows_private_product_to_members` — members still see real values.
- Existing `test_team_branding_api_permissions` (guest member can still read) and `test_list_sbom_releases_with_releases` remain green.

22 tests pass. `ruff` + `mypy` clean on the changed source files; no new lint debt in the test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)