### PR TITLE
feat(authz): introduce can() authorization front door (#1002 phase 1)

### DIFF
--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -1,0 +1,133 @@
+"""Single authorization decision point.
+
+``can(actor, action, resource)`` is the one front door for authorization. It maps
+a named ``action`` to the capability the codebase already enforces, then
+**delegates** to the existing checks — ``verify_item_access`` (role-based) and
+``check_component_access`` (resource-attribute-based) — so its decision is
+identical to the scattered inline role checks it is meant to replace.
+
+This is the first phase of consolidating authorization: introduce the facade
+with no behaviour change. Later work migrates call sites onto ``can`` and grows
+the action catalog / capability model; until then both styles coexist.
+
+Why a facade instead of a rewrite: every call site today passes a raw role list
+(``["owner", "admin"]``) to ``verify_item_access``. Naming the role sets as
+capabilities and giving each action one definition turns "what can an admin do"
+from an emergent property of ~170 call sites into a single table here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.http import HttpRequest
+
+# Roles — mirror the keys of ``settings.TEAMS_SUPPORTED_ROLES``.
+ROLE_OWNER = "owner"
+ROLE_ADMIN = "admin"
+ROLE_GUEST = "guest"
+ROLE_BOT = "bot"
+
+# Capability tiers: the role sets the current checks grant. Each is exactly an
+# ``allowed_roles`` list used at today's call sites, so an action that maps to a
+# tier is behaviour-identical to the inline check it replaces.
+ADMINISTER: tuple[str, ...] = (ROLE_OWNER,)
+"""Owner-only: billing, member management, workspace settings/deletion."""
+
+MANAGE: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN)
+"""Create/update/delete products, components, releases, and artifact metadata."""
+
+PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
+"""Upload artifacts — also granted to OIDC/CI ``bot`` identities."""
+
+READ_MEMBER: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_GUEST)
+"""Any workspace member may read internal (non-public) workspace data."""
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Outcome of an authorization check. Truthy iff access is allowed."""
+
+    allowed: bool
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.allowed
+
+
+# action ("<resource>:<verb>") -> the role tuple it requires. These mirror the
+# allowed_roles lists at today's call sites exactly.
+_ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
+    # owner-only administration
+    "workspace:administer": ADMINISTER,
+    "workspace:delete": ADMINISTER,
+    "billing:manage": ADMINISTER,
+    "member:manage": ADMINISTER,
+    # owner + admin management (the dominant capability)
+    "workspace:manage": MANAGE,
+    "product:create": MANAGE,
+    "product:manage": MANAGE,
+    "component:create": MANAGE,
+    "component:manage": MANAGE,
+    "release:manage": MANAGE,
+    "sbom:manage": MANAGE,
+    "document:manage": MANAGE,
+    # artifact upload — also allows OIDC/CI bot identities
+    "artifact:publish": PUBLISH,
+    # any-member read of internal workspace data
+    "workspace:read": READ_MEMBER,
+    "component:read_internal": READ_MEMBER,
+}
+
+# Actions authorized by resource attributes (visibility / NDA / access request)
+# rather than role. Delegated to ``check_component_access``; the resource must be
+# a Component or expose ``.component``.
+_ABAC_ACTIONS: frozenset[str] = frozenset({"component:access"})
+
+
+class UnknownActionError(KeyError):
+    """Raised when ``can`` is asked about an action that isn't registered."""
+
+
+def _stub_request_for_user(user: Any) -> HttpRequest:
+    """A request carrying just ``user`` and an EMPTY session.
+
+    Mirrors ``check_component_access_for_user``: the empty session makes
+    ``verify_item_access`` skip nothing it wouldn't already (the role is read
+    from the live DB), and there is no token scope. Use for delegated checks
+    that have no authenticated HTTP request to trust.
+    """
+    stub = HttpRequest()
+    stub.user = user
+    stub.session = {}  # type: ignore[assignment]
+    return stub
+
+
+def can(actor: Any, action: str, resource: Any) -> Decision:
+    """Authorize ``actor`` to perform ``action`` on ``resource``.
+
+    ``actor`` is an ``HttpRequest`` (preserving token-workspace scoping) or a
+    ``User`` (a delegated, session-less check against live DB state). ``action``
+    is a registered ``"<resource>:<verb>"`` string; an unregistered action
+    raises ``UnknownActionError`` so typos fail loudly in development rather than
+    silently allowing or denying.
+
+    Delegates to the existing enforcement functions, so the decision matches the
+    inline checks it replaces.
+    """
+    from sbomify.apps.core.services.access_control import check_component_access
+    from sbomify.apps.core.utils import verify_item_access
+
+    request = actor if isinstance(actor, HttpRequest) else _stub_request_for_user(actor)
+
+    if action in _ABAC_ACTIONS:
+        component = getattr(resource, "component", resource)
+        result = check_component_access(request, component)
+        return Decision(result.has_access, result.reason)
+
+    roles = _ROLE_ACTIONS.get(action)
+    if roles is None:
+        raise UnknownActionError(action)
+    allowed = verify_item_access(request, resource, list(roles))
+    return Decision(allowed, "" if allowed else f"requires role in {roles}")

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -41,7 +41,9 @@ MANAGE: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN)
 PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
 """Upload artifacts — also granted to OIDC/CI ``bot`` identities."""
 
-READ_MEMBER: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_GUEST)
+# Order mirrors the predominant call-site literal ``["guest", "owner", "admin"]``
+# (membership is order-independent, but the parity keeps the claim above honest).
+READ_MEMBER: tuple[str, ...] = (ROLE_GUEST, ROLE_OWNER, ROLE_ADMIN)
 """Any workspace member may read internal (non-public) workspace data."""
 
 

--- a/sbomify/apps/core/tests/test_authz.py
+++ b/sbomify/apps/core/tests/test_authz.py
@@ -1,0 +1,136 @@
+"""Characterization tests for the ``can()`` authorization front door.
+
+These pin the role->capability behaviour and prove ``can`` is a faithful
+delegation: its decision equals the existing ``verify_item_access`` /
+``check_component_access`` for every role, resource and action — so migrating a
+call site onto ``can`` cannot change behaviour.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest
+
+from sbomify.apps.core import authz
+from sbomify.apps.core.authz import Decision, UnknownActionError, can
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.utils import verify_item_access
+from sbomify.apps.teams.models import Member, Team
+
+
+def _user(username: str):
+    return get_user_model().objects.create_user(username=username[:150], password="x")
+
+
+def _member(team, user, role):
+    """Create a Member, honouring the bot-role guard.
+
+    ``role="bot"`` is reserved for OIDC synthetic identities; a pre_save signal
+    rejects manual creation unless the sanctioned provisioning flag is set.
+    """
+    member = Member(team=team, user=user, role=role)
+    if role == "bot":
+        member._is_oidc_bot_provisioning = True
+    member.save()
+    return member
+
+
+@pytest.fixture
+def workspace(db):
+    team = Team.objects.create(name="authz-team")
+    component = Component.objects.create(name="authz-comp", team=team)
+    return team, component
+
+
+# (action, resource, expected-allowed per role) — the role->capability matrix,
+# written to match what the inline checks grant today.
+_MATRIX = {
+    "workspace:administer": ("team", {"owner": True, "admin": False, "guest": False, "bot": False}),
+    "component:manage": ("component", {"owner": True, "admin": True, "guest": False, "bot": False}),
+    "artifact:publish": ("component", {"owner": True, "admin": True, "guest": False, "bot": True}),
+    "workspace:read": ("team", {"owner": True, "admin": True, "guest": True, "bot": False}),
+}
+_CASES = [(a, role, exp[role]) for a, (_res, exp) in _MATRIX.items() for role in ("owner", "admin", "guest", "bot")]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("action,role,expected", _CASES)
+def test_role_capability_matrix(workspace, action, role, expected):
+    team, component = workspace
+    resource = team if _MATRIX[action][0] == "team" else component
+    user = _user(f"{role}-{action.replace(':', '-')}")
+    _member(team, user, role)
+
+    decision = can(user, action, resource)
+    assert isinstance(decision, Decision)
+    assert decision.allowed is expected
+    assert bool(decision) is expected
+    # ...and (not decision) mirrors the legacy `if not verify_item_access(...)`.
+    assert (not decision) is (not expected)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("action", list(_MATRIX))
+def test_non_member_is_always_denied(workspace, action):
+    team, component = workspace
+    resource = team if _MATRIX[action][0] == "team" else component
+    assert can(_user(f"outsider-{action.replace(':', '-')}"), action, resource).allowed is False
+
+
+@pytest.mark.django_db
+def test_can_decision_equals_verify_item_access(workspace):
+    """The faithfulness guarantee: can() == verify_item_access for every role."""
+    team, component = workspace
+    for role in ("owner", "admin", "guest", "bot"):
+        user = _user(f"equiv-{role}")
+        _member(team, user, role)
+        req = HttpRequest()
+        req.user = user
+        req.session = {}
+        assert can(user, "component:manage", component).allowed == verify_item_access(
+            req, component, list(authz.MANAGE)
+        )
+        assert can(user, "artifact:publish", component).allowed == verify_item_access(
+            req, component, list(authz.PUBLISH)
+        )
+
+
+@pytest.mark.django_db
+def test_request_actor_preserves_token_workspace_scope(workspace):
+    """A request actor keeps verify_item_access's token scoping: a token scoped
+    to another workspace denies even an owner."""
+    team, component = workspace
+    owner = _user("scoped-owner")
+    _member(team, owner, "owner")
+    other_team = Team.objects.create(name="other-ws")
+
+    req = HttpRequest()
+    req.user = owner
+    req.session = {}
+    req.token_team = other_team  # scoped elsewhere
+    assert can(req, "component:manage", component).allowed is False
+
+    req.token_team = team  # in scope
+    assert can(req, "component:manage", component).allowed is True
+
+
+@pytest.mark.django_db
+def test_abac_action_delegates_to_component_access(workspace):
+    team, component = workspace
+    outsider = _user("abac-outsider")
+
+    component.visibility = Component.Visibility.PUBLIC
+    component.save()
+    assert can(outsider, "component:access", component).allowed is True
+
+    component.visibility = Component.Visibility.PRIVATE
+    component.save()
+    assert can(outsider, "component:access", component).allowed is False
+
+    member = _user("abac-member")
+    _member(team, member, "owner")
+    assert can(member, "component:access", component).allowed is True
+
+
+def test_unknown_action_raises():
+    with pytest.raises(UnknownActionError):
+        can(HttpRequest(), "component:teleport", object())

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -9,9 +9,10 @@ from ninja import File, Query, Router, UploadedFile
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.schemas import ErrorResponse
-from sbomify.apps.core.utils import broadcast_to_workspace, get_by_uuid_or_pk, verify_item_access
+from sbomify.apps.core.utils import broadcast_to_workspace, get_by_uuid_or_pk
 from sbomify.apps.oidc.permissions import is_authorised_for_component
 from sbomify.apps.sboms.models import Component
 from sbomify.apps.sboms.utils import verify_download_token
@@ -109,7 +110,7 @@ def create_document(
         # Allow OIDC bot tokens for trusted-publishing uploads; restrict
         # them to the bound component (see sboms/apis.py for full
         # rationale).
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
 from sbomify.apps.core.apis import get_component_metadata, patch_component_metadata
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.purl import extract_purl_qualifiers
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
@@ -371,7 +372,7 @@ def sbom_upload_cyclonedx(
         # check enforces that the bot can only push to ITS bound component,
         # not anywhere else in the workspace — see
         # ``sbomify.apps.oidc.permissions.is_authorised_for_component``.
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}
@@ -507,7 +508,7 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str, bom_type: str = "s
         # Allow OIDC bot tokens for trusted-publishing uploads; restrict
         # them to the bound component (see CycloneDX upload above for
         # the rationale).
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}
@@ -1208,7 +1209,7 @@ def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = Fals
     if sbom is None:
         return 404, {"detail": "SBOM not found", "error_code": ErrorCode.NOT_FOUND}
     if write:
-        if not verify_item_access(request, sbom.component, ["owner", "admin"]):
+        if not can(request, "sbom:manage", sbom.component):
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     else:
         access = check_component_access(request, sbom.component)

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -1202,7 +1202,7 @@ _MAX_PROVENANCE_SIZE = 10 * 1024 * 1024  # 10 MB
 def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = False) -> SBOM | tuple[int, dict[str, Any]]:
     """Look up an SBOM and verify access. Returns SBOM or (status, error_dict).
 
-    For write=True (uploads), requires owner/admin via verify_item_access.
+    For write=True (uploads), requires owner/admin via can("sbom:manage", ...).
     For write=False (downloads), uses check_component_access to support public SBOMs.
     """
     sbom = SBOM.objects.select_related("component", "component__team").filter(pk=sbom_id).first()


### PR DESCRIPTION
Phase 1 of #1002 — formalize the authorization model behind a single `can()` decision point. This PR lands the front door and proves it's a faithful, behavior-preserving facade; **no call-site is required to change** for it to be correct.

## What this adds

`core/authz.py` — `can(actor, action, resource) -> Decision`:
- maps a named **action** (`"<resource>:<verb>"`) to the capability the codebase already enforces, then **delegates** to the existing checks — `verify_item_access` (role-based) and `check_component_access` (resource-attribute-based). Its decision is **identical** to the inline role checks it replaces.
- **Capability tiers** name the role sets used today, so "what can an admin do" becomes one table instead of an emergent property of ~170 call sites:

  | tier | roles | today's `allowed_roles` |
  |---|---|---|
  | `ADMINISTER` | owner | `["owner"]` |
  | `MANAGE` | owner, admin | `["owner","admin"]` |
  | `PUBLISH` | owner, admin, bot | `["owner","admin","bot"]` |
  | `READ_MEMBER` | owner, admin, guest | `["guest","owner","admin"]` |

- `actor` may be an **`HttpRequest`** (preserves token-workspace scoping) or a **`User`** (session-less, live-DB check — same pattern as `check_component_access_for_user`).
- unknown actions raise `UnknownActionError` (typos fail loudly, not silently).

## Faithfulness — the whole point of Phase 1

`core/tests/test_authz.py` is a **characterization** suite (24 tests) that pins current behavior:
- the full **role × capability matrix** (owner/admin/guest/bot vs each tier),
- **`can() == verify_item_access`** for every role (the delegation guarantee),
- a request actor **preserves token scope** (a token scoped elsewhere denies even an owner),
- the resource-attribute action **delegates to `check_component_access`** (public vs private vs member),
- non-members and unknown actions are handled.

It already earned its keep: it surfaced the `Member(role="bot")` guard (bot is reserved for OIDC identities), confirming the matrix isn't vacuous.

## Proof: 4 privileged write paths migrated

To satisfy "used by at least the privileged write paths" with zero behavior change:
- `documents/apis.py` document upload, `sboms/apis.py` ×2 SBOM uploads → `can(request, "artifact:publish", component)`
- `sboms/apis.py` SBOM write → `can(request, "sbom:manage", sbom.component)`

Each was `verify_item_access(request, …, [same roles])`; the existing upload / OIDC-e2e / SBOM-CRUD tests pass unchanged (**644 passed, 5 skipped**), ruff + mypy clean.

## Deliberately out of scope (later phases)
- migrating the remaining inline role checks onto `can()` (Phase 2)
- the **CI lint gate** rejecting new inline `"owner"/"admin"/"guest"` checks (Phase 2)
- finer roles/capabilities (#468) and per-resource token scopes (#215) (Phase 3)

This keeps the PR small and reviewable: a facade + a behavior lock, nothing migrated en masse.