### PR TITLE
ci: publish own SBOMs via OIDC trusted publishing (exemplar for the org-wide rollout)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -550,7 +550,7 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          OIDC_AUDIENCE: stage.sbomify.com
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -619,7 +619,7 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          OIDC_AUDIENCE: stage.sbomify.com
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -699,7 +699,7 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
@@ -767,7 +767,7 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -550,7 +550,6 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          OIDC_AUDIENCE: stage.sbomify.com
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -619,7 +618,6 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          OIDC_AUDIENCE: stage.sbomify.com
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -699,7 +697,6 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
@@ -767,7 +764,6 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
         env:
-          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
**Lead PR of the org-wide rollout** of OIDC trusted publishing for the repos where we use the sbomify action ourselves. The sibling PRs are already open — see the tracker below.

## What changed

The four SBOM **generate-and-upload** jobs in `ci-cd.yml` switch from static API-token auth to GitHub OIDC trusted publishing (the same way `sbomify-action/sbomify.yaml` already dogfoods itself):

| Job | was | now |
|---|---|---|
| `generate-source-sboms-staging` | `TOKEN: secrets.SBOMIFY_STAGE_TOKEN` | **OIDC** (no token; audience derived from `API_BASE_URL` → `stage.sbomify.com`) |
| `generate-container-sboms-staging` | `TOKEN: secrets.SBOMIFY_STAGE_TOKEN` | **OIDC** (no token; audience derived from `API_BASE_URL` → `stage.sbomify.com`) |
| `generate-source-sboms-production` | `TOKEN: secrets.SBOMIFY_TOKEN` | **OIDC** (no token; audience defaults to `sbomify.com`) |
| `generate-container-sboms-production` | `TOKEN: secrets.SBOMIFY_TOKEN` | **OIDC** (no token; audience defaults to `sbomify.com`) |

All four jobs already declare `permissions: id-token: write` (for the adjacent build-provenance attestation), so no permission change is needed. `COMPONENT_ID`, `API_BASE_URL`, and every other input are unchanged. No secrets remain in these jobs.

_No explicit `OIDC_AUDIENCE` is set: the action derives it from `API_BASE_URL` — `app.sbomify.com`/prod → `sbomify.com`, `stage.sbomify.com` → `stage.sbomify.com` (per @vpetersson's review)._

## ⚠️ Merge prerequisites

1. **#1012 deployed.** The OIDC clock-skew fix (#1012) is **merged to master** but must be **deployed** — to **staging** for the staging jobs here, and to **prod** for the production jobs. (Merged ≠ deployed.) Without it, the exchange 401s under clock skew on `app.sbomify.com` — the same failure as the Screenly/Anthias binding showing "Last used: never".
2. **Trusted-publisher bindings created** for `sbomify/sbomify` → each component, on the matching instance:

   | Instance | Components (bind `sbomify/sbomify` →) |
   |---|---|
   | **stage.sbomify.com** | `FoKftlVn4uyq` (Python Stack), `Kpj3ZylyBDkb` (Frontend Stack), `odzUCI8r2any` (Container) |
   | **app.sbomify.com** | `2hg-dk8ixV` (Python Stack), `vKhyt5bLHk4B` (Frontend Stack), `iVajxXMIqqyi` (Container) |

   Without a binding, the exchange returns 403 (repo not bound).

## After merge — verify

A master push runs the staging jobs; a `v*` tag runs the production jobs. Confirm each binding's **"Last used"** flips from *never* and the SBOMs appear on the component. The `SBOMIFY_STAGE_TOKEN` / `SBOMIFY_TOKEN` secrets can then be retired (once every repo is migrated).

## Org-wide rollout tracker

| Repo | Workflow | PR | Notes |
|---|---|---|---|
| **sbomify** | `ci-cd.yml` | **this PR** | 4 jobs (stage + prod) |
| sbomify.com | `deploy.yml` | sbomify/sbomify.com#93 | 2 jobs (prod); adds `id-token: write` to both |
| py-libtea | `sbomify.yaml` | sbomify/py-libtea#28 | stage + prod |
| pypi-tea | `pypi.yaml` | sbomify/pypi-tea#34 | stage + prod |
| library | `sbom-builder.yml` | _pending_ | only the 2 `UPLOAD:true` steps; keeps `SBOMIFY_TOKEN` for the direct REST-API bash steps; per-app component IDs from `config.yaml` |

Not converted (no upload → no exchange): `sbomify-action/pypi.yaml`, `py-libtea/pypi.yaml`, `sbom-benchmarks`. Already OIDC (the template): `sbomify-action/sbomify.yaml`.