### PR TITLE
refactor(authz): migrate remaining inline role checks onto can() (#1002 phase 2b)

### DIFF
--- a/sbomify/apps/compliance/apis.py
+++ b/sbomify/apps/compliance/apis.py
@@ -11,8 +11,8 @@ from ninja import Router
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import User
-from sbomify.apps.core.utils import verify_item_access
 
 from .models import CRAAssessment, CRAExportPackage, OSCALFinding, OSCALObservation
 from .permissions import check_cra_access
@@ -157,7 +157,7 @@ def create_or_get_assessment(request: HttpRequest, product_id: str) -> _Response
     except Product.DoesNotExist:
         return 404, ErrorResponse(error="Product not found", error_code="not_found")
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, ErrorResponse(error="Forbidden", error_code="permission_denied")
 
     if not check_cra_access(product.team):

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -19,6 +19,7 @@ from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_au
 from sbomify.apps.billing.config import is_billing_enabled
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.billing.stripe_cache import get_subscription_cancel_at_period_end, invalidate_subscription_cache
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.posthog_service import capture_for_request
 from sbomify.apps.core.queries import (
@@ -27,7 +28,7 @@ from sbomify.apps.core.queries import (
     optimize_product_queryset,
 )
 from sbomify.apps.core.services.validation_response import validation_error_response
-from sbomify.apps.core.utils import broadcast_to_workspace, build_entity_info_dict, verify_item_access
+from sbomify.apps.core.utils import broadcast_to_workspace, build_entity_info_dict
 from sbomify.apps.sboms.schemas import ComponentMetaData, ComponentMetaDataPatch, SupplierSchema
 from sbomify.apps.sboms.utils import get_product_sbom_package, get_release_sbom_package
 from sbomify.apps.teams.apis import serialize_contact_profile
@@ -248,9 +249,7 @@ def _build_item_base(
         "team_id": str(item.team_id),
         "created_at": item.created_at.isoformat(),
         "has_crud_permissions": (
-            has_crud_permissions
-            if has_crud_permissions is not None
-            else verify_item_access(request, item, ["owner", "admin"])
+            has_crud_permissions if has_crud_permissions is not None else can(request, "workspace:manage", item).allowed
         ),
     }
 
@@ -612,7 +611,7 @@ def create_product(request: HttpRequest, payload: ProductCreateSchema) -> Any:
     try:
         # Check if user has permission to create products in this team
         team = Team.objects.get(id=team_id)
-        if not verify_item_access(request, team, ["owner", "admin"]):
+        if not can(request, "workspace:manage", team):
             return 403, {"detail": "Only owners and admins can create products", "error_code": ErrorCode.FORBIDDEN}
 
         allow_private = _private_items_allowed(team)
@@ -719,7 +718,7 @@ def _get_product_with_instance(
                 "error_code": ErrorCode.UNAUTHORIZED,
             }
 
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     response_payload = _build_item_response(request, product, "product")
@@ -757,7 +756,7 @@ def update_product(request: HttpRequest, product_id: str, payload: ProductUpdate
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can update products", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -803,7 +802,7 @@ def patch_product(request: HttpRequest, product_id: str, payload: ProductPatchSc
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can update products", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -826,7 +825,7 @@ def patch_product(request: HttpRequest, product_id: str, payload: ProductPatchSc
                     return 400, {"detail": "Some components were not found or inaccessible"}
 
                 for component in components_qs:
-                    if not verify_item_access(request, component, ["owner", "admin"]):
+                    if not can(request, "component:manage", component):
                         return 403, {"detail": f"No permission to modify component {component.name}"}
 
                 # Workspace-scoped (``is_global=True``) components are
@@ -876,7 +875,7 @@ def delete_product(request: HttpRequest, product_id: str) -> Any:
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can delete products", "error_code": ErrorCode.FORBIDDEN}
 
     # Capture data for broadcast before deletion
@@ -916,7 +915,7 @@ def create_product_identifier(request: HttpRequest, product_id: str, payload: Pr
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {
             "detail": "Only owners and admins can manage product identifiers",
             "error_code": ErrorCode.FORBIDDEN,
@@ -991,7 +990,7 @@ def list_product_identifiers(
         if not request.user or not request.user.is_authenticated:
             return 403, {"detail": "Authentication required for private items", "error_code": ErrorCode.UNAUTHORIZED}
 
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1033,7 +1032,7 @@ def update_product_identifier(
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {
             "detail": "Only owners and admins can manage product identifiers",
             "error_code": ErrorCode.FORBIDDEN,
@@ -1099,7 +1098,7 @@ def delete_product_identifier(request: HttpRequest, product_id: str, identifier_
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {
             "detail": "Only owners and admins can manage product identifiers",
             "error_code": ErrorCode.FORBIDDEN,
@@ -1150,7 +1149,7 @@ def bulk_update_product_identifiers(
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {
             "detail": "Only owners and admins can manage product identifiers",
             "error_code": ErrorCode.FORBIDDEN,
@@ -1224,7 +1223,7 @@ def create_product_link(request: HttpRequest, product_id: str, payload: ProductL
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can manage product links", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1281,7 +1280,7 @@ def list_product_links(request: HttpRequest, product_id: str, page: int = Query(
         if not request.user or not request.user.is_authenticated:
             return 403, {"detail": "Authentication required for private items", "error_code": ErrorCode.UNAUTHORIZED}
 
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1323,7 +1322,7 @@ def update_product_link(request: HttpRequest, product_id: str, link_id: str, pay
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can manage product links", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1377,7 +1376,7 @@ def delete_product_link(request: HttpRequest, product_id: str, link_id: str) -> 
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can manage product links", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1411,7 +1410,7 @@ def bulk_update_product_links(request: HttpRequest, product_id: str, payload: Pr
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can manage product links", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1486,7 +1485,7 @@ def create_component(request: HttpRequest, payload: ComponentCreateSchema) -> An
     try:
         # Check if user has permission to create components in this team
         team = Team.objects.get(id=team_id)
-        if not verify_item_access(request, team, ["owner", "admin"]):
+        if not can(request, "workspace:manage", team):
             return 403, {"detail": "Only owners and admins can create components", "error_code": ErrorCode.FORBIDDEN}
 
         if payload.is_global and payload.component_type != Component.ComponentType.DOCUMENT:  # type: ignore[comparison-overlap]
@@ -1637,7 +1636,7 @@ def get_component(request: HttpRequest, component_id: str, return_instance: bool
     if not request.user or not request.user.is_authenticated:
         return 403, {"detail": "Authentication required for private items", "error_code": ErrorCode.UNAUTHORIZED}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     response = component if return_instance else _build_item_response(request, component, "component")
@@ -1660,7 +1659,7 @@ def update_component(request: HttpRequest, component_id: str, payload: Component
     except Component.DoesNotExist:
         return 404, {"detail": "Component not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Only owners and admins can update components", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1764,7 +1763,7 @@ def patch_component(request: HttpRequest, component_id: str, payload: ComponentP
     except Component.DoesNotExist:
         return 404, {"detail": "Component not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Only owners and admins can update components", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -1892,7 +1891,7 @@ def delete_component(request: HttpRequest, component_id: str) -> Any:
     except Component.DoesNotExist:
         return 404, {"detail": "Component not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Only owners and admins can delete components", "error_code": ErrorCode.FORBIDDEN}
 
     # Capture data for broadcast before deletion
@@ -2081,7 +2080,7 @@ def patch_component_metadata(request: Any, component_id: str, metadata: Componen
     except Component.DoesNotExist:
         return 404, {"detail": "Component not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -2252,7 +2251,7 @@ def list_component_releases(
                 "detail": "Authentication required for private components",
                 "error_code": ErrorCode.UNAUTHORIZED,
             }
-        if not verify_item_access(request, component, ["owner", "admin"]):
+        if not can(request, "component:manage", component):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -2472,7 +2471,7 @@ def download_product_sbom(
     if not product.is_public:
         if not request.user or not request.user.is_authenticated:
             return 403, {"detail": "Authentication required for private products", "error_code": ErrorCode.UNAUTHORIZED}
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     # Normalize format early
@@ -2633,7 +2632,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
 
     # Check if release has SBOMs for download capability
     has_sboms = release.artifacts.filter(sbom__isnull=False).exists()
-    has_crud_permissions = verify_item_access(request, release.product, ["owner", "admin"])
+    has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
         "id": str(release.id),
@@ -2717,7 +2716,7 @@ def create_release(request: HttpRequest, payload: ReleaseCreateSchema) -> Any:
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.PRODUCT_NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Only owners and admins can create releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent creating releases with name "latest" manually
@@ -2806,7 +2805,7 @@ def get_release(request: HttpRequest, release_id: str) -> Any:
     if not release.product.is_public:
         if not request.user or not request.user.is_authenticated:
             return 403, {"detail": "Authentication required for private products", "error_code": ErrorCode.UNAUTHORIZED}
-        if not verify_item_access(request, release.product, ["owner", "admin"]):
+        if not can(request, "release:manage", release.product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     return 200, _build_release_response(request, release, include_artifacts=True)
@@ -2830,7 +2829,7 @@ def update_release(request: HttpRequest, release_id: str, payload: ReleaseUpdate
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Only owners and admins can update releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent modifying latest releases
@@ -2904,7 +2903,7 @@ def patch_release(request: HttpRequest, release_id: str, payload: ReleasePatchSc
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Only owners and admins can update releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent modifying latest releases
@@ -2986,7 +2985,7 @@ def delete_release(request: HttpRequest, release_id: str) -> Any:
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Only owners and admins can delete releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent deleting latest releases
@@ -3059,7 +3058,7 @@ def download_release(
             return 403, {"detail": "Authentication required", "error_code": ErrorCode.UNAUTHORIZED}
 
         # Guest members can read release artifacts if they have access
-        if not verify_item_access(request, release.product, ["guest", "owner", "admin"]):
+        if not can(request, "release:read", release.product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     # Get all SBOM artifacts in the release
@@ -3140,7 +3139,7 @@ def list_release_artifacts(
         if not request.user or not request.user.is_authenticated:
             return 403, {"detail": "Authentication required", "error_code": ErrorCode.UNAUTHORIZED}
 
-        if not verify_item_access(request, release.product, ["guest", "owner", "admin"]):
+        if not can(request, "release:read", release.product):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     if mode == "existing":
@@ -3320,7 +3319,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Only owners and admins can manage release artifacts", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent adding artifacts to latest releases
@@ -3429,7 +3428,7 @@ def remove_artifact_from_release(request: HttpRequest, release_id: str, artifact
     except ReleaseArtifact.DoesNotExist:
         return 404, {"detail": "Artifact not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Only owners and admins can manage release artifacts", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent removing artifacts from latest releases
@@ -3475,7 +3474,7 @@ def list_document_releases(
             return 403, {"detail": "Authentication required", "error_code": ErrorCode.UNAUTHORIZED}
 
         # Guest members can download documents if they have access
-        if not verify_item_access(request, document.component, ["guest", "owner", "admin"]):
+        if not can(request, "document:read", document.component):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     # Get all releases containing this document
@@ -3519,7 +3518,7 @@ def add_document_to_releases(request: HttpRequest, document_id: str, payload: Do
     except Document.DoesNotExist:
         return 404, {"detail": "Document not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, document.component, ["owner", "admin"]):
+    if not can(request, "document:manage", document.component):
         return 403, {"detail": "Only owners and admins can manage document releases", "error_code": ErrorCode.FORBIDDEN}
 
     from sbomify.apps.core.utils import add_artifact_to_release
@@ -3607,7 +3606,7 @@ def remove_document_from_release(request: HttpRequest, document_id: str, release
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, document.component, ["owner", "admin"]):
+    if not can(request, "document:manage", document.component):
         return 403, {"detail": "Only owners and admins can manage document releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent removing from latest releases
@@ -3648,13 +3647,13 @@ def list_sbom_releases(request: HttpRequest, sbom_id: str, page: int = Query(1),
             return 403, {"detail": "Authentication required", "error_code": ErrorCode.UNAUTHORIZED}
 
         # Guest members can download SBOMs if they have access
-        if not verify_item_access(request, sbom.component, ["guest", "owner", "admin"]):
+        if not can(request, "sbom:read", sbom.component):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     # Whether the requester is a member of the SBOM's workspace. Non-members may
     # reach this endpoint when the component is public/gated, so private product
     # names and IDs must be withheld from them to avoid leaking private products.
-    has_workspace_access = verify_item_access(request, sbom.component, ["guest", "owner", "admin"])
+    has_workspace_access = can(request, "sbom:read", sbom.component).allowed
 
     # Get all releases containing this SBOM
     release_artifacts_queryset = (
@@ -3700,7 +3699,7 @@ def add_sbom_to_releases(request: HttpRequest, sbom_id: str, payload: SBOMReleas
     except SBOM.DoesNotExist:
         return 404, {"detail": "SBOM not found", "error_code": ErrorCode.NOT_FOUND}
 
-    if not verify_item_access(request, sbom.component, ["owner", "admin"]):
+    if not can(request, "sbom:manage", sbom.component):
         return 403, {"detail": "Only owners and admins can manage SBOM releases", "error_code": ErrorCode.FORBIDDEN}
 
     from sbomify.apps.core.utils import add_artifact_to_release
@@ -3786,7 +3785,7 @@ def remove_sbom_from_release(request: HttpRequest, sbom_id: str, release_id: str
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, sbom.component, ["owner", "admin"]):
+    if not can(request, "sbom:manage", sbom.component):
         return 403, {"detail": "Only owners and admins can manage SBOM releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Verify release belongs to same team as the SBOM's component
@@ -3868,7 +3867,7 @@ def list_component_sboms(
             return 403, {"detail": "Authentication required for private items", "error_code": ErrorCode.UNAUTHORIZED}
 
         # Guest members can download components if they have access
-        if not verify_item_access(request, component, ["guest", "owner", "admin"]):
+        if not can(request, "component:read_internal", component):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     try:
@@ -4130,7 +4129,7 @@ def list_component_documents(
             return 403, {"detail": "Authentication required for private items", "error_code": ErrorCode.UNAUTHORIZED}
 
         # Guest members can download components if they have access
-        if not verify_item_access(request, component, ["guest", "owner", "admin"]):
+        if not can(request, "component:read_internal", component):
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     try:

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -1,0 +1,133 @@
+"""Single authorization decision point.
+
+``can(actor, action, resource)`` is the one front door for authorization. It maps
+a named ``action`` to the capability the codebase already enforces, then
+**delegates** to the existing checks — ``verify_item_access`` (role-based) and
+``check_component_access`` (resource-attribute-based) — so its decision is
+identical to the scattered inline role checks it is meant to replace.
+
+This is the first phase of consolidating authorization: introduce the facade
+with no behaviour change. Later work migrates call sites onto ``can`` and grows
+the action catalog / capability model; until then both styles coexist.
+
+Why a facade instead of a rewrite: every call site today passes a raw role list
+(``["owner", "admin"]``) to ``verify_item_access``. Naming the role sets as
+capabilities and giving each action one definition turns "what can an admin do"
+from an emergent property of ~170 call sites into a single table here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.http import HttpRequest
+
+# Roles — mirror the keys of ``settings.TEAMS_SUPPORTED_ROLES``.
+ROLE_OWNER = "owner"
+ROLE_ADMIN = "admin"
+ROLE_GUEST = "guest"
+ROLE_BOT = "bot"
+
+# Capability tiers: the role sets the current checks grant. Each is exactly an
+# ``allowed_roles`` list used at today's call sites, so an action that maps to a
+# tier is behaviour-identical to the inline check it replaces.
+ADMINISTER: tuple[str, ...] = (ROLE_OWNER,)
+"""Owner-only: billing, member management, workspace settings/deletion."""
+
+MANAGE: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN)
+"""Create/update/delete products, components, releases, and artifact metadata."""
+
+PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
+"""Upload artifacts — also granted to OIDC/CI ``bot`` identities."""
+
+READ_MEMBER: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_GUEST)
+"""Any workspace member may read internal (non-public) workspace data."""
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Outcome of an authorization check. Truthy iff access is allowed."""
+
+    allowed: bool
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.allowed
+
+
+# action ("<resource>:<verb>") -> the role tuple it requires. These mirror the
+# allowed_roles lists at today's call sites exactly.
+_ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
+    # owner-only administration
+    "workspace:administer": ADMINISTER,
+    "workspace:delete": ADMINISTER,
+    "billing:manage": ADMINISTER,
+    "member:manage": ADMINISTER,
+    # owner + admin management (the dominant capability)
+    "workspace:manage": MANAGE,
+    "product:create": MANAGE,
+    "product:manage": MANAGE,
+    "component:create": MANAGE,
+    "component:manage": MANAGE,
+    "release:manage": MANAGE,
+    "sbom:manage": MANAGE,
+    "document:manage": MANAGE,
+    # artifact upload — also allows OIDC/CI bot identities
+    "artifact:publish": PUBLISH,
+    # any-member read of internal workspace data
+    "workspace:read": READ_MEMBER,
+    "component:read_internal": READ_MEMBER,
+}
+
+# Actions authorized by resource attributes (visibility / NDA / access request)
+# rather than role. Delegated to ``check_component_access``; the resource must be
+# a Component or expose ``.component``.
+_ABAC_ACTIONS: frozenset[str] = frozenset({"component:access"})
+
+
+class UnknownActionError(KeyError):
+    """Raised when ``can`` is asked about an action that isn't registered."""
+
+
+def _stub_request_for_user(user: Any) -> HttpRequest:
+    """A request carrying just ``user`` and an EMPTY session.
+
+    Mirrors ``check_component_access_for_user``: the empty session makes
+    ``verify_item_access`` skip nothing it wouldn't already (the role is read
+    from the live DB), and there is no token scope. Use for delegated checks
+    that have no authenticated HTTP request to trust.
+    """
+    stub = HttpRequest()
+    stub.user = user
+    stub.session = {}  # type: ignore[assignment]
+    return stub
+
+
+def can(actor: Any, action: str, resource: Any) -> Decision:
+    """Authorize ``actor`` to perform ``action`` on ``resource``.
+
+    ``actor`` is an ``HttpRequest`` (preserving token-workspace scoping) or a
+    ``User`` (a delegated, session-less check against live DB state). ``action``
+    is a registered ``"<resource>:<verb>"`` string; an unregistered action
+    raises ``UnknownActionError`` so typos fail loudly in development rather than
+    silently allowing or denying.
+
+    Delegates to the existing enforcement functions, so the decision matches the
+    inline checks it replaces.
+    """
+    from sbomify.apps.core.services.access_control import check_component_access
+    from sbomify.apps.core.utils import verify_item_access
+
+    request = actor if isinstance(actor, HttpRequest) else _stub_request_for_user(actor)
+
+    if action in _ABAC_ACTIONS:
+        component = getattr(resource, "component", resource)
+        result = check_component_access(request, component)
+        return Decision(result.has_access, result.reason)
+
+    roles = _ROLE_ACTIONS.get(action)
+    if roles is None:
+        raise UnknownActionError(action)
+    allowed = verify_item_access(request, resource, list(roles))
+    return Decision(allowed, "" if allowed else f"requires role in {roles}")

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -41,7 +41,9 @@ MANAGE: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN)
 PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
 """Upload artifacts — also granted to OIDC/CI ``bot`` identities."""
 
-READ_MEMBER: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_GUEST)
+# Order mirrors the predominant call-site literal ``["guest", "owner", "admin"]``
+# (membership is order-independent, but the parity keeps the claim above honest).
+READ_MEMBER: tuple[str, ...] = (ROLE_GUEST, ROLE_OWNER, ROLE_ADMIN)
 """Any workspace member may read internal (non-public) workspace data."""
 
 

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -66,6 +66,7 @@ _ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
     "workspace:delete": ADMINISTER,
     "billing:manage": ADMINISTER,
     "member:manage": ADMINISTER,
+    "component:administer": ADMINISTER,
     # owner + admin management (the dominant capability)
     "workspace:manage": MANAGE,
     "product:create": MANAGE,
@@ -80,6 +81,7 @@ _ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
     # any-member read of internal (non-public) workspace data
     "workspace:read": READ_MEMBER,
     "component:read_internal": READ_MEMBER,
+    "product:read": READ_MEMBER,
     "release:read": READ_MEMBER,
     "document:read": READ_MEMBER,
     "sbom:read": READ_MEMBER,

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -77,9 +77,12 @@ _ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
     "document:manage": MANAGE,
     # artifact upload — also allows OIDC/CI bot identities
     "artifact:publish": PUBLISH,
-    # any-member read of internal workspace data
+    # any-member read of internal (non-public) workspace data
     "workspace:read": READ_MEMBER,
     "component:read_internal": READ_MEMBER,
+    "release:read": READ_MEMBER,
+    "document:read": READ_MEMBER,
+    "sbom:read": READ_MEMBER,
 }
 
 # Actions authorized by resource attributes (visibility / NDA / access request)

--- a/sbomify/apps/core/cle_apis.py
+++ b/sbomify/apps/core/cle_apis.py
@@ -7,6 +7,7 @@ from ninja import Query, Router
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.cle_schemas import (
     CLEEventCreateSchema,
     CLEEventResponseSchema,
@@ -25,7 +26,6 @@ from sbomify.apps.core.services.cle import (
     create_release_support_definition,
     create_support_definition,
 )
-from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.sboms.models import (
     ComponentCLEEvent,
     ComponentCLESupportDefinition,
@@ -63,7 +63,7 @@ def _get_product_or_404(request: HttpRequest, product_id: str) -> Product | tupl
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.PRODUCT_NOT_FOUND}
 
-    if not verify_item_access(request, product, ["owner", "admin"]):
+    if not can(request, "product:manage", product):
         return 403, {"detail": "Permission denied", "error_code": ErrorCode.FORBIDDEN}
 
     return product
@@ -79,7 +79,7 @@ def _get_component_or_404(request: HttpRequest, component_id: str) -> Component 
     except Component.DoesNotExist:
         return 404, {"detail": "Component not found", "error_code": ErrorCode.COMPONENT_NOT_FOUND}
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return 403, {"detail": "Permission denied", "error_code": ErrorCode.FORBIDDEN}
 
     return component
@@ -95,7 +95,7 @@ def _get_release_or_404(request: HttpRequest, release_id: str) -> Release | tupl
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not verify_item_access(request, release.product, ["owner", "admin"]):
+    if not can(request, "release:manage", release.product):
         return 403, {"detail": "Permission denied", "error_code": ErrorCode.FORBIDDEN}
 
     return release
@@ -116,7 +116,7 @@ def _get_component_release_or_404(
             "error_code": ErrorCode.COMPONENT_RELEASE_NOT_FOUND,
         }
 
-    if not verify_item_access(request, component_release.component, ["owner", "admin"]):
+    if not can(request, "component:manage", component_release.component):
         return 403, {"detail": "Permission denied", "error_code": ErrorCode.FORBIDDEN}
 
     return component_release

--- a/sbomify/apps/core/management/commands/create_pagination_test_data.py
+++ b/sbomify/apps/core/management/commands/create_pagination_test_data.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
                     mock_request.session = MagicMock()
 
                     # Upload SBOM via API - functions handle version detection and validation
-                    with patch("sbomify.apps.sboms.apis.verify_item_access", return_value=True):
+                    with patch("sbomify.apps.sboms.apis.can", return_value=True):
                         if "spdxVersion" in sbom_data_dict:
                             # SPDX format
                             status_code, response_data = sbom_upload_spdx(mock_request, component.id)

--- a/sbomify/apps/core/management/commands/create_pagination_test_data.py
+++ b/sbomify/apps/core/management/commands/create_pagination_test_data.py
@@ -10,6 +10,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.http import HttpRequest
 
+from sbomify.apps.core.authz import Decision
 from sbomify.apps.core.models import Component
 from sbomify.apps.sboms.apis import sbom_upload_cyclonedx, sbom_upload_spdx
 from sbomify.apps.teams.models import Team
@@ -118,7 +119,7 @@ class Command(BaseCommand):
                     mock_request.session = MagicMock()
 
                     # Upload SBOM via API - functions handle version detection and validation
-                    with patch("sbomify.apps.sboms.apis.can", return_value=True):
+                    with patch("sbomify.apps.sboms.apis.can", return_value=Decision(allowed=True)):
                         if "spdxVersion" in sbom_data_dict:
                             # SPDX format
                             status_code, response_data = sbom_upload_spdx(mock_request, component.id)

--- a/sbomify/apps/core/tests/test_authz.py
+++ b/sbomify/apps/core/tests/test_authz.py
@@ -134,3 +134,18 @@ def test_abac_action_delegates_to_component_access(workspace):
 def test_unknown_action_raises():
     with pytest.raises(UnknownActionError):
         can(HttpRequest(), "component:teleport", object())
+
+
+def test_decision_is_fail_closed_in_boolean_context():
+    """Security invariant: a denied Decision MUST be falsy.
+
+    Call sites guard with ``if not can(...)``; that only denies if ``Decision``
+    is falsy when ``allowed`` is False. Without ``__bool__`` the object would be
+    truthy, ``not can(...)`` would always be False, and every gate would fail
+    OPEN. This pins the fail-closed behaviour directly.
+    """
+    assert bool(Decision(allowed=False)) is False
+    assert bool(Decision(allowed=True)) is True
+    # `if not can(...)` -> enters the deny branch only for a denied decision.
+    assert (not Decision(allowed=False)) is True
+    assert (not Decision(allowed=True)) is False

--- a/sbomify/apps/core/tests/test_authz.py
+++ b/sbomify/apps/core/tests/test_authz.py
@@ -12,7 +12,7 @@ from django.http import HttpRequest
 
 from sbomify.apps.core import authz
 from sbomify.apps.core.authz import Decision, UnknownActionError, can
-from sbomify.apps.core.models import Component
+from sbomify.apps.core.models import Component, Product
 from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.teams.models import Member, Team
 
@@ -41,6 +41,15 @@ def workspace(db):
     return team, component
 
 
+def _resource_for(res_key, team, component):
+    """Resolve a matrix resource key to a model the action applies to."""
+    if res_key == "team":
+        return team
+    if res_key == "product":
+        return Product.objects.create(name="authz-prod", team=team)
+    return component
+
+
 # (action, resource, expected-allowed per role) — the role->capability matrix,
 # written to match what the inline checks grant today.
 _MATRIX = {
@@ -48,6 +57,8 @@ _MATRIX = {
     "component:manage": ("component", {"owner": True, "admin": True, "guest": False, "bot": False}),
     "artifact:publish": ("component", {"owner": True, "admin": True, "guest": False, "bot": True}),
     "workspace:read": ("team", {"owner": True, "admin": True, "guest": True, "bot": False}),
+    "component:administer": ("component", {"owner": True, "admin": False, "guest": False, "bot": False}),
+    "product:read": ("product", {"owner": True, "admin": True, "guest": True, "bot": False}),
 }
 _CASES = [(a, role, exp[role]) for a, (_res, exp) in _MATRIX.items() for role in ("owner", "admin", "guest", "bot")]
 
@@ -56,7 +67,7 @@ _CASES = [(a, role, exp[role]) for a, (_res, exp) in _MATRIX.items() for role in
 @pytest.mark.parametrize("action,role,expected", _CASES)
 def test_role_capability_matrix(workspace, action, role, expected):
     team, component = workspace
-    resource = team if _MATRIX[action][0] == "team" else component
+    resource = _resource_for(_MATRIX[action][0], team, component)
     user = _user(f"{role}-{action.replace(':', '-')}")
     _member(team, user, role)
 
@@ -72,7 +83,7 @@ def test_role_capability_matrix(workspace, action, role, expected):
 @pytest.mark.parametrize("action", list(_MATRIX))
 def test_non_member_is_always_denied(workspace, action):
     team, component = workspace
-    resource = team if _MATRIX[action][0] == "team" else component
+    resource = _resource_for(_MATRIX[action][0], team, component)
     assert can(_user(f"outsider-{action.replace(':', '-')}"), action, resource).allowed is False
 
 

--- a/sbomify/apps/core/tests/test_authz.py
+++ b/sbomify/apps/core/tests/test_authz.py
@@ -1,0 +1,136 @@
+"""Characterization tests for the ``can()`` authorization front door.
+
+These pin the role->capability behaviour and prove ``can`` is a faithful
+delegation: its decision equals the existing ``verify_item_access`` /
+``check_component_access`` for every role, resource and action — so migrating a
+call site onto ``can`` cannot change behaviour.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest
+
+from sbomify.apps.core import authz
+from sbomify.apps.core.authz import Decision, UnknownActionError, can
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.utils import verify_item_access
+from sbomify.apps.teams.models import Member, Team
+
+
+def _user(username: str):
+    return get_user_model().objects.create_user(username=username[:150], password="x")
+
+
+def _member(team, user, role):
+    """Create a Member, honouring the bot-role guard.
+
+    ``role="bot"`` is reserved for OIDC synthetic identities; a pre_save signal
+    rejects manual creation unless the sanctioned provisioning flag is set.
+    """
+    member = Member(team=team, user=user, role=role)
+    if role == "bot":
+        member._is_oidc_bot_provisioning = True
+    member.save()
+    return member
+
+
+@pytest.fixture
+def workspace(db):
+    team = Team.objects.create(name="authz-team")
+    component = Component.objects.create(name="authz-comp", team=team)
+    return team, component
+
+
+# (action, resource, expected-allowed per role) — the role->capability matrix,
+# written to match what the inline checks grant today.
+_MATRIX = {
+    "workspace:administer": ("team", {"owner": True, "admin": False, "guest": False, "bot": False}),
+    "component:manage": ("component", {"owner": True, "admin": True, "guest": False, "bot": False}),
+    "artifact:publish": ("component", {"owner": True, "admin": True, "guest": False, "bot": True}),
+    "workspace:read": ("team", {"owner": True, "admin": True, "guest": True, "bot": False}),
+}
+_CASES = [(a, role, exp[role]) for a, (_res, exp) in _MATRIX.items() for role in ("owner", "admin", "guest", "bot")]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("action,role,expected", _CASES)
+def test_role_capability_matrix(workspace, action, role, expected):
+    team, component = workspace
+    resource = team if _MATRIX[action][0] == "team" else component
+    user = _user(f"{role}-{action.replace(':', '-')}")
+    _member(team, user, role)
+
+    decision = can(user, action, resource)
+    assert isinstance(decision, Decision)
+    assert decision.allowed is expected
+    assert bool(decision) is expected
+    # ...and (not decision) mirrors the legacy `if not verify_item_access(...)`.
+    assert (not decision) is (not expected)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("action", list(_MATRIX))
+def test_non_member_is_always_denied(workspace, action):
+    team, component = workspace
+    resource = team if _MATRIX[action][0] == "team" else component
+    assert can(_user(f"outsider-{action.replace(':', '-')}"), action, resource).allowed is False
+
+
+@pytest.mark.django_db
+def test_can_decision_equals_verify_item_access(workspace):
+    """The faithfulness guarantee: can() == verify_item_access for every role."""
+    team, component = workspace
+    for role in ("owner", "admin", "guest", "bot"):
+        user = _user(f"equiv-{role}")
+        _member(team, user, role)
+        req = HttpRequest()
+        req.user = user
+        req.session = {}
+        assert can(user, "component:manage", component).allowed == verify_item_access(
+            req, component, list(authz.MANAGE)
+        )
+        assert can(user, "artifact:publish", component).allowed == verify_item_access(
+            req, component, list(authz.PUBLISH)
+        )
+
+
+@pytest.mark.django_db
+def test_request_actor_preserves_token_workspace_scope(workspace):
+    """A request actor keeps verify_item_access's token scoping: a token scoped
+    to another workspace denies even an owner."""
+    team, component = workspace
+    owner = _user("scoped-owner")
+    _member(team, owner, "owner")
+    other_team = Team.objects.create(name="other-ws")
+
+    req = HttpRequest()
+    req.user = owner
+    req.session = {}
+    req.token_team = other_team  # scoped elsewhere
+    assert can(req, "component:manage", component).allowed is False
+
+    req.token_team = team  # in scope
+    assert can(req, "component:manage", component).allowed is True
+
+
+@pytest.mark.django_db
+def test_abac_action_delegates_to_component_access(workspace):
+    team, component = workspace
+    outsider = _user("abac-outsider")
+
+    component.visibility = Component.Visibility.PUBLIC
+    component.save()
+    assert can(outsider, "component:access", component).allowed is True
+
+    component.visibility = Component.Visibility.PRIVATE
+    component.save()
+    assert can(outsider, "component:access", component).allowed is False
+
+    member = _user("abac-member")
+    _member(team, member, "owner")
+    assert can(member, "component:access", component).allowed is True
+
+
+def test_unknown_action_raises():
+    with pytest.raises(UnknownActionError):
+        can(HttpRequest(), "component:teleport", object())

--- a/sbomify/apps/core/views/__init__.py
+++ b/sbomify/apps/core/views/__init__.py
@@ -33,8 +33,9 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_http_methods
 
 from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.posthog_service import capture_for_request
-from sbomify.apps.core.utils import token_to_number, verify_item_access
+from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.core.views.component_details_private import ComponentDetailsPrivateView as ComponentDetailsPrivateView
 from sbomify.apps.core.views.component_details_public import ComponentDetailsPublicView as ComponentDetailsPublicView
 from sbomify.apps.core.views.component_item import ComponentItemPublicView as ComponentItemPublicView
@@ -531,7 +532,7 @@ def transfer_component_to_team(request: HttpRequest, component_id: str) -> HttpR
     except Component.DoesNotExist:
         return error_response(request, HttpResponseNotFound("Component not found"))
 
-    if not verify_item_access(request, component, ["owner"]):
+    if not can(request, "component:administer", component):
         return error_response(request, HttpResponseForbidden("Only allowed for owners of the component"))
 
     target_team = request.session.get("user_teams", {}).get(team_key, {})
@@ -575,7 +576,7 @@ def sbom_download_product(request: HttpRequest, product_id: str) -> HttpResponse
         return error_response(request, HttpResponseNotFound("Product not found"))
 
     if not product.is_public:
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return error_response(request, HttpResponseForbidden("Only allowed for members of the team"))
 
     # Get format parameters from query string and normalize early
@@ -616,7 +617,7 @@ def get_component_metadata(request: HttpRequest, component_id: str) -> HttpRespo
     except Component.DoesNotExist:
         return error_response(request, HttpResponseNotFound("Component not found"))
 
-    if not verify_item_access(request, component, ["owner", "admin"]):
+    if not can(request, "component:manage", component):
         return error_response(request, HttpResponseForbidden("Only allowed for members of the team"))
 
     metadata = component.metadata or {}

--- a/sbomify/apps/core/views/component_metadata.py
+++ b/sbomify/apps/core/views/component_metadata.py
@@ -14,9 +14,9 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.htmx import htmx_error_response, htmx_success_response
 from sbomify.apps.core.models import Component
-from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.teams.forms import ContactEntityFormSet, ContactProfileContactFormSet
 from sbomify.apps.teams.models import ContactEntity, ContactProfile, ContactProfileContact
 from sbomify.apps.teams.schemas import ContactProfileContactSchema
@@ -35,7 +35,7 @@ class ComponentMetadataFormView(LoginRequiredMixin, View):
         except Component.DoesNotExist:
             return htmx_error_response("Component not found")
 
-        if not verify_item_access(request, component, ["owner", "admin"]):
+        if not can(request, "component:manage", component):
             return htmx_error_response("Permission denied")
 
         # Get or create a component-private profile for editing
@@ -67,7 +67,7 @@ class ComponentMetadataFormView(LoginRequiredMixin, View):
         except Component.DoesNotExist:
             return htmx_error_response("Component not found")
 
-        if not verify_item_access(request, component, ["owner", "admin"]):
+        if not can(request, "component:manage", component):
             return htmx_error_response("Permission denied")
 
         try:

--- a/sbomify/apps/core/views/component_scope.py
+++ b/sbomify/apps/core/views/component_scope.py
@@ -6,8 +6,8 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpR
 from django.shortcuts import redirect
 from django.views import View
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import Component
-from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
 
 
@@ -23,7 +23,7 @@ class ComponentScopeView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
         if component.component_type != Component.ComponentType.DOCUMENT:
             return HttpResponseBadRequest("Only documents can be workspace-wide")
 
-        if not verify_item_access(request, component, ["owner", "admin"]):
+        if not can(request, "component:manage", component):
             return HttpResponseForbidden("Only owners and admins can change scope")
 
         target_scope = request.POST.get("target_scope")

--- a/sbomify/apps/core/views/product_lifecycle.py
+++ b/sbomify/apps/core/views/product_lifecycle.py
@@ -12,10 +12,10 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.htmx import htmx_error_response, htmx_success_response
 from sbomify.apps.core.models import Product
 from sbomify.apps.core.services.cle import create_cle_event
-from sbomify.apps.core.utils import verify_item_access
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +35,14 @@ class ProductLifecycleView(LoginRequiredMixin, View):
         except Product.DoesNotExist:
             return None, "Product not found"
 
-        if not verify_item_access(request, product, ["guest", "owner", "admin"]):
+        if not can(request, "product:read", product):
             return None, "Permission denied"
 
         return product, None
 
     def _get_context(self, request: HttpRequest, product: Product) -> dict[str, Any]:
         """Get context for rendering."""
-        can_edit = verify_item_access(request, product, ["owner", "admin"])
+        can_edit = can(request, "product:manage", product).allowed
         return {
             "product": product,
             "can_edit": can_edit,
@@ -64,7 +64,7 @@ class ProductLifecycleView(LoginRequiredMixin, View):
             return htmx_error_response(error or "Product not found")
 
         # Check edit permissions
-        if not verify_item_access(request, product, ["owner", "admin"]):
+        if not can(request, "product:manage", product):
             return htmx_error_response("Permission denied")
 
         # Parse dates from form

--- a/sbomify/apps/documents/apis.py
+++ b/sbomify/apps/documents/apis.py
@@ -9,9 +9,10 @@ from ninja import File, Query, Router, UploadedFile
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.schemas import ErrorResponse
-from sbomify.apps.core.utils import broadcast_to_workspace, get_by_uuid_or_pk, verify_item_access
+from sbomify.apps.core.utils import broadcast_to_workspace, get_by_uuid_or_pk
 from sbomify.apps.oidc.permissions import is_authorised_for_component
 from sbomify.apps.sboms.models import Component
 from sbomify.apps.sboms.utils import verify_download_token
@@ -109,7 +110,7 @@ def create_document(
         # Allow OIDC bot tokens for trusted-publishing uploads; restrict
         # them to the bound component (see sboms/apis.py for full
         # rationale).
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}

--- a/sbomify/apps/documents/services/documents.py
+++ b/sbomify/apps/documents/services/documents.py
@@ -6,8 +6,9 @@ from typing import Any
 from django.db import transaction
 from django.http import HttpRequest
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.services.results import ServiceResult
-from sbomify.apps.core.utils import broadcast_to_workspace, verify_item_access
+from sbomify.apps.core.utils import broadcast_to_workspace
 from sbomify.apps.documents.models import Document
 from sbomify.apps.documents.schemas import DocumentUpdateRequest
 
@@ -59,7 +60,7 @@ def update_document_metadata(
     except Document.DoesNotExist:
         return ServiceResult.failure("Document not found", status_code=404)
 
-    if not verify_item_access(request, document.component, ["owner", "admin"]):
+    if not can(request, "document:manage", document.component):
         return ServiceResult.failure("Only owners and admins can update documents", status_code=403)
 
     update_fields = []
@@ -95,7 +96,7 @@ def delete_document_record(request: HttpRequest, document_id: str) -> ServiceRes
     except Document.DoesNotExist:
         return ServiceResult.failure("Document not found", status_code=404)
 
-    if not verify_item_access(request, document.component, ["owner", "admin"]):
+    if not can(request, "document:manage", document.component):
         return ServiceResult.failure("Only owners and admins can delete documents", status_code=403)
 
     # Capture info for broadcast before deleting

--- a/sbomify/apps/oidc/apis.py
+++ b/sbomify/apps/oidc/apis.py
@@ -50,9 +50,10 @@ from ninja import Router, Schema
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import User
 from sbomify.apps.core.schemas import ErrorResponse
-from sbomify.apps.core.utils import get_client_ip, verify_item_access
+from sbomify.apps.core.utils import get_client_ip
 from sbomify.apps.oidc.models import OIDCBinding
 from sbomify.apps.oidc.services import (
     create_binding,
@@ -219,7 +220,7 @@ def _component_for_management(request: HttpRequest, component_id: str) -> Any | 
     from sbomify.apps.sboms.models import Component
 
     component = Component.objects.filter(pk=component_id).select_related("team").first()
-    if component is None or not verify_item_access(request, component, ["owner", "admin"]):
+    if component is None or not can(request, "component:manage", component):
         return None
     return component
 

--- a/sbomify/apps/oidc/permissions.py
+++ b/sbomify/apps/oidc/permissions.py
@@ -9,16 +9,16 @@ on any component other than the one its binding pins.
 
 Two-step pattern at the call site::
 
-    if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+    if not can(request, "artifact:publish", component):
         return 403, ...
     if not is_authorised_for_component(request, component):
         return 403, ...
 
 The two checks are independent:
 
-* ``verify_item_access`` enforces the workspace role (covers session
-  + PAT + bot membership). For PATs / sessions this is the whole
-  picture.
+* ``can(..., "artifact:publish", ...)`` enforces the workspace role
+  (owner/admin/bot, via ``verify_item_access``; covers session + PAT +
+  bot membership). For PATs / sessions this is the whole picture.
 * ``is_authorised_for_component`` is a no-op for PATs / sessions; for
   OIDC tokens it locks the bot to its bound component_id.
 """

--- a/sbomify/apps/oidc/views.py
+++ b/sbomify/apps/oidc/views.py
@@ -11,7 +11,7 @@ Business-logic ORM calls (creating / deleting bindings, listing them
 for a component) live in ``sbomify.apps.oidc.services`` and the views
 are thin dispatch over ``ServiceResult[T]``. The one exception is the
 ``_component_or_error`` helper, which resolves a ``Component`` row
-directly so the permission check (``verify_item_access``) can run
+directly so the permission check (``can(.., "component:manage", ..)``) can run
 before any service call — keeping permission checks in the view
 layer matches the rest of the codebase.
 """

--- a/sbomify/apps/oidc/views.py
+++ b/sbomify/apps/oidc/views.py
@@ -26,10 +26,10 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.htmx import htmx_error_response, htmx_success_response
 from sbomify.apps.core.models import User
 from sbomify.apps.core.url_utils import get_base_url
-from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.oidc.forms import OIDCBindingForm
 from sbomify.apps.oidc.services import create_binding, delete_binding, list_bindings_for_component
 from sbomify.apps.sboms.models import Component
@@ -72,7 +72,7 @@ class _TrustedPublishersBase(GuestAccessBlockedMixin, LoginRequiredMixin, View):
 
     def _component_or_error(self, request: HttpRequest, component_id: str) -> Component | None:
         component = Component.objects.filter(pk=component_id).select_related("team").first()
-        if component is None or not verify_item_access(request, component, ["owner", "admin"]):
+        if component is None or not can(request, "component:manage", component):
             self._error = htmx_error_response("Component not found or insufficient permissions.")
             return None
         return component

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -28,7 +28,6 @@ from sbomify.apps.core.utils import (
     dict_update,
     get_by_uuid_or_pk,
     obj_extract,
-    verify_item_access,
 )
 from sbomify.apps.oidc.permissions import is_authorised_for_component
 from sbomify.apps.sboms.utils import verify_download_token
@@ -327,7 +326,7 @@ def _public_api_item_access_checks(
 
     rec: Component | Product = get_object_or_404(model_class, pk=item_id)  # type: ignore[assignment]
 
-    if not verify_item_access(request, rec, ["owner", "admin"]):
+    if not can(request, "workspace:manage", rec):
         return 403, {"detail": "Forbidden"}
 
     return rec
@@ -932,7 +931,7 @@ def sbom_upload_file(
         if component is None:
             return 404, {"detail": "Component not found"}
 
-        if not verify_item_access(request, component, ["owner", "admin"]):
+        if not can(request, "component:manage", component):
             return 403, {"detail": "Forbidden"}
 
         # Validate file size before reading

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
 from sbomify.apps.core.apis import get_component_metadata, patch_component_metadata
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.purl import extract_purl_qualifiers
 from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
@@ -371,7 +372,7 @@ def sbom_upload_cyclonedx(
         # check enforces that the bot can only push to ITS bound component,
         # not anywhere else in the workspace — see
         # ``sbomify.apps.oidc.permissions.is_authorised_for_component``.
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}
@@ -507,7 +508,7 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str, bom_type: str = "s
         # Allow OIDC bot tokens for trusted-publishing uploads; restrict
         # them to the bound component (see CycloneDX upload above for
         # the rationale).
-        if not verify_item_access(request, component, ["owner", "admin", "bot"]):
+        if not can(request, "artifact:publish", component):
             return 403, {"detail": "Forbidden"}
         if not is_authorised_for_component(request, component):
             return 403, {"detail": "Forbidden"}
@@ -1208,7 +1209,7 @@ def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = Fals
     if sbom is None:
         return 404, {"detail": "SBOM not found", "error_code": ErrorCode.NOT_FOUND}
     if write:
-        if not verify_item_access(request, sbom.component, ["owner", "admin"]):
+        if not can(request, "sbom:manage", sbom.component):
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     else:
         access = check_component_access(request, sbom.component)

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -1202,7 +1202,7 @@ _MAX_PROVENANCE_SIZE = 10 * 1024 * 1024  # 10 MB
 def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = False) -> SBOM | tuple[int, dict[str, Any]]:
     """Look up an SBOM and verify access. Returns SBOM or (status, error_dict).
 
-    For write=True (uploads), requires owner/admin via verify_item_access.
+    For write=True (uploads), requires owner/admin via can("sbom:manage", ...).
     For write=False (downloads), uses check_component_access to support public SBOMs.
     """
     sbom = SBOM.objects.select_related("component", "component__team").filter(pk=sbom_id).first()

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -326,7 +326,7 @@ def _public_api_item_access_checks(
 
     rec: Component | Product = get_object_or_404(model_class, pk=item_id)  # type: ignore[assignment]
 
-    if not can(request, "workspace:manage", rec):
+    if not can(request, f"{item_type}:manage", rec):  # item_type is validated to product|component above
         return 403, {"detail": "Forbidden"}
 
     return rec

--- a/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
+++ b/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
@@ -161,7 +161,7 @@ class Command(BaseCommand):
                 format_type = ""
 
                 # Patch verify_item_access for the duration of the API call
-                with patch("sbomify.apps.sboms.apis.verify_item_access", return_value=True):
+                with patch("sbomify.apps.sboms.apis.can", return_value=True):
                     if "spdxVersion" in sbom_data_dict:
                         format_type = "spdx"
                         self.stdout.write(f"Processing {format_type.upper()} SBOM: {sbom_file}")

--- a/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
+++ b/sbomify/apps/sboms/management/commands/create_test_sbom_environment.py
@@ -11,6 +11,7 @@ from django.core.management.base import BaseCommand, CommandParser
 from django.db import transaction
 from django.http import HttpRequest
 
+from sbomify.apps.core.authz import Decision
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.sboms.apis import sbom_upload_cyclonedx, sbom_upload_spdx
 from sbomify.apps.sboms.models import SBOM, Component, Product, ProductComponent
@@ -160,8 +161,8 @@ class Command(BaseCommand):
 
                 format_type = ""
 
-                # Patch verify_item_access for the duration of the API call
-                with patch("sbomify.apps.sboms.apis.can", return_value=True):
+                # Patch can() to authorize the seeding API call
+                with patch("sbomify.apps.sboms.apis.can", return_value=Decision(allowed=True)):
                     if "spdxVersion" in sbom_data_dict:
                         format_type = "spdx"
                         self.stdout.write(f"Processing {format_type.upper()} SBOM: {sbom_file}")

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -7,9 +7,10 @@ from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.services.results import ServiceResult
-from sbomify.apps.core.utils import broadcast_to_workspace, verify_item_access
+from sbomify.apps.core.utils import broadcast_to_workspace
 from sbomify.apps.sboms.models import SBOM
 
 log = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ def delete_sbom_record(request: HttpRequest, sbom_id: str) -> ServiceResult[None
     except SBOM.DoesNotExist:
         return ServiceResult.failure("SBOM not found", status_code=404)
 
-    if not verify_item_access(request, sbom.component, ["owner", "admin"]):
+    if not can(request, "sbom:manage", sbom.component):
         return ServiceResult.failure("Only owners or admins of the component can delete SBOMs", status_code=403)
 
     # Capture info for broadcast before deleting

--- a/sbomify/apps/sboms/tests/test_views.py
+++ b/sbomify/apps/sboms/tests/test_views.py
@@ -442,8 +442,11 @@ def test_sbom_download_product_private_authorized(
     mock_open = mocker.patch("builtins.open")
     mock_open.return_value.__enter__.return_value.read.return_value = mock_zip_content
 
-    # Mock can() to return True (truthy) so the `if not can(...)` guard authorizes
-    mocker.patch("sbomify.apps.core.views.can", return_value=True)
+    # Mock can() with a real allowed Decision (not a bare bool) so the guard
+    # authorizes and the test stays faithful if the view ever uses .allowed.
+    from sbomify.apps.core.authz import Decision
+
+    mocker.patch("sbomify.apps.core.views.can", return_value=Decision(allowed=True))
 
     uri = reverse("core:sbom_download_product", kwargs={"product_id": sample_product.id})
     response = client.get(uri)

--- a/sbomify/apps/sboms/tests/test_views.py
+++ b/sbomify/apps/sboms/tests/test_views.py
@@ -442,8 +442,8 @@ def test_sbom_download_product_private_authorized(
     mock_open = mocker.patch("builtins.open")
     mock_open.return_value.__enter__.return_value.read.return_value = mock_zip_content
 
-    # Mock verify_item_access to return True for authorized access
-    mocker.patch("sbomify.apps.core.views.verify_item_access", return_value=True)
+    # Mock can() to return True (truthy) so the `if not can(...)` guard authorizes
+    mocker.patch("sbomify.apps.core.views.can", return_value=True)
 
     uri = reverse("core:sbom_download_product", kwargs={"product_id": sample_product.id})
     response = client.get(uri)

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -9,8 +9,8 @@ from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpRe
 from django.shortcuts import render
 from django.views import View
 
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.errors import error_response
-from sbomify.apps.core.utils import verify_item_access
 from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
@@ -25,7 +25,7 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         except SBOM.DoesNotExist:
             return error_response(request, HttpResponseNotFound("SBOM not found"))
 
-        if not verify_item_access(request, sbom, ["owner", "admin"]):
+        if not can(request, "sbom:manage", sbom):
             return error_response(request, HttpResponseForbidden("Only allowed for members of the team"))
 
         vulnerabilities_data: dict[str, Any] | None = None

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -26,7 +26,7 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             return error_response(request, HttpResponseNotFound("SBOM not found"))
 
         if not can(request, "sbom:manage", sbom):
-            return error_response(request, HttpResponseForbidden("Only allowed for members of the team"))
+            return error_response(request, HttpResponseForbidden("Only owners and admins can access this"))
 
         vulnerabilities_data: dict[str, Any] | None = None
         scan_timestamp_str = None

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -562,7 +562,7 @@ def get_team_vulnerability_trends(
     Returns aggregated vulnerability data points over the specified time period,
     grouped by the requested granularity (day/week/month).
     """
-    from sbomify.apps.core.utils import verify_item_access
+    from sbomify.apps.core.authz import can
 
     try:
         team = get_object_or_404(Team, key=team_key)
@@ -570,7 +570,7 @@ def get_team_vulnerability_trends(
         if _is_guest_member(request, team):
             return 403, {"detail": "Guest members can only access public pages"}
 
-        if not verify_item_access(request, team, ["owner", "admin"]):
+        if not can(request, "workspace:manage", team):
             return 403, {"detail": "Access denied"}
 
         end_date = timezone.now()
@@ -701,7 +701,7 @@ def get_team_vulnerability_heatmap(
     Returns a matrix-style dataset perfect for heatmap visualizations,
     showing vulnerability density patterns across different components over time.
     """
-    from sbomify.apps.core.utils import verify_item_access
+    from sbomify.apps.core.authz import can
 
     try:
         team = get_object_or_404(Team, key=team_key)
@@ -709,7 +709,7 @@ def get_team_vulnerability_heatmap(
         if _is_guest_member(request, team):
             return 403, {"detail": "Guest members can only access public pages"}
 
-        if not verify_item_access(request, team, ["owner", "admin"]):
+        if not can(request, "workspace:manage", team):
             return 403, {"detail": "Access denied"}
 
         end_date = timezone.now()


### PR DESCRIPTION
Phase 2b of #1002 — migrate the **remaining 24** inline `verify_item_access()` role checks onto `can()`, completing the call-site migration begun in #1015 (core/apis.py).

> **Stacks on #1015 → #1014.** Merge order: #1014 → #1015 → this. The diff reduces to just these files once the lower PRs land.

## What changed (13 files)

`vulnerability_scanning`, `core/cle_apis`, `compliance`, `oidc` (apis + views), the four `core/views/*`, the `sboms`/`documents` services, and the two `sboms/apis.py` sites #1015's scope didn't cover. Each `verify_item_access(actor, resource, [roles])` → `can(actor, "<action>", resource)`, where the action's capability tier equals the former role list:

- `["owner","admin"]` → `*:manage` / `workspace:manage` (MANAGE)
- `["guest","owner","admin"]` → `product:read` (READ_MEMBER)
- `["owner"]` → `component:administer` (ADMINISTER, the owner-only component path)

Two new catalog actions (`product:read`, `component:administer`). The one value-context site (`product_lifecycle` `can_edit = …`) uses `.allowed`.

## Faithfulness — independently verified

An **adversarial review (4 agents)** checked all 24 conversions: every action's tier *exactly* equals the removed role set, actor/resource unchanged, value-context handled, all actions registered, no fail-open. **0 issues.** Plus the comprehensive suite (core+sboms+documents+oidc+vuln-scanning+compliance) passes — the deny-path tests (guest→403 etc.) are the empirical proof the guards still deny.

The migration also repointed **3 stale mock targets** that patched `verify_item_access` in modules now importing `can` (1 test + 2 dev management commands), and refreshed the `oidc/permissions` docstring.

## On the "fail-open" security flag

Automated review flags every `if not can(...)` as a truthy-object fail-open. **It isn't:** `Decision.__bool__` returns `self.allowed`, so `if not can(...)` enters the deny branch exactly when `allowed=False` (fail-*closed*). This is the reviewer's own suggested mitigation (b) — `__bool__` + a dedicated `test_decision_is_fail_closed_in_boolean_context` assert that `bool(can(...))` matches `.allowed` on both paths. The adversarial review and the deny-path tests confirm it. The pattern is consistent across all three phases; adopting explicit `.allowed` + a lint rule is a clean optional convention for the team (it pairs with the Phase-2 lint gate still on the roadmap).

## Remaining for the epic
- The **CI lint gate** rejecting new inline `"owner"/"admin"/"guest"` checks (the last Phase-2 deliverable).
- The `TeamRoleRequiredMixin.allowed_roles` (16 sites — declarative, already centralized) and the parameterized `compliance/permissions` helpers — optional later cleanup.
- Phase 3: finer roles (#468) + token scopes (#215).