### PR TITLE
fix(docker): strip test_data fixtures from prod image to kill phantom CVEs (#1020)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,13 @@ fly.toml
 .env
 localstack-volume/
 test_env
-sboms/tests/test_data/osv-scanner.toml
+# Test fixtures: sample SBOMs/lockfiles used only by the test suite. They are
+# never needed at runtime, and baking them in via `COPY . .` makes image
+# scanners read them as installed packages — surfacing phantom CVEs for the
+# historical dependency snapshots they describe. Exclude every test_data dir
+# (the prior `sboms/tests/test_data/osv-scanner.toml` pattern was relative to
+# the wrong root and matched nothing).
+**/test_data/
 **/__snapshots__/
 **/__diffs__/
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,13 +5,7 @@ fly.toml
 .env
 localstack-volume/
 test_env
-# Test fixtures: sample SBOMs/lockfiles used only by the test suite. They are
-# never needed at runtime, and baking them in via `COPY . .` makes image
-# scanners read them as installed packages — surfacing phantom CVEs for the
-# historical dependency snapshots they describe. Exclude every test_data dir
-# (the prior `sboms/tests/test_data/osv-scanner.toml` pattern was relative to
-# the wrong root and matched nothing).
-**/test_data/
+sboms/tests/test_data/osv-scanner.toml
 **/__snapshots__/
 **/__diffs__/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -303,7 +303,7 @@ RUN mkdir -p /code/staticfiles && \
     ln -s /usr/bin/python /code/.venv/bin/python && \
     ln -s /usr/bin/python /code/.venv/bin/python3 && \
     ln -s /usr/bin/python "/code/.venv/bin/${PYTHON_MINOR}" && \
-    find /code -type d -name test_data -prune -exec rm -rf {} + && \
+    find /code/sbomify -type d -name test_data -prune -exec rm -rf {} + && \
     mkdir -p /staged-dirs/var/lib/dramatiq-prometheus /staged-dirs/tmp/.cache && \
     chown -R 65532:65532 /staged-dirs/var /staged-dirs/tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -288,6 +288,14 @@ ENV UV_NO_SYNC=1
 # Chainguard Python is at /usr/bin/python, not /usr/local/bin/python3.X.
 # The python3.X symlink name is derived dynamically to avoid hardcoding the minor version.
 # psycopg2-binary bundles libpq, so no shared library staging is needed.
+#
+# Strip test_data/ fixtures from the prod tree before it is copied into the
+# distroless image. They are sample SBOMs/lockfiles used only by the test suite;
+# `COPY . .` bakes them in, where the image SBOM scanner reads them as installed
+# packages and reports phantom CVEs for the historical snapshots they describe.
+# This runs ONLY in the collectstatic -> python-app-prod path, so the dev image
+# (python-app-dev, built from python-dependencies) keeps the fixtures that the
+# create_test_sbom_environment management command loads.
 RUN mkdir -p /code/staticfiles && \
     uv run python manage.py collectstatic --noinput && \
     PYTHON_MINOR=$(python3 -c 'import sys; print("python%d.%d" % sys.version_info[:2])') && \
@@ -295,6 +303,7 @@ RUN mkdir -p /code/staticfiles && \
     ln -s /usr/bin/python /code/.venv/bin/python && \
     ln -s /usr/bin/python /code/.venv/bin/python3 && \
     ln -s /usr/bin/python "/code/.venv/bin/${PYTHON_MINOR}" && \
+    find /code -type d -name test_data -prune -exec rm -rf {} + && \
     mkdir -p /staged-dirs/var/lib/dramatiq-prometheus /staged-dirs/tmp/.cache && \
     chown -R 65532:65532 /staged-dirs/var /staged-dirs/tmp
 


### PR DESCRIPTION
Part of #1020. Removes a large **false-positive** cluster from the Container component SBOM.

### The phantom findings
The container scan reported `django 5.1.4` (Critical), `h11 0.14.0` (Critical), `urllib3 2.2.3`, a `poetry.lock` target, and ~20 more — **none of which are runtime dependencies**. They come from sample SBOMs committed under `sbomify/apps/sboms/tests/test_data/` (snapshots of a *historical poetry-era* sbomify). The Dockerfile's `COPY . .` bakes them into `/code`, where the image scanner reads them as installed packages. The **real** `.venv` (from `uv.lock`) already pins django 5.2.14 / h11 0.16.0 / urllib3 2.7.0 — all patched.

### Fix (revised after review)
Strip `test_data/` dirs in the **`collectstatic` stage**, which feeds *only* the distroless `python-app-prod` image (`COPY --from=collectstatic /code /code`).

This is prod-only by design: the dev image (`python-app-dev`, built from `python-dependencies`, not `collectstatic`) keeps the fixtures, so the `create_test_sbom_environment` management command still works in the dev container — whereas a blanket `.dockerignore` would have removed them everywhere (the dev backend runs the baked image with no source mount). `docker buildx build --check` passes.