### PR TITLE
perf(billing): move Stripe sync out of the team_context context processor (#838)

### DIFF
--- a/sbomify/apps/billing/cron.py
+++ b/sbomify/apps/billing/cron.py
@@ -12,7 +12,7 @@ from typing import Any
 import dramatiq
 from dramatiq_crontab import cron
 
-from .tasks import check_stale_trials_task
+from .tasks import check_stale_trials_task, sync_active_subscriptions_task
 
 
 # Schedule stale trial check to run daily at 2:00 AM UTC
@@ -40,3 +40,22 @@ def daily_stale_trial_check(*args: Any, **kwargs: Any) -> None:
     cases where webhooks were missed or failed to process.
     """
     check_stale_trials_task.send()
+
+
+# Schedule a full subscription sync daily at 3:30 AM UTC. Webhooks are the
+# primary path that keeps billing_plan_limits current; this is the safety net
+# for missed/failed webhooks, and replaces the per-request Stripe sync that used
+# to run in the team_context context processor.
+@cron("30 3 * * *")  # type: ignore[untyped-decorator]  # Daily at 3:30 AM UTC
+@dramatiq.actor(
+    queue_name="billing_cron",
+    max_retries=1,
+    time_limit=600000,  # 10 minute timeout
+)
+def daily_subscription_sync(*args: Any, **kwargs: Any) -> None:
+    """Daily safety-net sync of all teams with a Stripe subscription.
+
+    Subscription data is normally synced by Stripe webhooks; this catches any
+    cases where webhooks were missed or failed to process.
+    """
+    sync_active_subscriptions_task.send()

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -176,6 +176,41 @@ You can reply to this email and we'll receive your message at {settings.ENTERPRI
 
 
 @dramatiq.actor(queue_name="billing", max_retries=1, time_limit=600000)  # 10 minutes
+def sync_active_subscriptions_task() -> None:
+    """Safety-net sync of every team that has a Stripe subscription.
+
+    Subscription data is normally kept current by Stripe webhooks
+    (customer.subscription.updated / invoice.*). This task — scheduled daily by
+    ``billing.cron.daily_subscription_sync`` — is the fallback for missed/failed
+    webhooks, and replaces the per-request Stripe sync that used to run inside
+    the ``team_context`` context processor on every authenticated page load.
+    """
+    from sbomify.apps.billing.stripe_sync import sync_subscription_from_stripe
+    from sbomify.apps.teams.models import Team
+
+    record_task_breadcrumb("sync_active_subscriptions_task", "start")
+    if not is_billing_enabled():
+        logger.info("Billing is not enabled, skipping subscription sync")
+        return
+
+    teams_with_subscriptions = Team.objects.exclude(billing_plan_limits__isnull=True).filter(
+        billing_plan_limits__has_key="stripe_subscription_id"
+    )
+
+    synced = 0
+    errors = 0
+    for team in teams_with_subscriptions.iterator():
+        try:
+            if sync_subscription_from_stripe(team, force_refresh=True):
+                synced += 1
+        except Exception:
+            logger.warning("Failed to sync subscription for team %s", team.key, exc_info=True)
+            errors += 1
+
+    logger.info("Subscription sync complete: synced=%d, errors=%d", synced, errors)
+
+
+@dramatiq.actor(queue_name="billing", max_retries=1, time_limit=600000)  # 10 minutes
 def check_stale_trials_task() -> None:
     """
     Check for stale trial subscriptions and sync them with Stripe.

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -193,9 +193,9 @@ def sync_active_subscriptions_task() -> None:
         logger.info("Billing is not enabled, skipping subscription sync")
         return
 
-    teams_with_subscriptions = Team.objects.exclude(billing_plan_limits__isnull=True).filter(
-        billing_plan_limits__has_key="stripe_subscription_id"
-    )
+    # JSON path lookup (portable across SQLite/Postgres, unlike has_key) — also
+    # naturally excludes a null subscription id.
+    teams_with_subscriptions = Team.objects.filter(billing_plan_limits__stripe_subscription_id__isnull=False)
 
     synced = 0
     errors = 0

--- a/sbomify/apps/billing/tests/test_stripe_sync.py
+++ b/sbomify/apps/billing/tests/test_stripe_sync.py
@@ -277,48 +277,32 @@ class TestSyncCaching:
 class TestSyncIntegration:
     """Test sync integration with views and context processors."""
 
-    @patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
-    def test_context_processor_calls_sync(self, mock_sync, sample_user, team_with_subscription):
-        """Test that context processor calls sync on page load."""
+    def test_context_processor_does_not_call_sync(self, sample_user, team_with_subscription, mocker):
+        """The context processor must NOT make a blocking Stripe sync on page load.
+
+        Subscription data is kept fresh by webhooks + the daily safety-net task;
+        team_context reads billing_plan_limits straight from the DB.
+        """
         from django.test import RequestFactory
 
         from sbomify.apps.core.context_processors import team_context
+
+        mock_sync = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
 
         factory = RequestFactory()
         request = factory.get("/")
         request.user = sample_user
         request.session = {"current_team": {"key": team_with_subscription.key}}
 
-        # Mock sync to succeed
-        mock_sync.return_value = True
-
         context = team_context(request)
-        assert "team" in context
-        # Sync should be called
-        mock_sync.assert_called_once()
+        assert context["team"] == team_with_subscription
+        assert "is_owner" in context
+        assert "billing_enabled" in context
+        mock_sync.assert_not_called()
 
-    @patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
-    def test_context_processor_handles_sync_failure(self, mock_sync, sample_user, team_with_subscription):
-        """Test that context processor handles sync failure gracefully."""
-        from django.test import RequestFactory
-
-        from sbomify.apps.core.context_processors import team_context
-
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = sample_user
-        request.session = {"current_team": {"key": team_with_subscription.key}}
-
-        # Mock sync to fail
-        mock_sync.side_effect = Exception("Sync failed")
-
-        # Should not crash
-        context = team_context(request)
-        assert "team" in context  # Should still return team
-
-    @patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
-    def test_context_processor_reraises_cancelled_error(self, mock_sync, sample_user, team_with_subscription):
-        """Test that CancelledError is re-raised (not swallowed) for proper ASGI abort."""
+    def test_context_processor_reraises_cancelled_error(self, sample_user, team_with_subscription, mocker):
+        """A request cancelled mid-DB-query (ASGI client disconnect) must re-raise
+        CancelledError so the request aborts properly, rather than being swallowed."""
         import asyncio
 
         from django.test import RequestFactory
@@ -330,10 +314,38 @@ class TestSyncIntegration:
         request.user = sample_user
         request.session = {"current_team": {"key": team_with_subscription.key}}
 
-        mock_sync.side_effect = asyncio.CancelledError()
-
+        mocker.patch(
+            "sbomify.apps.teams.models.Member.objects.filter",
+            side_effect=asyncio.CancelledError(),
+        )
         with pytest.raises(asyncio.CancelledError):
             team_context(request)
+
+    def test_periodic_task_syncs_teams_with_subscriptions(self, team_with_subscription, mocker):
+        """The daily safety-net task syncs every team that has a Stripe subscription
+        (the fallback for missed webhooks that replaces the per-request sync)."""
+        from sbomify.apps.billing.tasks import sync_active_subscriptions_task
+
+        mocker.patch("sbomify.apps.billing.tasks.is_billing_enabled", return_value=True)
+        mock_sync = mocker.patch(
+            "sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe", return_value=True
+        )
+
+        sync_active_subscriptions_task()
+
+        synced_teams = [call.args[0] for call in mock_sync.call_args_list]
+        assert team_with_subscription in synced_teams
+
+    def test_periodic_task_noop_when_billing_disabled(self, mocker):
+        """When billing is disabled the safety-net task does nothing."""
+        from sbomify.apps.billing.tasks import sync_active_subscriptions_task
+
+        mocker.patch("sbomify.apps.billing.tasks.is_billing_enabled", return_value=False)
+        mock_sync = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
+
+        sync_active_subscriptions_task()
+
+        mock_sync.assert_not_called()
 
     @patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
     def test_team_settings_calls_sync(self, mock_sync, client, sample_user, team_with_subscription):
@@ -350,9 +362,15 @@ class TestSyncIntegration:
         # Sync should be called
         mock_sync.assert_called_once()
 
-    @patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
+    @patch("sbomify.apps.billing.views.sync_subscription_from_stripe")
     def test_billing_return_calls_sync(self, mock_sync, client, sample_user, team_with_subscription):
-        """Test that billing return view calls sync after checkout."""
+        """The billing return view syncs the subscription after checkout.
+
+        Patched at the view's import binding because the view calls
+        sync_subscription_from_stripe directly (not via the context processor,
+        which no longer syncs). Stripe objects are fully concretized so nothing
+        MagicMock leaks into the JSON billing_plan_limits.
+        """
         from unittest.mock import patch as mock_patch
 
         client.force_login(sample_user)
@@ -371,9 +389,16 @@ class TestSyncIntegration:
             mock_subscription.id = "sub_test_new"  # Different ID to avoid idempotency check
             mock_subscription.status = "active"
             mock_subscription.current_period_end = int((timezone.now() + datetime.timedelta(days=30)).timestamp())
+            mock_subscription.cancel_at_period_end = False
+            mock_subscription.cancel_at = None
+            mock_subscription.trial_end = None
+            mock_subscription.items = None  # skip the line-item interval lookup
             mock_client.get_subscription.return_value = mock_subscription
 
             mock_customer = MagicMock()
+            mock_customer.id = "cus_test_123"
+            mock_client.get_customer.return_value = mock_customer
+
             # Ensure plan exists
             from sbomify.apps.billing.models import BillingPlan
 
@@ -381,9 +406,6 @@ class TestSyncIntegration:
 
             response = client.get("/billing/return/?session_id=cs_test_123", follow=True)
 
-            # Should be successful (likely redirect to dashboard, which is 200 with follow=True,
-            # or 302 if follow=False. With follow=True, dashboard usually returns 200)
             assert response.status_code == 200
-
-            # Should call sync after processing
+            # The view syncs after persisting the subscription.
             mock_sync.assert_called_once()

--- a/sbomify/apps/core/context_processors.py
+++ b/sbomify/apps/core/context_processors.py
@@ -170,7 +170,8 @@ def team_context(request: Any) -> Any:
     This enables global access to 'team' and 'is_owner' for banners/navigation
     without requiring every view to pass them explicitly.
 
-    Also syncs subscription data from Stripe to ensure billing status is always up-to-date.
+    Reads billing status from the DB only — no Stripe API calls. ``billing_plan_limits``
+    is kept current by Stripe webhooks plus a daily safety-net sync task.
     """
     if not request.user.is_authenticated:
         return {}
@@ -187,43 +188,21 @@ def team_context(request: Any) -> Any:
         # We could use select_related hooks or simple caching here if performance is an issue
         team = Team.objects.get(key=team_key)
 
-        # Sync subscription data from Stripe if subscription exists
-        # This ensures billing status is always current for banners/notifications
-        from sbomify.apps.billing.config import is_billing_enabled
-
-        billing_limits = team.billing_plan_limits or {}
-        stripe_sub_id = billing_limits.get("stripe_subscription_id")
-        if is_billing_enabled() and stripe_sub_id:
-            try:
-                from sbomify.apps.billing.stripe_sync import sync_subscription_from_stripe
-
-                # Sync in background (non-blocking) - if it fails, we still show the page
-                # Use force_refresh=False to use cache, but sync will still check for changes
-                result = sync_subscription_from_stripe(team, force_refresh=False)
-                if result:
-                    # Refresh team to get updated billing_plan_limits
-                    team.refresh_from_db()
-                    logger.debug(f"Successfully synced subscription for team {team_key}")
-                else:
-                    logger.debug(f"Sync returned False for team {team_key} (may not have subscription)")
-            except asyncio.CancelledError:
-                # ASGI cancels the coroutine on client disconnect during blocking Stripe calls.
-                # Must be caught before Exception (on Python <3.14, CancelledError IS an Exception).
-                logger.debug(f"Stripe sync cancelled for team {team_key} (client disconnected)")
-                raise
-            except Exception as e:
-                # Don't break page rendering if Stripe sync fails
-                logger.warning(f"Failed to sync subscription for team {team_key}: {e}", exc_info=True)
-
-        # Determine if owner
-        # Optimization: Check if the session already has reliable role info,
-        # but fetching DB ensures latest status (important for billing updates etc)
+        # Determine if owner. Billing status (banners/notifications) is read
+        # straight from team.billing_plan_limits below; it is NOT synced from
+        # Stripe here. That blocking 1-5s API call ran on EVERY authenticated
+        # request — degrading page loads and causing ASGI CancelledError on
+        # client disconnect. The DB is kept current by Stripe webhooks
+        # (customer.subscription.updated / invoice.*) plus a daily safety-net
+        # task (billing.cron.daily_subscription_sync).
         is_owner = False
         member = Member.objects.filter(team=team, user=request.user).first()
         if member and member.role == "owner":
             is_owner = True
 
         from django.conf import settings
+
+        from sbomify.apps.billing.config import is_billing_enabled
 
         return {
             "team": team,


### PR DESCRIPTION
## What & why

Closes #838. `team_context()` runs on **every authenticated page render** and was calling `sync_subscription_from_stripe()` — a blocking **1–5s Stripe API call** (plus `select_for_update` and an invoice-fallback call). This degraded page loads for all authenticated users and caused `asyncio.CancelledError` under ASGI when clients disconnected mid-request (PR #837 was the stopgap).

## Changes (acceptance criteria)

- ✅ **`team_context()` no longer calls `sync_subscription_from_stripe()`** — billing status for banners/notifications is read straight from `team.billing_plan_limits` (DB only, no external API).
- ✅ **Synced via webhooks** — `billing_plan_limits` is kept current by Stripe webhooks (`customer.subscription.updated`, `invoice.*`) handled in `billing.views` → `billing_processing`. (Already in place.)
- ✅ **Daily background safety-net** — new `sync_active_subscriptions_task` syncs *every* team with a Stripe subscription (broader than the existing stale-trial-only check), scheduled by `billing.cron.daily_subscription_sync` at 03:30 UTC.
- ✅ **Banners/notifications still work** — they read the same DB field, kept fresh by webhooks + the daily task.
- ✅ **Page load improves** — the blocking per-request Stripe call is gone.

## Test changes

- `test_billing_return_calls_sync` repointed at the **view's** `sync_subscription_from_stripe` binding (the view imports it top-level; the test was implicitly asserting the *context-processor* sync) and its Stripe mocks concretized so nothing leaks a `MagicMock` into the JSON `billing_plan_limits`.
- Context-processor tests now assert **no** sync call on render, plus `CancelledError` is still re-raised when a DB query is cancelled (ASGI abort).
- New tests for the periodic task (syncs subscription teams; no-op when billing disabled).

Billing app + core view suites pass (334 tests); ruff/mypy clean.