### PR TITLE
chore: bump version to 26.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sbomify-frontend-components",
   "private": true,
-  "version": "26.2.0",
+  "version": "26.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbomify"
-version = "26.2.0"
+version = "26.3.0"
 description = "sbomify - the security artifact hub"
 authors = [{ name = "sbomify", email = "hello@sbomify.com" }]
 requires-python = ">=3.13,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2695,7 +2695,7 @@ wheels = [
 
 [[package]]
 name = "sbomify"
-version = "26.2.0"
+version = "26.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps the project version to **26.3.0** for the 26.3 release cut.

## Changes
- \`pyproject.toml\` → \`26.3.0\`
- \`package.json\` → \`26.3.0\`
- \`uv.lock\` → regenerated via \`uv lock\` (sbomify self-entry \`v26.2.0 → v26.3.0\`)

\`bun.lock\` needs no change — its self-entry carries no version field. Same three-file footprint as the previous bump (\`a81ead3a\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)