### PR TITLE
fix(security): re-check current access on signed artifact downloads (#997)

### DIFF
--- a/sbomify/apps/core/services/access_control.py
+++ b/sbomify/apps/core/services/access_control.py
@@ -238,3 +238,24 @@ def check_component_access(
         requires_authentication=False,
         requires_access_request=False,
     )
+
+
+def check_component_access_for_user(
+    user: User, component: Component, team: Team | None = None
+) -> ComponentAccessResult:
+    """Access check for a user with no HTTP-request context.
+
+    Use this for delegated checks (e.g. re-validating a signed-download
+    token's user) where there is no authenticated session to trust. It
+    evaluates LIVE database state only: it builds a stub request carrying
+    just the user and an EMPTY session, so the PRIVATE-component path in
+    ``verify_item_access`` never short-circuits on a (possibly stale)
+    ``session["user_teams"]`` role cache. Routes through
+    ``check_component_access`` so the rules stay in one place.
+    """
+    stub = HttpRequest()
+    stub.user = user
+    # Empty session -> verify_item_access skips its session role-cache and
+    # falls through to the authoritative DB membership lookup.
+    stub.session = {}  # type: ignore[assignment]
+    return check_component_access(stub, component, team)

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -290,12 +290,13 @@ def download_document_signed(request: HttpRequest, document_id: str, token: str 
     if payload.get("document_id") != document_id:
         return 403, {"detail": "Token is not valid for this document"}
 
-    # For private components, we need to ensure the token is valid
-    # The token itself provides the authorization
+    # Non-public components: the signed token only proves which artifact +
+    # user the URL was minted for. It is NOT standalone authorization — we
+    # re-check the token user's current access below (#997).
     from sbomify.apps.sboms.models import Component
 
     if document.component.visibility != Component.Visibility.PUBLIC:
-        # Additional security: verify the user from the token exists
+        # Verify the user from the token exists (and is live)
         user_id = payload.get("user_id")
         if not user_id:
             return 403, {"detail": "Invalid token: missing user information"}

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -303,7 +303,7 @@ def download_document_signed(request: HttpRequest, document_id: str, token: str 
 
         from django.contrib.auth import get_user_model
 
-        from sbomify.apps.core.services.access_control import check_component_access
+        from sbomify.apps.core.services.access_control import check_component_access_for_user
 
         # Match PAT auth liveness filtering: a soft-deleted / deactivated
         # account must not download via a signed URL during the purge grace
@@ -315,12 +315,10 @@ def download_document_signed(request: HttpRequest, document_id: str, token: str 
             return 403, {"detail": "Invalid token: user not found"}
 
         # The signed token delegates a download; it is not standalone
-        # authorization. Re-check the token user's CURRENT access so a
-        # revoked member/guest cannot keep downloading via a captured signed
-        # URL for the token TTL (#997). The endpoint is auth=None, so bind the
-        # token user onto the request and use the canonical access service.
-        request.user = token_user
-        access_result = check_component_access(request, document.component)
+        # authorization. Re-check the token user's CURRENT access against live
+        # DB state (no session role-cache) so a revoked member/guest cannot
+        # keep downloading via a captured signed URL for the token TTL (#997).
+        access_result = check_component_access_for_user(token_user, document.component)
         if not access_result.has_access:
             log.info(
                 "Signed URL access denied for document %s, user %s: %s",

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -300,13 +300,34 @@ def download_document_signed(request: HttpRequest, document_id: str, token: str 
         if not user_id:
             return 403, {"detail": "Invalid token: missing user information"}
 
-        try:
-            from django.contrib.auth import get_user_model
+        from django.contrib.auth import get_user_model
 
-            User = get_user_model()
-            User.objects.get(id=user_id)
+        from sbomify.apps.core.services.access_control import check_component_access
+
+        # Match PAT auth liveness filtering: a soft-deleted / deactivated
+        # account must not download via a signed URL during the purge grace
+        # window (sbomify.apps.access_tokens.utils.get_user_and_token_record).
+        User = get_user_model()
+        try:
+            token_user = User.objects.get(id=user_id, is_active=True, deleted_at__isnull=True)
         except User.DoesNotExist:
             return 403, {"detail": "Invalid token: user not found"}
+
+        # The signed token delegates a download; it is not standalone
+        # authorization. Re-check the token user's CURRENT access so a
+        # revoked member/guest cannot keep downloading via a captured signed
+        # URL for the token TTL (#997). The endpoint is auth=None, so bind the
+        # token user onto the request and use the canonical access service.
+        request.user = token_user
+        access_result = check_component_access(request, document.component)
+        if not access_result.has_access:
+            log.info(
+                "Signed URL access denied for document %s, user %s: %s",
+                document_id,
+                user_id,
+                access_result.reason,
+            )
+            return 403, {"detail": "Access has been revoked or is no longer valid"}
 
         # Log the access for audit purposes
         log.info(f"Signed URL access to private document {document_id} by user {user_id}")

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -844,10 +844,11 @@ def download_sbom_signed(
     if payload.get("sbom_id") != sbom_id:
         return 403, {"detail": "Token is not valid for this SBOM"}
 
-    # For private components, we need to ensure the token is valid
-    # The token itself provides the authorization
+    # Non-public components: the signed token only proves which artifact +
+    # user the URL was minted for. It is NOT standalone authorization — we
+    # re-check the token user's current access below (#997).
     if sbom.component.visibility != Component.Visibility.PUBLIC:
-        # Additional security: verify the user from the token exists
+        # Verify the user from the token exists (and is live)
         user_id = payload.get("user_id")
         if not user_id:
             return 403, {"detail": "Invalid token: missing user information"}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -852,13 +852,33 @@ def download_sbom_signed(
         if not user_id:
             return 403, {"detail": "Invalid token: missing user information"}
 
-        try:
-            from django.contrib.auth import get_user_model
+        from django.contrib.auth import get_user_model
 
-            User = get_user_model()
-            User.objects.get(id=user_id)
+        # Match PAT auth liveness filtering: a soft-deleted / deactivated
+        # account must not download via a signed URL during the purge grace
+        # window (sbomify.apps.access_tokens.utils.get_user_and_token_record).
+        User = get_user_model()
+        try:
+            token_user = User.objects.get(id=user_id, is_active=True, deleted_at__isnull=True)
         except User.DoesNotExist:
             return 403, {"detail": "Invalid token: user not found"}
+
+        # The signed token only delegates a download; it is NOT standalone
+        # authorization. Re-check the token user's CURRENT access so that
+        # revoking their membership/NDA immediately invalidates any signed
+        # URL they captured, instead of leaving it valid for the token TTL
+        # (#997). The endpoint is auth=None, so bind the token user onto the
+        # request and route through the canonical access service.
+        request.user = token_user
+        access_result = check_component_access(request, sbom.component)
+        if not access_result.has_access:
+            log.info(
+                "Signed URL access denied for SBOM %s, user %s: %s",
+                sbom_id,
+                user_id,
+                access_result.reason,
+            )
+            return 403, {"detail": "Access has been revoked or is no longer valid"}
 
         # Log the access for audit purposes
         log.info(f"Signed URL access to private SBOM {sbom_id} by user {user_id}")

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -19,7 +19,7 @@ from sbomify.apps.core.apis import get_component_metadata, patch_component_metad
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.purl import extract_purl_qualifiers
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
-from sbomify.apps.core.services.access_control import check_component_access
+from sbomify.apps.core.services.access_control import check_component_access, check_component_access_for_user
 from sbomify.apps.core.utils import (
     ExtractSpec,
     broadcast_to_workspace,
@@ -865,13 +865,11 @@ def download_sbom_signed(
             return 403, {"detail": "Invalid token: user not found"}
 
         # The signed token only delegates a download; it is NOT standalone
-        # authorization. Re-check the token user's CURRENT access so that
-        # revoking their membership/NDA immediately invalidates any signed
-        # URL they captured, instead of leaving it valid for the token TTL
-        # (#997). The endpoint is auth=None, so bind the token user onto the
-        # request and route through the canonical access service.
-        request.user = token_user
-        access_result = check_component_access(request, sbom.component)
+        # authorization. Re-check the token user's CURRENT access against live
+        # DB state (no session role-cache) so that revoking their
+        # membership/NDA immediately invalidates a captured signed URL instead
+        # of leaving it valid for the token TTL (#997).
+        access_result = check_component_access_for_user(token_user, sbom.component)
         if not access_result.has_access:
             log.info(
                 "Signed URL access denied for SBOM %s, user %s: %s",

--- a/sbomify/apps/sboms/tests/test_signed_urls.py
+++ b/sbomify/apps/sboms/tests/test_signed_urls.py
@@ -382,7 +382,7 @@ class TestSignedURLs:
             mock_s3_client.return_value.get_document_data.return_value = b"doc bytes"
             assert self.client.get(url, {"token": token}).status_code == 403
 
-    def test_signed_document_download_gated_guest_allowed_then_revoked(self, guest_user):  # noqa: F811
+    def test_signed_document_download_gated_guest_allowed_then_revoked(self, guest_user):
         """#997: an approved gated guest keeps signed-URL access (no
         regression), but a REVOKED guest is denied. Guards that the fix
         routes through the gated-access service rather than naively
@@ -417,7 +417,7 @@ class TestSignedURLs:
             )
             assert self.client.get(url, {"token": token}).status_code == 403
 
-    def test_signed_sbom_download_gated_guest_allowed_then_revoked(self, guest_user):  # noqa: F811
+    def test_signed_sbom_download_gated_guest_allowed_then_revoked(self, guest_user):
         """#997: the SBOM signed-download path also routes any non-PUBLIC
         component (including GATED) through check_component_access — an
         approved gated guest keeps access, a revoked one is denied.

--- a/sbomify/apps/sboms/tests/test_signed_urls.py
+++ b/sbomify/apps/sboms/tests/test_signed_urls.py
@@ -378,6 +378,39 @@ class TestSignedURLs:
             )
             assert self.client.get(url, {"token": token}).status_code == 403
 
+    def test_signed_sbom_download_gated_guest_allowed_then_revoked(self, guest_user):  # noqa: F811
+        """#997: the SBOM signed-download path also routes any non-PUBLIC
+        component (including GATED) through check_component_access — an
+        approved gated guest keeps access, a revoked one is denied.
+        """
+        from sbomify.apps.documents.access_models import AccessRequest
+        from sbomify.apps.teams.models import Member
+
+        gated_component = Component.objects.create(
+            name="Gated SBOM Component",
+            team=self.team,
+            visibility=Component.Visibility.GATED,
+            component_type=Component.ComponentType.BOM,
+        )
+        gated_sbom = SBOM.objects.create(
+            name="Gated SBOM",
+            component=gated_component,
+            format="cyclonedx",
+            version="1.0.0",
+            sbom_filename="gated_sbom.json",
+        )
+        Member.objects.create(team=self.team, user=guest_user, role="guest")
+
+        token = make_download_token(gated_sbom.id, str(guest_user.id))
+        url = f"/api/v1/sboms/{gated_sbom.id}/download/signed"
+        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_sbom_data.return_value = b'{"gated": "sbom"}'
+            assert self.client.get(url, {"token": token}).status_code == 200
+            AccessRequest.objects.create(
+                team=self.team, user=guest_user, status=AccessRequest.Status.REVOKED
+            )
+            assert self.client.get(url, {"token": token}).status_code == 403
+
 
 @pytest.mark.django_db
 class TestSignedURLIntegration:

--- a/sbomify/apps/sboms/tests/test_signed_urls.py
+++ b/sbomify/apps/sboms/tests/test_signed_urls.py
@@ -343,6 +343,45 @@ class TestSignedURLs:
             get_user_model().objects.filter(id=self.user.id).update(is_active=False)
             assert self.client.get(url, {"token": token}).status_code == 403
 
+    def test_signed_download_revoked_with_stale_session_cache_denied(self):
+        """#1008: revocation is enforced from LIVE DB state, never a stale
+        session role-cache. A revoked user who is still logged in (their
+        session still lists them as owner) must still get 403 — verify_item_access
+        short-circuits on session["user_teams"], so the re-check must not run
+        against that cache.
+        """
+        from sbomify.apps.teams.models import Member
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["user_teams"] = {self.team.key: {"role": "owner"}}
+        session.save()
+        Member.objects.filter(team=self.team, user=self.user).delete()
+
+        token = make_download_token(self.private_sbom.id, str(self.user.id))
+        url = f"/api/v1/sboms/{self.private_sbom.id}/download/signed"
+        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_sbom_data.return_value = b'{"test": "data"}'
+            assert self.client.get(url, {"token": token}).status_code == 403
+
+    def test_signed_document_download_revoked_with_stale_session_cache_denied(self):
+        """#1008 document equivalent: a stale session role-cache must not
+        override live-DB revocation on the document signed-download path.
+        """
+        from sbomify.apps.teams.models import Member
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session["user_teams"] = {self.team.key: {"role": "owner"}}
+        session.save()
+        Member.objects.filter(team=self.team, user=self.user).delete()
+
+        token = make_document_download_token(self.private_document.id, str(self.user.id))
+        url = f"/api/v1/documents/{self.private_document.id}/download/signed"
+        with patch("sbomify.apps.documents.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_document_data.return_value = b"doc bytes"
+            assert self.client.get(url, {"token": token}).status_code == 403
+
     def test_signed_document_download_gated_guest_allowed_then_revoked(self, guest_user):  # noqa: F811
         """#997: an approved gated guest keeps signed-URL access (no
         regression), but a REVOKED guest is denied. Guards that the fix

--- a/sbomify/apps/sboms/tests/test_signed_urls.py
+++ b/sbomify/apps/sboms/tests/test_signed_urls.py
@@ -301,6 +301,83 @@ class TestSignedURLs:
 
             assert response.status_code == 200
 
+    def test_signed_download_revoked_member_denied(self):
+        """#997: a captured signed URL stops working once the token user's
+        access is revoked. The token signature is delegation, not standalone
+        authorization. Issue (owner) -> 200, revoke membership -> 403.
+        """
+        from sbomify.apps.teams.models import Member
+
+        token = make_download_token(self.private_sbom.id, str(self.user.id))
+        url = f"/api/v1/sboms/{self.private_sbom.id}/download/signed"
+        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_sbom_data.return_value = b'{"test": "data"}'
+            assert self.client.get(url, {"token": token}).status_code == 200
+            Member.objects.filter(team=self.team, user=self.user).delete()
+            assert self.client.get(url, {"token": token}).status_code == 403
+
+    def test_signed_document_download_revoked_member_denied(self):
+        """#997 document equivalent: revoked member's signed URL -> 403."""
+        from sbomify.apps.teams.models import Member
+
+        token = make_document_download_token(self.private_document.id, str(self.user.id))
+        url = f"/api/v1/documents/{self.private_document.id}/download/signed"
+        with patch("sbomify.apps.documents.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_document_data.return_value = b"doc bytes"
+            assert self.client.get(url, {"token": token}).status_code == 200
+            Member.objects.filter(team=self.team, user=self.user).delete()
+            assert self.client.get(url, {"token": token}).status_code == 403
+
+    def test_signed_download_soft_deleted_user_denied(self):
+        """#997 hardening: a soft-deleted (deactivated) token user is denied,
+        matching PAT auth — don't keep serving bytes during the 14-day purge
+        grace window.
+        """
+        from django.contrib.auth import get_user_model
+
+        token = make_download_token(self.private_sbom.id, str(self.user.id))
+        url = f"/api/v1/sboms/{self.private_sbom.id}/download/signed"
+        with patch("sbomify.apps.sboms.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_sbom_data.return_value = b'{"test": "data"}'
+            assert self.client.get(url, {"token": token}).status_code == 200
+            get_user_model().objects.filter(id=self.user.id).update(is_active=False)
+            assert self.client.get(url, {"token": token}).status_code == 403
+
+    def test_signed_document_download_gated_guest_allowed_then_revoked(self, guest_user):  # noqa: F811
+        """#997: an approved gated guest keeps signed-URL access (no
+        regression), but a REVOKED guest is denied. Guards that the fix
+        routes through the gated-access service rather than naively
+        requiring owner/admin.
+        """
+        from sbomify.apps.documents.access_models import AccessRequest
+        from sbomify.apps.teams.models import Member
+
+        gated_component = Component.objects.create(
+            name="Gated Document Component",
+            team=self.team,
+            visibility=Component.Visibility.GATED,
+            component_type=Component.ComponentType.DOCUMENT,
+        )
+        gated_document = Document.objects.create(
+            name="Gated Document",
+            component=gated_component,
+            version="1.0.0",
+            document_filename="gated_document.pdf",
+            content_type="application/pdf",
+        )
+        # Approved gated guest (no company NDA configured -> no signature required).
+        Member.objects.create(team=self.team, user=guest_user, role="guest")
+
+        token = make_document_download_token(gated_document.id, str(guest_user.id))
+        url = f"/api/v1/documents/{gated_document.id}/download/signed"
+        with patch("sbomify.apps.documents.apis.S3Client") as mock_s3_client:
+            mock_s3_client.return_value.get_document_data.return_value = b"gated bytes"
+            assert self.client.get(url, {"token": token}).status_code == 200
+            AccessRequest.objects.create(
+                team=self.team, user=guest_user, status=AccessRequest.Status.REVOKED
+            )
+            assert self.client.get(url, {"token": token}).status_code == 403
+
 
 @pytest.mark.django_db
 class TestSignedURLIntegration:


### PR DESCRIPTION
## What & why

Closes #997. The signed-download endpoints (`download_sbom_signed`, `download_document_signed`) are `auth=None` and served PRIVATE/GATED artifact bytes on a valid signed token while only checking that the token's **user row still existed** — never the user's **current** access. Combined with the 7-day token TTL, a revoked user (guest removed, employee offboarded) kept read access to private SBOMs/documents for up to a week via any signed URL they had captured. These URLs are embedded as external-reference links inside **aggregated product SBOMs**, so they're routinely exposed downstream.

## Fix

After validating the token, bind the token's user onto the (`auth=None`) request and route through the canonical `check_component_access` service before serving bytes. Revocation now takes effect immediately:

- **PRIVATE** → `verify_item_access(owner/admin)` — denied once membership is removed.
- **GATED** → a `REVOKED` `AccessRequest` denies (and cleans up the guest `Member`); an **approved guest with a current NDA still downloads**, so legitimate gated access is preserved.
- Also filtered the token-user lookup on `is_active` / `deleted_at` (matching PAT auth in `access_tokens/utils.py`) so a **soft-deleted** account can't download during the 14-day purge grace window.

`check_component_access` is the existing single source of truth (49 passing tests) — no shadow access path is introduced.

## Scope decisions

- **PUBLIC artifacts unchanged** — the re-check lives strictly inside the existing `if visibility != PUBLIC:` branch, so public downloads keep working with zero new overhead.
- **`SIGNED_URL_MAX_AGE` left at 7 days, deliberately.** Aggregated product SBOMs embed these signed URLs *at generation time* into their CycloneDX `externalReferences`, served as long as that aggregate is served — shortening the TTL to hours would break those references. The runtime re-check closes the revocation hole **regardless of TTL**, so the (secondary) TTL hardening is deferred rather than degrade a working feature. Happy to thread a per-token `expires_in` if maintainers want short direct-download TTLs separately.

## Tests (acceptance criteria)

- ✅ Revoked member's previously-issued signed URL → **403** (SBOM **and** document).
- ✅ Approved gated guest → 200, then `REVOKED` → 403 (proves the fix routes through the gated service, not a naive owner/admin gate).
- ✅ Soft-deleted user → 403.

Full signed-URL suite (28) + documents/sboms download/access tests (119) + access-control service tests (49) all pass; ruff/mypy clean.

## Verification

Validated end-to-end and adversarially reviewed (security pass): confirmed `token_team` falls through to a live DB membership read on this path, `request.user` mutation is per-request and side-effect-free, PUBLIC isn't regressed, and these two endpoints are the **only** `verify_download_token` callers.