### PR TITLE
fix(oidc): tolerate clock skew when verifying GitHub OIDC tokens

### DIFF
--- a/sbomify/apps/oidc/tests/test_apis.py
+++ b/sbomify/apps/oidc/tests/test_apis.py
@@ -54,6 +54,58 @@ def github_binding(component: Component, sample_user):
     return binding
 
 
+class TestClockSkewExchange:
+    """End-to-end reproduction of the production failure through the real
+    exchange endpoint: when GitHub's issuer clock runs ahead of the verifier, a
+    fresh token's ``iat``/``nbf`` is slightly in the future. With the old
+    ``leeway=0`` every exchange 401'd ("Last used: never"); with the clock-skew
+    leeway the full path (verify → coerce → binding lookup → mint) must succeed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _pin_leeway(self, settings) -> None:
+        # Deterministic regardless of any OIDC_GITHUB_LEEWAY_SECONDS env override.
+        settings.OIDC_GITHUB_LEEWAY_SECONDS = 60
+
+    @pytest.mark.django_db
+    def test_future_iat_nbf_token_still_exchanges(
+        self, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        now = int(time.time())
+        # Simulate GitHub's issuer clock ~30s ahead of ours -> future iat/nbf.
+        token = github_claims_factory(
+            repository_owner_id=67890, repository_id=12345, iat=now + 30, nbf=now + 30
+        )
+        response = Client().post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200, response.content
+        assert "access_token" in response.json()
+
+    @pytest.mark.django_db
+    def test_zero_leeway_rejects_future_token(
+        self, settings, github_claims_factory, mock_github_jwks, github_binding, component
+    ) -> None:
+        """Anchors the root cause: with no leeway (the old behavior) the very same
+        future-iat/nbf token is rejected by the endpoint with 401 — the exact
+        production failure this fix removes."""
+        settings.OIDC_GITHUB_LEEWAY_SECONDS = 0
+        now = int(time.time())
+        token = github_claims_factory(
+            repository_owner_id=67890, repository_id=12345, iat=now + 30, nbf=now + 30
+        )
+        response = Client().post(
+            EXCHANGE_URL,
+            data=json.dumps({"component_id": component.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401, response.content
+
+
 class TestSuccessfulExchange:
     @pytest.mark.django_db
     def test_returns_short_lived_token_and_creates_db_row(

--- a/sbomify/apps/oidc/tests/test_utils.py
+++ b/sbomify/apps/oidc/tests/test_utils.py
@@ -38,6 +38,13 @@ class TestClockSkewLeeway:
     401 — failing every exchange. The verifier must tolerate a small clock skew.
     """
 
+    @pytest.fixture(autouse=True)
+    def _pin_leeway(self, settings) -> None:
+        # Pin the leeway so these tests are deterministic regardless of any
+        # OIDC_GITHUB_LEEWAY_SECONDS env override: 30s of skew is within it,
+        # 3600s is well beyond it.
+        settings.OIDC_GITHUB_LEEWAY_SECONDS = 60
+
     def test_iat_slightly_in_future_is_accepted(self, github_claims_factory, mock_github_jwks) -> None:
         now = int(time.time())
         token = github_claims_factory(iat=now + 30)

--- a/sbomify/apps/oidc/tests/test_utils.py
+++ b/sbomify/apps/oidc/tests/test_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import time
-from typing import Any
 from unittest.mock import MagicMock
 
 import jwt as pyjwt
@@ -29,6 +28,33 @@ class TestHappyPath:
         assert claims["repository"] == "acme/widget"
         assert claims["actor"] == "octocat"
         assert claims["aud"] == "sbomify.com"
+
+
+class TestClockSkewLeeway:
+    """GitHub's issuer clock can run a few seconds ahead of the verifier, so a
+    freshly minted token's ``iat``/``nbf`` is often slightly in the *future* at
+    verification time. With PyJWT's default ``leeway=0`` this raises
+    ``ImmatureSignatureError`` ("not yet valid"), which the verifier remaps to a
+    401 — failing every exchange. The verifier must tolerate a small clock skew.
+    """
+
+    def test_iat_slightly_in_future_is_accepted(self, github_claims_factory, mock_github_jwks) -> None:
+        now = int(time.time())
+        token = github_claims_factory(iat=now + 30)
+        claims = verify_github_oidc_token(token)
+        assert claims["repository"] == "acme/widget"
+
+    def test_nbf_slightly_in_future_is_accepted(self, github_claims_factory, mock_github_jwks) -> None:
+        now = int(time.time())
+        token = github_claims_factory(nbf=now + 30)
+        claims = verify_github_oidc_token(token)
+        assert claims["repository"] == "acme/widget"
+
+    def test_far_future_beyond_leeway_still_rejected(self, github_claims_factory, mock_github_jwks) -> None:
+        now = int(time.time())
+        token = github_claims_factory(iat=now + 3600, nbf=now + 3600, exp=now + 7200)
+        with pytest.raises(OIDCInvalidSignature):
+            verify_github_oidc_token(token)
 
 
 class TestSignatureFailures:

--- a/sbomify/apps/oidc/utils.py
+++ b/sbomify/apps/oidc/utils.py
@@ -249,9 +249,13 @@ def verify_github_oidc_token(token: str) -> dict[str, Any]:
     * RS256 signature against GitHub's JWKS
     * ``iss`` == ``settings.OIDC_GITHUB_ISSUER``
     * ``aud`` == ``settings.OIDC_GITHUB_AUDIENCE``
-    * ``exp`` is in the future (PyJWT default leeway = 0s)
-    * ``iat`` is not in the future (``verify_iat=True``; PyJWT
-      default leeway = 0s, applied symmetrically)
+    * ``exp`` is in the future, ``iat``/``nbf`` are not in the future
+      (``verify_iat=True``) — each tolerant of up to
+      ``settings.OIDC_GITHUB_LEEWAY_SECONDS`` of clock skew, applied
+      symmetrically. GitHub's issuer clock often runs a few seconds ahead
+      of ours, so a fresh token's ``iat``/``nbf`` is slightly in the future
+      at verification time; with zero leeway PyJWT would reject it as "not
+      yet valid" and every exchange would 401.
     * required claims present: ``iss``, ``aud``, ``exp``, ``iat``,
       ``sub``
 
@@ -275,6 +279,7 @@ def verify_github_oidc_token(token: str) -> dict[str, Any]:
             algorithms=["RS256"],
             issuer=settings.OIDC_GITHUB_ISSUER,
             audience=settings.OIDC_GITHUB_AUDIENCE,
+            leeway=settings.OIDC_GITHUB_LEEWAY_SECONDS,
             options={
                 # PyJWT's ``require`` ONLY enforces claim presence —
                 # the corresponding ``verify_*`` options control

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -784,6 +784,12 @@ OIDC_GITHUB_JWKS_URL = os.environ.get(
 OIDC_GITHUB_AUDIENCE = os.environ.get("OIDC_GITHUB_AUDIENCE", "sbomify.com")
 OIDC_TOKEN_TTL_SECONDS = int(os.environ.get("OIDC_TOKEN_TTL_SECONDS", "900"))  # 15 minutes
 OIDC_JWKS_CACHE_SECONDS = int(os.environ.get("OIDC_JWKS_CACHE_SECONDS", "3600"))  # 1 hour
+# Clock-skew tolerance (seconds) applied symmetrically to nbf/iat/exp when
+# verifying GitHub OIDC tokens. GitHub's issuer clock can run a few seconds
+# ahead of ours, so a freshly minted token's nbf/iat is often slightly in the
+# future at verification time; with zero leeway PyJWT rejects it as "not yet
+# valid" and every exchange fails. 60s matches common JWT clock-skew guidance.
+OIDC_GITHUB_LEEWAY_SECONDS = int(os.environ.get("OIDC_GITHUB_LEEWAY_SECONDS", "60"))
 
 # Localstack and AWS/S3 related settings
 AWS_REGION = os.environ.get("AWS_REGION", "")


### PR DESCRIPTION
## Symptom

GitHub Actions OIDC trusted publishing fails **every** exchange with `401 invalid OIDC token` — bindings show **"Last used: never"**. Seen in [Anthias CI](https://github.com/Screenly/Anthias/actions/runs/27192583927/job/80489020402):

```
INFO   Authenticating to sbomify via GitHub OIDC (component=…, audience=sbomify.com)
ERROR  sbomify rejected the GitHub OIDC token (401)… Detail: invalid OIDC token
```

## Root cause

`verify_github_oidc_token()` calls `jwt.decode(...)` with `verify_iat=True` and **PyJWT's default `leeway=0`**. GitHub OIDC tokens carry `nbf`/`iat` at ~mint time, and GitHub's issuer clock typically runs a few seconds **ahead** of the verifier, so at verification time `nbf`/`iat` is slightly in the future. With zero leeway, PyJWT raises `ImmatureSignatureError` ("the token is not yet valid") — an `InvalidTokenError` subclass — which the verifier's catch-all remaps to `OIDCInvalidSignature` → **401**.

### Why it shipped green but never worked
The OIDC test factory sets `iat=now` and omits `nbf` against the real clock, so it only ever exercises the non-future case. Every real GitHub token (issuer clock ahead) hits the future case and is rejected.

### Confirmed, competitors eliminated
- **Reproduced mechanically** (PyJWT 2.12.0, exact decode options): `iat/nbf=now+5, leeway=0` → `ImmatureSignatureError`; `leeway=60` → accepted.
- **Audience** matches (`sbomify.com` on both sides, sourced from the same `OIDC_GITHUB_AUDIENCE` setting). **Issuer** is the GitHub standard. **Signature/JWKS** would be 503, not 401. **Claim coercion** cleanly accepts the IDs. **Binding** IDs match `screenly/anthias` exactly (`id=5169716`, `owner_id=20972724`) — and a binding mismatch is 403, not 401.

## Fix

Pass `leeway=settings.OIDC_GITHUB_LEEWAY_SECONDS` (default **60s**, env-overridable) to `jwt.decode`, absorbing clock skew symmetrically across `nbf`/`iat`/`exp`. 60s matches common JWT clock-skew guidance and is negligible against the token's short (~5 min) TTL. If a deployment's skew is larger, bump `OIDC_GITHUB_LEEWAY_SECONDS`.

## Tests

`TestClockSkewLeeway` reproduces the failure and pins the fix:
- a token with `iat` ~30s in the future is **accepted** (was `OIDCInvalidSignature`),
- a token with `nbf` ~30s in the future is **accepted**,
- a far-future token (beyond the leeway) is **still rejected** (guards against an over-broad leeway).

Full OIDC suite: **143 passed**; ruff + mypy clean.