### PR TITLE
feat(cbom): derive crypto-asset inventory + read endpoint (#1001)

### DIFF
--- a/sbomify/apps/core/templates/core/component_item.html.j2
+++ b/sbomify/apps/core/templates/core/component_item.html.j2
@@ -197,6 +197,10 @@
                     </div>
                 </div>
             {% endif %}
+            {# Cryptographic Assets (CBOM) — lazy-loaded; collapses when there are none #}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
             {# Assessment Results Section #}
             {% if assessment_runs %}
                 <div>

--- a/sbomify/apps/core/templates/core/component_item_public.html.j2
+++ b/sbomify/apps/core/templates/core/component_item_public.html.j2
@@ -111,6 +111,12 @@
                 </a>
             </div>
         </div>
+        {# Cryptographic Assets (CBOM) — lazy-loaded for SBOM artifacts; collapses when there are none #}
+        {% if component.component_type == 'bom' %}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
+        {% endif %}
     </div>
 {% endblock %}
 {% block scripts %}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -36,6 +36,7 @@ from sbomify.apps.teams.models import ContactProfile
 from .models import SBOM, Component, Product
 from .schemas import (
     ComponentMetaData,
+    CryptoInventorySchema,
     CycloneDXSupportedVersion,
     SBOMResponseSchema,
     SBOMUploadRequest,
@@ -52,7 +53,7 @@ from .schemas import (
     validate_cyclonedx_sbom,
     validate_spdx_sbom,
 )
-from .services.sboms import delete_sbom_record, get_sbom_detail
+from .services.sboms import delete_sbom_record, get_crypto_inventory, get_sbom_detail
 
 log = logging.getLogger(__name__)
 
@@ -727,6 +728,24 @@ def get_cyclonedx_component_metadata(
 def get_sbom(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
     """Get a specific SBOM by ID."""
     result = get_sbom_detail(request, sbom_id)
+    if not result.ok:
+        return result.status_code or 400, {"detail": result.error or "Invalid request"}
+
+    return 200, result.value or {}
+
+
+@router.get(
+    "/{sbom_id}/crypto-inventory",
+    response={200: CryptoInventorySchema, 403: ErrorResponse, 404: ErrorResponse},
+    auth=None,  # Allow unauthenticated access for public SBOMs
+)
+def get_sbom_crypto_inventory(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
+    """Return the derived cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Projects the ``cryptographic-asset`` components of the stored CycloneDX
+    artifact. Non-crypto SBOMs return an empty inventory rather than an error.
+    """
+    result = get_crypto_inventory(request, sbom_id)
     if not result.ok:
         return result.status_code or 400, {"detail": result.error or "Invalid request"}
 

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -81,25 +81,45 @@ def _dict_or_none(value: Any) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Coerce a CycloneDX scalar to ``str`` (keep hashable, schema-clean).
+
+    A spec-conformant value is already a string. A scalar (int/float/bool) is
+    stringified so data is not lost. Anything else (dict/list) is dropped to
+    ``None`` — it would be unhashable for ``by_asset_type`` and would violate the
+    ``str | None`` API schema, both of which the module promises never to raise on.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):  # bool is an int subclass — fine
+        return str(value)
+    return None
+
+
+def _str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(v) for v in value if isinstance(v, (str, int, float)))
+
+
 def _project_asset(component: dict[str, Any]) -> CryptoAsset:
     crypto = _dict_or_none(component.get("cryptoProperties")) or {}
     algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
-    functions = algo.get("cryptoFunctions")
     return CryptoAsset(
-        name=component.get("name"),
-        bom_ref=component.get("bom-ref"),
-        oid=crypto.get("oid") or component.get("oid"),
-        asset_type=crypto.get("assetType"),
-        primitive=algo.get("primitive"),
-        algorithm_family=algo.get("algorithmFamily"),
-        parameter_set=algo.get("parameterSetIdentifier"),
-        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        name=_str_or_none(component.get("name")),
+        bom_ref=_str_or_none(component.get("bom-ref")),
+        oid=_str_or_none(crypto.get("oid") or component.get("oid")),
+        asset_type=_str_or_none(crypto.get("assetType")),
+        primitive=_str_or_none(algo.get("primitive")),
+        algorithm_family=_str_or_none(algo.get("algorithmFamily")),
+        parameter_set=_str_or_none(algo.get("parameterSetIdentifier")),
+        curve=_str_or_none(algo.get("curve") or algo.get("ellipticCurve")),
         nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
         classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
-        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
-        mode=algo.get("mode"),
-        padding=algo.get("padding"),
-        execution_environment=algo.get("executionEnvironment"),
+        crypto_functions=_str_tuple(algo.get("cryptoFunctions")),
+        mode=_str_or_none(algo.get("mode")),
+        padding=_str_or_none(algo.get("padding")),
+        execution_environment=_str_or_none(algo.get("executionEnvironment")),
         certificate=_dict_or_none(crypto.get("certificateProperties")),
         protocol=_dict_or_none(crypto.get("protocolProperties")),
         related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -1,0 +1,126 @@
+"""Derive a crypto-asset inventory (CBOM) from a CycloneDX document.
+
+CycloneDX 1.6+ represents cryptographic assets as ``components[]`` entries with
+``type == "cryptographic-asset"`` and a ``cryptoProperties`` object (algorithm /
+certificate / protocol / related-crypto-material). sbomify stores the raw
+artifact immutably in S3 and never extracts these (ADR-004), so the inventory is
+**derived on read** from the stored document — there is no separate persisted
+copy to keep in sync.
+
+``derive_crypto_inventory`` is a pure function over the parsed JSON: it filters
+the crypto-asset components and projects the PQC-relevant fields into plain
+dataclasses. It tolerates both CycloneDX 1.6 and 1.7 field spellings (1.7
+renamed ``curve`` -> ``ellipticCurve`` and added ``algorithmFamily``) and
+malformed/partial entries. It does not validate the document — callers upload
+through the schema validator; this only reads.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+CRYPTO_ASSET_TYPE = "cryptographic-asset"
+
+
+@dataclass(frozen=True)
+class CryptoAsset:
+    """One ``cryptographic-asset`` component, projected for inventory + PQC use."""
+
+    name: str | None
+    bom_ref: str | None
+    oid: str | None
+    asset_type: str | None  # algorithm | certificate | protocol | related-crypto-material
+
+    # algorithmProperties projection (the fields PQC readiness keys on)
+    primitive: str | None = None
+    algorithm_family: str | None = None  # CycloneDX 1.7
+    parameter_set: str | None = None
+    curve: str | None = None  # 1.6 "curve" / 1.7 "ellipticCurve"
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: tuple[str, ...] = ()
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+
+    # other asset-type sub-objects kept as-is (raw); less central to PQC scoring
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+    # full cryptoProperties for any downstream field this projection omits
+    raw: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CryptoInventory:
+    """The crypto assets derived from a single CycloneDX document."""
+
+    assets: tuple[CryptoAsset, ...] = ()
+
+    @property
+    def count(self) -> int:
+        return len(self.assets)
+
+    @property
+    def by_asset_type(self) -> dict[str, int]:
+        """Count of assets per ``assetType`` (entries with no assetType omitted)."""
+        return dict(Counter(a.asset_type for a in self.assets if a.asset_type))
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _project_asset(component: dict[str, Any]) -> CryptoAsset:
+    crypto = _dict_or_none(component.get("cryptoProperties")) or {}
+    algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
+    functions = algo.get("cryptoFunctions")
+    return CryptoAsset(
+        name=component.get("name"),
+        bom_ref=component.get("bom-ref"),
+        oid=crypto.get("oid") or component.get("oid"),
+        asset_type=crypto.get("assetType"),
+        primitive=algo.get("primitive"),
+        algorithm_family=algo.get("algorithmFamily"),
+        parameter_set=algo.get("parameterSetIdentifier"),
+        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
+        classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
+        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
+        mode=algo.get("mode"),
+        padding=algo.get("padding"),
+        execution_environment=algo.get("executionEnvironment"),
+        certificate=_dict_or_none(crypto.get("certificateProperties")),
+        protocol=_dict_or_none(crypto.get("protocolProperties")),
+        related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),
+        raw=crypto or None,
+    )
+
+
+def derive_crypto_inventory(sbom_json: dict[str, Any] | None) -> CryptoInventory:
+    """Project the ``cryptographic-asset`` components of a CycloneDX doc.
+
+    Returns an empty inventory for a non-dict input, a document with no
+    ``components``, or one with no crypto assets. Never raises on partial data.
+    """
+    if not isinstance(sbom_json, dict):
+        return CryptoInventory()
+    components = sbom_json.get("components")
+    if not isinstance(components, list):
+        return CryptoInventory()
+    assets = tuple(
+        _project_asset(component)
+        for component in components
+        if isinstance(component, dict) and component.get("type") == CRYPTO_ASSET_TYPE
+    )
+    return CryptoInventory(assets=assets)

--- a/sbomify/apps/sboms/schemas.py
+++ b/sbomify/apps/sboms/schemas.py
@@ -27,6 +27,8 @@ __all__ = [
     "ComponentMetaData",
     "ComponentMetaDataUpdate",
     "ComponentSupplierContactSchema",
+    "CryptoAssetSchema",
+    "CryptoInventorySchema",
     "CustomLicenseSchema",
     "CycloneDXSupportedVersion",
     "LicenseSchema",
@@ -90,6 +92,38 @@ class SBOMResponseSchema(BaseModel):
     signature_blob_key: str | None = None
     signature_type: str | None = None
     provenance_blob_key: str | None = None
+
+
+class CryptoAssetSchema(Schema):
+    """One ``cryptographic-asset`` component, projected for the CBOM inventory."""
+
+    name: str | None = None
+    bom_ref: str | None = None
+    oid: str | None = None
+    asset_type: str | None = None
+    primitive: str | None = None
+    algorithm_family: str | None = None
+    parameter_set: str | None = None
+    curve: str | None = None
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: list[str] = Field(default_factory=list)
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+
+class CryptoInventorySchema(Schema):
+    """Derived cryptographic-asset inventory (CBOM) for a single SBOM."""
+
+    sbom_id: str
+    component_id: str
+    count: int
+    by_asset_type: dict[str, int]
+    assets: list[CryptoAssetSchema]
 
 
 class DashboardSBOMUploadInfo(Schema):

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -138,7 +138,7 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
-    if raw is None:
+    if not raw:  # None or empty body == missing/corrupt artifact (matches download_sbom)
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     try:

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -144,6 +144,8 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
     try:
         document = json.loads(raw)
     except (ValueError, TypeError):
+        # ValueError covers JSONDecodeError and UnicodeDecodeError (non-UTF-8 bytes),
+        # so a corrupt artifact degrades to an empty inventory rather than a 500.
         document = None
 
     inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -11,6 +12,7 @@ from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, derive_crypto_inventory
 from sbomify.apps.sboms.models import SBOM
 
 log = logging.getLogger(__name__)
@@ -90,3 +92,67 @@ def get_sbom_detail(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[st
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_sbom(sbom))
+
+
+def _serialize_crypto_asset(asset: CryptoAsset) -> dict[str, Any]:
+    return {
+        "name": asset.name,
+        "bom_ref": asset.bom_ref,
+        "oid": asset.oid,
+        "asset_type": asset.asset_type,
+        "primitive": asset.primitive,
+        "algorithm_family": asset.algorithm_family,
+        "parameter_set": asset.parameter_set,
+        "curve": asset.curve,
+        "nist_quantum_security_level": asset.nist_quantum_security_level,
+        "classical_security_level": asset.classical_security_level,
+        "crypto_functions": list(asset.crypto_functions),
+        "mode": asset.mode,
+        "padding": asset.padding,
+        "execution_environment": asset.execution_environment,
+        "certificate": asset.certificate,
+        "protocol": asset.protocol,
+        "related_material": asset.related_material,
+    }
+
+
+def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[str, Any]]:
+    """Derive the cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Reads the immutable artifact from storage and projects its
+    ``cryptographic-asset`` components (ADR-004 — nothing is persisted or
+    mutated). Returns an empty inventory when the artifact carries no crypto
+    assets or is not a parseable CycloneDX document.
+    """
+    try:
+        sbom = SBOM.objects.select_related("component", "component__team").get(pk=sbom_id)
+    except SBOM.DoesNotExist:
+        return ServiceResult.failure("SBOM not found", status_code=404)
+
+    from sbomify.apps.core.services.access_control import check_component_access
+
+    if not check_component_access(request, sbom.component).has_access:
+        return ServiceResult.failure("Forbidden", status_code=403)
+
+    if not sbom.sbom_filename:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
+    if raw is None:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    try:
+        document = json.loads(raw)
+    except (ValueError, TypeError):
+        document = None
+
+    inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)
+    return ServiceResult.success(
+        {
+            "sbom_id": str(sbom.id),
+            "component_id": str(sbom.component.id),
+            "count": inventory.count,
+            "by_asset_type": inventory.by_asset_type,
+            "assets": [_serialize_crypto_asset(a) for a in inventory.assets],
+        }
+    )

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,0 +1,69 @@
+{% comment %}
+Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
+partial (no base template) and swapped into its own placeholder. Shows raw
+inventory facts derived from the immutable CycloneDX artifact — no post-quantum
+safe/vulnerable judgment (that is a later, separate increment).
+{% endcomment %}
+<section id="crypto-inventory-card" class="tw-card">
+    <div class="px-6 py-4 border-b border-border">
+        <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+            <i class="fas fa-lock text-primary"></i>
+            Cryptographic Assets
+            <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-border/50 text-text-muted">{{ crypto_inventory.count }}</span>
+        </h4>
+    </div>
+    <div class="p-6 space-y-6">
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            <div class="px-4 py-3 rounded-lg bg-border/30 text-center">
+                <div class="text-2xl font-bold text-text">{{ crypto_inventory.count }}</div>
+                <div class="text-xs text-text-muted uppercase tracking-wide mt-1">Total</div>
+            </div>
+            {% for asset_type, n in crypto_inventory.by_asset_type.items %}
+                <div class="px-4 py-3 rounded-lg bg-info/10 border border-info/20 text-center">
+                    <div class="text-2xl font-bold text-info">{{ n }}</div>
+                    <div class="text-xs text-info uppercase tracking-wide mt-1">{{ asset_type }}</div>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-left text-text-muted border-b border-border">
+                        <th class="py-2 pr-4 font-medium">Asset</th>
+                        <th class="py-2 pr-4 font-medium">Type</th>
+                        <th class="py-2 pr-4 font-medium">Primitive</th>
+                        <th class="py-2 pr-4 font-medium">Parameters</th>
+                        <th class="py-2 pr-4 font-medium">NIST Quantum Level</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for asset in crypto_inventory.assets %}
+                        <tr class="border-b border-border/50">
+                            <td class="py-2 pr-4 font-medium text-text">{{ asset.name|default:"—" }}</td>
+                            <td class="py-2 pr-4">
+                                <span class="tw-badge tw-badge-secondary">{{ asset.asset_type|default:"unknown" }}</span>
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">{{ asset.primitive|default:"—" }}</td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.algorithm_family %}{{ asset.algorithm_family }}{% endif %}
+                                {% if asset.parameter_set %}{{ asset.parameter_set }}{% endif %}
+                                {% if asset.curve %}· {{ asset.curve }}{% endif %}
+                                {% if not asset.algorithm_family and not asset.parameter_set and not asset.curve %}—{% endif %}
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.nist_quantum_security_level is not None %}
+                                    {{ asset.nist_quantum_security_level }}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="text-xs text-text-muted m-0">
+            Derived from the CycloneDX document. sbomify does not modify the uploaded artifact.
+        </p>
+    </div>
+</section>

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -87,3 +87,32 @@ def test_non_crypto_sbom_yields_empty_inventory():
 def test_handles_empty_or_missing_components():
     assert derive_crypto_inventory({}).count == 0
     assert derive_crypto_inventory({"components": []}).count == 0
+
+
+def test_malformed_field_types_never_raise_and_stay_schema_clean():
+    """Garbage field types must not raise (incl. by_asset_type's Counter) nor break the str|None API schema."""
+    doc = {
+        "components": [
+            {
+                "type": "cryptographic-asset",
+                "name": ["not", "a", "string"],
+                "cryptoProperties": {
+                    "assetType": {"nested": "dict"},  # unhashable -> would break Counter
+                    "algorithmProperties": {
+                        "primitive": ["list"],  # non-str on a str field
+                        "parameterSetIdentifier": 768,  # scalar -> coerced to "768"
+                        "cryptoFunctions": ["keygen", {"x": 1}],  # mixed -> only str-able kept
+                    },
+                },
+            }
+        ]
+    }
+    inv = derive_crypto_inventory(doc)
+    assert inv.count == 1
+    assert inv.by_asset_type == {}  # non-string assetType dropped, no TypeError
+    asset = inv.assets[0]
+    assert asset.asset_type is None
+    assert asset.name is None  # non-string dropped
+    assert asset.primitive is None  # list dropped
+    assert asset.parameter_set == "768"  # scalar coerced to str
+    assert all(isinstance(f, str) for f in asset.crypto_functions)

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -1,0 +1,89 @@
+"""Tests for the CBOM crypto-asset inventory derivation (#1001 increment 1)."""
+
+import json
+from pathlib import Path
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory, derive_crypto_inventory
+
+_DATA = Path(__file__).parent / "test_data"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_DATA / name).read_text())
+
+
+def _by_name(inv: CryptoInventory, name: str) -> CryptoAsset:
+    return next(a for a in inv.assets if a.name == name)
+
+
+def test_derives_crypto_assets_from_cbom_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    assert isinstance(inv, CryptoInventory)
+    # 6 cryptographic-asset components; the plain library is excluded
+    assert inv.count == 6
+    assert all(isinstance(a, CryptoAsset) for a in inv.assets)
+    assert "left-pad" not in {a.name for a in inv.assets}
+    # asset-type breakdown (algorithm x3, certificate, protocol; broken entry -> None)
+    assert inv.by_asset_type.get("algorithm") == 3
+    assert inv.by_asset_type.get("certificate") == 1
+    assert inv.by_asset_type.get("protocol") == 1
+
+
+def test_projects_algorithm_fields_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    rsa = _by_name(inv, "RSA-2048")
+    assert rsa.asset_type == "algorithm"
+    assert rsa.bom_ref == "crypto-rsa2048"
+    assert rsa.oid == "1.2.840.113549.1.1.1"
+    assert rsa.primitive == "pke"
+    assert rsa.parameter_set == "2048"
+    assert rsa.nist_quantum_security_level == 0
+    assert "encrypt" in rsa.crypto_functions
+
+    ecdsa = _by_name(inv, "ECDSA-P256")
+    assert ecdsa.primitive == "signature"
+    assert ecdsa.curve == "secp256r1"
+
+    mlkem = _by_name(inv, "ML-KEM-768")
+    assert mlkem.primitive == "kem"
+    assert mlkem.nist_quantum_security_level == 3
+
+
+def test_projects_certificate_and_protocol_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    cert = _by_name(inv, "server-cert")
+    assert cert.asset_type == "certificate"
+    assert cert.certificate and cert.certificate.get("subjectName") == "CN=demo.example.com"
+
+    proto = _by_name(inv, "TLS")
+    assert proto.asset_type == "protocol"
+    assert proto.protocol and proto.protocol.get("version") == "1.3"
+
+
+def test_tolerates_missing_crypto_properties():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    broken = _by_name(inv, "broken-entry")
+    assert broken.asset_type is None
+    assert broken.primitive is None  # no crash
+
+
+def test_1_7_field_aliases_elliptic_curve_and_family():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.7.cdx.json"))
+    assert inv.count == 2
+    ecdsa = _by_name(inv, "ECDSA-P384")
+    assert ecdsa.curve == "secp384r1"  # 1.7 uses ellipticCurve
+    assert ecdsa.algorithm_family == "ecdsa"
+    mldsa = _by_name(inv, "ML-DSA-65")
+    assert mldsa.algorithm_family == "ml-dsa"
+    assert mldsa.primitive == "signature"
+
+
+def test_non_crypto_sbom_yields_empty_inventory():
+    inv = derive_crypto_inventory(_load("sbomify_syft.cdx.json"))
+    assert inv.count == 0
+    assert inv.assets == ()
+
+
+def test_handles_empty_or_missing_components():
+    assert derive_crypto_inventory({}).count == 0
+    assert derive_crypto_inventory({"components": []}).count == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -82,3 +82,12 @@ def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFi
     _mock_s3(mocker, b"{}")
     response = Client().get(_url(sample_sbom.id))  # no session, component is private
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    # Corrupt (non-UTF-8) bytes must degrade to an empty inventory, never a 500.
+    _mock_s3(mocker, b"\xff\xfe\x00not-valid-utf8")
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.json()["count"] == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -65,8 +65,14 @@ def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa
 
 
 @pytest.mark.django_db
-def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
-    _mock_s3(mocker, None)
+@pytest.mark.parametrize("payload", [None, b""])
+def test_404_when_artifact_missing_from_storage(
+    sample_sbom: SBOM,  # noqa: F811
+    mocker: MockerFixture,
+    payload: bytes | None,
+):
+    # An empty object body is corruption/absence, not a crypto-free SBOM: 404, not an empty inventory.
+    _mock_s3(mocker, payload)
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 404
 

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -1,0 +1,78 @@
+"""API tests for the derived crypto-inventory endpoint (#1001 increment 2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _url(sbom_id: str) -> str:
+    return reverse("api-1:get_sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_returns_derived_crypto_inventory(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sbom_id"] == sample_sbom.id
+    assert body["count"] == 6
+    assert body["by_asset_type"]["algorithm"] == 3
+    names = {a["name"] for a in body["assets"]}
+    assert "RSA-2048" in names
+    assert "left-pad" not in names  # plain library excluded
+
+
+@pytest.mark.django_db
+def test_empty_inventory_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_url("doesnotexist1"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, None)
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = Client().get(_url(sample_sbom.id))  # no session, component is private
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
@@ -1,0 +1,102 @@
+"""Tests for the lazy-loaded crypto-inventory UI card (#1001 increment 3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM, Component
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _card_url(sbom_id: str) -> str:
+    return reverse("sboms:sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_card_renders_for_cbom_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Cryptographic Assets" in html
+    assert "RSA-2048" in html  # an algorithm asset name
+    assert "ML-KEM-768" in html
+    assert "left-pad" not in html  # plain library excluded
+    # raw NIST quantum level shown verbatim, including 0 (not hidden as falsy)
+    assert "algorithm" in html  # asset-type breakdown label
+
+
+@pytest.mark.django_db
+def test_card_is_a_partial_not_a_full_page(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    html = _owner_client(sample_sbom).get(_card_url(sample_sbom.id)).content.decode()
+    assert "<html" not in html.lower()
+    assert "<!doctype" not in html.lower()
+
+
+@pytest.mark.django_db
+def test_card_empty_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""  # nothing to show -> placeholder collapses
+
+
+@pytest.mark.django_db
+def test_card_empty_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_card_url("doesnotexist1"))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""
+
+
+@pytest.mark.django_db
+def test_card_does_not_leak_private_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))  # anon, component is private
+    assert response.status_code == 200
+    assert "RSA-2048" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_card_visible_on_public_component_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    sample_sbom.component.visibility = Component.Visibility.PUBLIC
+    sample_sbom.component.save()
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert "RSA-2048" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_item_page_wires_lazy_placeholder(sample_sbom: SBOM):  # noqa: F811
+    """The SBOM item detail page lazy-loads the card via hx-get (no S3 read at page render)."""
+    client = _owner_client(sample_sbom)
+    item_url = reverse("core:component_item", args=[sample_sbom.component.id, "sboms", sample_sbom.id])
+    response = client.get(item_url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert _card_url(sample_sbom.id) in html
+    assert 'hx-trigger="load"' in html

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
@@ -1,0 +1,35 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "1.0"}},
+  "components": [
+    {"type": "library", "name": "left-pad", "version": "1.3.0", "bom-ref": "lib-leftpad"},
+    {
+      "type": "cryptographic-asset", "name": "RSA-2048", "bom-ref": "crypto-rsa2048",
+      "cryptoProperties": {"assetType": "algorithm", "oid": "1.2.840.113549.1.1.1",
+        "algorithmProperties": {"primitive": "pke", "parameterSetIdentifier": "2048", "classicalSecurityLevel": 112, "nistQuantumSecurityLevel": 0, "cryptoFunctions": ["encrypt", "decrypt"]}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P256", "bom-ref": "crypto-ecdsa",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "curve": "secp256r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-KEM-768", "bom-ref": "crypto-mlkem",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "kem", "parameterSetIdentifier": "768", "nistQuantumSecurityLevel": 3}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "server-cert", "bom-ref": "crypto-cert",
+      "cryptoProperties": {"assetType": "certificate",
+        "certificateProperties": {"subjectName": "CN=demo.example.com", "issuerName": "CN=Demo CA", "certificateFormat": "X.509"}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "TLS", "bom-ref": "crypto-tls",
+      "cryptoProperties": {"assetType": "protocol",
+        "protocolProperties": {"type": "tls", "version": "1.3"}}
+    },
+    {"type": "cryptographic-asset", "name": "broken-entry", "bom-ref": "crypto-broken"}
+  ]
+}

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
@@ -1,0 +1,18 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "2.0"}},
+  "components": [
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P384", "bom-ref": "c-ecdsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ecdsa", "ellipticCurve": "secp384r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-DSA-65", "bom-ref": "c-mldsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ml-dsa", "parameterSetIdentifier": "65", "nistQuantumSecurityLevel": 3}}
+    }
+  ]
+}

--- a/sbomify/apps/sboms/urls.py
+++ b/sbomify/apps/sboms/urls.py
@@ -2,7 +2,12 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 from django.views.generic import RedirectView
 
-from sbomify.apps.sboms.views import SbomDownloadView, SbomsTableView, SbomVulnerabilitiesView
+from sbomify.apps.sboms.views import (
+    SbomCryptoInventoryView,
+    SbomDownloadView,
+    SbomsTableView,
+    SbomVulnerabilitiesView,
+)
 
 app_name = "sboms"
 urlpatterns: list[URLPattern] = [
@@ -66,5 +71,10 @@ urlpatterns: list[URLPattern] = [
         SbomsTableView.as_view(),
         name="sboms_table_public",
         kwargs={"is_public_view": True},
+    ),
+    path(
+        "sbom/<str:sbom_id>/crypto-inventory",
+        SbomCryptoInventoryView.as_view(),
+        name="sbom_crypto_inventory",
     ),
 ]

--- a/sbomify/apps/sboms/views/__init__.py
+++ b/sbomify/apps/sboms/views/__init__.py
@@ -1,9 +1,11 @@
+from sbomify.apps.sboms.views.sbom_crypto_inventory import SbomCryptoInventoryView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_download import SbomDownloadView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_upload_cyclonedx import SbomUploadCycloneDxView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_vulnerabilities import SbomVulnerabilitiesView  # noqa: F401
 from sbomify.apps.sboms.views.sboms_table import SbomsTableView  # noqa: F401
 
 __all__ = [
+    "SbomCryptoInventoryView",
     "SbomDownloadView",
     "SbomUploadCycloneDxView",
     "SbomVulnerabilitiesView",

--- a/sbomify/apps/sboms/views/sbom_crypto_inventory.py
+++ b/sbomify/apps/sboms/views/sbom_crypto_inventory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+
+from sbomify.apps.sboms.services.sboms import get_crypto_inventory
+
+CARD_TEMPLATE = "sboms/components/crypto_inventory_card.html.j2"
+
+
+class SbomCryptoInventoryView(View):
+    """Lazy-loaded (hx-get) crypto-asset inventory card for one SBOM.
+
+    Rendered as an HTMX partial so the per-SBOM artifact read does not block the
+    detail-page render. Authorization is delegated to ``get_crypto_inventory``
+    (the same ``check_component_access`` used by the other SBOM read paths), so
+    the card works on both the private and public item pages without a login
+    mixin. Any failure or an empty inventory renders nothing — with
+    ``hx-swap="outerHTML"`` the placeholder simply collapses, never leaking
+    existence or erroring on an ordinary (non-crypto) SBOM.
+    """
+
+    def get(self, request: HttpRequest, sbom_id: str) -> HttpResponse:
+        result = get_crypto_inventory(request, sbom_id)
+        if not result.ok or not (result.value or {}).get("count"):
+            return HttpResponse("")
+        return render(request, CARD_TEMPLATE, {"crypto_inventory": result.value})


### PR DESCRIPTION
## Summary

First three increments of the CBOM epic (#1001): make the cryptographic assets that already pass through CycloneDX 1.6/1.7 uploads **visible** — in the API and in the UI — without touching the stored artifact.

CycloneDX 1.6+ represents crypto assets as `components[]` entries with `type == "cryptographic-asset"` and a `cryptoProperties` object (algorithm / certificate / protocol / related-crypto-material). sbomify ingests and stores these immutably but never surfaces them — so the inventory is **derived on read** from the stored document. No migration, no backfill, no second copy to keep in sync (ADR-004).

## What's in this PR

**Increment 1 — pure derivation (`crypto_inventory.py`)**
- `derive_crypto_inventory(sbom_json) -> CryptoInventory`: a pure projection over a parsed CycloneDX document into plain dataclasses (`CryptoAsset`, `CryptoInventory`).
- Projects the PQC-relevant `algorithmProperties` fields (primitive, parameter set, curve, `nistQuantumSecurityLevel`, etc.) plus certificate/protocol/related-material sub-objects.
- Tolerates both CycloneDX **1.6 and 1.7** spellings (`curve` → `ellipticCurve`, new `algorithmFamily`) and malformed/partial entries. Never raises on bad data.

**Increment 2 — read endpoint**
- `GET /api/v1/sboms/{sbom_id}/crypto-inventory` → `CryptoInventorySchema` (count, `by_asset_type` breakdown, projected assets).
- Loads the immutable artifact via a `get_crypto_inventory` service, reusing the **same access control** as the other SBOM read endpoints (public / gated / private).
- Non-crypto SBOMs return an empty inventory; a missing/empty artifact body returns 404 (not a silently-empty inventory — per Copilot review).

**Increment 3 — UI card**
- A per-SBOM **Cryptographic Assets** card on the private and public SBOM item detail pages.
- **HTMX-lazy** (`hx-get` + `hx-trigger="load"`): the per-SBOM artifact read happens *after* page render, and the placeholder collapses to nothing when an SBOM has no crypto assets — so ordinary (non-crypto) SBOMs are visually unaffected and the page render is never blocked on an S3 read.
- Authorization is delegated to `get_crypto_inventory`'s `check_component_access`, so the **same** lazy view serves authenticated and public viewers.
- Shows **raw inventory facts only** (asset name, type, primitive, parameters, raw `nistQuantumSecurityLevel`) — deliberately **no** safe/vulnerable PQC judgment yet (that's increment 4, below).

## Tests

- `test_crypto_inventory.py` — 8 unit tests over new CBOM 1.6/1.7 fixtures (field projection, 1.6/1.7 aliasing, asset-type breakdown, library exclusion, malformed-entry tolerance, empty/non-crypto docs).
- `test_crypto_inventory_api.py` — 6 endpoint tests (derived inventory, empty for non-crypto, 404 unknown / missing / empty-body, 403 private-without-access).
- `test_crypto_inventory_card.py` — 7 card tests (renders for CBOM, is a partial not a full page, collapses for non-crypto / unknown, no private leak to anon, visible on public component, item page wires the lazy placeholder).
- Full `sboms` suite green (417 passed); ruff + mypy + djlint clean.

## Not in scope (later increments — some need product sign-off)

- **Increment 4** — PQC classification module (algorithm → quantum-safe / vulnerable) + readiness scoring. The gray zones (AES-128, SHA-256, Falcon) and "what counts as ready" need a product decision; the standard to cite is likely NIST IR 8547.
- **Increment 5** — PQC-readiness assessment plugin.
- **Increment 6** — CRA / trust-center surfacing.

Part of #1001.
