### PR TITLE
perf(sboms): cache aggregated release/product SBOMs + drop redundant query (#998)

### DIFF
--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -74,7 +74,9 @@ class S3Client:
             response = self.s3.Bucket(settings.AWS_SBOMS_STORAGE_BUCKET_NAME).Object(object_name).get()
             return response["Body"].read()  # type: ignore[no-any-return]
         except ClientError as e:
-            if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "NoSuchBucket", "404"):
+            # Only a missing object is an expected cache miss. A missing bucket is
+            # a misconfiguration and must fail loudly rather than degrade silently.
+            if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "404"):
                 return None
             raise
 

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -56,6 +56,30 @@ class S3Client:
 
         return self.get_file_data(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, object_name)
 
+    def get_cached_aggregate(self, object_name: str) -> bytes | None:
+        """Return a cached aggregated-SBOM blob by key, or None if absent (#998).
+
+        Aggregated release/product SBOMs are expensive to build (O(N) member
+        fetches). For public releases the result is content-addressed (the key
+        embeds an artifact-set hash), so it is cached in the SBOMS bucket and
+        served directly on repeat downloads. Unlike ``get_file_data``, a missing
+        key returns ``None`` rather than raising.
+        """
+        if self.bucket_type != "SBOMS":
+            raise ValueError("This method is only for SBOMS bucket")
+        try:
+            return self.get_file_data(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, object_name)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "NoSuchBucket", "404"):
+                return None
+            raise
+
+    def put_cached_aggregate(self, object_name: str, data: bytes) -> None:
+        """Store a built aggregated-SBOM blob under the given cache key (#998)."""
+        if self.bucket_type != "SBOMS":
+            raise ValueError("This method is only for SBOMS bucket")
+        self.upload_data_as_file(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, object_name, data)
+
     _HEX_SHA256_RE = re.compile(r"[a-f0-9]{64}\Z")
 
     def _upload_sbom_artifact(self, sbom_id: str, sbom_hash: str, data: bytes, suffix: str) -> str:

--- a/sbomify/apps/core/object_store.py
+++ b/sbomify/apps/core/object_store.py
@@ -62,13 +62,17 @@ class S3Client:
         Aggregated release/product SBOMs are expensive to build (O(N) member
         fetches). For public releases the result is content-addressed (the key
         embeds an artifact-set hash), so it is cached in the SBOMS bucket and
-        served directly on repeat downloads. Unlike ``get_file_data``, a missing
-        key returns ``None`` rather than raising.
+        served directly on repeat downloads. A missing key returns ``None``.
+
+        Fetches directly rather than via ``get_file_data`` because a cache miss
+        (``NoSuchKey``) is expected on every cold build — ``get_file_data``
+        prints the ``ClientError`` before re-raising, which would spam logs.
         """
         if self.bucket_type != "SBOMS":
             raise ValueError("This method is only for SBOMS bucket")
         try:
-            return self.get_file_data(settings.AWS_SBOMS_STORAGE_BUCKET_NAME, object_name)
+            response = self.s3.Bucket(settings.AWS_SBOMS_STORAGE_BUCKET_NAME).Object(object_name).get()
+            return response["Body"].read()  # type: ignore[no-any-return]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "NoSuchBucket", "404"):
                 return None

--- a/sbomify/apps/core/tests/s3_fixtures.py
+++ b/sbomify/apps/core/tests/s3_fixtures.py
@@ -23,6 +23,9 @@ class MockS3Client:
         self.uploaded_files: dict[str, bytes] = {}
         self.should_raise_error = False
         self.error_message = "S3 operation failed"
+        # Per-object call tracking so cache tests can assert what was fetched
+        # (member SBOMs vs the cached aggregate) — #998.
+        self.get_calls: list[str] = []
 
     def upload_data_as_file(self, bucket_name: str, object_name: str, data: bytes) -> None:
         """Mock upload_data_as_file method."""
@@ -58,7 +61,23 @@ class MockS3Client:
             raise ValueError("This method is only for SBOMS bucket")
         if self.should_raise_error:
             raise Exception(self.error_message)
+        self.get_calls.append(object_name)
         return self.uploaded_files.get(object_name)
+
+    def get_cached_aggregate(self, object_name: str) -> bytes | None:
+        """Mock get_cached_aggregate (#998): None on miss, never raises NoSuchKey."""
+        if self.bucket_type != "SBOMS":
+            raise ValueError("This method is only for SBOMS bucket")
+        if self.should_raise_error:
+            raise Exception(self.error_message)
+        self.get_calls.append(object_name)
+        return self.uploaded_files.get(object_name)
+
+    def put_cached_aggregate(self, object_name: str, data: bytes) -> None:
+        """Mock put_cached_aggregate (#998)."""
+        if self.bucket_type != "SBOMS":
+            raise ValueError("This method is only for SBOMS bucket")
+        self.uploaded_files[object_name] = data
 
     def get_document_data(self, object_name: str) -> bytes | None:
         """Mock get_document_data method."""

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -96,6 +96,9 @@ class BaseSBOMBuilder(ABC):
         self.user = user
         self.temp_files: list[Path] = []
         self.target_folder: Optional[Path] = None
+        # Set when a member SBOM fetch fails (non-fatal — the member is skipped).
+        # Callers use this to avoid caching an incomplete aggregate (#998).
+        self.had_member_fetch_error: bool = False
 
     @property
     @abstractmethod
@@ -172,6 +175,9 @@ class BaseSBOMBuilder(ABC):
             return download_path, str(sbom.id)
         except Exception as e:
             log.warning(f"Failed to download SBOM {sbom.sbom_filename}: {e}")
+            # A transient fetch error skips this member; flag the build as
+            # incomplete so the partial aggregate is not cached (#998).
+            self.had_member_fetch_error = True
             return None
 
     def select_best_sbom(self, sboms: list[Any]) -> Any:

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -974,6 +974,17 @@ class ReleaseSPDX30Builder(SPDX30Mixin, ReleaseSPDX3Builder):
 # =============================================================================
 
 
+def default_version_for_format(output_format: SBOMFormat | str) -> SBOMVersion:
+    """Single source of truth for the default SBOM version per output format.
+
+    Used by ``get_sbom_builder`` (to pick a builder when no version is given) and
+    by the aggregate-cache key resolution (``sboms.utils._resolve_output_version``)
+    so the cache key and the actually-built version can never drift apart.
+    """
+    fmt = SBOMFormat(output_format) if isinstance(output_format, str) else output_format
+    return SBOMVersion.CDX_1_6 if fmt == SBOMFormat.CYCLONEDX else SBOMVersion.SPDX_2_3
+
+
 def get_sbom_builder(
     entity_type: str,
     output_format: SBOMFormat | str,
@@ -1002,12 +1013,9 @@ def get_sbom_builder(
     if isinstance(output_format, str):
         output_format = SBOMFormat(output_format.lower())
 
-    # Normalize version and set defaults
+    # Normalize version and set defaults (shared with the aggregate cache key)
     if version is None:
-        if output_format == SBOMFormat.CYCLONEDX:
-            version = SBOMVersion.CDX_1_6
-        else:
-            version = SBOMVersion.SPDX_2_3
+        version = default_version_for_format(output_format)
     elif isinstance(version, str):
         version = SBOMVersion(version)
 

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -567,13 +567,13 @@ class ReleaseSPDXBuilder(BaseSPDXBuilder):
             if supplier:
                 package["supplier"] = supplier
 
-            # Add external reference to original SBOM
-            from sbomify.apps.sboms.models import SBOM
+            # Add external reference to original SBOM. ``sbom_instance`` is the
+            # select_related-loaded artifact.sbom (same row sbom_id points to),
+            # so re-fetching it per artifact is redundant (#998).
             from sbomify.apps.sboms.utils import get_download_url_for_sbom
 
             try:
-                original_sbom = SBOM.objects.get(id=sbom_id)
-                download_url = get_download_url_for_sbom(original_sbom, self.user, settings.APP_BASE_URL)
+                download_url = get_download_url_for_sbom(sbom_instance, self.user, settings.APP_BASE_URL)
                 package["externalRefs"] = [
                     {
                         "referenceCategory": "OTHER",
@@ -836,13 +836,13 @@ class ReleaseSPDX3Builder(BaseSPDXBuilder):
             if version:
                 pkg_element["software_packageVersion"] = str(version)
 
-            # Add external reference to original SBOM
-            from sbomify.apps.sboms.models import SBOM as SBOMModel
+            # Add external reference to original SBOM. ``sbom_instance`` is the
+            # select_related-loaded artifact.sbom (same row sbom_id points to),
+            # so re-fetching it per artifact is redundant (#998).
             from sbomify.apps.sboms.utils import get_download_url_for_sbom
 
             try:
-                original_sbom = SBOMModel.objects.get(id=sbom_id)
-                download_url = get_download_url_for_sbom(original_sbom, self.user, settings.APP_BASE_URL)
+                download_url = get_download_url_for_sbom(sbom_instance, self.user, settings.APP_BASE_URL)
                 pkg_element["externalRef"] = [
                     {
                         "type": "ExternalRef",

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -147,6 +147,25 @@ class TestAggregateCache:
 
         assert not [k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]
 
+    def test_incomplete_build_is_not_cached(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        """If a member fetch fails (transient S3 error -> member skipped), the
+        partial aggregate must NOT be cached — otherwise the incomplete document
+        would be frozen under this artifact-set hash indefinitely.
+        """
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        # Simulate a transient fetch failure: drop one member's bytes from S3.
+        missing = release.artifacts.order_by("sbom__id").first().sbom
+        s3_sboms_mock.uploaded_files.pop(missing.sbom_filename, None)
+
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+
+        assert not [
+            k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")
+        ], "an incomplete build (skipped member) must not be cached"
+
     def test_spdx_builder_no_redundant_per_artifact_sbom_get(
         self, tmp_path, team_with_business_plan, s3_sboms_mock, mocker  # noqa: F811
     ):

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -166,6 +166,22 @@ class TestAggregateCache:
             k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")
         ], "an incomplete build (skipped member) must not be cached"
 
+    def test_malicious_names_cannot_escape_target_folder(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        """Product/release names are user-controlled; the built file must stay a
+        basename inside target_folder even if a name contains path separators.
+        """
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        release.product.name = "../../evil"
+        release.product.save()
+        release.name = "../escape"
+        release.save()
+
+        path = get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+        assert path.resolve().parent == tmp_path.resolve(), "build must not escape target_folder"
+
     def test_spdx_builder_no_redundant_per_artifact_sbom_get(
         self, tmp_path, team_with_business_plan, s3_sboms_mock, mocker  # noqa: F811
     ):

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -106,6 +106,34 @@ class TestAggregateCache:
         # The now-private member is excluded from the rebuilt public aggregate.
         assert rebuilt != first
 
+    def test_private_member_change_does_not_bust_cache(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        """A PRIVATE member never appears in a public aggregate, so changing it
+        must NOT bust the public cache — only the included (public) members do.
+        """
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        priv = _make_member_sbom(team, s3_sboms_mock, "secret")
+        priv.component.visibility = Component.Visibility.PRIVATE
+        priv.component.save()
+        ReleaseArtifact.objects.create(release=release, sbom=priv)
+
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")  # cold build creates the cache
+        keys_before = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert len(keys_before) == 1
+
+        # Replace the PRIVATE member's content (new filename); the public aggregate is unchanged.
+        s3_sboms_mock.uploaded_files["secret-v2.json"] = s3_sboms_mock.uploaded_files["secret.json"]
+        priv.sbom_filename = "secret-v2.json"
+        priv.save()
+
+        s3_sboms_mock.get_calls.clear()
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+        keys_after = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert keys_after == keys_before, "a private-member change must not bust the public cache"
+        assert "alpha.json" not in s3_sboms_mock.get_calls, "should have been a cache hit"
+
     def test_private_product_is_not_cached(
         self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
     ):

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -1,0 +1,108 @@
+"""Tests for aggregated release/product SBOM caching + builder query cleanup (#998)."""
+
+import json
+
+import pytest
+
+from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+from sbomify.apps.core.tests.s3_fixtures import s3_sboms_mock  # noqa: F401
+from sbomify.apps.core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.utils import get_release_sbom_package
+
+
+def _make_member_sbom(team, s3_mock, name: str) -> SBOM:
+    """Create a PUBLIC component + SBOM whose bytes live in the mocked S3."""
+    component = Component.objects.create(
+        name=f"{name}-comp",
+        team=team,
+        visibility=Component.Visibility.PUBLIC,
+        component_type=Component.ComponentType.BOM,
+    )
+    body = json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "metadata": {"component": {"name": name, "type": "library", "version": "1.0.0"}},
+            "components": [],
+        }
+    ).encode()
+    filename = f"{name}.json"
+    s3_mock.uploaded_files[filename] = body
+    return SBOM.objects.create(
+        name=name, component=component, format="cyclonedx", version="1.0.0", sbom_filename=filename
+    )
+
+
+def _public_release(team, s3_mock, *, member_names=("alpha", "beta")) -> Release:
+    product = Product.objects.create(name="CacheProd", team=team, is_public=True)
+    release = Release.objects.create(product=product, name="v1.0.0")
+    for nm in member_names:
+        ReleaseArtifact.objects.create(release=release, sbom=_make_member_sbom(team, s3_mock, nm))
+    return release
+
+
+@pytest.mark.django_db
+class TestAggregateCache:
+    def test_cache_hit_serves_without_refetching_members(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        member_files = {a.sbom.sbom_filename for a in release.artifacts.all()}
+
+        # Cold build: members are fetched and a cache object is written.
+        s3_sboms_mock.get_calls.clear()
+        first = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+        assert member_files & set(s3_sboms_mock.get_calls), "cold build should fetch members"
+        cache_keys = [k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/release/")]
+        assert len(cache_keys) == 1
+
+        # Warm build: served from cache — members are NOT re-fetched.
+        s3_sboms_mock.get_calls.clear()
+        second = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+        assert not (member_files & set(s3_sboms_mock.get_calls)), "warm build must not re-fetch members"
+        assert cache_keys[0] in s3_sboms_mock.get_calls
+        assert first == second
+
+    def test_changed_artifact_set_busts_cache(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")  # warm
+        assert len([k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]) == 1
+
+        # Add a third member -> new artifact-set hash -> new cache key -> rebuild.
+        ReleaseArtifact.objects.create(release=release, sbom=_make_member_sbom(team, s3_sboms_mock, "gamma"))
+        s3_sboms_mock.get_calls.clear()
+        rebuilt = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+
+        assert "gamma.json" in s3_sboms_mock.get_calls, "changed set must re-fetch members"
+        assert len([k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]) == 2
+        assert b"gamma" in rebuilt
+
+    def test_private_product_is_not_cached(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        release.product.is_public = False
+        release.product.save()
+
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+
+        assert not [k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]
+
+    def test_spdx_builder_no_redundant_per_artifact_sbom_get(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock, mocker  # noqa: F811
+    ):
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock, member_names=("one", "two", "three"))
+
+        get_spy = mocker.patch.object(SBOM.objects, "get", wraps=SBOM.objects.get)
+        get_release_sbom_package(release, tmp_path, output_format="spdx")
+        # The builders use the select_related-loaded artifact.sbom, so they must
+        # not issue a per-artifact SBOM.objects.get during aggregation.
+        assert get_spy.call_count == 0

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -70,7 +70,7 @@ class TestAggregateCache:
     ):
         team = team_with_business_plan
         release = _public_release(team, s3_sboms_mock)
-        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")  # warm
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")  # cold build creates the cache
         assert len([k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]) == 1
 
         # Add a third member -> new artifact-set hash -> new cache key -> rebuild.
@@ -81,6 +81,30 @@ class TestAggregateCache:
         assert "gamma.json" in s3_sboms_mock.get_calls, "changed set must re-fetch members"
         assert len([k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")]) == 2
         assert b"gamma" in rebuilt
+
+    def test_member_visibility_change_busts_cache(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        """A member flipping PUBLIC->PRIVATE drops out of a public aggregate, so
+        the cache key MUST change — otherwise the stale doc would keep exposing a
+        now-private member. (Visibility is part of the artifact-set hash.)
+        """
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        first = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+        keys_before = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert len(keys_before) == 1
+
+        member = release.artifacts.order_by("sbom__id").first().sbom
+        member.component.visibility = Component.Visibility.PRIVATE
+        member.component.save()
+
+        rebuilt = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+        keys_after = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert keys_after != keys_before, "visibility change must produce a new cache key"
+        assert len(keys_after) == 2
+        # The now-private member is excluded from the rebuilt public aggregate.
+        assert rebuilt != first
 
     def test_private_product_is_not_cached(
         self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811

--- a/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
+++ b/sbomify/apps/sboms/tests/test_release_aggregate_cache.py
@@ -106,6 +106,26 @@ class TestAggregateCache:
         # The now-private member is excluded from the rebuilt public aggregate.
         assert rebuilt != first
 
+    def test_product_rename_busts_cache(
+        self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
+    ):
+        """The aggregate embeds the product/release name, so a rename (same
+        artifact set) must bust the cache and rebuild — not serve the old name.
+        """
+        team = team_with_business_plan
+        release = _public_release(team, s3_sboms_mock)
+        get_release_sbom_package(release, tmp_path, output_format="cyclonedx")
+        keys_before = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert len(keys_before) == 1
+
+        release.product.name = "Renamed Product"
+        release.product.save()
+
+        rebuilt = get_release_sbom_package(release, tmp_path, output_format="cyclonedx").read_bytes()
+        keys_after = {k for k in s3_sboms_mock.uploaded_files if k.startswith("aggregates/")}
+        assert keys_after != keys_before, "a product rename must bust the cache"
+        assert b"Renamed Product" in rebuilt
+
     def test_private_member_change_does_not_bust_cache(
         self, tmp_path, team_with_business_plan, s3_sboms_mock  # noqa: F811
     ):

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1592,11 +1592,18 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
       references it renders from product links + identifiers. So a rename or a
       link/identifier edit also triggers a rebuild.
 
-    Rows are ordered and fields ``\\x1f``-delimited so distinct inputs can't
-    collide. (ADR-004: member artifacts are immutable, so the filename is a
-    faithful content fingerprint.)
+    Rows are ordered, and every field is length-prefixed (netstring-style) before
+    hashing so user-controlled values cannot collide regardless of content — no
+    reliance on a delimiter byte that a name/URL could itself contain. (ADR-004:
+    member artifacts are immutable, so the filename is a faithful fingerprint.)
     """
-    digest = hashlib.sha256(b"v3")
+    digest = hashlib.sha256(b"v4")
+
+    def feed(*parts: Any) -> None:
+        for part in parts:
+            b = str(part).encode()
+            digest.update(f"{len(b)}:".encode())
+            digest.update(b)
 
     members = (
         release.artifacts.filter(sbom__isnull=False, sbom__component__visibility=Component.Visibility.PUBLIC)
@@ -1604,17 +1611,17 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
         .values_list("sbom__id", "sbom__sbom_filename")
     )
     for sid, fname in members.iterator():
-        digest.update(f"|m:{sid}\x1f{fname}".encode())
+        feed("m", sid, fname)
 
     # Mutable metadata embedded in the aggregate's top-level component.
     product = release.product
-    digest.update(f"|name:{product.name}\x1f{release.name}".encode())
+    feed("name", product.name, release.name)
     for ident_type, value in product.identifiers.order_by("id").values_list("identifier_type", "value").iterator():
-        digest.update(f"|id:{ident_type}\x1f{value}".encode())
+        feed("id", ident_type, value)
     for lt, title, url, desc in (
         product.links.order_by("id").values_list("link_type", "title", "url", "description").iterator()
     ):
-        digest.update(f"|ln:{lt}\x1f{title}\x1f{url}\x1f{desc}".encode())
+        feed("ln", lt, title, url, desc)
 
     return digest.hexdigest()
 
@@ -1682,7 +1689,7 @@ def get_release_sbom_package(
         resolved_version = _resolve_output_version(format_lower, version)
         fingerprint = compute_release_aggregate_fingerprint(release)
         cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{fingerprint}.json"
-        from botocore.exceptions import ClientError
+        from botocore.exceptions import BotoCoreError, ClientError
 
         s3 = S3Client("SBOMS")
         # The cache is an optimization — a read failure scoped to the cache
@@ -1696,6 +1703,11 @@ def get_release_sbom_package(
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") == "NoSuchBucket":
                 raise
+            log.warning("Aggregate cache read failed for %s, rebuilding: %s", cache_key, e)
+            cached = None
+        except BotoCoreError as e:
+            # Connection errors, timeouts, etc. — the cache is best-effort, so any
+            # boto read failure falls back to a rebuild rather than 500'ing.
             log.warning("Aggregate cache read failed for %s, rebuilding: %s", cache_key, e)
             cached = None
         if cached is not None:

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1550,6 +1550,23 @@ def get_product_sbom_package(
     return product_sbom_path
 
 
+def compute_release_artifact_set_hash(release: Any) -> str:
+    """Deterministic, content-sensitive fingerprint of a release's SBOM artifact set.
+
+    Computed from the DB only (no S3 reads). ``sbom_filename`` is the sha256 of
+    the artifact bytes (see object_store.upload_sbom), so including it makes the
+    hash change whenever a member is added, removed, or replaced — exactly what
+    the aggregate cache key needs. Ordered by ``sbom__id`` so the fingerprint is
+    independent of row insertion order. (ADR-004: artifacts are immutable, so the
+    filename is a faithful content fingerprint.)
+    """
+    members = (
+        release.artifacts.filter(sbom__isnull=False).order_by("sbom__id").values_list("sbom__id", "sbom__sbom_filename")
+    )
+    payload = "|".join(f"{sid}:{fname}" for sid, fname in members)
+    return hashlib.sha256(f"v1|{payload}".encode()).hexdigest()
+
+
 def get_release_sbom_package(
     release: Any,
     target_folder: Path,
@@ -1588,16 +1605,6 @@ def get_release_sbom_package(
     if version and version not in supported[format_lower]:
         raise ValueError(f"Unsupported version {version} for {output_format}. Supported: {supported[format_lower]}")
 
-    # Get the appropriate builder
-    builder = get_sbom_builder(
-        entity_type="release",
-        output_format=format_lower,
-        version=version,
-        entity=release,
-        user=user,
-    )
-    sbom = builder(target_folder)
-
     # Determine file extension based on format
     # Both CDX and SPDX builders return Pydantic models for consistent serialization
     if format_lower == "spdx":
@@ -1606,7 +1613,42 @@ def get_release_sbom_package(
         extension = ".cdx.json"
 
     sbom_path = target_folder / f"{release.product.name}-{release.name}{extension}"
-    sbom_path.write_text(sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True))
+
+    # Aggregated SBOMs are expensive to build (O(N) serial member fetches) and
+    # the public release/product download endpoints are unauthenticated — a
+    # cheap DoS amplifier (#998). For PUBLIC products the aggregate is
+    # content-addressable (only public members, which carry plain non-expiring
+    # URLs), so cache it in S3 keyed by an artifact-set hash and serve it
+    # directly on repeat downloads. Private releases are NOT cached: they are
+    # authenticated-only (not the DoS vector) and embed short-lived signed
+    # member URLs that must stay fresh.
+    cache_key: str | None = None
+    s3: Any = None
+    if release.product.is_public:
+        from sbomify.apps.core.object_store import S3Client
+
+        set_hash = compute_release_artifact_set_hash(release)
+        cache_key = f"aggregates/release/{release.id}/{format_lower}-{version or 'default'}-{set_hash}.json"
+        s3 = S3Client("SBOMS")
+        cached = s3.get_cached_aggregate(cache_key)
+        if cached is not None:
+            sbom_path.write_bytes(cached)
+            return sbom_path
+
+    # Cache miss (or private release): build the aggregate.
+    builder = get_sbom_builder(
+        entity_type="release",
+        output_format=format_lower,
+        version=version,
+        entity=release,
+        user=user,
+    )
+    sbom = builder(target_folder)
+    body = sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True).encode()
+    sbom_path.write_bytes(body)
+
+    if cache_key is not None and s3 is not None:
+        s3.put_cached_aggregate(cache_key, body)
 
     return sbom_path
 

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1564,29 +1564,32 @@ def _resolve_output_version(output_format: str, version: str | None) -> str:
 
 
 def compute_release_artifact_set_hash(release: Any) -> str:
-    """Deterministic, content-sensitive fingerprint of a release's SBOM artifact set.
+    """Deterministic fingerprint of the members that appear in a PUBLIC aggregate.
 
-    Computed from the DB only (no S3 reads). The fingerprint covers, per member:
+    Computed from the DB only (no S3 reads). Only PUBLIC-visibility members are
+    fingerprinted, because the aggregate cache is used solely for public products
+    and the builders exclude non-public members from a public product's
+    aggregate. Filtering to exactly the included set means:
 
-    * ``sbom__id`` — identity of the member SBOM,
-    * ``sbom__sbom_filename`` — the sha256 of the artifact bytes (see
-      object_store.upload_sbom), so a replaced artifact busts the key,
-    * ``sbom__component__visibility`` — because for PUBLIC products the builder
-      EXCLUDES non-public members; a visibility flip (PUBLIC <-> PRIVATE) changes
-      which members appear in the aggregate, so it MUST change the cache key or a
-      stale doc could keep exposing a now-private member.
+    * adding/removing/replacing a PUBLIC member — or a member flipping
+      PUBLIC <-> PRIVATE, i.e. entering/leaving the public set — busts the key
+      (a stale doc must never keep exposing a now-private member); while
+    * changing a PRIVATE/GATED member — which never appears in the public
+      aggregate — does NOT needlessly bust it.
 
-    Ordered by ``sbom__id`` so the fingerprint is independent of row insertion
-    order. (ADR-004: artifacts are immutable, so the filename is a faithful
-    content fingerprint.)
+    ``sbom_filename`` is the sha256 of the artifact bytes (object_store.upload_sbom),
+    so a replaced member busts the key. Ordered by ``sbom__id`` for determinism.
+    (ADR-004: artifacts are immutable, so the filename is a faithful fingerprint.)
     """
+    from sbomify.apps.sboms.models import Component
+
     members = (
-        release.artifacts.filter(sbom__isnull=False)
+        release.artifacts.filter(sbom__isnull=False, sbom__component__visibility=Component.Visibility.PUBLIC)
         .order_by("sbom__id")
-        .values_list("sbom__id", "sbom__sbom_filename", "sbom__component__visibility")
+        .values_list("sbom__id", "sbom__sbom_filename")
     )
-    payload = "|".join(f"{sid}:{fname}:{vis}" for sid, fname, vis in members)
-    return hashlib.sha256(f"v1|{payload}".encode()).hexdigest()
+    payload = "|".join(f"{sid}:{fname}" for sid, fname in members)
+    return hashlib.sha256(f"v2|{payload}".encode()).hexdigest()
 
 
 def get_release_sbom_package(

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1542,7 +1542,7 @@ def get_product_sbom_package(
     # Rename file to use product name instead of release name
     format_lower = output_format.lower()
     extension = ".spdx.json" if format_lower == "spdx" else ".cdx.json"
-    product_sbom_path = target_folder / f"{product.name}{extension}"
+    product_sbom_path = target_folder / _safe_sbom_filename(product.name, extension)
 
     # Move the release SBOM to product SBOM path
     sbom_path.rename(product_sbom_path)
@@ -1563,6 +1563,19 @@ def _resolve_output_version(output_format: str, version: str | None) -> str:
     return "1.6" if output_format == "cyclonedx" else "2.3"
 
 
+def _safe_sbom_filename(stem: str, extension: str) -> str:
+    """Build a target filename from user-derived names (product/release) that
+    cannot escape ``target_folder``.
+
+    Product and release names are user-controlled; joining them onto a path with
+    ``target_folder / name`` would allow path traversal (``..``) or absolute-path
+    override if they contained separators. Neutralize path separators + null
+    bytes and strip leading dots/spaces so the result is always a pure basename.
+    """
+    safe = stem.replace("/", "_").replace("\\", "_").replace("\x00", "").lstrip(". ")
+    return f"{safe or 'sbom'}{extension}"
+
+
 def compute_release_artifact_set_hash(release: Any) -> str:
     """Deterministic fingerprint of the members that appear in a PUBLIC aggregate.
 
@@ -1581,8 +1594,6 @@ def compute_release_artifact_set_hash(release: Any) -> str:
     so a replaced member busts the key. Ordered by ``sbom__id`` for determinism.
     (ADR-004: artifacts are immutable, so the filename is a faithful fingerprint.)
     """
-    from sbomify.apps.sboms.models import Component
-
     members = (
         release.artifacts.filter(sbom__isnull=False, sbom__component__visibility=Component.Visibility.PUBLIC)
         .order_by("sbom__id")
@@ -1637,7 +1648,7 @@ def get_release_sbom_package(
     else:
         extension = ".cdx.json"
 
-    sbom_path = target_folder / f"{release.product.name}-{release.name}{extension}"
+    sbom_path = target_folder / _safe_sbom_filename(f"{release.product.name}-{release.name}", extension)
 
     # Aggregated SBOMs are expensive to build (O(N) serial member fetches) and
     # the public release/product download endpoints are unauthenticated — a

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1655,12 +1655,20 @@ def get_release_sbom_package(
         resolved_version = _resolve_output_version(format_lower, version)
         set_hash = compute_release_artifact_set_hash(release)
         cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{set_hash}.json"
+        from botocore.exceptions import ClientError
+
         s3 = S3Client("SBOMS")
-        # The cache is an optimization — a read failure (e.g. AccessDenied on
-        # the prefix) must fall back to a rebuild, not 500 the download.
+        # The cache is an optimization — a read failure scoped to the cache
+        # (e.g. AccessDenied on the aggregates/ prefix while members stay
+        # readable) falls back to a rebuild rather than 500'ing the download. A
+        # MISSING BUCKET is a whole-bucket misconfiguration — the rebuild reads
+        # members from the same bucket and would fail too — so let it surface
+        # loudly (get_cached_aggregate only swallows NoSuchKey).
         try:
             cached = s3.get_cached_aggregate(cache_key)
-        except Exception as e:
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "NoSuchBucket":
+                raise
             log.warning("Aggregate cache read failed for %s, rebuilding: %s", cache_key, e)
             cached = None
         if cached is not None:

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1553,14 +1553,15 @@ def get_product_sbom_package(
 def _resolve_output_version(output_format: str, version: str | None) -> str:
     """Resolve the concrete format version the builder would use.
 
-    Mirrors ``get_sbom_builder``'s defaults (CycloneDX -> 1.6, SPDX -> 2.3) so
-    the aggregate cache key never depends on a ``None`` sentinel — otherwise a
-    future change to the default version could serve a stale cached object for
-    the new default. MUST stay in sync with ``get_sbom_builder``.
+    Defers to the shared ``builders.default_version_for_format`` (the same source
+    ``get_sbom_builder`` uses) so the aggregate cache key never depends on a
+    ``None`` sentinel and can't drift from the version actually built.
     """
     if version:
         return version
-    return "1.6" if output_format == "cyclonedx" else "2.3"
+    from sbomify.apps.sboms.builders import default_version_for_format
+
+    return str(default_version_for_format(output_format).value)
 
 
 def _safe_sbom_filename(stem: str, extension: str) -> str:
@@ -1599,8 +1600,13 @@ def compute_release_artifact_set_hash(release: Any) -> str:
         .order_by("sbom__id")
         .values_list("sbom__id", "sbom__sbom_filename")
     )
-    payload = "|".join(f"{sid}:{fname}" for sid, fname in members)
-    return hashlib.sha256(f"v2|{payload}".encode()).hexdigest()
+    # Hash incrementally and stream the rows so a release with many members never
+    # materializes one large concatenated string (keeps byte-for-byte determinism
+    # with the previous "v2|a:b|c:d" scheme).
+    digest = hashlib.sha256(b"v2")
+    for sid, fname in members.iterator():
+        digest.update(f"|{sid}:{fname}".encode())
+    return digest.hexdigest()
 
 
 def get_release_sbom_package(

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1577,35 +1577,45 @@ def _safe_sbom_filename(stem: str, extension: str) -> str:
     return f"{safe or 'sbom'}{extension}"
 
 
-def compute_release_artifact_set_hash(release: Any) -> str:
-    """Deterministic fingerprint of the members that appear in a PUBLIC aggregate.
+def compute_release_aggregate_fingerprint(release: Any) -> str:
+    """Deterministic fingerprint of EVERY mutable input that shapes a public aggregate.
 
-    Computed from the DB only (no S3 reads). Only PUBLIC-visibility members are
-    fingerprinted, because the aggregate cache is used solely for public products
-    and the builders exclude non-public members from a public product's
-    aggregate. Filtering to exactly the included set means:
+    Computed from the DB only (no S3 reads). A change to any of these busts the
+    cache key so the next download rebuilds:
 
-    * adding/removing/replacing a PUBLIC member — or a member flipping
-      PUBLIC <-> PRIVATE, i.e. entering/leaving the public set — busts the key
-      (a stale doc must never keep exposing a now-private member); while
-    * changing a PRIVATE/GATED member — which never appears in the public
-      aggregate — does NOT needlessly bust it.
+    * its PUBLIC member SBOMs (id + ``sbom_filename``, which is the sha256 of the
+      bytes). Only PUBLIC members are fingerprinted — exactly the set a public
+      aggregate contains — so a member flipping PUBLIC <-> PRIVATE busts the key
+      while private/gated member churn does not needlessly rebuild; and
+    * the release/product METADATA the builder embeds: the product + release
+      names (the aggregate's top-level component name) and the product external
+      references it renders from product links + identifiers. So a rename or a
+      link/identifier edit also triggers a rebuild.
 
-    ``sbom_filename`` is the sha256 of the artifact bytes (object_store.upload_sbom),
-    so a replaced member busts the key. Ordered by ``sbom__id`` for determinism.
-    (ADR-004: artifacts are immutable, so the filename is a faithful fingerprint.)
+    Rows are ordered and fields ``\\x1f``-delimited so distinct inputs can't
+    collide. (ADR-004: member artifacts are immutable, so the filename is a
+    faithful content fingerprint.)
     """
+    digest = hashlib.sha256(b"v3")
+
     members = (
         release.artifacts.filter(sbom__isnull=False, sbom__component__visibility=Component.Visibility.PUBLIC)
         .order_by("sbom__id")
         .values_list("sbom__id", "sbom__sbom_filename")
     )
-    # Hash incrementally and stream the rows so a release with many members never
-    # materializes one large concatenated string (keeps byte-for-byte determinism
-    # with the previous "v2|a:b|c:d" scheme).
-    digest = hashlib.sha256(b"v2")
     for sid, fname in members.iterator():
-        digest.update(f"|{sid}:{fname}".encode())
+        digest.update(f"|m:{sid}\x1f{fname}".encode())
+
+    # Mutable metadata embedded in the aggregate's top-level component.
+    product = release.product
+    digest.update(f"|name:{product.name}\x1f{release.name}".encode())
+    for ident_type, value in product.identifiers.order_by("id").values_list("identifier_type", "value").iterator():
+        digest.update(f"|id:{ident_type}\x1f{value}".encode())
+    for lt, title, url, desc in (
+        product.links.order_by("id").values_list("link_type", "title", "url", "description").iterator()
+    ):
+        digest.update(f"|ln:{lt}\x1f{title}\x1f{url}\x1f{desc}".encode())
+
     return digest.hexdigest()
 
 
@@ -1670,8 +1680,8 @@ def get_release_sbom_package(
         from sbomify.apps.core.object_store import S3Client
 
         resolved_version = _resolve_output_version(format_lower, version)
-        set_hash = compute_release_artifact_set_hash(release)
-        cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{set_hash}.json"
+        fingerprint = compute_release_aggregate_fingerprint(release)
+        cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{fingerprint}.json"
         from botocore.exceptions import ClientError
 
         s3 = S3Client("SBOMS")

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1656,7 +1656,13 @@ def get_release_sbom_package(
         set_hash = compute_release_artifact_set_hash(release)
         cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{set_hash}.json"
         s3 = S3Client("SBOMS")
-        cached = s3.get_cached_aggregate(cache_key)
+        # The cache is an optimization — a read failure (e.g. AccessDenied on
+        # the prefix) must fall back to a rebuild, not 500 the download.
+        try:
+            cached = s3.get_cached_aggregate(cache_key)
+        except Exception as e:
+            log.warning("Aggregate cache read failed for %s, rebuilding: %s", cache_key, e)
+            cached = None
         if cached is not None:
             sbom_path.write_bytes(cached)
             return sbom_path
@@ -1673,8 +1679,19 @@ def get_release_sbom_package(
     body = sbom.model_dump_json(indent=2, exclude_none=True, exclude_unset=True, by_alias=True).encode()
     sbom_path.write_bytes(body)
 
+    # Only cache a COMPLETE build. The builders skip a member on an S3 fetch
+    # error (non-fatal, returns a partial aggregate); caching that would freeze
+    # an incomplete document under this artifact-set hash indefinitely, so a
+    # transient blip would persist. Cache writes are best-effort — a failure to
+    # store must not fail the download.
     if cache_key is not None and s3 is not None:
-        s3.put_cached_aggregate(cache_key, body)
+        if getattr(builder, "had_member_fetch_error", False):
+            log.warning("Skipping aggregate cache for %s: build had member fetch errors", cache_key)
+        else:
+            try:
+                s3.put_cached_aggregate(cache_key, body)
+            except Exception as e:
+                log.warning("Aggregate cache write failed for %s (served anyway): %s", cache_key, e)
 
     return sbom_path
 

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1550,20 +1550,42 @@ def get_product_sbom_package(
     return product_sbom_path
 
 
+def _resolve_output_version(output_format: str, version: str | None) -> str:
+    """Resolve the concrete format version the builder would use.
+
+    Mirrors ``get_sbom_builder``'s defaults (CycloneDX -> 1.6, SPDX -> 2.3) so
+    the aggregate cache key never depends on a ``None`` sentinel — otherwise a
+    future change to the default version could serve a stale cached object for
+    the new default. MUST stay in sync with ``get_sbom_builder``.
+    """
+    if version:
+        return version
+    return "1.6" if output_format == "cyclonedx" else "2.3"
+
+
 def compute_release_artifact_set_hash(release: Any) -> str:
     """Deterministic, content-sensitive fingerprint of a release's SBOM artifact set.
 
-    Computed from the DB only (no S3 reads). ``sbom_filename`` is the sha256 of
-    the artifact bytes (see object_store.upload_sbom), so including it makes the
-    hash change whenever a member is added, removed, or replaced — exactly what
-    the aggregate cache key needs. Ordered by ``sbom__id`` so the fingerprint is
-    independent of row insertion order. (ADR-004: artifacts are immutable, so the
-    filename is a faithful content fingerprint.)
+    Computed from the DB only (no S3 reads). The fingerprint covers, per member:
+
+    * ``sbom__id`` — identity of the member SBOM,
+    * ``sbom__sbom_filename`` — the sha256 of the artifact bytes (see
+      object_store.upload_sbom), so a replaced artifact busts the key,
+    * ``sbom__component__visibility`` — because for PUBLIC products the builder
+      EXCLUDES non-public members; a visibility flip (PUBLIC <-> PRIVATE) changes
+      which members appear in the aggregate, so it MUST change the cache key or a
+      stale doc could keep exposing a now-private member.
+
+    Ordered by ``sbom__id`` so the fingerprint is independent of row insertion
+    order. (ADR-004: artifacts are immutable, so the filename is a faithful
+    content fingerprint.)
     """
     members = (
-        release.artifacts.filter(sbom__isnull=False).order_by("sbom__id").values_list("sbom__id", "sbom__sbom_filename")
+        release.artifacts.filter(sbom__isnull=False)
+        .order_by("sbom__id")
+        .values_list("sbom__id", "sbom__sbom_filename", "sbom__component__visibility")
     )
-    payload = "|".join(f"{sid}:{fname}" for sid, fname in members)
+    payload = "|".join(f"{sid}:{fname}:{vis}" for sid, fname, vis in members)
     return hashlib.sha256(f"v1|{payload}".encode()).hexdigest()
 
 
@@ -1627,8 +1649,9 @@ def get_release_sbom_package(
     if release.product.is_public:
         from sbomify.apps.core.object_store import S3Client
 
+        resolved_version = _resolve_output_version(format_lower, version)
         set_hash = compute_release_artifact_set_hash(release)
-        cache_key = f"aggregates/release/{release.id}/{format_lower}-{version or 'default'}-{set_hash}.json"
+        cache_key = f"aggregates/release/{release.id}/{format_lower}-{resolved_version}-{set_hash}.json"
         s3 = S3Client("SBOMS")
         cached = s3.get_cached_aggregate(cache_key)
         if cached is not None:


### PR DESCRIPTION
## What & why

Addresses #998. The public release/product SBOM download endpoints (`download_release`/`download_product_sbom`, `auth=None` for public products) rebuilt the aggregated document **on every request** — a serial S3 download + `json.loads` per member artifact — making them a cheap DoS amplification vector, even though the member artifacts are immutable (ADR-004).

## Changes (acceptance criteria)

- ✅ **Cached artifact for an unchanged release** — `get_release_sbom_package` now keys an aggregate by `release_id + format + version + artifact-set-hash` and stores it in S3. A cache hit streams the prebuilt bytes with **zero per-member S3 fetches**; a miss builds, stores, and serves.
  - The artifact-set-hash (`compute_release_artifact_set_hash`) is **DB-only** (no S3 reads): `sbom_filename` *is* the content sha256, so any add/remove/replace of a member busts the key. No explicit invalidation needed.
- ✅ **Redundant per-artifact `SBOM.objects.get` removed** from the SPDX 2.3 and SPDX 3.0 builders — the `select_related`-loaded `artifact.sbom` is reused.
- `S3Client` gains `get_cached_aggregate` / `put_cached_aggregate`.

## Scope decisions

- **Caching is restricted to PUBLIC products** — deliberately. That's exactly the unauthenticated DoS vector, and a public aggregate contains only public members (plain, **non-expiring** URLs), so it's safe to cache indefinitely. Private releases are **not** cached: they're authenticated-only (not the DoS vector) and embed short-lived **signed** member URLs that must stay fresh — caching those would serve stale/expired links.
- **Cold-build parallelization deferred to a follow-up.** Caching already makes the expensive serial build run **at most once per artifact-set** (eliminating the amplification — an attacker can't cheaply re-trigger it). Parallelizing that one-time cold-path fetch with a bounded `ThreadPoolExecutor` (per the `sbom_compliance_service.py` pattern) is the remaining optimization and touches the three builder loops with thread-safety care — cleaner as its own PR.
- **Orphaned old cache objects** (when an artifact set changes) are a documented follow-up — a lifecycle/GC sweep on the `aggregates/release/` prefix.

## Tests

- Cache hit serves without re-fetching members (asserts member filenames absent from S3 get-calls on the warm request).
- A changed artifact set busts the cache (new hash → new key → rebuild, new component present).
- Private products are not cached.
- SPDX builders issue no per-artifact `SBOM.objects.get`.

Builders + signed-URL + release-API + product/release aggregation suites all pass (no regression); ruff/mypy clean.