### PR TITLE
fix(billing): retry transient Stripe webhook failures instead of dropping them (#996)

### DIFF
--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -75,9 +75,9 @@ def _raise_classified_webhook_error(exc: Exception) -> NoReturn:
     if isinstance(exc, StripeError):
         # Explicit terminal business error or a terminal Stripe failure — preserve it.
         raise exc
-    # Keep the message generic (it is re-logged by the view); the original exception —
-    # which may carry Stripe identifiers — stays only in the chained traceback (exc_info).
-    logger.error("Unexpected webhook handler error: %s", type(exc).__name__, exc_info=True)
+    # Don't log here: the webhook view logs this (with exc_info) when it returns 5xx,
+    # so logging again would double the stack trace. Keep the message generic; the
+    # original exception (with any Stripe identifiers) stays in the chained traceback.
     raise BillingRetryableError(f"Unexpected error processing webhook event ({type(exc).__name__})") from exc
 
 
@@ -824,7 +824,7 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
             billing_limits = (team.billing_plan_limits or {}).copy()
             billing_limits["subscription_status"] = "active"
             billing_limits["last_updated"] = timezone.now().isoformat()
-            billing_limits["last_payment_amount"] = invoice.amount_paid / 100.0 if invoice.amount_paid else 0
+            billing_limits["last_payment_amount"] = invoice.amount_paid / 100.0 if invoice.amount_paid else 0.0
             billing_limits["last_payment_currency"] = invoice.currency
             billing_limits["last_processed_webhook_id"] = webhook_id
 
@@ -843,7 +843,7 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
 
         from sbomify.apps.core.posthog_service import capture
 
-        amount = invoice.amount_paid / 100.0 if invoice.amount_paid else 0
+        amount = invoice.amount_paid / 100.0 if invoice.amount_paid else 0.0
         workspace_key = team.key
         distinct_id = workspace_key or "system"
         capture(
@@ -972,7 +972,7 @@ def handle_checkout_completed(session: Any) -> None:
                 "stripe_subscription_id": session.subscription,
                 "subscription_status": subscription.status,
                 "last_updated": timezone.now().isoformat(),
-                "last_payment_amount": session.amount_total / 100.0 if session.amount_total else 0,
+                "last_payment_amount": session.amount_total / 100.0 if session.amount_total else 0.0,
                 "last_payment_currency": session.currency,
                 "last_processed_checkout_session": session.id,
             }
@@ -1002,7 +1002,7 @@ def handle_checkout_completed(session: Any) -> None:
 
         from sbomify.apps.core.posthog_service import capture, group_identify
 
-        amount = session.amount_total / 100.0 if session.amount_total else 0
+        amount = session.amount_total / 100.0 if session.amount_total else 0.0
         if team_key:
             capture(
                 team_key,

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -503,7 +503,17 @@ def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id:
         team.save()
 
     if subscription.status == "trialing" and subscription.trial_end:
-        handle_trial_period(subscription, team)
+        try:
+            handle_trial_period(subscription, team)
+        except BillingRetryableError:
+            raise
+        except StripeError as e:
+            # handle_trial_period is @handle_stripe_errors-decorated, so a transient
+            # internal failure (e.g. a DB blip during the trial-expiry downgrade) is
+            # flattened to a plain StripeError. Reclassify as retryable so the
+            # subscription.updated path returns 5xx (visible + Stripe retries) rather
+            # than silently acknowledging it with 200 — matching the checkout path.
+            raise BillingRetryableError(f"Trial-period processing failed transiently: {e!s}") from e
 
     return billing_limits
 

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -410,11 +410,10 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
     except BillingRetryableError:
         raise
     except StripeError:
-        logger.warning(
-            "Permanent failure fetching customer %s for subscription %s; treating as no team",
-            subscription.customer,
-            subscription.id,
-        )
+        # Don't log the Stripe customer/subscription identifiers here (flagged as
+        # sensitive by code scanning); the subscription id is still carried in the
+        # terminal Team.DoesNotExist raised below.
+        logger.warning("Permanent failure fetching Stripe customer during team resolution; treating as no team")
         customer = None
 
     if customer is not None and customer.metadata and "team_key" in customer.metadata:

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -36,17 +36,20 @@ logger = getLogger(__name__)
 stripe_client = get_stripe_client()
 
 
-def _best_effort(description: str, fn: Any, *args: Any) -> None:
-    """Run a non-billing-critical, post-commit side effect without failing the webhook.
+def _best_effort(description: str, fn: Any, *args: Any, **kwargs: Any) -> None:
+    """Run a non-billing-critical side effect (cache invalidation, notifications, analytics)
+    without failing the webhook.
 
-    The billing state is already committed by the time these run, and the idempotency
-    guard would skip them on a retry anyway — so a transient failure here must not raise
-    (which would only trigger a futile retry that re-skips the side effect). Log and move on.
+    These run alongside — usually after — the billing-state write, which is the only part
+    that must be durable. A transient failure here must not raise: a 5xx would trigger a
+    retry that the idempotency guard then skips, so the side effect is lost either way and
+    the retry is futile. Log and move on; the cache is short-TTL self-healing and the
+    billing state is reconciled by subsequent Stripe events / the trial-sync cron.
     """
     try:
-        fn(*args)
+        fn(*args, **kwargs)
     except Exception as e:
-        logger.warning("Non-critical post-commit side effect failed (%s): %s", description, e)
+        logger.warning("Non-critical side effect failed (%s): %s", description, e)
 
 
 def _raise_classified_webhook_error(exc: Exception) -> NoReturn:
@@ -344,7 +347,13 @@ def handle_subscription_updated(subscription: Any, event: Any = None) -> None:
         previous_status = billing_limits.get("subscription_status")
         billing_limits = _update_billing_from_subscription(team, subscription, webhook_id)
 
-        _send_subscription_notifications(team, subscription.status, previous_status)
+        _best_effort(
+            "subscription updated notifications",
+            _send_subscription_notifications,
+            team,
+            subscription.status,
+            previous_status,
+        )
 
         from sbomify.apps.core.posthog_service import capture, group_identify
 
@@ -529,14 +538,16 @@ def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id:
         try:
             handle_trial_period(subscription, team)
         except BillingRetryableError:
+            # Transient handle_trial_period failures (DB blip during the trial-expiry
+            # downgrade, etc.) are already surfaced as BillingRetryableError by its
+            # @handle_stripe_errors decorator — propagate so the event retries (5xx).
             raise
         except StripeError as e:
-            # handle_trial_period is @handle_stripe_errors-decorated, so a transient
-            # internal failure (e.g. a DB blip during the trial-expiry downgrade) is
-            # flattened to a plain StripeError. Reclassify as retryable so the
-            # subscription.updated path returns 5xx (visible + Stripe retries) rather
-            # than silently acknowledging it with 200 — matching the checkout path.
-            raise BillingRetryableError(f"Trial-period processing failed transiently: {e!s}") from e
+            # Defensive: handle_trial_period makes no Stripe calls today, so it cannot
+            # raise a plain terminal StripeError — but if that ever changes, reclassify it
+            # as retryable here rather than letting a trial-processing failure be
+            # acknowledged with 200.
+            raise BillingRetryableError(f"Trial-period processing failed: {e!s}") from e
 
     return billing_limits
 
@@ -683,7 +694,9 @@ def handle_subscription_deleted(subscription: Any, event: Any = None) -> None:
                 team.billing_plan_limits = billing_limits
                 team.save()
 
-        notify_team_owners(team, email_notifications.notify_subscription_ended)
+        _best_effort(
+            "subscription ended notification", notify_team_owners, team, email_notifications.notify_subscription_ended
+        )
         logger.info("Subscription ended notification sent")
 
         from sbomify.apps.core.posthog_service import capture, group_identify
@@ -744,7 +757,13 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
 
         _best_effort("invoice cache invalidation", invalidate_subscription_cache, invoice.subscription, team.key)
 
-        notify_team_owners(team, email_notifications.notify_payment_failed, invoice.id)
+        _best_effort(
+            "payment failed notification",
+            notify_team_owners,
+            team,
+            email_notifications.notify_payment_failed,
+            invoice.id,
+        )
         logger.warning(f"Payment failed notification sent (invoice {invoice.id})")
 
         from sbomify.apps.core.posthog_service import capture
@@ -815,7 +834,9 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
 
         _best_effort("invoice cache invalidation", invalidate_subscription_cache, invoice.subscription, team.key)
 
-        notify_team_owners(team, email_notifications.notify_payment_succeeded)
+        _best_effort(
+            "payment succeeded notification", notify_team_owners, team, email_notifications.notify_payment_succeeded
+        )
         logger.info("Payment successful notification sent")
 
         from sbomify.apps.core.posthog_service import capture
@@ -933,6 +954,13 @@ def handle_checkout_completed(session: Any) -> None:
         with transaction.atomic():
             team = Team.objects.select_for_update().get(pk=team.pk)
 
+            # Re-check under the row lock: the unlocked guard above closes the common
+            # sequential-redelivery case, but two concurrent deliveries could both pass
+            # it before either committed. The lock serializes them here.
+            if (team.billing_plan_limits or {}).get("last_processed_checkout_session") == session.id:
+                logger.info("Checkout session %s already processed (checked after lock), skipping", session.id)
+                return
+
             team.billing_plan = plan.key
             team.has_selected_billing_plan = True
             billing_limits: dict[str, Any] = {
@@ -960,6 +988,12 @@ def handle_checkout_completed(session: Any) -> None:
             team.save()
 
         if subscription.status == "trialing":
+            # Runs after the idempotency marker is committed: a transient failure here
+            # returns 5xx, but the redelivery short-circuits on the marker rather than
+            # re-running this step. That is a deliberate trade-off — re-running would
+            # risk a duplicate trial-ending email, since handle_trial_period is not
+            # idempotent — and the trial markers/expiry downgrade are reconciled by the
+            # subsequent customer.subscription.updated event and the trial-sync cron.
             handle_trial_period(subscription, team)
 
         logger.info("Successfully processed checkout session for team %s", team_key)

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -75,8 +75,10 @@ def _raise_classified_webhook_error(exc: Exception) -> NoReturn:
     if isinstance(exc, StripeError):
         # Explicit terminal business error or a terminal Stripe failure — preserve it.
         raise exc
-    logger.error("Unexpected webhook handler error: %s: %s", type(exc).__name__, exc, exc_info=True)
-    raise BillingRetryableError(f"{type(exc).__name__}: {exc!s}") from exc
+    # Keep the message generic (it is re-logged by the view); the original exception —
+    # which may carry Stripe identifiers — stays only in the chained traceback (exc_info).
+    logger.error("Unexpected webhook handler error: %s", type(exc).__name__, exc_info=True)
+    raise BillingRetryableError(f"Unexpected error processing webhook event ({type(exc).__name__})") from exc
 
 
 class BillingResourceType(str, Enum):
@@ -425,8 +427,9 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
             logger.warning("Found team by customer metadata")
             return team, team.billing_plan_limits or {}
 
-    # Definitively unresolved after every strategy → terminal "no team".
-    raise Team.DoesNotExist(f"No team found for subscription {subscription.id}")
+    # Definitively unresolved after every strategy → terminal "no team". Keep the
+    # message free of the Stripe subscription id (re-logged by the webhook view).
+    raise Team.DoesNotExist("No team found for the subscription in this webhook event")
 
 
 def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id: str) -> dict[str, Any]:

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import datetime
 from enum import Enum
 from functools import wraps
-from typing import Any
+from typing import Any, NoReturn
 
 from django.conf import settings
 from django.db import models, transaction
@@ -34,6 +34,46 @@ from .stripe_client import BillingRetryableError, StripeError, get_stripe_client
 logger = getLogger(__name__)
 
 stripe_client = get_stripe_client()
+
+
+def _best_effort(description: str, fn: Any, *args: Any) -> None:
+    """Run a non-billing-critical, post-commit side effect without failing the webhook.
+
+    The billing state is already committed by the time these run, and the idempotency
+    guard would skip them on a retry anyway — so a transient failure here must not raise
+    (which would only trigger a futile retry that re-skips the side effect). Log and move on.
+    """
+    try:
+        fn(*args)
+    except Exception as e:
+        logger.warning("Non-critical post-commit side effect failed (%s): %s", description, e)
+
+
+def _raise_classified_webhook_error(exc: Exception) -> NoReturn:
+    """Single source of truth for the webhook retryable/terminal contract.
+
+    Every webhook handler funnels its failures through here so the 200-vs-5xx policy
+    lives in one place instead of being hand-rolled (and drifting) across handlers:
+
+    * ``BillingRetryableError`` (incl. transient Stripe failures surfaced by the
+      ``handle_stripe_errors`` decorator) -> propagate so the view returns 5xx and
+      Stripe retries.
+    * ``Team.DoesNotExist`` / an explicit terminal ``StripeError`` (e.g. an invalid
+      subscription status, or a terminal Stripe failure such as a missing customer)
+      -> terminal: the view acknowledges with 200.
+    * Anything else (unexpected) -> retryable, so a transient bug/outage is not
+      silently dropped.
+    """
+    if isinstance(exc, BillingRetryableError):
+        raise exc
+    if isinstance(exc, Team.DoesNotExist):
+        # Terminal: a genuinely nonexistent team cannot be conjured by a retry.
+        raise StripeError(str(exc) or "No team found for webhook event") from exc
+    if isinstance(exc, StripeError):
+        # Explicit terminal business error or a terminal Stripe failure — preserve it.
+        raise exc
+    logger.error("Unexpected webhook handler error: %s: %s", type(exc).__name__, exc, exc_info=True)
+    raise BillingRetryableError(f"{type(exc).__name__}: {exc!s}") from exc
 
 
 class BillingResourceType(str, Enum):
@@ -299,7 +339,7 @@ def handle_subscription_updated(subscription: Any, event: Any = None) -> None:
             logger.info("Webhook already processed, skipping")
             return
 
-        invalidate_subscription_cache(subscription.id, team.key)
+        _best_effort("subscription cache invalidation", invalidate_subscription_cache, subscription.id, team.key)
 
         previous_status = billing_limits.get("subscription_status")
         billing_limits = _update_billing_from_subscription(team, subscription, webhook_id)
@@ -329,30 +369,8 @@ def handle_subscription_updated(subscription: Any, event: Any = None) -> None:
 
         logger.info(f"Updated subscription status to {subscription.status}")
 
-    except BillingRetryableError:
-        # Already classified as retryable downstream — propagate so the view returns 5xx.
-        raise
-    except Team.DoesNotExist:
-        # Every lookup strategy exhausted: the team genuinely does not exist.
-        # Terminal — retrying cannot conjure a team, so acknowledge (200).
-        logger.error("No team found for subscription")
-        raise StripeError("No team found for subscription")
-    except StripeError:
-        # Explicitly-raised terminal business error (e.g. invalid status) — acknowledge.
-        raise
     except Exception as e:
-        # Unexpected failure (e.g. a transient DB error): retry rather than drop.
-        subscription_id = getattr(subscription, "id", None) or (
-            subscription.get("id") if isinstance(subscription, dict) else None
-        )
-        logger.error(
-            "Error processing subscription update: %s: %s",
-            type(e).__name__,
-            str(e),
-            exc_info=True,
-            extra={"subscription_id": subscription_id},
-        )
-        raise BillingRetryableError(f"Error processing subscription update: {type(e).__name__}: {e!s}") from e
+        _raise_classified_webhook_error(e)
 
 
 def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, Any]]:
@@ -374,18 +392,23 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
     except Team.DoesNotExist:
         pass
 
-    # Last resort: recover the team via the Stripe customer's metadata. A failure
-    # to reach Stripe here is transient, so it must be retried — not misclassified
-    # as a terminal "no team" and silently acknowledged.
+    # Last resort: recover the team via the Stripe customer's metadata. A *transient*
+    # Stripe outage here must be retried (BillingRetryableError); a *permanent* failure
+    # (e.g. no such customer) cannot be resolved by retrying, so fall through to the
+    # terminal "no team" path rather than amplifying futile retries.
     try:
         customer = stripe_client.get_customer(subscription.customer)
-    except StripeError as e:
-        raise BillingRetryableError(
-            f"Could not fetch customer {subscription.customer} to resolve team "
-            f"for subscription {subscription.id}: {e!s}"
-        ) from e
+    except BillingRetryableError:
+        raise
+    except StripeError:
+        logger.warning(
+            "Permanent failure fetching customer %s for subscription %s; treating as no team",
+            subscription.customer,
+            subscription.id,
+        )
+        customer = None
 
-    if customer.metadata and "team_key" in customer.metadata:
+    if customer is not None and customer.metadata and "team_key" in customer.metadata:
         try:
             team = Team.objects.get(key=customer.metadata["team_key"])
         except Team.DoesNotExist:
@@ -560,7 +583,7 @@ def handle_subscription_deleted(subscription: Any, event: Any = None) -> None:
             logger.info("Webhook already processed for deleted subscription, skipping")
             return
 
-        invalidate_subscription_cache(subscription.id, team.key)
+        _best_effort("subscription cache invalidation", invalidate_subscription_cache, subscription.id, team.key)
 
         cancel_at_period_end = billing_limits.get("cancel_at_period_end", False)
         scheduled_downgrade_plan = billing_limits.get("scheduled_downgrade_plan")
@@ -682,15 +705,8 @@ def handle_subscription_deleted(subscription: Any, event: Any = None) -> None:
 
         logger.info("Subscription canceled")
 
-    except BillingRetryableError:
-        raise
-    except Team.DoesNotExist:
-        logger.error(f"No team found for subscription {subscription.id}")
-        raise StripeError(f"No team found for subscription {subscription.id}")
     except Exception as e:
-        # Transient failure during cancellation/downgrade — retry rather than strand a stale plan.
-        logger.error("Error processing subscription deletion: %s: %s", type(e).__name__, str(e), exc_info=True)
-        raise BillingRetryableError(f"Error processing subscription deletion: {type(e).__name__}: {e!s}") from e
+        _raise_classified_webhook_error(e)
 
 
 @handle_stripe_errors
@@ -726,7 +742,7 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
             team.billing_plan_limits = billing_limits
             team.save()
 
-        invalidate_subscription_cache(invoice.subscription, team.key)
+        _best_effort("invoice cache invalidation", invalidate_subscription_cache, invoice.subscription, team.key)
 
         notify_team_owners(team, email_notifications.notify_payment_failed, invoice.id)
         logger.warning(f"Payment failed notification sent (invoice {invoice.id})")
@@ -744,15 +760,8 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
 
         logger.warning("Payment failed")
 
-    except BillingRetryableError:
-        raise
-    except Team.DoesNotExist:
-        logger.error(f"No team found for subscription {invoice.subscription}")
-        raise StripeError(f"No team found for subscription {invoice.subscription}")
     except Exception as e:
-        # Transient failure recording the past_due flag — retry, don't drop the event.
-        logger.error("Error processing payment failure: %s: %s", type(e).__name__, str(e), exc_info=True)
-        raise BillingRetryableError(f"Error processing payment failure: {type(e).__name__}: {e!s}") from e
+        _raise_classified_webhook_error(e)
 
 
 @handle_stripe_errors
@@ -804,7 +813,7 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
             team.billing_plan_limits = billing_limits
             team.save()
 
-        invalidate_subscription_cache(invoice.subscription, team.key)
+        _best_effort("invoice cache invalidation", invalidate_subscription_cache, invoice.subscription, team.key)
 
         notify_team_owners(team, email_notifications.notify_payment_succeeded)
         logger.info("Payment successful notification sent")
@@ -826,15 +835,8 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
             groups={"workspace": workspace_key} if workspace_key else None,
         )
 
-    except BillingRetryableError:
-        raise
-    except Team.DoesNotExist:
-        logger.error(f"No team found for subscription {invoice.subscription}")
-        raise StripeError(f"No team found for subscription {invoice.subscription}")
     except Exception as e:
-        # Transient failure recording the successful payment — retry, don't drop the event.
-        logger.error("Error processing payment success: %s: %s", type(e).__name__, str(e), exc_info=True)
-        raise BillingRetryableError(f"Error processing payment success: {type(e).__name__}: {e!s}") from e
+        _raise_classified_webhook_error(e)
 
 
 def get_current_limits(team: Team) -> dict[str, Any]:
@@ -882,6 +884,14 @@ def handle_checkout_completed(session: Any) -> None:
 
     try:
         team = Team.objects.get(key=team_key)
+
+        # Idempotency: a redelivery of the same checkout session must short-circuit
+        # BEFORE the outbound Stripe calls (get_subscription / cancel_subscription),
+        # otherwise each retry re-issues them. Keyed on the session id since the view
+        # dispatches this handler without an event object.
+        if (team.billing_plan_limits or {}).get("last_processed_checkout_session") == session.id:
+            logger.info("Checkout session %s already processed for team %s, skipping", session.id, team_key)
+            return
 
         plan_key = session.metadata.get("plan_key", "business")
         plan = BillingPlan.objects.get(key=plan_key)
@@ -934,6 +944,7 @@ def handle_checkout_completed(session: Any) -> None:
                 "last_updated": timezone.now().isoformat(),
                 "last_payment_amount": session.amount_total / 100.0 if session.amount_total else 0,
                 "last_payment_currency": session.currency,
+                "last_processed_checkout_session": session.id,
             }
 
             if hasattr(subscription, "current_period_end") and subscription.current_period_end:
@@ -972,21 +983,10 @@ def handle_checkout_completed(session: Any) -> None:
                 "workspace", team_key, {"billing_plan": plan.key, "subscription_status": subscription.status}
             )
 
-    except BillingRetryableError:
-        # Already classified as retryable (e.g. a failed old-subscription cancel) — propagate.
-        raise
-    except Team.DoesNotExist:
-        # The checkout references a team that no longer exists — terminal, acknowledge.
-        logger.error(f"Team with key {team_key} not found")
-        raise StripeError(f"Team with key {team_key} not found")
-    except BillingPlan.DoesNotExist as e:
-        # A momentarily-unresolvable plan (deploy/sync race) — retry rather than drop a paid checkout.
-        logger.critical(f"Billing plan {plan_key} not found during checkout — retrying instead of dropping")
-        raise BillingRetryableError(f"Billing plan {plan_key} not found") from e
     except Exception as e:
-        # Unexpected/transient failure while persisting the checkout — retry, don't drop the paid event.
-        logger.error("Error processing checkout: %s", str(e), exc_info=True)
-        raise BillingRetryableError(f"Error processing checkout: {e!s}") from e
+        # Team.DoesNotExist -> terminal; a missing BillingPlan / unexpected failure -> retryable
+        # (don't drop a paid checkout). See _raise_classified_webhook_error.
+        _raise_classified_webhook_error(e)
 
 
 @handle_stripe_errors

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -29,7 +29,7 @@ from .billing_helpers import (
 from .config import get_unlimited_plan_limits, is_billing_enabled
 from .models import BillingPlan
 from .stripe_cache import get_subscription_cancel_at_period_end, invalidate_subscription_cache
-from .stripe_client import StripeError, get_stripe_client, handle_stripe_errors
+from .stripe_client import BillingRetryableError, StripeError, get_stripe_client, handle_stripe_errors
 
 logger = getLogger(__name__)
 
@@ -329,10 +329,19 @@ def handle_subscription_updated(subscription: Any, event: Any = None) -> None:
 
         logger.info(f"Updated subscription status to {subscription.status}")
 
+    except BillingRetryableError:
+        # Already classified as retryable downstream — propagate so the view returns 5xx.
+        raise
     except Team.DoesNotExist:
+        # Every lookup strategy exhausted: the team genuinely does not exist.
+        # Terminal — retrying cannot conjure a team, so acknowledge (200).
         logger.error("No team found for subscription")
         raise StripeError("No team found for subscription")
+    except StripeError:
+        # Explicitly-raised terminal business error (e.g. invalid status) — acknowledge.
+        raise
     except Exception as e:
+        # Unexpected failure (e.g. a transient DB error): retry rather than drop.
         subscription_id = getattr(subscription, "id", None) or (
             subscription.get("id") if isinstance(subscription, dict) else None
         )
@@ -343,7 +352,7 @@ def handle_subscription_updated(subscription: Any, event: Any = None) -> None:
             exc_info=True,
             extra={"subscription_id": subscription_id},
         )
-        raise StripeError(f"Error processing subscription update: {type(e).__name__}: {e!s}")
+        raise BillingRetryableError(f"Error processing subscription update: {type(e).__name__}: {e!s}") from e
 
 
 def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, Any]]:
@@ -365,16 +374,28 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
     except Team.DoesNotExist:
         pass
 
+    # Last resort: recover the team via the Stripe customer's metadata. A failure
+    # to reach Stripe here is transient, so it must be retried — not misclassified
+    # as a terminal "no team" and silently acknowledged.
     try:
         customer = stripe_client.get_customer(subscription.customer)
-        if customer.metadata and "team_key" in customer.metadata:
+    except StripeError as e:
+        raise BillingRetryableError(
+            f"Could not fetch customer {subscription.customer} to resolve team "
+            f"for subscription {subscription.id}: {e!s}"
+        ) from e
+
+    if customer.metadata and "team_key" in customer.metadata:
+        try:
             team = Team.objects.get(key=customer.metadata["team_key"])
+        except Team.DoesNotExist:
+            pass
+        else:
             logger.warning("Found team by customer metadata")
             return team, team.billing_plan_limits or {}
-        raise Team.DoesNotExist("No team key in customer metadata")
-    except Exception as e:
-        logger.error(f"Failed to recover team for subscription {subscription.id}: {e!s}")
-        raise StripeError(f"No team found for subscription {subscription.id}")
+
+    # Definitively unresolved after every strategy → terminal "no team".
+    raise Team.DoesNotExist(f"No team found for subscription {subscription.id}")
 
 
 def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id: str) -> dict[str, Any]:
@@ -429,10 +450,16 @@ def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id:
             else:
                 logger.warning("Could not find customer ID in subscription")
 
-        subscription_items = getattr(subscription, "items", None)
+        # Real StripeObjects subclass dict, so ``subscription.items`` resolves to the
+        # dict METHOD rather than the line-item list. Read items via subscript access
+        # for dict-like payloads; fall back to attribute access for plain objects.
+        if isinstance(subscription, dict):
+            items_obj = subscription.get("items")
+        else:
+            items_obj = getattr(subscription, "items", None)
         items_data = None
-        if subscription_items is not None and hasattr(subscription_items, "data"):
-            items_data = subscription_items.data
+        if items_obj is not None:
+            items_data = items_obj.get("data") if isinstance(items_obj, dict) else getattr(items_obj, "data", None)
 
         if items_data:
             try:
@@ -464,8 +491,13 @@ def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id:
                         "max_components": plan.max_components,
                     }
                 )
-            except BillingPlan.DoesNotExist:
-                logger.critical("Billing plan not found during subscription update")
+            except BillingPlan.DoesNotExist as e:
+                # Persisting subscription_status=active with stale limits here would
+                # silently corrupt entitlements. Raise inside the atomic block so the
+                # whole update rolls back and Stripe retries (self-heals a deploy/sync
+                # race; alerts ops via the 5xx if the plan is genuinely missing).
+                logger.critical("Billing plan not found during subscription update — not persisting stale limits")
+                raise BillingRetryableError("Billing plan not found during subscription update") from e
 
         team.billing_plan_limits = billing_limits
         team.save()
@@ -640,9 +672,15 @@ def handle_subscription_deleted(subscription: Any, event: Any = None) -> None:
 
         logger.info("Subscription canceled")
 
+    except BillingRetryableError:
+        raise
     except Team.DoesNotExist:
         logger.error(f"No team found for subscription {subscription.id}")
         raise StripeError(f"No team found for subscription {subscription.id}")
+    except Exception as e:
+        # Transient failure during cancellation/downgrade — retry rather than strand a stale plan.
+        logger.error("Error processing subscription deletion: %s: %s", type(e).__name__, str(e), exc_info=True)
+        raise BillingRetryableError(f"Error processing subscription deletion: {type(e).__name__}: {e!s}") from e
 
 
 @handle_stripe_errors
@@ -696,9 +734,15 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
 
         logger.warning("Payment failed")
 
+    except BillingRetryableError:
+        raise
     except Team.DoesNotExist:
         logger.error(f"No team found for subscription {invoice.subscription}")
         raise StripeError(f"No team found for subscription {invoice.subscription}")
+    except Exception as e:
+        # Transient failure recording the past_due flag — retry, don't drop the event.
+        logger.error("Error processing payment failure: %s: %s", type(e).__name__, str(e), exc_info=True)
+        raise BillingRetryableError(f"Error processing payment failure: {type(e).__name__}: {e!s}") from e
 
 
 @handle_stripe_errors
@@ -772,9 +816,15 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
             groups={"workspace": workspace_key} if workspace_key else None,
         )
 
+    except BillingRetryableError:
+        raise
     except Team.DoesNotExist:
         logger.error(f"No team found for subscription {invoice.subscription}")
         raise StripeError(f"No team found for subscription {invoice.subscription}")
+    except Exception as e:
+        # Transient failure recording the successful payment — retry, don't drop the event.
+        logger.error("Error processing payment success: %s: %s", type(e).__name__, str(e), exc_info=True)
+        raise BillingRetryableError(f"Error processing payment success: {type(e).__name__}: {e!s}") from e
 
 
 def get_current_limits(team: Team) -> dict[str, Any]:
@@ -836,26 +886,29 @@ def handle_checkout_completed(session: Any) -> None:
                 stripe_client.cancel_subscription(existing_subscription_id)
                 logger.info("Successfully cancelled old subscription")
             except StripeError as e:
+                # A failed cancel (often a transient Stripe outage) must NOT be
+                # acknowledged: returning 200 strands both subscriptions active
+                # (double billing) with no retry. Raise retryable so Stripe
+                # re-delivers; a persistent failure exhausts retries and alerts.
                 logger.critical(
                     "CRITICAL: Failed to cancel old subscription: %s. "
-                    "Cannot proceed with checkout - both subscriptions would be active. "
-                    "MANUAL INTERVENTION REQUIRED immediately.",
+                    "Both subscriptions would be active — deferring via retry.",
                     e,
                 )
-                raise StripeError(
-                    "Cannot complete checkout: failed to cancel existing subscription. "
-                    "Both subscriptions would be active. Manual intervention required."
-                )
+                raise BillingRetryableError(
+                    "Cannot complete checkout yet: failed to cancel existing subscription; "
+                    "retrying to avoid leaving both subscriptions active."
+                ) from e
             except Exception as e:
                 logger.critical(
                     "CRITICAL: Unexpected error cancelling old subscription: %s. "
-                    "Cannot proceed with checkout - both subscriptions would be active.",
+                    "Both subscriptions would be active — deferring via retry.",
                     e,
                 )
-                raise StripeError(
-                    "Cannot complete checkout: unexpected error cancelling existing subscription. "
-                    "Manual intervention required."
-                )
+                raise BillingRetryableError(
+                    "Cannot complete checkout yet: unexpected error cancelling existing subscription; "
+                    "retrying to avoid leaving both subscriptions active."
+                ) from e
 
         with transaction.atomic():
             team = Team.objects.select_for_update().get(pk=team.pk)
@@ -909,15 +962,21 @@ def handle_checkout_completed(session: Any) -> None:
                 "workspace", team_key, {"billing_plan": plan.key, "subscription_status": subscription.status}
             )
 
+    except BillingRetryableError:
+        # Already classified as retryable (e.g. a failed old-subscription cancel) — propagate.
+        raise
     except Team.DoesNotExist:
+        # The checkout references a team that no longer exists — terminal, acknowledge.
         logger.error(f"Team with key {team_key} not found")
         raise StripeError(f"Team with key {team_key} not found")
-    except BillingPlan.DoesNotExist:
-        logger.error(f"Billing plan {plan_key} not found")
-        raise StripeError(f"Billing plan {plan_key} not found")
+    except BillingPlan.DoesNotExist as e:
+        # A momentarily-unresolvable plan (deploy/sync race) — retry rather than drop a paid checkout.
+        logger.critical(f"Billing plan {plan_key} not found during checkout — retrying instead of dropping")
+        raise BillingRetryableError(f"Billing plan {plan_key} not found") from e
     except Exception as e:
+        # Unexpected/transient failure while persisting the checkout — retry, don't drop the paid event.
         logger.error("Error processing checkout: %s", str(e), exc_info=True)
-        raise StripeError(f"Error processing checkout: {e!s}")
+        raise BillingRetryableError(f"Error processing checkout: {e!s}") from e
 
 
 @handle_stripe_errors

--- a/sbomify/apps/billing/schemas.py
+++ b/sbomify/apps/billing/schemas.py
@@ -22,6 +22,9 @@ class BillingLimitsData(TypedDict, total=False):
     next_billing_date: str | None
     last_updated: str
     last_processed_webhook_id: str | None
+    last_processed_checkout_session: str
+    last_payment_amount: float
+    last_payment_currency: str | None
 
 
 class PlanSchema(Schema):

--- a/sbomify/apps/billing/stripe_client.py
+++ b/sbomify/apps/billing/stripe_client.py
@@ -65,24 +65,24 @@ def handle_stripe_errors(func: F) -> F:
         # Terminal failures: the same request cannot succeed on retry.
         except stripe.error.CardError as e:
             logger.error("Card error: code=%s, param=%s", e.code, e.param)
-            raise StripeError(f"Card error: {e.user_message}")
+            raise StripeError(f"Card error: {e.user_message}") from e
         except stripe.error.InvalidRequestError as e:
             logger.error("Invalid Stripe request: param=%s, message=%s", e.param, str(e))
-            raise StripeError("Invalid request to payment provider.")
-        except stripe.error.AuthenticationError:
+            raise StripeError("Invalid request to payment provider.") from e
+        except stripe.error.AuthenticationError as e:
             logger.error("Stripe authentication error")
-            raise StripeError("Authentication with payment provider failed.")
+            raise StripeError("Authentication with payment provider failed.") from e
         # Transient failures: a retry may succeed once Stripe recovers.
         except stripe.error.RateLimitError as e:
             logger.error("Rate limit error: %s", e.code)
-            raise BillingRetryableError("Too many requests made to Stripe API")
-        except stripe.error.APIConnectionError:
+            raise BillingRetryableError("Too many requests made to Stripe API") from e
+        except stripe.error.APIConnectionError as e:
             logger.error("Stripe API connection error")
-            raise BillingRetryableError("Could not connect to payment provider.")
+            raise BillingRetryableError("Could not connect to payment provider.") from e
         except stripe.error.StripeError as e:
             # Unclassified Stripe error (e.g. an API 5xx) — default to retryable.
             logger.error("Stripe error: code=%s, message=%s", e.code, str(e), exc_info=True)
-            raise BillingRetryableError("A payment processing error occurred.")
+            raise BillingRetryableError("A payment processing error occurred.") from e
         except Exception as e:
             logger.error("Unexpected error in Stripe operation: %s", type(e).__name__, exc_info=True)
             raise BillingRetryableError("An unexpected error occurred.") from e

--- a/sbomify/apps/billing/stripe_client.py
+++ b/sbomify/apps/billing/stripe_client.py
@@ -62,27 +62,30 @@ def handle_stripe_errors(func: F) -> F:
             return func(*args, **kwargs)
         except StripeError:
             raise
+        # Terminal failures: the same request cannot succeed on retry.
         except stripe.error.CardError as e:
             logger.error("Card error: code=%s, param=%s", e.code, e.param)
             raise StripeError(f"Card error: {e.user_message}")
-        except stripe.error.RateLimitError as e:
-            logger.error("Rate limit error: %s", e.code)
-            raise StripeError("Too many requests made to Stripe API")
         except stripe.error.InvalidRequestError as e:
             logger.error("Invalid Stripe request: param=%s, message=%s", e.param, str(e))
             raise StripeError("Invalid request to payment provider.")
         except stripe.error.AuthenticationError:
             logger.error("Stripe authentication error")
             raise StripeError("Authentication with payment provider failed.")
+        # Transient failures: a retry may succeed once Stripe recovers.
+        except stripe.error.RateLimitError as e:
+            logger.error("Rate limit error: %s", e.code)
+            raise BillingRetryableError("Too many requests made to Stripe API")
         except stripe.error.APIConnectionError:
             logger.error("Stripe API connection error")
-            raise StripeError("Could not connect to payment provider.")
+            raise BillingRetryableError("Could not connect to payment provider.")
         except stripe.error.StripeError as e:
+            # Unclassified Stripe error (e.g. an API 5xx) — default to retryable.
             logger.error("Stripe error: code=%s, message=%s", e.code, str(e), exc_info=True)
-            raise StripeError("A payment processing error occurred.")
+            raise BillingRetryableError("A payment processing error occurred.")
         except Exception as e:
             logger.error("Unexpected error in Stripe operation: %s", type(e).__name__, exc_info=True)
-            raise StripeError("An unexpected error occurred.") from e
+            raise BillingRetryableError("An unexpected error occurred.") from e
 
     return wrapper  # type: ignore[return-value]
 

--- a/sbomify/apps/billing/stripe_client.py
+++ b/sbomify/apps/billing/stripe_client.py
@@ -22,7 +22,28 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 class StripeError(Exception):
-    """Base class for Stripe-related errors."""
+    """Base class for Stripe-related errors.
+
+    Treated as a *terminal* business error by the webhook view: the event is
+    acknowledged (HTTP 200) and Stripe stops retrying. Use this only when a
+    retry cannot possibly change the outcome (e.g. an unknown event type or a
+    genuinely nonexistent team).
+    """
+
+    pass
+
+
+class BillingRetryableError(StripeError):
+    """A transient/recoverable failure that Stripe should retry.
+
+    Subclasses :class:`StripeError` so existing ``except StripeError`` handlers
+    (and the ``handle_stripe_errors`` decorator's ``except StripeError: raise``)
+    keep working unchanged, while the webhook view can catch this *first* and
+    return a 5xx so Stripe re-delivers the event. Raise for conditions that may
+    succeed on a later attempt: transient DB/Stripe outages, a checkout race
+    where the team↔subscription mapping is not yet written, or a billing plan
+    that is momentarily unresolvable.
+    """
 
     pass
 

--- a/sbomify/apps/billing/tests/test_billing_processing.py
+++ b/sbomify/apps/billing/tests/test_billing_processing.py
@@ -16,7 +16,7 @@ from sbomify.apps.sboms.models import Product
 from sbomify.apps.teams.models import Member, Team
 from sbomify.logging import getLogger
 
-from ..stripe_client import StripeError
+from ..stripe_client import BillingRetryableError, StripeError
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -239,6 +239,82 @@ class TestBillingProcessing:
         self.team.delete()
         with pytest.raises(StripeError):
             billing_processing.handle_subscription_updated(self.subscription)
+
+    # ------------------------------------------------------------------
+    # #996: retryable vs terminal classification across ALL handlers.
+    # A transient/recoverable failure must raise BillingRetryableError so the
+    # webhook view returns 5xx and Stripe re-delivers — never a silent 200 drop.
+    # ------------------------------------------------------------------
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_checkout_failed_cancel_is_retryable_not_dropped(self, mock_email):
+        """Issue #996: a failed old-subscription cancel must retry, not double-bill silently."""
+        old_sub_id = "sub_old_999"
+        self.team.billing_plan_limits["stripe_subscription_id"] = old_sub_id
+        self.team.save()
+
+        self.session.subscription = "sub_new_111"
+        self.stripe_client.get_subscription.return_value = MagicMock(
+            id="sub_new_111",
+            status="active",
+            trial_end=None,
+            items=MagicMock(data=[MagicMock(price=MagicMock(product="prod_123", metadata={"plan_key": "business"}))]),
+            metadata={"plan_key": "business"},
+        )
+        # Stripe outage while cancelling the old subscription.
+        self.stripe_client.cancel_subscription.side_effect = StripeError("Stripe temporarily unavailable")
+
+        with pytest.raises(BillingRetryableError):
+            billing_processing.handle_checkout_completed(self.session)
+
+        # Must NOT have switched to the new subscription (no double-billing persisted).
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["stripe_subscription_id"] == old_sub_id
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_checkout_transient_failure_is_retryable(self, mock_email):
+        """A transient failure while persisting a checkout must retry, not drop the paid event."""
+        self.stripe_client.get_subscription.side_effect = Exception("transient infra blip")
+
+        with pytest.raises(BillingRetryableError):
+            billing_processing.handle_checkout_completed(self.session)
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_checkout_missing_plan_is_retryable(self, mock_email):
+        """A momentarily-unresolvable BillingPlan during checkout must retry (deploy/sync race)."""
+        self.session.metadata = {"team_key": self.team.key, "plan_key": "does_not_exist"}
+
+        with pytest.raises(BillingRetryableError):
+            billing_processing.handle_checkout_completed(self.session)
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_payment_succeeded_transient_failure_is_retryable(self, mock_email):
+        """A transient cache/DB failure recording a successful payment must retry."""
+        with patch(
+            "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
+            side_effect=Exception("redis blip"),
+        ):
+            with pytest.raises(BillingRetryableError):
+                billing_processing.handle_payment_succeeded(self.invoice)
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_payment_failed_transient_failure_is_retryable(self, mock_email):
+        """A transient cache/DB failure recording a past_due flag must retry."""
+        with patch(
+            "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
+            side_effect=Exception("redis blip"),
+        ):
+            with pytest.raises(BillingRetryableError):
+                billing_processing.handle_payment_failed(self.invoice)
+
+    def test_subscription_deleted_transient_failure_is_retryable(self):
+        """A transient failure during cancellation/downgrade must retry, not strand a stale plan."""
+        with patch(
+            "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
+            side_effect=Exception("redis blip"),
+        ):
+            with pytest.raises(BillingRetryableError):
+                billing_processing.handle_subscription_deleted(self.subscription)
 
 
 

--- a/sbomify/apps/billing/tests/test_billing_processing.py
+++ b/sbomify/apps/billing/tests/test_billing_processing.py
@@ -244,16 +244,31 @@ class TestBillingProcessing:
         """Last-resort team resolution: a transient get_customer failure must retry, not 200-drop.
 
         When neither the subscription_id nor customer_id DB lookups match, the resolver
-        falls back to stripe_client.get_customer(). A transient failure there must surface
-        as BillingRetryableError (5xx), not be acknowledged as terminal.
+        falls back to stripe_client.get_customer(). A transient failure there (surfaced as
+        BillingRetryableError by the decorator) must propagate as retryable (5xx).
         """
         # Make both DB lookups miss by pointing the event at IDs no team has.
         self.subscription.id = "sub_unmapped_e2e"
         self.subscription.customer = "cus_unmapped_e2e"
-        self.stripe_client.get_customer.side_effect = StripeError("Could not connect to payment provider.")
+        self.stripe_client.get_customer.side_effect = BillingRetryableError("Could not connect to payment provider.")
 
         with pytest.raises(BillingRetryableError):
             billing_processing.handle_subscription_updated(self.subscription)
+
+    def test_resolve_team_permanent_get_customer_failure_is_terminal(self):
+        """A permanent get_customer failure (e.g. no such customer) must be terminal (200), not retried.
+
+        Reclassifying a permanent 'no such customer' as retryable would burn Stripe's
+        ~3-day retry window on a condition that can never succeed (review follow-up).
+        """
+        self.subscription.id = "sub_unmapped_e2e"
+        self.subscription.customer = "cus_unmapped_e2e"
+        # A plain StripeError models a terminal Stripe failure (InvalidRequestError -> StripeError).
+        self.stripe_client.get_customer.side_effect = StripeError("Invalid request to payment provider.")
+
+        with pytest.raises(StripeError) as exc:
+            billing_processing.handle_subscription_updated(self.subscription)
+        assert not isinstance(exc.value, BillingRetryableError)
 
     def test_resolve_team_customer_metadata_points_to_missing_team_is_terminal(self):
         """If get_customer succeeds but its metadata team_key resolves to no team -> terminal (200)."""
@@ -314,33 +329,55 @@ class TestBillingProcessing:
             billing_processing.handle_checkout_completed(self.session)
 
     @patch("sbomify.apps.billing.billing_processing.email_notifications")
-    def test_payment_succeeded_transient_failure_is_retryable(self, mock_email):
-        """A transient cache/DB failure recording a successful payment must retry."""
-        with patch(
-            "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
-            side_effect=Exception("redis blip"),
-        ):
+    def test_checkout_completed_is_idempotent_on_redelivery(self, mock_email):
+        """A redelivered checkout session must short-circuit before re-issuing Stripe calls."""
+        billing_processing.handle_checkout_completed(self.session)
+        calls_after_first = self.stripe_client.get_subscription.call_count
+
+        billing_processing.handle_checkout_completed(self.session)  # Stripe redelivery
+
+        # The redelivery must NOT re-issue the outbound get_subscription call.
+        assert self.stripe_client.get_subscription.call_count == calls_after_first
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["last_processed_checkout_session"] == self.session.id
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_payment_succeeded_precommit_db_failure_is_retryable(self, mock_email):
+        """A transient failure writing the billing state (pre-commit) must retry."""
+        with patch("sbomify.apps.teams.models.Team.save", side_effect=Exception("db write blip")):
             with pytest.raises(BillingRetryableError):
                 billing_processing.handle_payment_succeeded(self.invoice)
 
     @patch("sbomify.apps.billing.billing_processing.email_notifications")
-    def test_payment_failed_transient_failure_is_retryable(self, mock_email):
-        """A transient cache/DB failure recording a past_due flag must retry."""
-        with patch(
-            "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
-            side_effect=Exception("redis blip"),
-        ):
+    def test_payment_failed_precommit_db_failure_is_retryable(self, mock_email):
+        """A transient failure writing the past_due state (pre-commit) must retry."""
+        with patch("sbomify.apps.teams.models.Team.save", side_effect=Exception("db write blip")):
             with pytest.raises(BillingRetryableError):
                 billing_processing.handle_payment_failed(self.invoice)
 
-    def test_subscription_deleted_transient_failure_is_retryable(self):
-        """A transient failure during cancellation/downgrade must retry, not strand a stale plan."""
+    def test_subscription_deleted_precommit_db_failure_is_retryable(self):
+        """A transient failure writing the cancellation (pre-commit) must retry, not strand a stale plan."""
+        with patch("sbomify.apps.teams.models.Team.save", side_effect=Exception("db write blip")):
+            with pytest.raises(BillingRetryableError):
+                billing_processing.handle_subscription_deleted(self.subscription)
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_payment_succeeded_postcommit_cache_failure_is_best_effort(self, mock_email):
+        """A post-commit cache-invalidation blip must NOT fail the webhook (best-effort).
+
+        The billing state is already committed; a retry would only idempotency-skip the
+        cache invalidation, so raising (5xx) would be a futile retry. It must return
+        normally and leave the committed state intact.
+        """
         with patch(
             "sbomify.apps.billing.billing_processing.invalidate_subscription_cache",
             side_effect=Exception("redis blip"),
         ):
-            with pytest.raises(BillingRetryableError):
-                billing_processing.handle_subscription_deleted(self.subscription)
+            # Does not raise, despite the cache failure.
+            billing_processing.handle_payment_succeeded(self.invoice)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "active"
 
     @patch("sbomify.apps.billing.billing_processing.email_notifications")
     def test_subscription_updated_trial_period_transient_failure_is_retryable(self, mock_email):

--- a/sbomify/apps/billing/tests/test_billing_processing.py
+++ b/sbomify/apps/billing/tests/test_billing_processing.py
@@ -240,6 +240,32 @@ class TestBillingProcessing:
         with pytest.raises(StripeError):
             billing_processing.handle_subscription_updated(self.subscription)
 
+    def test_resolve_team_transient_get_customer_failure_is_retryable(self):
+        """Last-resort team resolution: a transient get_customer failure must retry, not 200-drop.
+
+        When neither the subscription_id nor customer_id DB lookups match, the resolver
+        falls back to stripe_client.get_customer(). A transient failure there must surface
+        as BillingRetryableError (5xx), not be acknowledged as terminal.
+        """
+        # Make both DB lookups miss by pointing the event at IDs no team has.
+        self.subscription.id = "sub_unmapped_e2e"
+        self.subscription.customer = "cus_unmapped_e2e"
+        self.stripe_client.get_customer.side_effect = StripeError("Could not connect to payment provider.")
+
+        with pytest.raises(BillingRetryableError):
+            billing_processing.handle_subscription_updated(self.subscription)
+
+    def test_resolve_team_customer_metadata_points_to_missing_team_is_terminal(self):
+        """If get_customer succeeds but its metadata team_key resolves to no team -> terminal (200)."""
+        self.subscription.id = "sub_unmapped_e2e"
+        self.subscription.customer = "cus_unmapped_e2e"
+        self.stripe_client.get_customer.return_value = MagicMock(metadata={"team_key": "no_such_team"})
+
+        # Terminal: a genuinely nonexistent team is a plain StripeError, not retryable.
+        with pytest.raises(StripeError) as exc:
+            billing_processing.handle_subscription_updated(self.subscription)
+        assert not isinstance(exc.value, BillingRetryableError)
+
     # ------------------------------------------------------------------
     # #996: retryable vs terminal classification across ALL handlers.
     # A transient/recoverable failure must raise BillingRetryableError so the
@@ -315,6 +341,26 @@ class TestBillingProcessing:
         ):
             with pytest.raises(BillingRetryableError):
                 billing_processing.handle_subscription_deleted(self.subscription)
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_subscription_updated_trial_period_transient_failure_is_retryable(self, mock_email):
+        """A transient failure inside handle_trial_period (trialing path) must retry, not 200-drop.
+
+        handle_trial_period is @handle_stripe_errors-decorated, so any internal failure
+        surfaces as a plain StripeError. Without reclassification it would be caught by
+        handle_subscription_updated's `except StripeError: raise` (terminal -> 200),
+        silently dropping the trialing event — the exact #996 class, and inconsistent
+        with the checkout path which already retries.
+        """
+        self.subscription.status = "trialing"
+        self.subscription.trial_end = int((timezone.now() + datetime.timedelta(days=3)).timestamp())
+
+        with patch(
+            "sbomify.apps.billing.billing_processing.handle_trial_period",
+            side_effect=StripeError("An unexpected error occurred."),
+        ):
+            with pytest.raises(BillingRetryableError):
+                billing_processing.handle_subscription_updated(self.subscription)
 
 
 

--- a/sbomify/apps/billing/tests/test_billing_processing.py
+++ b/sbomify/apps/billing/tests/test_billing_processing.py
@@ -342,6 +342,21 @@ class TestBillingProcessing:
         assert self.team.billing_plan_limits["last_processed_checkout_session"] == self.session.id
 
     @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_checkout_completed_trialing_is_idempotent_on_redelivery(self, mock_email):
+        """A redelivered TRIALING checkout must not re-run handle_trial_period (no duplicate trial email)."""
+        self.subscription.status = "trialing"
+        self.subscription.trial_end = int((timezone.now() + datetime.timedelta(days=14)).timestamp())
+        self.stripe_client.get_subscription.return_value = self.subscription
+
+        with patch("sbomify.apps.billing.billing_processing.handle_trial_period") as mock_trial:
+            billing_processing.handle_checkout_completed(self.session)
+            assert mock_trial.call_count == 1  # ran on first delivery
+
+            billing_processing.handle_checkout_completed(self.session)  # Stripe redelivery
+            # The guard short-circuits before the trial-period side-effect path is reached.
+            assert mock_trial.call_count == 1
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
     def test_payment_succeeded_precommit_db_failure_is_retryable(self, mock_email):
         """A transient failure writing the billing state (pre-commit) must retry."""
         with patch("sbomify.apps.teams.models.Team.save", side_effect=Exception("db write blip")):
@@ -375,6 +390,18 @@ class TestBillingProcessing:
         ):
             # Does not raise, despite the cache failure.
             billing_processing.handle_payment_succeeded(self.invoice)
+
+        self.team.refresh_from_db()
+        assert self.team.billing_plan_limits["subscription_status"] == "active"
+
+    @patch("sbomify.apps.billing.billing_processing.email_notifications")
+    def test_payment_succeeded_postcommit_notify_failure_is_best_effort(self, mock_email):
+        """A post-commit notification outage must NOT fail the webhook (best-effort, like cache)."""
+        with patch(
+            "sbomify.apps.billing.billing_processing.notify_team_owners",
+            side_effect=Exception("smtp blip"),
+        ):
+            billing_processing.handle_payment_succeeded(self.invoice)  # does not raise
 
         self.team.refresh_from_db()
         assert self.team.billing_plan_limits["subscription_status"] == "active"

--- a/sbomify/apps/billing/tests/test_billing_processing_updates.py
+++ b/sbomify/apps/billing/tests/test_billing_processing_updates.py
@@ -1,10 +1,33 @@
 from unittest.mock import MagicMock
 
 import pytest
+import stripe
 
 from sbomify.apps.billing.billing_processing import handle_subscription_updated
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.teams.models import Team
+
+
+def _real_subscription(**overrides):
+    """Build a genuine Stripe ``Subscription`` object (not a MagicMock).
+
+    Real StripeObjects subclass dict, so ``.items`` resolves to the dict METHOD
+    (shadowing the subscription's line items) — exactly the production condition
+    that a MagicMock silently hides.
+    """
+    data = {
+        "id": "sub_test_123",
+        "object": "subscription",
+        "customer": "cus_test_123",
+        "status": "active",
+        "cancel_at_period_end": False,
+        "cancel_at": None,
+        "current_period_end": 1893456000,
+        "metadata": {"plan_key": "enterprise"},
+        "items": {"object": "list", "data": [{"price": {"id": "price_test_enterprise"}}]},
+    }
+    data.update(overrides)
+    return stripe.Subscription.construct_from(data, "sk_test_dummy")
 
 
 @pytest.fixture
@@ -57,15 +80,86 @@ def test_handle_subscription_updated_price_id_match(enterprise_plan_with_price, 
 @pytest.mark.django_db
 def test_handle_subscription_updated_cancel_at_period_end_sync(enterprise_plan_with_price, team_with_subscription):
     """Test that cancel_at_period_end flag is synced from subscription."""
-    
+
     mock_sub = MagicMock()
     mock_sub.id = "sub_test_123"
     mock_sub.customer = "cus_test_123"
     mock_sub.status = "active"
     mock_sub.items.data = [MagicMock(price=MagicMock(id="price_test_enterprise"))]
     mock_sub.cancel_at_period_end = True
-    
+
     handle_subscription_updated(mock_sub)
-    
+
     team_with_subscription.refresh_from_db()
     assert team_with_subscription.billing_plan_limits["cancel_at_period_end"] is True
+
+
+@pytest.mark.django_db
+def test_handle_subscription_updated_missing_plan_raises_and_does_not_persist_active(team_with_subscription):
+    """When the BillingPlan cannot be resolved, the event must retry — never persist stale 'active' limits.
+
+    Reproduces #996: the handler logged ``critical`` but still saved
+    ``subscription_status=active`` with stale plan limits. The fix raises a
+    retryable error so the whole transaction rolls back and Stripe retries.
+    """
+    from sbomify.apps.billing.stripe_client import BillingRetryableError
+
+    # Pre-seed STALE values so the rollback assertions below are meaningful rather
+    # than tautological (the fixture otherwise lacks both keys).
+    team_with_subscription.billing_plan_limits.update(
+        {"subscription_status": "past_due", "last_processed_webhook_id": "evt_old"}
+    )
+    team_with_subscription.save()
+
+    mock_sub = MagicMock()
+    mock_sub.id = "sub_test_123"
+    mock_sub.customer = "cus_test_123"
+    mock_sub.status = "active"
+    mock_sub.current_period_end = 1893456000
+    mock_sub.cancel_at_period_end = False
+    mock_sub.cancel_at = None
+    # Price ID matches no plan, and the metadata fallback key does not exist either.
+    mock_sub.metadata = {"plan_key": "does_not_exist"}
+    mock_sub.items.data = [MagicMock(price=MagicMock(id="price_unmatched"))]
+
+    with pytest.raises(BillingRetryableError):
+        handle_subscription_updated(mock_sub)
+
+    team_with_subscription.refresh_from_db()
+    # Rollback: the stale values must be preserved, NOT overwritten with the
+    # incoming 'active' status / new webhook id from the partially-applied update.
+    assert team_with_subscription.billing_plan_limits["subscription_status"] == "past_due"
+    assert team_with_subscription.billing_plan_limits["last_processed_webhook_id"] == "evt_old"
+
+
+@pytest.mark.django_db
+def test_subscription_updated_syncs_plan_from_items_on_real_stripe_object(
+    enterprise_plan_with_price, team_with_subscription
+):
+    """Plan/limits must sync from the subscription's line items for REAL Stripe events.
+
+    Guards against the ``StripeObject.items`` shadowing bug: ``getattr(sub, "items")``
+    returns the dict method, so the line-item plan-resolution block was skipped for
+    real webhook payloads (a MagicMock hid this because attribute access worked).
+    """
+    sub = _real_subscription()  # price_test_enterprise -> enterprise plan
+
+    handle_subscription_updated(sub)
+
+    team_with_subscription.refresh_from_db()
+    assert team_with_subscription.billing_plan == "enterprise"
+    assert team_with_subscription.billing_plan_limits["max_products"] == enterprise_plan_with_price.max_products
+
+
+@pytest.mark.django_db
+def test_subscription_updated_missing_plan_is_retryable_on_real_stripe_object(team_with_subscription):
+    """The missing-plan retryable path must be reachable for REAL Stripe events too."""
+    from sbomify.apps.billing.stripe_client import BillingRetryableError
+
+    sub = _real_subscription(
+        metadata={"plan_key": "does_not_exist"},
+        items={"object": "list", "data": [{"price": {"id": "price_unmatchable"}}]},
+    )
+
+    with pytest.raises(BillingRetryableError):
+        handle_subscription_updated(sub)

--- a/sbomify/apps/billing/tests/test_stripe_client.py
+++ b/sbomify/apps/billing/tests/test_stripe_client.py
@@ -6,7 +6,7 @@ import pytest
 import stripe
 from django.conf import settings
 
-from sbomify.apps.billing.stripe_client import StripeClient, StripeError
+from sbomify.apps.billing.stripe_client import BillingRetryableError, StripeClient, StripeError
 
 
 class TestStripeClient:
@@ -52,6 +52,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "Card error" in str(exc_info.value)
+        # Terminal: a declined card will not succeed on retry.
+        assert not isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_rate_limit_error(self, mock_retrieve):
@@ -62,6 +64,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "Too many requests made to Stripe API" in str(exc_info.value)
+        # Transient: rate limiting clears, so this is retryable.
+        assert isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_invalid_request_error(self, mock_retrieve):
@@ -72,6 +76,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "Invalid request to payment provider." in str(exc_info.value)
+        # Terminal: a bad request / resource_missing will not succeed on retry.
+        assert not isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_authentication_error(self, mock_retrieve):
@@ -82,6 +88,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "Authentication with payment provider failed." in str(exc_info.value)
+        # Terminal: a credential/config error will not self-heal on retry.
+        assert not isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_api_connection_error(self, mock_retrieve):
@@ -92,6 +100,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "Could not connect to payment provider." in str(exc_info.value)
+        # Transient: a connection blip is retryable.
+        assert isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_generic_stripe_error(self, mock_retrieve):
@@ -102,6 +112,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "A payment processing error occurred." in str(exc_info.value)
+        # Transient by default: an unclassified Stripe API error (e.g. a 5xx) is retryable.
+        assert isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.retrieve")
     def test_get_customer_unexpected_error(self, mock_retrieve):
@@ -112,6 +124,8 @@ class TestStripeClient:
             self.client.get_customer("cus_123")
 
         assert "An unexpected error occurred." in str(exc_info.value)
+        # Unexpected: retry rather than silently treat as terminal.
+        assert isinstance(exc_info.value, BillingRetryableError)
 
     @patch("stripe.Customer.create")
     def test_create_customer_success(self, mock_create):

--- a/sbomify/apps/billing/tests/test_views.py
+++ b/sbomify/apps/billing/tests/test_views.py
@@ -369,4 +369,103 @@ def test_stripe_webhook_error_handling(factory):
             assert response.status_code == 500
 
 
+@pytest.mark.django_db
+def test_stripe_webhook_retryable_error_returns_5xx(factory, team_with_business_plan):
+    """A retryable handler failure must NOT be acknowledged (200) — Stripe has to retry."""
+    from sbomify.apps.billing.stripe_client import BillingRetryableError
+    from sbomify.apps.billing.views import StripeWebhookView
+
+    mock_event = MagicMock()
+    mock_event.type = "customer.subscription.updated"
+    mock_event.id = "evt_retryable_996"
+    mock_event.data.object = {"id": "sub_test123", "customer": "cus_test123"}
+
+    request = factory.post(
+        reverse("billing:webhook"),
+        data=json.dumps({"type": "customer.subscription.updated"}),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("sbomify.apps.billing.views.stripe_client") as mock_stripe_client:
+        mock_stripe_client.construct_webhook_event.return_value = mock_event
+        with patch(
+            "sbomify.apps.billing.billing_processing.handle_subscription_updated",
+            side_effect=BillingRetryableError("transient team-lookup failure"),
+        ):
+            response = StripeWebhookView.as_view()(request)
+
+    # Stripe retries on any non-2xx; the dropped-event bug returned 200 here.
+    assert response.status_code >= 500
+
+
+@pytest.mark.django_db
+def test_stripe_webhook_terminal_error_returns_200(factory, team_with_business_plan):
+    """A genuinely terminal business error stays acknowledged (200) so Stripe stops retrying."""
+    from sbomify.apps.billing.stripe_client import StripeError
+    from sbomify.apps.billing.views import StripeWebhookView
+
+    mock_event = MagicMock()
+    mock_event.type = "customer.subscription.updated"
+    mock_event.id = "evt_terminal_996"
+    mock_event.data.object = {"id": "sub_test123", "customer": "cus_test123"}
+
+    request = factory.post(
+        reverse("billing:webhook"),
+        data=json.dumps({"type": "customer.subscription.updated"}),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("sbomify.apps.billing.views.stripe_client") as mock_stripe_client:
+        mock_stripe_client.construct_webhook_event.return_value = mock_event
+        with patch(
+            "sbomify.apps.billing.billing_processing.handle_subscription_updated",
+            side_effect=StripeError("no such team — truly nonexistent"),
+        ):
+            response = StripeWebhookView.as_view()(request)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_stripe_webhook_subscription_updated_real_handler(factory, team_with_business_plan):
+    """Happy-path webhook that does NOT mock the handler — exercises real team/plan resolution."""
+    from sbomify.apps.billing.views import StripeWebhookView
+
+    assert "last_processed_webhook_id" not in (team_with_business_plan.billing_plan_limits or {})
+
+    subscription = MagicMock()
+    subscription.id = "sub_test123"
+    subscription.customer = "cus_test123"
+    subscription.status = "active"
+    subscription.current_period_end = 1893456000
+    subscription.metadata = {"plan_key": "business"}
+    subscription.cancel_at_period_end = False
+    subscription.cancel_at = None
+    subscription.items.data = [MagicMock(price=MagicMock(id="price_test_business_monthly"))]
+
+    mock_event = MagicMock()
+    mock_event.type = "customer.subscription.updated"
+    mock_event.id = "evt_real_handler_996"
+    mock_event.data.object = subscription
+
+    request = factory.post(
+        reverse("billing:webhook"),
+        data=json.dumps({"type": "customer.subscription.updated"}),
+        content_type="application/json",
+    )
+    request.headers = {"Stripe-Signature": "test_sig"}
+
+    with patch("sbomify.apps.billing.views.stripe_client") as mock_stripe_client:
+        mock_stripe_client.construct_webhook_event.return_value = mock_event
+        response = StripeWebhookView.as_view()(request)
+
+    assert response.status_code == 200
+    team_with_business_plan.refresh_from_db()
+    # Proves the real handler ran end-to-end (idempotency marker only written by the handler).
+    assert team_with_business_plan.billing_plan_limits["last_processed_webhook_id"] == "evt_real_handler_996"
+    assert team_with_business_plan.billing_plan == "business"
+
+
 

--- a/sbomify/apps/billing/tests/test_views.py
+++ b/sbomify/apps/billing/tests/test_views.py
@@ -430,20 +430,36 @@ def test_stripe_webhook_terminal_error_returns_200(factory, team_with_business_p
 
 @pytest.mark.django_db
 def test_stripe_webhook_subscription_updated_real_handler(factory, team_with_business_plan):
-    """Happy-path webhook that does NOT mock the handler — exercises real team/plan resolution."""
+    """Happy-path webhook that does NOT mock the handler — exercises real team/plan resolution.
+
+    Uses a genuine ``stripe.Subscription`` (not a MagicMock) so the production
+    items-dict access path runs through the view, and seeds the team on ``community``
+    so the plan flip to ``business`` is an *active* proof the resolver ran (not a
+    tautology against a fixture that already starts on business).
+    """
+    import stripe
+
     from sbomify.apps.billing.views import StripeWebhookView
 
+    # Seed a different starting plan so the post-webhook assertion is meaningful.
+    team_with_business_plan.billing_plan = "community"
+    team_with_business_plan.save()
     assert "last_processed_webhook_id" not in (team_with_business_plan.billing_plan_limits or {})
 
-    subscription = MagicMock()
-    subscription.id = "sub_test123"
-    subscription.customer = "cus_test123"
-    subscription.status = "active"
-    subscription.current_period_end = 1893456000
-    subscription.metadata = {"plan_key": "business"}
-    subscription.cancel_at_period_end = False
-    subscription.cancel_at = None
-    subscription.items.data = [MagicMock(price=MagicMock(id="price_test_business_monthly"))]
+    subscription = stripe.Subscription.construct_from(
+        {
+            "id": "sub_test123",
+            "object": "subscription",
+            "customer": "cus_test123",
+            "status": "active",
+            "current_period_end": 1893456000,
+            "metadata": {"plan_key": "business"},
+            "cancel_at_period_end": False,
+            "cancel_at": None,
+            "items": {"object": "list", "data": [{"price": {"id": "price_test_business_monthly"}}]},
+        },
+        "sk_test_dummy",
+    )
 
     mock_event = MagicMock()
     mock_event.type = "customer.subscription.updated"
@@ -465,6 +481,7 @@ def test_stripe_webhook_subscription_updated_real_handler(factory, team_with_bus
     team_with_business_plan.refresh_from_db()
     # Proves the real handler ran end-to-end (idempotency marker only written by the handler).
     assert team_with_business_plan.billing_plan_limits["last_processed_webhook_id"] == "evt_real_handler_996"
+    # Active proof the items-dict plan-resolution path ran: community -> business.
     assert team_with_business_plan.billing_plan == "business"
 
 

--- a/sbomify/apps/billing/views.py
+++ b/sbomify/apps/billing/views.py
@@ -42,7 +42,7 @@ from .billing_helpers import (
 )
 from .forms import PublicEnterpriseContactForm
 from .models import BillingPlan
-from .stripe_client import StripeError, get_stripe_client
+from .stripe_client import BillingRetryableError, StripeError, get_stripe_client
 from .stripe_pricing_service import StripePricingService
 from .stripe_sync import sync_subscription_from_stripe
 from .tasks import send_enterprise_inquiry_email
@@ -736,7 +736,8 @@ class StripeWebhookView(View):
             logger.error("Webhook signature verification failed")
             return HttpResponseForbidden("Invalid signature")
 
-        # Phase 2: Process event — 200 on business errors (acknowledged), 500 on unexpected (Stripe retries)
+        # Phase 2: Process event. Acknowledge (200) only genuinely terminal business
+        # errors; return 5xx for retryable/unexpected failures so Stripe re-delivers.
         try:
             if event.type == "checkout.session.completed":
                 session = event.data.object
@@ -758,6 +759,10 @@ class StripeWebhookView(View):
 
             return HttpResponse(status=200)
 
+        except BillingRetryableError as e:
+            # Transient/recoverable failure — do NOT acknowledge, let Stripe retry.
+            logger.error("Retryable webhook error (Stripe will retry): %s", e)
+            return HttpResponse(status=503)
         except StripeError as e:
             logger.error("Stripe business logic error (acknowledged): %s", e)
             return HttpResponse(status=200)

--- a/sbomify/apps/billing/views.py
+++ b/sbomify/apps/billing/views.py
@@ -761,11 +761,15 @@ class StripeWebhookView(View):
 
         except BillingRetryableError as e:
             # Transient/recoverable failure — do NOT acknowledge, let Stripe retry.
+            # 503 (vs the 500 below) is deliberate: it flags an *anticipated* transient
+            # condition for ops, distinct from an unexpected crash. Both are non-2xx, so
+            # Stripe re-delivers either way.
             logger.error("Retryable webhook error (Stripe will retry): %s", e)
             return HttpResponse(status=503)
         except StripeError as e:
             logger.error("Stripe business logic error (acknowledged): %s", e)
             return HttpResponse(status=200)
         except Exception as e:
+            # Unexpected/unclassified error — 500 so Stripe retries and ops gets paged.
             logger.exception("Unexpected webhook error: %s", e)
             return HttpResponse(status=500)

--- a/sbomify/apps/billing/views.py
+++ b/sbomify/apps/billing/views.py
@@ -764,7 +764,8 @@ class StripeWebhookView(View):
             # 503 (vs the 500 below) is deliberate: it flags an *anticipated* transient
             # condition for ops, distinct from an unexpected crash. Both are non-2xx, so
             # Stripe re-delivers either way.
-            logger.error("Retryable webhook error (Stripe will retry): %s", e)
+            # exc_info captures the chained root cause (these are raised `from e`).
+            logger.error("Retryable webhook error (Stripe will retry): %s", e, exc_info=True)
             return HttpResponse(status=503)
         except StripeError as e:
             logger.error("Stripe business logic error (acknowledged): %s", e)


### PR DESCRIPTION
## Summary

Fixes #996. The Stripe webhook view mapped **every** handler `StripeError` to HTTP `200`, but handlers raise `StripeError` for **recoverable** conditions too (transient DB/Stripe failures, a checkout-race where the team↔subscription mapping isn't written yet, a momentarily-missing `BillingPlan`, a failed old-subscription cancel). Stripe treats `200` as delivered and never retries, so those events were **silently dropped** — billing state drifts with only a single log line. A second path committed an *active* subscription with **stale plan limits** when the `BillingPlan` lookup failed.

## Fix

Introduce `BillingRetryableError(StripeError)`. Because it subclasses `StripeError`, it flows through the `handle_stripe_errors` decorator unchanged; the webhook view simply catches it **before** the generic `StripeError` clause.

**Classification rule, applied consistently across all five webhook handlers** (`subscription.updated`, `subscription.deleted`, `payment_failed`, `payment_succeeded`, `checkout.completed`):

| | Examples | Webhook response |
|---|---|---|
| **Terminal** | unknown event type, truly-nonexistent team, invalid status, declined card | `200` (acknowledge) |
| **Retryable** | transient DB/Stripe/cache failure, checkout race, missing `BillingPlan`, failed old-sub cancel | `5xx` (Stripe retries) |

Key changes:
- `_resolve_team_from_subscription` catches only `Team.DoesNotExist`; a transient `get_customer` failure becomes retryable; exhausting every strategy raises terminal `Team.DoesNotExist`.
- `_update_billing_from_subscription` raises retryable on `BillingPlan.DoesNotExist` **inside the atomic block**, so the stale `active` write rolls back.
- `handle_checkout_completed`'s "manual intervention after failed cancel" path (named in the issue) now retries instead of acknowledging a double-billing state.

### Secondary fix (found during E2E)
A real Stripe `Subscription` is a `dict` subclass, so `getattr(subscription, "items")` returns the **dict method**, and the line-item plan-resolution block in `_update_billing_from_subscription` was skipped for real webhook payloads (the existing `MagicMock` tests hid this — attribute access worked on a mock). Items are now read via subscript access, so plan/limits actually sync on `customer.subscription.updated`. Added real-`StripeObject` tests that reproduce and guard against it.

## Testing

- **Unit/integration:** 308 billing tests pass. New tests pin the 200-vs-5xx contract for every handler, the missing-plan rollback (with non-tautological assertions), and the real-`StripeObject` items behaviour.
- **Live end-to-end** against a running instance with `stripe listen` forwarding real signed events:
  - Terminal → `200`: happy update, invalid status, `payment_failed`→past_due, `payment_succeeded`, `deleted`→canceled, unknown team, realistic nonexistent-team.
  - **Retryable → `503`**: transient `get_customer` failure; checkout missing `BillingPlan`.
  - Signature handling: unsigned/bad-sig → `403`, wrong content-type → `400`.
  - **Browser checkout (existing + new workspace):** real Stripe Checkout → real webhooks (`checkout.session.completed`, `subscription.created`, `payment_succeeded`) **all `200`**, entitlements applied. `non-2xx` count across all happy-path events: **0** (no over-retry).

## Notes / out of scope
- **Trial-period failures are retryable on both paths.** A transient `handle_trial_period` failure surfaces as `BillingRetryableError` (5xx) via the `handle_stripe_errors` decorator, consistently across `subscription.updated` and checkout. (The webhook returns 5xx; there is no terminal/200 trial-period path.)
- **Deliberate trade-off:** on a *checkout redelivery*, the idempotency guard short-circuits and does not re-run `handle_trial_period`. Re-running it could send a duplicate trial-ending email (it is not idempotent); the trial markers / trial-expiry downgrade are instead reconciled by the subsequent `customer.subscription.updated` event and the trial-sync cron. Documented at the call site.
- Non-critical post-commit side effects (cache invalidation, owner notifications) are best-effort: a transient outage there is logged, not retried, so it cannot trigger a futile retry that the idempotency guard would skip.

## Acceptance criteria
- [x] A retryable handler failure yields a non-2xx response (Stripe retries).
- [x] A test that lets a handler raise and asserts the status mapping.
- [x] A happy-path webhook test that does **not** mock the handler.


