### PR TITLE
fix(authz): enforce token read-scope on the components-list endpoint (#1028)

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -1588,6 +1588,16 @@ def list_components(
         if not team_id:
             return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
 
+        # Route this internal read through can() so a narrow-scoped API token
+        # (e.g. a publish-only CI token) honours its scope: listing components
+        # exposes private workspace data, which a non-read token scope must not
+        # reach. No behaviour change for sessions or full/unscoped tokens —
+        # component:read_internal is the READ_MEMBER tier every current member
+        # already satisfies; it only adds the token action-scope gate.
+        team = Team.objects.filter(id=team_id).first()
+        if team is not None and not can(request, "component:read_internal", team):
+            return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
         components_queryset = optimize_component_queryset(Component.objects.filter(team_id=team_id))
         has_crud_permissions = _get_team_crud_permission(request, team_id)
 

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -3149,3 +3149,35 @@ def test_delete_component_admin_forbidden(sample_team_with_owner_member: Member)
 
     assert response.status_code == 403
     assert Component.objects.filter(id=component.id).exists()
+
+
+@pytest.mark.django_db
+def test_list_components_enforces_token_read_scope(sample_team_with_owner_member: Member):  # noqa: F811
+    """#1028: the components-list endpoint now routes through can(), so a
+    narrow-scoped token (no read scope) is denied — it previously bypassed the
+    token-scope gate and could enumerate private workspace components.
+    """
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.core.authz import SCOPE_PRESETS
+
+    team = sample_team_with_owner_member.team
+    user = sample_team_with_owner_member.user
+    Component.objects.create(name="scope-gap-private", team=team)
+    url = reverse("api-1:list_components")
+
+    def tok(scopes):
+        s = create_personal_access_token(user)
+        AccessToken.objects.create(user=user, encoded_token=s, description="t", team=team, scopes=scopes)
+        return s
+
+    client = Client()
+    # publish-only token: no read scope -> 403 (was 200 before the fix)
+    pub = tok(["artifact:publish"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}").status_code == 403
+    # read-only preset (includes component:read_internal) -> 200
+    ro = tok(SCOPE_PRESETS["read_only"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}").status_code == 200
+    # unscoped (full) token -> 200, unchanged
+    full = tok(None)
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200


### PR DESCRIPTION
Fixes the proven case of #1028 — found while e2e-testing #1002 token scoping on staging.

## The gap
Token action-scopes (#1026) are enforced inside `can()`. `list_components` authorized via the legacy `_is_guest_member` + team-filter pattern and **never called `can()`**, so the scope gate never fired. A **publish-only** CI token could `GET /api/v1/components` and enumerate **all** workspace components, including private ones.

**Reproduced live on stage.sbomify.com:** a `["artifact:publish"]`-scoped token returned **200** + the full private-inclusive list (a full token's view), while correctly getting 403 on create/manage/private-read.

## Fix
Route the read through `can(request, "component:read_internal", team)`:
- `component:read_internal` is the `READ_MEMBER` tier — **every current member already satisfies it**, so sessions and full/unscoped (`NULL`) tokens are unaffected.
- It only adds the **token action-scope gate**: a `read_only` token passes, a `publish-only` token now gets **403**.

## Test
`test_list_components_enforces_token_read_scope`: publish-only → 403, read-only preset → 200, unscoped → 200. Existing component-list tests green (17), mypy clean.

## Scope of this PR
Exemplar fix for the **proven** endpoint. The remaining `can()`-bypassing reads (`get_dashboard_summary`, `vulnerability_scanning` team-stats reads, contact profiles, etc.) are the follow-up sweep tracked in **#1028**. (Note: the `tea.*` list endpoints are public-only by design and don't leak.)

Part of #215 / #1002. Closes nothing yet — #1028 stays open for the sweep.