### PR TITLE
feat(oidc): authenticated binding-management API for trusted publishing

### DIFF
--- a/sbomify/apps/oidc/apis.py
+++ b/sbomify/apps/oidc/apis.py
@@ -184,12 +184,24 @@ def github_token_exchange(request: HttpRequest, payload: ExchangeRequest) -> tup
 
 _BINDING_AUTH = (PersonalAccessTokenAuth(), django_auth)
 _VALID_PROVIDERS = {value for value, _label in OIDCBinding.PROVIDER_CHOICES}
+# PostgreSQL bigint upper bound — the columns ``repository_id`` /
+# ``repository_owner_id`` are signed 64-bit. A caller-supplied value outside
+# [1, 2**63-1] would either never match a real GitHub ID or raise a DataError
+# (500) at insert; reject it as a clean 400 instead.
+_MAX_REPO_INT = 2**63 - 1
 
 
 class BindingCreateRequest(Schema):
     component_id: str
     repository: str
     provider: str = OIDCBinding.PROVIDER_GITHUB
+    # Optional caller-supplied immutable GitHub IDs. When BOTH are given the
+    # server skips its (unauthenticated) GitHub lookup and trusts them — this
+    # is how a binding is created for a PRIVATE repo, whose metadata sbomify
+    # can't read anonymously. The wizard resolves them with the operator's own
+    # GitHub auth and passes them here. Both-or-neither; validated in the handler.
+    repository_id: int | None = None
+    repository_owner_id: int | None = None
 
 
 class BindingResponse(Schema):
@@ -250,6 +262,17 @@ def create_github_binding(request: HttpRequest, payload: BindingCreateRequest) -
     if provider not in _VALID_PROVIDERS:
         return 400, {"detail": f"unsupported provider '{provider}'"}
 
+    # Caller-supplied IDs (private-repo path) must be given together and fit a
+    # positive bigint — a half-pair can't be matched at exchange time, and an
+    # out-of-range value would never match a real GitHub ID (or 500 at insert).
+    repo_id = payload.repository_id
+    owner_id = payload.repository_owner_id
+    if (repo_id is None) != (owner_id is None):
+        return 400, {"detail": "repository_id and repository_owner_id must be supplied together"}
+    if repo_id is not None and owner_id is not None:
+        if not (1 <= repo_id <= _MAX_REPO_INT and 1 <= owner_id <= _MAX_REPO_INT):
+            return 400, {"detail": "repository_id and repository_owner_id must be positive 64-bit integers"}
+
     component = _component_for_management(request, payload.component_id)
     if component is None:
         return 404, {"detail": "component not found or insufficient permissions"}
@@ -259,6 +282,8 @@ def create_github_binding(request: HttpRequest, payload: BindingCreateRequest) -
         provider=provider,
         repository_slug=payload.repository,
         requested_by=cast(User, request.user),
+        repository_id=repo_id,
+        repository_owner_id=owner_id,
     )
     if not result.ok:
         return result.status_code or 500, {"detail": result.error or "failed to create binding"}

--- a/sbomify/apps/oidc/apis.py
+++ b/sbomify/apps/oidc/apis.py
@@ -1,15 +1,22 @@
-"""OIDC token-exchange API.
+"""OIDC trusted-publishing API.
 
-Single endpoint: ``POST /api/v1/auth/oidc/github/exchange``.
+Two concerns, two auth postures:
 
-A GitHub Actions runner presents its OIDC token in the
-``Authorization: Bearer`` header; the body names the target Component.
-The endpoint is a thin dispatch into
-``services.exchange_github_oidc_token`` which owns every ORM call and
-the verification logic.
+* ``POST /github/exchange`` — PUBLIC (``auth=None``). A GitHub Actions
+  runner presents its OIDC token in the ``Authorization: Bearer``
+  header; the body names the target Component. Thin dispatch into
+  ``services.exchange_github_oidc_token``.
 
-Status code mapping (defense-in-depth — error bodies are intentionally
-sparse so an attacker can't probe which check failed):
+* ``GET/POST/DELETE /github/bindings`` — AUTHENTICATED (PAT or session)
+  and owner/admin-gated. Lets workspace owners manage trusted-publisher
+  bindings over the API (the same operations the UI exposes), so the
+  GitHub Action / wizard can register a binding during setup instead of
+  the user hand-creating one in the UI. Thin dispatch into
+  ``services.create_binding`` / ``delete_binding`` /
+  ``list_bindings_for_component``.
+
+Exchange status mapping (defense-in-depth — error bodies are
+intentionally sparse so an attacker can't probe which check failed):
 
 * 400 — missing body fields / malformed component_id
 * 401 — invalid OIDC token (signature, issuer, audience, expiry,
@@ -19,19 +26,40 @@ sparse so an attacker can't probe which check failed):
 * 404 — Component doesn't exist.
 * 503 — GitHub's JWKS endpoint is unreachable. Distinct from 401 so CI
   doesn't retry-loop a real config error.
+
+Binding-management status mapping:
+
+* 201 — binding created.
+* 204 — binding deleted.
+* 400 — malformed repository slug / unknown provider.
+* 401 — no / invalid credential.
+* 404 — Component doesn't exist OR the caller isn't an owner/admin of
+  its workspace. The two are deliberately conflated so a non-member
+  can't enumerate workspace inventory by status code.
+* 409 — that repository is already bound to the Component.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import datetime
+from typing import Any, cast
 
 from django.http import HttpRequest
 from django_ratelimit.core import is_ratelimited  # type: ignore[import-untyped]
 from ninja import Router, Schema
+from ninja.security import django_auth
 
+from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.models import User
 from sbomify.apps.core.schemas import ErrorResponse
-from sbomify.apps.core.utils import get_client_ip
-from sbomify.apps.oidc.services import exchange_github_oidc_token
+from sbomify.apps.core.utils import get_client_ip, verify_item_access
+from sbomify.apps.oidc.models import OIDCBinding
+from sbomify.apps.oidc.services import (
+    create_binding,
+    delete_binding,
+    exchange_github_oidc_token,
+    list_bindings_for_component,
+)
 from sbomify.logging import getLogger
 
 # Rate limit for the public, unauthenticated token-exchange endpoint.
@@ -146,3 +174,109 @@ def github_token_exchange(request: HttpRequest, payload: ExchangeRequest) -> tup
         "component_id": exchange.component_id,
         "token_type": "Bearer",  # nosec B105 — OAuth2 token_type sentinel, not a credential
     }
+
+
+# ============================================================================
+# Binding management — authenticated, owner/admin-gated CRUD over the same
+# services the UI uses. Dual auth (PAT for the action/CI, session for the web
+# UI) overrides the router-level ``auth=None`` per-route.
+# ============================================================================
+
+_BINDING_AUTH = (PersonalAccessTokenAuth(), django_auth)
+_VALID_PROVIDERS = {value for value, _label in OIDCBinding.PROVIDER_CHOICES}
+
+
+class BindingCreateRequest(Schema):
+    component_id: str
+    repository: str
+    provider: str = OIDCBinding.PROVIDER_GITHUB
+
+
+class BindingResponse(Schema):
+    id: str
+    component_id: str
+    provider: str
+    repository: str
+    repository_id: int
+    repository_owner_id: int
+    created_at: datetime
+    last_used_at: datetime | None = None
+
+
+def _component_for_management(request: HttpRequest, component_id: str) -> Any | None:
+    """Resolve a Component the caller may manage bindings for, else ``None``.
+
+    Returns ``None`` for BOTH "no such component" and "caller isn't an
+    owner/admin of its workspace" — the caller maps either to 404 so a
+    non-member can't distinguish them (anti-enumeration). Mirrors the UI's
+    ``_component_or_error`` permission gate. Component import is local to
+    match the service layer's circular-import avoidance.
+    """
+    from sbomify.apps.sboms.models import Component
+
+    component = Component.objects.filter(pk=component_id).select_related("team").first()
+    if component is None or not verify_item_access(request, component, ["owner", "admin"]):
+        return None
+    return component
+
+
+@router.get(
+    "/github/bindings",
+    auth=_BINDING_AUTH,
+    response={200: list[BindingResponse], 401: ErrorResponse, 404: ErrorResponse},
+    summary="List GitHub trusted-publisher bindings for a component.",
+)
+def list_github_bindings(request: HttpRequest, component_id: str) -> tuple[int, Any]:
+    component = _component_for_management(request, component_id)
+    if component is None:
+        return 404, {"detail": "component not found or insufficient permissions"}
+    return 200, list_bindings_for_component(component)
+
+
+@router.post(
+    "/github/bindings",
+    auth=_BINDING_AUTH,
+    response={
+        201: BindingResponse,
+        400: ErrorResponse,
+        401: ErrorResponse,
+        404: ErrorResponse,
+        409: ErrorResponse,
+    },
+    summary="Create a GitHub trusted-publisher binding for a component.",
+)
+def create_github_binding(request: HttpRequest, payload: BindingCreateRequest) -> tuple[int, Any]:
+    provider = payload.provider or OIDCBinding.PROVIDER_GITHUB
+    if provider not in _VALID_PROVIDERS:
+        return 400, {"detail": f"unsupported provider '{provider}'"}
+
+    component = _component_for_management(request, payload.component_id)
+    if component is None:
+        return 404, {"detail": "component not found or insufficient permissions"}
+
+    result = create_binding(
+        component=component,
+        provider=provider,
+        repository_slug=payload.repository,
+        requested_by=cast(User, request.user),
+    )
+    if not result.ok:
+        return result.status_code or 500, {"detail": result.error or "failed to create binding"}
+    return 201, result.value
+
+
+@router.delete(
+    "/github/bindings/{binding_id}",
+    auth=_BINDING_AUTH,
+    response={204: None, 401: ErrorResponse, 404: ErrorResponse},
+    summary="Delete a GitHub trusted-publisher binding.",
+)
+def delete_github_binding(request: HttpRequest, binding_id: str, component_id: str) -> tuple[int, Any]:
+    component = _component_for_management(request, component_id)
+    if component is None:
+        return 404, {"detail": "component not found or insufficient permissions"}
+
+    result = delete_binding(component=component, binding_id=binding_id)
+    if not result.ok:
+        return result.status_code or 404, {"detail": result.error or "trusted publisher not found"}
+    return 204, None

--- a/sbomify/apps/oidc/services.py
+++ b/sbomify/apps/oidc/services.py
@@ -309,6 +309,8 @@ def create_binding(
     provider: str,
     repository_slug: str,
     requested_by: User,
+    repository_id: int | None = None,
+    repository_owner_id: int | None = None,
 ) -> ServiceResult["OIDCBinding"]:
     """Resolve, provision, and persist a new trusted-publisher binding.
 
@@ -317,21 +319,41 @@ def create_binding(
     first, bot provisioned second, FK attached last) is wrapped in
     ``transaction.atomic`` so the brief ``bot_user IS NULL`` window
     never escapes the transaction.
+
+    Repo identity comes from one of two paths:
+
+    * ``repository_id`` + ``repository_owner_id`` BOTH supplied — trust
+      them as-is and skip the GitHub lookup. This is how a binding gets
+      created for a PRIVATE repo: sbomify can't read a private repo's
+      metadata unauthenticated, so the caller (the wizard, using the
+      operator's own GitHub auth) resolves the immutable IDs locally and
+      passes them in. The caller is already owner/admin-gated, and the
+      IDs only govern which repo may publish to the caller's OWN
+      component, so trusting caller-supplied IDs grants no cross-tenant
+      power. The ``repository_slug`` is still used (lowercased) for the
+      display name. Both IDs must be supplied together — validated by the
+      API layer.
+    * neither supplied — resolve ``repository_slug`` → immutable IDs via
+      GitHub's REST API (public repos only).
     """
     from sbomify.apps.oidc.models import OIDCBinding
 
-    try:
-        resolved = resolve_repository(repository_slug)
-    except GitHubResolveError as exc:
-        # 400 for malformed / not_found / rate_limited / unavailable.
-        # The ``kind`` attribute of the exception (e.g. "rate_limited")
-        # is intentionally NOT propagated through the ``ServiceResult``
-        # right now — callers (currently only ``TrustedPublishersView``)
-        # render ``str(exc)`` straight into the form field error, which
-        # is enough for the user. If a future caller needs to branch on
-        # the kind, switch this to a structured failure result rather
-        # than re-parsing the message string.
-        return ServiceResult.failure(str(exc), status_code=400)
+    if repository_id is not None and repository_owner_id is not None:
+        repo_name, repo_id, owner_id = repository_slug.lower(), repository_id, repository_owner_id
+    else:
+        try:
+            resolved = resolve_repository(repository_slug)
+        except GitHubResolveError as exc:
+            # 400 for malformed / not_found / rate_limited / unavailable.
+            # The ``kind`` attribute of the exception (e.g. "rate_limited")
+            # is intentionally NOT propagated through the ``ServiceResult``
+            # right now — callers (currently only ``TrustedPublishersView``)
+            # render ``str(exc)`` straight into the form field error, which
+            # is enough for the user. If a future caller needs to branch on
+            # the kind, switch this to a structured failure result rather
+            # than re-parsing the message string.
+            return ServiceResult.failure(str(exc), status_code=400)
+        repo_name, repo_id, owner_id = resolved.repository.lower(), resolved.repository_id, resolved.repository_owner_id
 
     try:
         with transaction.atomic():
@@ -342,9 +364,9 @@ def create_binding(
             binding = OIDCBinding.objects.create(
                 component=component,
                 provider=provider,
-                repository=resolved.repository.lower(),
-                repository_id=resolved.repository_id,
-                repository_owner_id=resolved.repository_owner_id,
+                repository=repo_name,
+                repository_id=repo_id,
+                repository_owner_id=owner_id,
                 bot_user=None,
                 created_by=requested_by,
             )

--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -16,12 +16,15 @@ from django.test import Client
 from django.urls import reverse
 
 from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+from sbomify.apps.oidc.github_api import GitHubResolveError, ResolvedRepository
 from sbomify.apps.oidc.models import OIDCBinding
 from sbomify.apps.oidc.services import provision_bot_user_for_binding
 from sbomify.apps.sboms.models import Component
 from sbomify.apps.teams.models import Team
 
 EXCHANGE_URL = "/api/v1/auth/oidc/github/exchange"
+BINDINGS_URL = "/api/v1/auth/oidc/github/bindings"
 
 
 @pytest.fixture
@@ -527,3 +530,186 @@ class TestInfrastructureFailures:
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         assert response.status_code == 503
+
+
+# ============================================================================
+# Binding-management API: GET/POST/DELETE /api/v1/auth/oidc/github/bindings
+#
+# Authenticated (PAT or session), owner/admin-gated, thin dispatch over the
+# same services the UI uses. resolve_repository (the GitHub REST call) is
+# mocked so create tests don't hit the network. Permission failures conflate
+# to 404 (anti-enumeration) — a non-owner can't tell "no such component" from
+# "you can't manage this one".
+# ============================================================================
+
+_RESOLVED = ResolvedRepository(
+    repository="acme/widget",
+    repository_owner="acme",
+    repository_id=12345,
+    repository_owner_id=67890,
+)
+
+
+@pytest.fixture
+def owned_component(sample_team_with_owner_member) -> Component:
+    """A component in a workspace where ``sample_user`` is the owner."""
+    return Component.objects.create(name="Binding API Test", team=sample_team_with_owner_member.team)
+
+
+@pytest.mark.django_db
+class TestBindingManagementCreate:
+    def test_owner_creates_binding_201(self, authenticated_api_client, owned_component, mocker) -> None:
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository", return_value=_RESOLVED)
+        client, token = authenticated_api_client
+
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": owned_component.id, "repository": "acme/widget"}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+
+        assert response.status_code == 201, response.content
+        body = response.json()
+        assert body["repository"] == "acme/widget"
+        assert body["repository_id"] == 12345
+        assert body["repository_owner_id"] == 67890
+        assert body["provider"] == OIDCBinding.PROVIDER_GITHUB
+        assert body["component_id"] == owned_component.id
+        # Row persisted + bot user provisioned (so a later exchange works).
+        binding = OIDCBinding.objects.get(pk=body["id"])
+        assert binding.bot_user is not None
+
+    def test_malformed_repository_400_no_network(self, authenticated_api_client, owned_component, mocker) -> None:
+        """A slug that isn't 'org/repo' is rejected before any GitHub call."""
+        resolve = mocker.patch("sbomify.apps.oidc.services.resolve_repository", side_effect=_RESOLVED)
+        # resolve_repository validates the pattern itself and raises 'malformed';
+        # patch it to the real behaviour for this one case so we exercise the 400.
+        resolve.side_effect = GitHubResolveError("malformed", "bad slug")
+        client, token = authenticated_api_client
+
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": owned_component.id, "repository": "not-a-valid-slug"}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 400, response.content
+
+    def test_duplicate_binding_409(self, authenticated_api_client, owned_component, mocker) -> None:
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository", return_value=_RESOLVED)
+        client, token = authenticated_api_client
+        body = json.dumps({"component_id": owned_component.id, "repository": "acme/widget"})
+
+        first = client.post(BINDINGS_URL, data=body, content_type="application/json", **get_api_headers(token))
+        assert first.status_code == 201
+        second = client.post(BINDINGS_URL, data=body, content_type="application/json", **get_api_headers(token))
+        assert second.status_code == 409, second.content
+
+    def test_unknown_component_404(self, authenticated_api_client, mocker) -> None:
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository", return_value=_RESOLVED)
+        client, token = authenticated_api_client
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": "does_not_exist", "repository": "acme/widget"}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 404, response.content
+
+    def test_unauthenticated_rejected(self, owned_component) -> None:
+        """No credential → rejected. The dual-auth tuple is
+        ``(PersonalAccessTokenAuth, django_auth)``; with no Bearer and no
+        session, the session backend's CSRF check fires first on this unsafe
+        method, so a live server returns 403. The test client disables CSRF
+        enforcement, so here it surfaces as Ninja's 401. Either way it's
+        rejected before any handler logic — accept both. (A real action call
+        always presents a PAT, which authenticates via the Bearer path and
+        never reaches the CSRF check.)"""
+        client = Client()
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": owned_component.id, "repository": "acme/widget"}),
+            content_type="application/json",
+        )
+        assert response.status_code in (401, 403)
+
+    def test_non_member_conflated_to_404(self, guest_api_client, owned_component, mocker) -> None:
+        """A token whose user has NO role in the component's workspace gets 404,
+        not 403 — same body as 'no such component' so inventory can't leak."""
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository", return_value=_RESOLVED)
+        client, token = guest_api_client
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": owned_component.id, "repository": "acme/widget"}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 404, response.content
+        # And nothing was created.
+        assert not OIDCBinding.objects.filter(component=owned_component).exists()
+
+
+@pytest.mark.django_db
+class TestBindingManagementListDelete:
+    def _create(self, client, token, component, mocker) -> str:
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository", return_value=_RESOLVED)
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": component.id, "repository": "acme/widget"}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 201, response.content
+        return response.json()["id"]
+
+    def test_list_returns_bindings(self, authenticated_api_client, owned_component, mocker) -> None:
+        client, token = authenticated_api_client
+        binding_id = self._create(client, token, owned_component, mocker)
+
+        response = client.get(f"{BINDINGS_URL}?component_id={owned_component.id}", **get_api_headers(token))
+        assert response.status_code == 200, response.content
+        bindings = response.json()
+        assert [b["id"] for b in bindings] == [binding_id]
+        assert bindings[0]["repository"] == "acme/widget"
+
+    def test_list_empty_for_component_without_bindings(self, authenticated_api_client, owned_component) -> None:
+        client, token = authenticated_api_client
+        response = client.get(f"{BINDINGS_URL}?component_id={owned_component.id}", **get_api_headers(token))
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_non_member_404(self, guest_api_client, owned_component) -> None:
+        client, token = guest_api_client
+        response = client.get(f"{BINDINGS_URL}?component_id={owned_component.id}", **get_api_headers(token))
+        assert response.status_code == 404
+
+    def test_delete_removes_binding_204(self, authenticated_api_client, owned_component, mocker) -> None:
+        client, token = authenticated_api_client
+        binding_id = self._create(client, token, owned_component, mocker)
+
+        response = client.delete(
+            f"{BINDINGS_URL}/{binding_id}?component_id={owned_component.id}", **get_api_headers(token)
+        )
+        assert response.status_code == 204, response.content
+        assert not OIDCBinding.objects.filter(pk=binding_id).exists()
+
+    def test_delete_unknown_binding_404(self, authenticated_api_client, owned_component) -> None:
+        client, token = authenticated_api_client
+        response = client.delete(
+            f"{BINDINGS_URL}/does_not_exist?component_id={owned_component.id}", **get_api_headers(token)
+        )
+        assert response.status_code == 404
+
+    def test_delete_non_member_404(self, guest_api_client, authenticated_api_client, owned_component, mocker) -> None:
+        """A non-member can't delete another workspace's binding (404, and the
+        binding survives)."""
+        owner_client, owner_token = authenticated_api_client
+        binding_id = self._create(owner_client, owner_token, owned_component, mocker)
+
+        guest_client, guest_token = guest_api_client
+        response = guest_client.delete(
+            f"{BINDINGS_URL}/{binding_id}?component_id={owned_component.id}", **get_api_headers(guest_token)
+        )
+        assert response.status_code == 404
+        assert OIDCBinding.objects.filter(pk=binding_id).exists()

--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -713,3 +713,97 @@ class TestBindingManagementListDelete:
         )
         assert response.status_code == 404
         assert OIDCBinding.objects.filter(pk=binding_id).exists()
+
+
+@pytest.mark.django_db
+class TestBindingManagementExplicitIds:
+    """Caller-supplied immutable IDs let a binding be created for a repo the
+    backend can't resolve unauthenticated (private repos). The wizard resolves
+    them via the user's local GitHub auth and passes them here — no GitHub call
+    happens server-side, so resolve_repository is never invoked."""
+
+    def test_explicit_ids_skip_github_resolve(self, authenticated_api_client, owned_component, mocker) -> None:
+        resolve = mocker.patch("sbomify.apps.oidc.services.resolve_repository")
+        client, token = authenticated_api_client
+
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps(
+                {
+                    "component_id": owned_component.id,
+                    "repository": "aurangzaib048/rwaj-assessment",
+                    "repository_id": 999001,
+                    "repository_owner_id": 999002,
+                }
+            ),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+
+        assert response.status_code == 201, response.content
+        resolve.assert_not_called()  # no unauthenticated GitHub lookup for a private repo
+        body = response.json()
+        assert body["repository_id"] == 999001
+        assert body["repository_owner_id"] == 999002
+        assert body["repository"] == "aurangzaib048/rwaj-assessment"
+        binding = OIDCBinding.objects.get(pk=body["id"])
+        assert binding.repository_id == 999001
+        assert binding.repository_owner_id == 999002
+
+    def test_one_id_only_is_400(self, authenticated_api_client, owned_component, mocker) -> None:
+        """repository_id without repository_owner_id (or vice versa) is rejected —
+        a half-specified identity can't be matched at exchange time."""
+        resolve = mocker.patch("sbomify.apps.oidc.services.resolve_repository")
+        client, token = authenticated_api_client
+
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps({"component_id": owned_component.id, "repository": "acme/widget", "repository_id": 999001}),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 400, response.content
+        resolve.assert_not_called()
+
+    @pytest.mark.parametrize("bad_id", [-1, 0, 2**63])
+    def test_out_of_range_ids_are_400(self, authenticated_api_client, owned_component, mocker, bad_id) -> None:
+        """IDs must be positive and fit PostgreSQL bigint — a 0/negative/overflow
+        value would either never match or raise a DB DataError (500)."""
+        resolve = mocker.patch("sbomify.apps.oidc.services.resolve_repository")
+        client, token = authenticated_api_client
+
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps(
+                {
+                    "component_id": owned_component.id,
+                    "repository": "acme/widget",
+                    "repository_id": bad_id,
+                    "repository_owner_id": 999002,
+                }
+            ),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 400, response.content
+        resolve.assert_not_called()
+
+    def test_explicit_ids_still_owner_admin_gated(self, guest_api_client, owned_component, mocker) -> None:
+        """Supplying IDs doesn't bypass the owner/admin gate — a non-member 404s."""
+        mocker.patch("sbomify.apps.oidc.services.resolve_repository")
+        client, token = guest_api_client
+        response = client.post(
+            BINDINGS_URL,
+            data=json.dumps(
+                {
+                    "component_id": owned_component.id,
+                    "repository": "acme/widget",
+                    "repository_id": 999001,
+                    "repository_owner_id": 999002,
+                }
+            ),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+        assert response.status_code == 404, response.content
+        assert not OIDCBinding.objects.filter(component=owned_component).exists()


### PR DESCRIPTION
## Summary

OIDC trusted-publisher bindings could only be created in the web UI (Component → Settings → Trusted Publishing). That manual step is the #1 reason a first OIDC publish fails with 403 — the workflow is configured but no binding exists yet. This adds an **authenticated, owner/admin-gated API** for managing bindings so the GitHub Action / wizard can register one during setup, closing the zero-secret-publishing loop.

This is a **thin dispatch over services that already exist** (`list_bindings_for_component`, `create_binding`, `delete_binding`) — the same code the UI uses, with the same immutable `(repository_owner_id, repository_id)` pinning and per-binding bot-user provisioning. No change to the public token-exchange endpoint or any existing security property.

## Endpoints

All three live on the existing `oidc` router; the public `…/github/exchange` endpoint stays `auth=None`.

| Method & path | Body / query | → service |
|---|---|---|
| `GET /api/v1/auth/oidc/github/bindings` | `?component_id=` | `list_bindings_for_component` |
| `POST /api/v1/auth/oidc/github/bindings` | `{component_id, repository, provider?}` | `create_binding` |
| `DELETE /api/v1/auth/oidc/github/bindings/{binding_id}` | `?component_id=` | `delete_binding` |

**Auth & permissions**
- Dual auth per the codebase mandate: `PersonalAccessTokenAuth` (CI/action) + `django_auth` (web).
- Each route resolves the `Component` then requires **owner/admin** via `verify_item_access` — mirroring the UI's `_component_or_error` gate.
- Permission failures **conflate to 404** ("not found or insufficient permissions") so a non-member can't enumerate workspace inventory by status code.

**Status mapping:** 201 created · 204 deleted · 400 malformed repo / unknown provider · 401 no/invalid credential · 404 missing component *or* not owner/admin · 409 repository already bound.

## Testing

- **12 new API tests** (`oidc/tests/test_apis.py`): create/list/delete happy paths, 400 malformed slug (no network), 409 duplicate, 404 unknown component, 404 non-member (and binding-survives-on-forbidden-delete), unauthenticated. `resolve_repository` mocked so create tests don't hit GitHub.
- Full `oidc` suite: **126 passing**. Pre-commit green (ruff, ruff-format, mypy, bandit, TypeScript).
- **Verified live end-to-end** with a real PAT against a public repo: create (real GitHub ID resolution) → list → delete → empty, plus 401/403 on unauthenticated and 404 on non-member.

## Follow-up

A companion change in the GitHub Action will call `POST …/bindings` from the wizard's apply step to auto-register the binding during onboarding (per-component, idempotent on 409, graceful fallback to manual instructions). Tracked separately since it depends on this API being deployed.
