### PR TITLE
fix(vuln-trends): make dashboard summary cards a point-in-time snapshot (closes #1019)

### DIFF
--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -199,6 +199,41 @@ class TestVulnerabilityTrendsView:
             assert response.context["summary"]["high"] == 80, f"days={days}"
             assert response.context["summary"]["total"] == 80, f"days={days}"
 
+    def test_summary_includes_sboms_scanned_before_the_window(self, team_with_member, component_with_sbom):
+        """Snapshot reflects current state even if the latest scan predates the window.
+
+        The cards are a point-in-time count, so an SBOM whose most recent scan is
+        older than the selected TIME RANGE must still contribute its latest counts,
+        and the count must be identical regardless of the window. (The timeline
+        chart stays windowed and may show nothing for that range — only the cards
+        are time-range-independent.)
+        """
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+
+        now = timezone.now()
+        run = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(high=7),
+        )
+        # Last (and only) scan is 60 days ago — outside the 7- and 30-day windows.
+        AssessmentRun.objects.filter(pk=run.pk).update(created_at=now - timedelta(days=60))
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+
+        for days in ("7", "30", "90"):
+            response = client.get(self._get_url(days=days))
+            assert response.status_code == 200
+            assert response.context["summary"]["high"] == 7, f"days={days}"
+            assert response.context["summary"]["total"] == 7, f"days={days}"
+
     def test_summary_collapses_same_day_rescans(self, team_with_member, component_with_sbom):
         """Two scans of the same SBOM+provider on the same day count once (latest)."""
         team, user = team_with_member

--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -121,6 +121,10 @@ class TestVulnerabilityTrendsView:
         Note: The actual ASGI cursor fix (transaction.atomic wrapping .iterator())
         cannot be reproduced under the sync test client. This test validates the
         data path works end-to-end with multi-row iteration.
+
+        The summary cards are a point-in-time snapshot: re-scans of the same SBOM
+        by the same provider collapse to the most recent run, so the cards reflect
+        the latest run (i=0 → critical=0, high=1) rather than the sum across days.
         """
         team, user = team_with_member
         sbom, _ = component_with_sbom
@@ -144,10 +148,93 @@ class TestVulnerabilityTrendsView:
 
         response = client.get(self._get_url(days="7"))
         assert response.status_code == 200
-        # Sum of critical: 0+1+2+3+4 = 10, high: 1+2+3+4+5 = 15
-        assert response.context["summary"]["critical"] == 10
-        assert response.context["summary"]["high"] == 15
-        assert response.context["summary"]["total"] == 25
+        # Latest run (i=0, today) wins: critical=0, high=1 — NOT the 30-day sum.
+        assert response.context["summary"]["critical"] == 0
+        assert response.context["summary"]["high"] == 1
+        assert response.context["summary"]["total"] == 1
+
+    def test_summary_is_point_in_time_not_time_range_sum(self, team_with_member, component_with_sbom):
+        """The summary cards must NOT scale with the time range.
+
+        Regression for the dashboard reading 16k High under Latest/30 Days: the
+        cards summed every day's scan counts across the window, multiplying the
+        same persistent vulnerabilities by the number of days. They must instead
+        report the latest scan's counts (a snapshot), independent of TIME RANGE.
+        """
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+
+        now = timezone.now()
+        # An old large scan and a recent smaller scan of the SAME sbom+provider.
+        old_run = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(high=500),
+        )
+        AssessmentRun.objects.filter(pk=old_run.pk).update(created_at=now - timedelta(days=20))
+        new_run = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(high=80),
+        )
+        AssessmentRun.objects.filter(pk=new_run.pk).update(created_at=now - timedelta(days=1))
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+
+        # 30-day and 90-day windows must give the SAME snapshot (latest = 80).
+        for days in ("30", "90"):
+            response = client.get(self._get_url(days=days))
+            assert response.status_code == 200
+            assert response.context["summary"]["high"] == 80, f"days={days}"
+            assert response.context["summary"]["total"] == 80, f"days={days}"
+
+    def test_summary_collapses_same_day_rescans(self, team_with_member, component_with_sbom):
+        """Two scans of the same SBOM+provider on the same day count once (latest)."""
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+
+        now = timezone.now()
+        first = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(critical=5),
+        )
+        AssessmentRun.objects.filter(pk=first.pk).update(created_at=now - timedelta(hours=5))
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(critical=2),
+        )
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+
+        response = client.get(self._get_url())
+        assert response.status_code == 200
+        # Most recent run wins (critical=2), not the same-day sum (7).
+        assert response.context["summary"]["critical"] == 2
+        assert response.context["summary"]["total"] == 2
 
     def test_days_parameter_clamped(self, team_with_member):
         """Days parameter is clamped between 7 and 365."""

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -269,9 +269,10 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
 
             if connection.vendor == "postgresql":
                 # Postgres resolves the latest run per pair in one indexed pass
-                # via DISTINCT ON — no client-side scan of the whole history.
+                # via DISTINCT ON — no client-side scan of the whole history. The
+                # -id secondary sort breaks created_at ties deterministically.
                 for snap in (
-                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at")
+                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")
                     .values("result", "plugin_name", "sbom_id")
                     .iterator()
@@ -282,15 +283,16 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # Portable fallback (the SQLite test backend has no DISTINCT ON):
                 # pick the latest run per pair over lightweight columns, then load
                 # result blobs for the winning runs only. Test-scale data, so the
-                # full scan is cheap.
-                latest_run_at: dict[tuple[Any, str], Any] = {}
+                # full scan is cheap. Compare (created_at, id) so equal timestamps
+                # break deterministically, matching the Postgres -id tiebreak.
+                latest_run_key: dict[tuple[Any, str], tuple[Any, Any]] = {}
                 latest_run_id: dict[tuple[Any, str], Any] = {}
                 for run_id, sbom_id, plugin_name, created in snapshot_scope.values_list(
                     "id", "sbom_id", "plugin_name", "created_at"
                 ).iterator():
                     key = (sbom_id, plugin_name or "unknown")
-                    if key not in latest_run_at or created > latest_run_at[key]:
-                        latest_run_at[key] = created
+                    if key not in latest_run_key or (created, run_id) > latest_run_key[key]:
+                        latest_run_key[key] = (created, run_id)
                         latest_run_id[key] = run_id
                 results_by_id = {
                     row["id"]: row["result"]

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from typing import Any, cast
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Prefetch
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render
@@ -233,10 +233,11 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # (sbom, provider) regardless of how long ago it ran, so the summary
         # cards are independent of the selected time range (a SBOM whose latest
         # scan predates the window still contributes its current counts). Only
-        # created_at__lte (now) is applied — no lower bound. The latest run per
-        # pair is resolved in Python (below) rather than via Postgres-only
-        # DISTINCT ON, so the view stays portable to the SQLite test backend.
+        # created_at__lte (now) is applied — no lower bound; distinct() drops the
+        # duplicate rows the products M2M join would otherwise produce.
         snapshot_scope = scoped_query.filter(created_at__lte=end_date)
+        if product_id:
+            snapshot_scope = snapshot_scope.distinct()
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result
@@ -249,14 +250,11 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # and distinct SBOMs each contribute; re-scans collapse to the latest.
         # Without this the cards reported the area under the trend curve — the
         # same persistent vulnerabilities multiplied by the number of days (and
-        # by every re-scan) in the window. Resolved in two steps so we scan only
-        # lightweight columns over all of history and load result blobs for the
-        # winning runs alone.
-        latest_run_at: dict[tuple[Any, str], Any] = {}
-        latest_run_id: dict[tuple[Any, str], Any] = {}
+        # by every re-scan) in the window.
+        latest_run_counts: dict[tuple[Any, str], dict[str, int]] = {}
 
         with transaction.atomic():
-            for run in timeline_query.values("created_at", "result", "plugin_name").iterator():
+            for run in timeline_query.values("created_at", "result").iterator():
                 day_key = run["created_at"].date().isoformat()
                 counts = extract_severity_counts(run["result"])
 
@@ -269,27 +267,38 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 daily_data[day_key]["medium"] += counts["medium"]
                 daily_data[day_key]["low"] += counts["low"]
 
-            # Step 1: find the latest run id per (sbom, provider) reading only
-            # lightweight columns (no result blobs, no DISTINCT ON).
-            for run_id, sbom_id, plugin_name, created in snapshot_scope.values_list(
-                "id", "sbom_id", "plugin_name", "created_at"
-            ).iterator():
-                key = (sbom_id, plugin_name or "unknown")
-                if key not in latest_run_at or created > latest_run_at[key]:
-                    latest_run_at[key] = created
-                    latest_run_id[key] = run_id
-
-            # Step 2: load result blobs for the winning runs only.
-            results_by_id = {
-                row["id"]: row["result"]
-                for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values()))
-                .values("id", "result")
-                .iterator()
-            }
-
-        latest_run_counts = {
-            key: extract_severity_counts(results_by_id.get(run_id)) for key, run_id in latest_run_id.items()
-        }
+            if connection.vendor == "postgresql":
+                # Postgres resolves the latest run per pair in one indexed pass
+                # via DISTINCT ON — no client-side scan of the whole history.
+                for snap in (
+                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at")
+                    .distinct("sbom_id", "plugin_name")
+                    .values("result", "plugin_name", "sbom_id")
+                    .iterator()
+                ):
+                    key = (snap["sbom_id"], snap["plugin_name"] or "unknown")
+                    latest_run_counts[key] = extract_severity_counts(snap["result"])
+            else:
+                # Portable fallback (the SQLite test backend has no DISTINCT ON):
+                # pick the latest run per pair over lightweight columns, then load
+                # result blobs for the winning runs only. Test-scale data, so the
+                # full scan is cheap.
+                latest_run_at: dict[tuple[Any, str], Any] = {}
+                latest_run_id: dict[tuple[Any, str], Any] = {}
+                for run_id, sbom_id, plugin_name, created in snapshot_scope.values_list(
+                    "id", "sbom_id", "plugin_name", "created_at"
+                ).iterator():
+                    key = (sbom_id, plugin_name or "unknown")
+                    if key not in latest_run_at or created > latest_run_at[key]:
+                        latest_run_at[key] = created
+                        latest_run_id[key] = run_id
+                results_by_id = {
+                    row["id"]: row["result"]
+                    for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values())).values("id", "result")
+                }
+                latest_run_counts = {
+                    key: extract_severity_counts(results_by_id.get(run_id)) for key, run_id in latest_run_id.items()
+                }
 
         # Build time series with all days (including zeros)
         time_series = []
@@ -311,7 +320,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
 
         # Summary cards + the severity/provider breakdowns report the snapshot:
         # the sum over each in-scope SBOM's most recent run per provider, sourced
-        # from snapshot_query (no lower time bound). Changing the TIME RANGE only
+        # from snapshot_scope (no lower time bound). Changing the TIME RANGE only
         # reshapes the timeline chart — it never changes these current counts.
         summary = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
         provider_data: dict[str, dict[str, int]] = {}

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -229,27 +229,38 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # Wrapped in transaction.atomic() to keep the server-side cursor valid
         # under ASGI, where connection recycling can invalidate named cursors.
         daily_data: dict[str, dict[str, int]] = {}
-        provider_data: dict[str, dict[str, int]] = {}
+
+        # Snapshot accumulators keyed by (sbom_id, provider): re-scans of the
+        # same SBOM by the same provider collapse to the most recent run, so the
+        # summary cards + severity/provider breakdowns are a point-in-time count
+        # rather than a running sum over the time range. Distinct providers and
+        # distinct SBOMs each still contribute. Without this the cards reported
+        # the area under the trend curve — the same persistent vulnerabilities
+        # multiplied by the number of days (and by every re-scan) in the window.
+        latest_run_ts: dict[tuple[Any, str], Any] = {}
+        latest_run_counts: dict[tuple[Any, str], dict[str, int]] = {}
 
         with transaction.atomic():
-            for run in base_query.values("created_at", "result", "plugin_name").iterator():
-                day_key = run["created_at"].date().isoformat()
+            for run in base_query.values("created_at", "result", "plugin_name", "sbom_id").iterator():
+                created_at = run["created_at"]
+                day_key = created_at.date().isoformat()
                 counts = extract_severity_counts(run["result"])
+                provider = run["plugin_name"] or "unknown"
 
+                # Timeline chart: per-day scan activity (a trend, not a snapshot).
                 if day_key not in daily_data:
                     daily_data[day_key] = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
-
                 daily_data[day_key]["total"] += counts["total"]
                 daily_data[day_key]["critical"] += counts["critical"]
                 daily_data[day_key]["high"] += counts["high"]
                 daily_data[day_key]["medium"] += counts["medium"]
                 daily_data[day_key]["low"] += counts["low"]
 
-                provider = run["plugin_name"] or "unknown"
-                if provider not in provider_data:
-                    provider_data[provider] = {"scans": 0, "vulnerabilities": 0}
-                provider_data[provider]["scans"] += 1
-                provider_data[provider]["vulnerabilities"] += counts["total"]
+                # Snapshot: keep only the most recent run per (sbom, provider).
+                snapshot_key = (run["sbom_id"], provider)
+                if snapshot_key not in latest_run_ts or created_at > latest_run_ts[snapshot_key]:
+                    latest_run_ts[snapshot_key] = created_at
+                    latest_run_counts[snapshot_key] = counts
 
         # Build time series with all days (including zeros)
         time_series = []
@@ -269,13 +280,18 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             )
             current_date += timedelta(days=1)
 
-        summary = {
-            "total": sum(d["total"] for d in daily_data.values()),
-            "critical": sum(d["critical"] for d in daily_data.values()),
-            "high": sum(d["high"] for d in daily_data.values()),
-            "medium": sum(d["medium"] for d in daily_data.values()),
-            "low": sum(d["low"] for d in daily_data.values()),
-        }
+        # Summary cards + the severity/provider breakdowns report the snapshot:
+        # the sum over each in-scope SBOM's most recent run per provider. This is
+        # independent of the time range — widening the window adds older runs to
+        # the timeline but never changes the current counts.
+        summary = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
+        provider_data: dict[str, dict[str, int]] = {}
+        for (_sbom_id, provider), counts in latest_run_counts.items():
+            for severity in summary:
+                summary[severity] += counts[severity]
+            stats = provider_data.setdefault(provider, {"scans": 0, "vulnerabilities": 0})
+            stats["scans"] += 1
+            stats["vulnerabilities"] += counts["total"]
 
         chart_labels = [d["label"] for d in time_series]
         chart_data = {

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -229,17 +229,14 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         if product_id:
             timeline_query = timeline_query.distinct()
 
-        # Snapshot query: the CURRENT state — the single most recent run per
-        # (sbom, provider) regardless of how long ago it ran. DISTINCT ON keeps
-        # one row per pair (collapsing re-scans and any join duplicates), so the
-        # summary cards are independent of the selected time range: a SBOM whose
-        # latest scan predates the window still contributes its current counts.
-        # Only created_at__lte (now) is applied — no lower bound.
-        snapshot_query = (
-            scoped_query.filter(created_at__lte=end_date)
-            .order_by("sbom_id", "plugin_name", "-created_at")
-            .distinct("sbom_id", "plugin_name")
-        )
+        # Snapshot scope: the CURRENT state — the single most recent run per
+        # (sbom, provider) regardless of how long ago it ran, so the summary
+        # cards are independent of the selected time range (a SBOM whose latest
+        # scan predates the window still contributes its current counts). Only
+        # created_at__lte (now) is applied — no lower bound. The latest run per
+        # pair is resolved in Python (below) rather than via Postgres-only
+        # DISTINCT ON, so the view stays portable to the SQLite test backend.
+        snapshot_scope = scoped_query.filter(created_at__lte=end_date)
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result
@@ -248,12 +245,15 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # under ASGI, where connection recycling can invalidate named cursors.
         daily_data: dict[str, dict[str, int]] = {}
 
-        # Snapshot accumulators keyed by (sbom_id, provider). Distinct providers
+        # Snapshot: the most recent run per (sbom, provider). Distinct providers
         # and distinct SBOMs each contribute; re-scans collapse to the latest.
         # Without this the cards reported the area under the trend curve — the
         # same persistent vulnerabilities multiplied by the number of days (and
-        # by every re-scan) in the window.
-        latest_run_counts: dict[tuple[Any, str], dict[str, int]] = {}
+        # by every re-scan) in the window. Resolved in two steps so we scan only
+        # lightweight columns over all of history and load result blobs for the
+        # winning runs alone.
+        latest_run_at: dict[tuple[Any, str], Any] = {}
+        latest_run_id: dict[tuple[Any, str], Any] = {}
 
         with transaction.atomic():
             for run in timeline_query.values("created_at", "result", "plugin_name").iterator():
@@ -269,9 +269,27 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 daily_data[day_key]["medium"] += counts["medium"]
                 daily_data[day_key]["low"] += counts["low"]
 
-            for snap in snapshot_query.values("result", "plugin_name", "sbom_id").iterator():
-                provider = snap["plugin_name"] or "unknown"
-                latest_run_counts[(snap["sbom_id"], provider)] = extract_severity_counts(snap["result"])
+            # Step 1: find the latest run id per (sbom, provider) reading only
+            # lightweight columns (no result blobs, no DISTINCT ON).
+            for run_id, sbom_id, plugin_name, created in snapshot_scope.values_list(
+                "id", "sbom_id", "plugin_name", "created_at"
+            ).iterator():
+                key = (sbom_id, plugin_name or "unknown")
+                if key not in latest_run_at or created > latest_run_at[key]:
+                    latest_run_at[key] = created
+                    latest_run_id[key] = run_id
+
+            # Step 2: load result blobs for the winning runs only.
+            results_by_id = {
+                row["id"]: row["result"]
+                for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values()))
+                .values("id", "result")
+                .iterator()
+            }
+
+        latest_run_counts = {
+            key: extract_severity_counts(results_by_id.get(run_id)) for key, run_id in latest_run_id.items()
+        }
 
         # Build time series with all days (including zeros)
         time_series = []

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -187,24 +187,24 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         end_date = timezone.now()
         start_date = end_date - timedelta(days=days)
 
-        # Build base query
-        base_query = AssessmentRun.objects.filter(
+        # Scope filters shared by the timeline (windowed) and the snapshot
+        # (current state). The created_at window is applied separately below so
+        # the summary cards can stay time-range-independent.
+        scoped_query = AssessmentRun.objects.filter(
             sbom__component__team=team,
             category="security",
             status="completed",
-            created_at__gte=start_date,
-            created_at__lte=end_date,
         ).select_related("sbom", "sbom__component")
 
         if component_id:
-            base_query = base_query.filter(sbom__component_id=component_id)
+            scoped_query = scoped_query.filter(sbom__component_id=component_id)
 
         if product_id:
-            base_query = base_query.filter(sbom__component__products__id=product_id).distinct()
+            scoped_query = scoped_query.filter(sbom__component__products__id=product_id)
 
         if release_id:
-            # Restrict the trend to the SBOMs belonging to the selected release(s)
-            # via the ReleaseArtifact junction. "" (All Releases) skips this block
+            # Restrict to the SBOMs belonging to the selected release(s) via the
+            # ReleaseArtifact junction. "" (All Releases) skips this block
             # entirely. The LATEST sentinel resolves to the is_latest release of
             # each in-scope product (the chosen product, or every team product
             # under All Products); a concrete id resolves to that one release.
@@ -221,7 +221,25 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             sbom_ids_in_release = ReleaseArtifact.objects.filter(
                 release_id__in=release_ids, sbom__isnull=False
             ).values_list("sbom_id", flat=True)
-            base_query = base_query.filter(sbom_id__in=sbom_ids_in_release)
+            scoped_query = scoped_query.filter(sbom_id__in=sbom_ids_in_release)
+
+        # Timeline chart: runs WITHIN the selected window. distinct() guards the
+        # per-day sums against the products M2M join double-counting rows.
+        timeline_query = scoped_query.filter(created_at__gte=start_date, created_at__lte=end_date)
+        if product_id:
+            timeline_query = timeline_query.distinct()
+
+        # Snapshot query: the CURRENT state — the single most recent run per
+        # (sbom, provider) regardless of how long ago it ran. DISTINCT ON keeps
+        # one row per pair (collapsing re-scans and any join duplicates), so the
+        # summary cards are independent of the selected time range: a SBOM whose
+        # latest scan predates the window still contributes its current counts.
+        # Only created_at__lte (now) is applied — no lower bound.
+        snapshot_query = (
+            scoped_query.filter(created_at__lte=end_date)
+            .order_by("sbom_id", "plugin_name", "-created_at")
+            .distinct("sbom_id", "plugin_name")
+        )
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result
@@ -230,22 +248,17 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # under ASGI, where connection recycling can invalidate named cursors.
         daily_data: dict[str, dict[str, int]] = {}
 
-        # Snapshot accumulators keyed by (sbom_id, provider): re-scans of the
-        # same SBOM by the same provider collapse to the most recent run, so the
-        # summary cards + severity/provider breakdowns are a point-in-time count
-        # rather than a running sum over the time range. Distinct providers and
-        # distinct SBOMs each still contribute. Without this the cards reported
-        # the area under the trend curve — the same persistent vulnerabilities
-        # multiplied by the number of days (and by every re-scan) in the window.
-        latest_run_ts: dict[tuple[Any, str], Any] = {}
+        # Snapshot accumulators keyed by (sbom_id, provider). Distinct providers
+        # and distinct SBOMs each contribute; re-scans collapse to the latest.
+        # Without this the cards reported the area under the trend curve — the
+        # same persistent vulnerabilities multiplied by the number of days (and
+        # by every re-scan) in the window.
         latest_run_counts: dict[tuple[Any, str], dict[str, int]] = {}
 
         with transaction.atomic():
-            for run in base_query.values("created_at", "result", "plugin_name", "sbom_id").iterator():
-                created_at = run["created_at"]
-                day_key = created_at.date().isoformat()
+            for run in timeline_query.values("created_at", "result", "plugin_name").iterator():
+                day_key = run["created_at"].date().isoformat()
                 counts = extract_severity_counts(run["result"])
-                provider = run["plugin_name"] or "unknown"
 
                 # Timeline chart: per-day scan activity (a trend, not a snapshot).
                 if day_key not in daily_data:
@@ -256,11 +269,9 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 daily_data[day_key]["medium"] += counts["medium"]
                 daily_data[day_key]["low"] += counts["low"]
 
-                # Snapshot: keep only the most recent run per (sbom, provider).
-                snapshot_key = (run["sbom_id"], provider)
-                if snapshot_key not in latest_run_ts or created_at > latest_run_ts[snapshot_key]:
-                    latest_run_ts[snapshot_key] = created_at
-                    latest_run_counts[snapshot_key] = counts
+            for snap in snapshot_query.values("result", "plugin_name", "sbom_id").iterator():
+                provider = snap["plugin_name"] or "unknown"
+                latest_run_counts[(snap["sbom_id"], provider)] = extract_severity_counts(snap["result"])
 
         # Build time series with all days (including zeros)
         time_series = []
@@ -281,9 +292,9 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             current_date += timedelta(days=1)
 
         # Summary cards + the severity/provider breakdowns report the snapshot:
-        # the sum over each in-scope SBOM's most recent run per provider. This is
-        # independent of the time range — widening the window adds older runs to
-        # the timeline but never changes the current counts.
+        # the sum over each in-scope SBOM's most recent run per provider, sourced
+        # from snapshot_query (no lower time bound). Changing the TIME RANGE only
+        # reshapes the timeline chart — it never changes these current counts.
         summary = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
         provider_data: dict[str, dict[str, int]] = {}
         for (_sbom_id, provider), counts in latest_run_counts.items():
@@ -313,9 +324,9 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "provider_values": json.dumps([p["vulnerabilities"] for p in provider_data.values()]),
         }
 
-        # Build recent scans
+        # Build recent scans (within the selected window, matching the timeline).
         recent_runs = list(
-            base_query.order_by("-created_at")[:5].values(
+            timeline_query.order_by("-created_at")[:5].values(
                 "id",
                 "sbom__id",
                 "sbom__name",

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -223,21 +223,19 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             ).values_list("sbom_id", flat=True)
             scoped_query = scoped_query.filter(sbom_id__in=sbom_ids_in_release)
 
-        # Timeline chart: runs WITHIN the selected window. distinct() guards the
-        # per-day sums against the products M2M join double-counting rows.
+        # The product filter joins through the ProductComponent M2M, but
+        # (product, component) is unique there, so filtering by a single
+        # product_id yields at most one join row per run — no .distinct() needed.
+
+        # Timeline chart: runs WITHIN the selected window.
         timeline_query = scoped_query.filter(created_at__gte=start_date, created_at__lte=end_date)
-        if product_id:
-            timeline_query = timeline_query.distinct()
 
         # Snapshot scope: the CURRENT state — the single most recent run per
         # (sbom, provider) regardless of how long ago it ran, so the summary
         # cards are independent of the selected time range (a SBOM whose latest
         # scan predates the window still contributes its current counts). Only
-        # created_at__lte (now) is applied — no lower bound; distinct() drops the
-        # duplicate rows the products M2M join would otherwise produce.
+        # created_at__lte (now) is applied — no lower bound.
         snapshot_scope = scoped_query.filter(created_at__lte=end_date)
-        if product_id:
-            snapshot_scope = snapshot_scope.distinct()
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result


### PR DESCRIPTION
## What

Fixes the dashboard **Vulnerability Trends** summary cards reading absurd numbers (16,935 High under **All Products / Latest / 30 Days**) when a single day's tooltip showed High: 512.

## Why it happened

The cards were the **area under the trend curve**. `summary` summed every day's bucket across the whole time range, and each day's bucket itself summed across all in-scope SBOMs and every re-scan:

```python
summary = {"high": sum(d["high"] for d in daily_data.values()), ...}  # Σ_days Σ_scans
```

So the same persistent vulnerabilities were recounted once per day in the window (~30×) and once per re-scan. 512/day × ~30 days ≈ 16,935.

## Fix

Compute the cards, the **Severity** breakdown, and the **Providers** breakdown from a **point-in-time snapshot**: the most recent run per `(SBOM, provider)`.

- Independent of TIME RANGE — widening the window adds older points to the timeline chart but never changes the current counts.
- Distinct providers and distinct SBOMs each still contribute; re-scans of the same SBOM+provider collapse to the latest.
- The **Timeline** chart keeps its per-day trend semantics (it's legitimately a trend).

The parallel `apis.py` analytics endpoint already uses per-period **averages**, so it was never affected.

## Tests

- `test_summary_is_point_in_time_not_time_range_sum` — 30-day and 90-day windows yield the same snapshot (latest scan), not a scaled sum.
- `test_summary_collapses_same_day_rescans` — two scans of the same SBOM+provider on one day count once (latest).
- `test_trends_with_multiple_days_of_data` — updated to assert snapshot (latest run), not the cross-day sum it previously encoded.
- Existing multi-provider / multi-SBOM / release-scoping tests still pass (96 passing in the app suite).

## Follow-up (not in this PR)

Cross-SBOM CVE-level dedup (the same advisory in N components counts N times) is a separate, heavier change — `extract_severity_counts` only returns aggregate counts and the findings blobs are deliberately not materialized. Tracked under the dogfooding epic #1020.

Closes #1019
