### PR TITLE
fix(security): verify_item_access reads roles from the DB, not the session cache (#1002)

### DIFF
--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -212,3 +212,50 @@ class TestAddArtifactToReleaseCrossTeamCheck:
         result = add_artifact_to_release(release, document=doc)
         assert result["created"] is True
         assert result["replaced"] is False
+
+
+@pytest.mark.django_db
+class TestVerifyItemAccessIsDbAuthoritative:
+    """verify_item_access must read the role from the DB, never from the mutable
+    (possibly stale) session ``user_teams`` cache — a demoted or removed member
+    must not keep elevated access until the cache happens to refresh."""
+
+    @staticmethod
+    def _request(user, user_teams):
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.session = {"user_teams": user_teams}
+        return request
+
+    def test_stale_cached_role_does_not_grant_elevated_access(self, sample_team_with_owner_member):
+        from sbomify.apps.core.utils import verify_item_access
+
+        member = sample_team_with_owner_member
+        team = member.team
+
+        # Demote to guest in the DB; the session cache is stale and still says owner.
+        member.role = "guest"
+        member.save(update_fields=["role"])
+        request = self._request(member.user, {team.key: {"role": "owner"}})
+
+        # Owner/admin-only check is denied based on the live DB role (guest)...
+        assert verify_item_access(request, team, ["owner", "admin"]) is False
+        # ...while the user's real (guest) access still works.
+        assert verify_item_access(request, team, ["guest"]) is True
+
+    def test_stale_cached_role_for_removed_member_is_denied(self, sample_team_with_owner_member):
+        from sbomify.apps.core.utils import verify_item_access
+        from sbomify.apps.teams.models import Member
+
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+
+        # Remove the membership (queryset delete leaves the fixture instance intact
+        # for teardown); the session cache is stale and still grants owner.
+        Member.objects.filter(pk=sample_team_with_owner_member.pk).delete()
+        request = self._request(user, {team.key: {"role": "owner"}})
+
+        assert verify_item_access(request, team, ["owner", "admin"]) is False
+        assert verify_item_access(request, team, None) is False

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -420,59 +420,36 @@ def verify_item_access(
 
     If the request was authenticated with a scoped access token, access is
     denied when the item belongs to a different team than the token's scope.
+
+    The role is read authoritatively from the database (the ``Member`` row), NOT
+    from the session's cached ``user_teams`` snapshot. That snapshot is mutable
+    and only refreshed periodically, so a demoted or removed member would keep
+    their old (elevated) role on it until the next refresh — trusting it for an
+    authorization decision is a privilege-escalation / revocation-bypass risk.
     """
     if not request.user.is_authenticated:
         return False
 
-    # Enforce token workspace scoping
-    token_team = getattr(request, "token_team", None)
-    if token_team is not None:
-        item_team_id = _extract_team_id(item)
-        if item_team_id is not None and item_team_id != token_team.id:
-            return False
+    team_id = _extract_team_id(item)
 
-    team_id = None
-    team_key = None
+    # Enforce token workspace scoping.
+    token_team = getattr(request, "token_team", None)
+    if token_team is not None and team_id is not None and team_id != token_team.id:
+        return False
+
+    if not team_id:
+        return False
 
     # Import here to avoid circular imports
     from sbomify.apps.teams.models import Member
 
-    # Handle Team objects directly
-    if hasattr(item, "_meta") and item._meta.label == "teams.Team":
-        team_id = item.id
-        team_key = item.key
-    # Handle objects with team relationship
-    elif hasattr(item, "team_id"):
-        team_id = item.team_id
-        if hasattr(item, "team"):
-            team_key = item.team.key
-    elif hasattr(item, "team"):
-        team_id = item.team.id if hasattr(item.team, "id") else None
-        team_key = item.team.key if hasattr(item.team, "key") else None
-    # Handle SBOM objects (component.team relationship)
-    elif hasattr(item, "component") and hasattr(item.component, "team_id"):
-        team_id = item.component.team_id
-        team_key = item.component.team.key
-
-    # Check session data first
-    if team_key and "user_teams" in request.session:
-        team_data = request.session["user_teams"].get(team_key)
-        if team_data and "role" in team_data:
-            # If no roles are specified, any role is allowed
-            if allowed_roles is None:
-                return True
-            return team_data["role"] in allowed_roles
-
-    # Fall back to database check
-    if team_id:
-        member = Member.objects.filter(user=request.user, team_id=team_id).first()
-        if member:
-            # If no roles are specified, any role is allowed
-            if allowed_roles is None:
-                return True
-            return member.role in allowed_roles
-
-    return False
+    member = Member.objects.filter(user=request.user, team_id=team_id).first()
+    if member is None:
+        return False
+    # If no roles are specified, any role is allowed.
+    if allowed_roles is None:
+        return True
+    return member.role in allowed_roles
 
 
 def add_artifact_to_release(

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -437,7 +437,7 @@ def verify_item_access(
     if token_team is not None and team_id is not None and team_id != token_team.id:
         return False
 
-    if not team_id:
+    if team_id is None:
         return False
 
     # Import here to avoid circular imports

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -414,9 +414,9 @@ def verify_item_access(
     """
     Verify if the user has access to the item based on the allowed roles.
 
-    This function works with any model that has a team relationship.
-    For Team objects, it uses the team directly.
-    For other objects, it looks for team_id or team.key attributes.
+    This function works with any model that has a team relationship. The team is
+    resolved via ``_extract_team_id``: a Team object is used directly, otherwise
+    the team id is taken from the object's ``team_id`` / ``team`` / ``component``.
 
     If the request was authenticated with a scoped access token, access is
     denied when the item belongs to a different team than the token's scope.


### PR DESCRIPTION
## What & why

`verify_item_access()` (`core/utils.py`) short-circuited on the role cached in `request.session["user_teams"][team_key]["role"]` **before** ever hitting the DB:

```python
# Check session data first
if team_key and "user_teams" in request.session:
    team_data = request.session["user_teams"].get(team_key)
    if team_data and "role" in team_data:
        if allowed_roles is None:
            return True
        return team_data["role"] in allowed_roles
# Fall back to database check
...
```

That `user_teams` snapshot is **mutable and only refreshed periodically** (by a template tag, ~5 min). So a **demoted or removed member kept their old, elevated role** for any authorization decision on the API path until the cache happened to refresh — a privilege-escalation / revocation-bypass window. This is the **stale-session-role finding** called out in the authorization-model epic (#1002, problem #2); it's a standalone security fix and does **not** depend on the rest of that epic.

`TeamRoleRequiredMixin` (the web-view path) already queried the DB unconditionally, so the bug was **asymmetric** — only the `verify_item_access` (API) path trusted the cache.

## Fix

Resolve the team via the existing `_extract_team_id()` helper (already used here for token scoping) and read the role **authoritatively from the live `Member` row**. The session-cache short-circuit — and the now-unused `team_key` plumbing — are removed. Behavior is unchanged for any current member (their cache matched the DB); only the *stale* case changes, which is the bug.

Perf note: this adds one indexed `Member` lookup per authorization check (the function already did this on the cache-miss path). Authorization correctness over a micro-cache is the right trade for a security-bearing check.

## Tests

- A stale cached `owner` role does **not** grant owner/admin access when the live DB role is `guest` (demotion) — and the user's real `guest` access still works.
- A stale cached `owner` role for a **removed** member is denied for both role-gated and any-role (`allowed_roles=None`) checks.

## Verification

Targeted sync authz regression is green (**131 passed**: permission-consistency, access-control-service, component-visibility, public-access, views, token tests). The broad run's failures are all **pre-existing async/channels/e2e infrastructure tests** (asgi/broadcast/consumer/Playwright) — they pass in isolation, fail only under event-loop pollution in big combined runs, and **none reference `verify_item_access`**. ruff/mypy clean.