### PR TITLE
feat(cbom): NIST-grounded PQC readiness classification (#1001, stacked on #1030)

### DIFF
--- a/sbomify/apps/core/templates/core/component_item.html.j2
+++ b/sbomify/apps/core/templates/core/component_item.html.j2
@@ -197,6 +197,10 @@
                     </div>
                 </div>
             {% endif %}
+            {# Cryptographic Assets (CBOM) — lazy-loaded; collapses when there are none #}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
             {# Assessment Results Section #}
             {% if assessment_runs %}
                 <div>

--- a/sbomify/apps/core/templates/core/component_item_public.html.j2
+++ b/sbomify/apps/core/templates/core/component_item_public.html.j2
@@ -111,6 +111,12 @@
                 </a>
             </div>
         </div>
+        {# Cryptographic Assets (CBOM) — lazy-loaded for SBOM artifacts; collapses when there are none #}
+        {% if component.component_type == 'bom' %}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
+        {% endif %}
     </div>
 {% endblock %}
 {% block scripts %}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -36,6 +36,7 @@ from sbomify.apps.teams.models import ContactProfile
 from .models import SBOM, Component, Product
 from .schemas import (
     ComponentMetaData,
+    CryptoInventorySchema,
     CycloneDXSupportedVersion,
     SBOMResponseSchema,
     SBOMUploadRequest,
@@ -52,7 +53,7 @@ from .schemas import (
     validate_cyclonedx_sbom,
     validate_spdx_sbom,
 )
-from .services.sboms import delete_sbom_record, get_sbom_detail
+from .services.sboms import delete_sbom_record, get_crypto_inventory, get_sbom_detail
 
 log = logging.getLogger(__name__)
 
@@ -727,6 +728,24 @@ def get_cyclonedx_component_metadata(
 def get_sbom(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
     """Get a specific SBOM by ID."""
     result = get_sbom_detail(request, sbom_id)
+    if not result.ok:
+        return result.status_code or 400, {"detail": result.error or "Invalid request"}
+
+    return 200, result.value or {}
+
+
+@router.get(
+    "/{sbom_id}/crypto-inventory",
+    response={200: CryptoInventorySchema, 403: ErrorResponse, 404: ErrorResponse},
+    auth=None,  # Allow unauthenticated access for public SBOMs
+)
+def get_sbom_crypto_inventory(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
+    """Return the derived cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Projects the ``cryptographic-asset`` components of the stored CycloneDX
+    artifact. Non-crypto SBOMs return an empty inventory rather than an error.
+    """
+    result = get_crypto_inventory(request, sbom_id)
     if not result.ok:
         return result.status_code or 400, {"detail": result.error or "Invalid request"}
 

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -81,25 +81,45 @@ def _dict_or_none(value: Any) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Coerce a CycloneDX scalar to ``str`` (keep hashable, schema-clean).
+
+    A spec-conformant value is already a string. A scalar (int/float/bool) is
+    stringified so data is not lost. Anything else (dict/list) is dropped to
+    ``None`` — it would be unhashable for ``by_asset_type`` and would violate the
+    ``str | None`` API schema, both of which the module promises never to raise on.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):  # bool is an int subclass — fine
+        return str(value)
+    return None
+
+
+def _str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(v) for v in value if isinstance(v, (str, int, float)))
+
+
 def _project_asset(component: dict[str, Any]) -> CryptoAsset:
     crypto = _dict_or_none(component.get("cryptoProperties")) or {}
     algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
-    functions = algo.get("cryptoFunctions")
     return CryptoAsset(
-        name=component.get("name"),
-        bom_ref=component.get("bom-ref"),
-        oid=crypto.get("oid") or component.get("oid"),
-        asset_type=crypto.get("assetType"),
-        primitive=algo.get("primitive"),
-        algorithm_family=algo.get("algorithmFamily"),
-        parameter_set=algo.get("parameterSetIdentifier"),
-        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        name=_str_or_none(component.get("name")),
+        bom_ref=_str_or_none(component.get("bom-ref")),
+        oid=_str_or_none(crypto.get("oid") or component.get("oid")),
+        asset_type=_str_or_none(crypto.get("assetType")),
+        primitive=_str_or_none(algo.get("primitive")),
+        algorithm_family=_str_or_none(algo.get("algorithmFamily")),
+        parameter_set=_str_or_none(algo.get("parameterSetIdentifier")),
+        curve=_str_or_none(algo.get("curve") or algo.get("ellipticCurve")),
         nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
         classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
-        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
-        mode=algo.get("mode"),
-        padding=algo.get("padding"),
-        execution_environment=algo.get("executionEnvironment"),
+        crypto_functions=_str_tuple(algo.get("cryptoFunctions")),
+        mode=_str_or_none(algo.get("mode")),
+        padding=_str_or_none(algo.get("padding")),
+        execution_environment=_str_or_none(algo.get("executionEnvironment")),
         certificate=_dict_or_none(crypto.get("certificateProperties")),
         protocol=_dict_or_none(crypto.get("protocolProperties")),
         related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -1,0 +1,126 @@
+"""Derive a crypto-asset inventory (CBOM) from a CycloneDX document.
+
+CycloneDX 1.6+ represents cryptographic assets as ``components[]`` entries with
+``type == "cryptographic-asset"`` and a ``cryptoProperties`` object (algorithm /
+certificate / protocol / related-crypto-material). sbomify stores the raw
+artifact immutably in S3 and never extracts these (ADR-004), so the inventory is
+**derived on read** from the stored document — there is no separate persisted
+copy to keep in sync.
+
+``derive_crypto_inventory`` is a pure function over the parsed JSON: it filters
+the crypto-asset components and projects the PQC-relevant fields into plain
+dataclasses. It tolerates both CycloneDX 1.6 and 1.7 field spellings (1.7
+renamed ``curve`` -> ``ellipticCurve`` and added ``algorithmFamily``) and
+malformed/partial entries. It does not validate the document — callers upload
+through the schema validator; this only reads.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+CRYPTO_ASSET_TYPE = "cryptographic-asset"
+
+
+@dataclass(frozen=True)
+class CryptoAsset:
+    """One ``cryptographic-asset`` component, projected for inventory + PQC use."""
+
+    name: str | None
+    bom_ref: str | None
+    oid: str | None
+    asset_type: str | None  # algorithm | certificate | protocol | related-crypto-material
+
+    # algorithmProperties projection (the fields PQC readiness keys on)
+    primitive: str | None = None
+    algorithm_family: str | None = None  # CycloneDX 1.7
+    parameter_set: str | None = None
+    curve: str | None = None  # 1.6 "curve" / 1.7 "ellipticCurve"
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: tuple[str, ...] = ()
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+
+    # other asset-type sub-objects kept as-is (raw); less central to PQC scoring
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+    # full cryptoProperties for any downstream field this projection omits
+    raw: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CryptoInventory:
+    """The crypto assets derived from a single CycloneDX document."""
+
+    assets: tuple[CryptoAsset, ...] = ()
+
+    @property
+    def count(self) -> int:
+        return len(self.assets)
+
+    @property
+    def by_asset_type(self) -> dict[str, int]:
+        """Count of assets per ``assetType`` (entries with no assetType omitted)."""
+        return dict(Counter(a.asset_type for a in self.assets if a.asset_type))
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _project_asset(component: dict[str, Any]) -> CryptoAsset:
+    crypto = _dict_or_none(component.get("cryptoProperties")) or {}
+    algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
+    functions = algo.get("cryptoFunctions")
+    return CryptoAsset(
+        name=component.get("name"),
+        bom_ref=component.get("bom-ref"),
+        oid=crypto.get("oid") or component.get("oid"),
+        asset_type=crypto.get("assetType"),
+        primitive=algo.get("primitive"),
+        algorithm_family=algo.get("algorithmFamily"),
+        parameter_set=algo.get("parameterSetIdentifier"),
+        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
+        classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
+        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
+        mode=algo.get("mode"),
+        padding=algo.get("padding"),
+        execution_environment=algo.get("executionEnvironment"),
+        certificate=_dict_or_none(crypto.get("certificateProperties")),
+        protocol=_dict_or_none(crypto.get("protocolProperties")),
+        related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),
+        raw=crypto or None,
+    )
+
+
+def derive_crypto_inventory(sbom_json: dict[str, Any] | None) -> CryptoInventory:
+    """Project the ``cryptographic-asset`` components of a CycloneDX doc.
+
+    Returns an empty inventory for a non-dict input, a document with no
+    ``components``, or one with no crypto assets. Never raises on partial data.
+    """
+    if not isinstance(sbom_json, dict):
+        return CryptoInventory()
+    components = sbom_json.get("components")
+    if not isinstance(components, list):
+        return CryptoInventory()
+    assets = tuple(
+        _project_asset(component)
+        for component in components
+        if isinstance(component, dict) and component.get("type") == CRYPTO_ASSET_TYPE
+    )
+    return CryptoInventory(assets=assets)

--- a/sbomify/apps/sboms/pqc.py
+++ b/sbomify/apps/sboms/pqc.py
@@ -1,0 +1,228 @@
+"""Post-quantum (PQC) readiness classification for crypto assets.
+
+Classifies a :class:`~sbomify.apps.sboms.crypto_inventory.CryptoAsset` as
+quantum-safe, quantum-vulnerable, needs-review, or unknown, and aggregates an
+inventory into an overall readiness verdict.
+
+The table is grounded in NIST guidance — FIPS 203 (ML-KEM), 204 (ML-DSA),
+205 (SLH-DSA), draft 206 (FN-DSA/Falcon), NIST IR 8547, and NSA CNSA 2.0 — and
+was adversarially verified. Notable, sometimes counter-intuitive, rules:
+
+- Standardized PQC (ML-KEM/ML-DSA/SLH-DSA, incl. legacy names Kyber/Dilithium/
+  SPHINCS+) is SAFE. Selected-but-not-yet-finalized PQC (FN-DSA/Falcon, HQC) and
+  stateful special-use schemes (XMSS/LMS) are REVIEW.
+- Shor-breakable public-key crypto (RSA, DSA, DH, ECDH, ECDSA, EdDSA incl.
+  Ed25519/Ed448, X25519/X448, ElGamal, any EC) is VULNERABLE.
+- Symmetric/hash are only Grover-weakened, not broken: AES-192/256, ChaCha20,
+  SHA-256/384/512, SHA-3 are SAFE; **SHA-256 is SAFE — Grover does not attack
+  collision resistance and NIST keeps SHA-2 approved**. AES-128 (~64-bit
+  post-Grover), 3DES (withdrawn; legacy-decrypt only) and bare/unsized symmetric
+  are REVIEW. MD5/SHA-1 are classically broken -> REVIEW.
+- ``nistQuantumSecurityLevel`` is a NIST *strength-category floor*, not a
+  quantum-safe flag. Algorithm identity decides the verdict; the declared level
+  only raises a ``data_quality_flag`` when it looks mislabeled, and never on its
+  own asserts SAFE for an unrecognized algorithm.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory
+
+
+class PqcStatus(str, Enum):
+    SAFE = "quantum_safe"
+    VULNERABLE = "quantum_vulnerable"
+    REVIEW = "review"
+    UNKNOWN = "unknown"
+
+
+# Overall inventory readiness verdicts.
+OVERALL_AT_RISK = "at_risk"
+OVERALL_NEEDS_REVIEW = "needs_review"
+OVERALL_READY = "ready"
+OVERALL_NOT_ASSESSED = "not_assessed"
+
+
+@dataclass(frozen=True)
+class PqcAssessment:
+    status: PqcStatus
+    family: str | None
+    reason: str
+    data_quality_flag: str | None = None
+
+
+@dataclass(frozen=True)
+class PqcResult:
+    asset: CryptoAsset
+    assessment: PqcAssessment
+
+
+@dataclass(frozen=True)
+class PqcSummary:
+    overall: str
+    counts: dict[str, int]
+    results: tuple[PqcResult, ...]
+
+
+# Substrings distinctive enough to match once the PQC families have been ruled
+# out first (e.g. "dsa" here only reaches ECDSA/DSA/EdDSA, since ML-DSA/SLH-DSA/
+# FN-DSA are matched earlier).
+_VULNERABLE_SUBSTRINGS = (
+    "rsa",
+    "ecdsa",
+    "eddsa",
+    "ed25519",
+    "ed448",
+    "ecdh",
+    "x25519",
+    "x448",
+    "elgamal",
+    "ecmqv",
+    "ecies",
+    "diffie",
+    "hellman",
+    "ffdh",
+    "dsa",
+    "secp",
+    "sect",
+    "brainpool",
+    "prime256v1",
+    "curve25519",
+    "curve448",
+    "nistp",
+)
+# Short tokens matched whole to avoid false positives.
+_VULNERABLE_TOKENS = frozenset({"dh", "dhe", "ec", "ecc", "mqv", "p-256", "p-384", "p-521", "p256", "p384", "p521"})
+
+_PQC_SAFE_SUBSTRINGS = ("ml-kem", "mlkem", "kyber", "ml-dsa", "mldsa", "dilithium", "slh-dsa", "slhdsa", "sphincs")
+# PQC-adjacent but not a finalized FIPS standard, or stateful special-use.
+_PQC_REVIEW_SUBSTRINGS = (
+    "fn-dsa",
+    "falcon",
+    "hqc",
+    "bike",
+    "mceliece",
+    "frodo",
+    "ntru",
+    "saber",
+    "xmss",
+    "lms",
+    "hss",
+)
+
+
+def _haystack(asset: CryptoAsset) -> str:
+    parts = [asset.name, asset.algorithm_family, asset.curve]
+    return " ".join(p for p in parts if isinstance(p, str)).lower()
+
+
+def _tokens(haystack: str) -> set[str]:
+    return set(re.split(r"[^a-z0-9]+", haystack))
+
+
+def _classify_symmetric_or_hash(hay: str) -> tuple[PqcStatus, str, str] | None:
+    """Symmetric ciphers and hashes (Grover-weakened, not Shor-broken), or None."""
+    if "md5" in hay or re.search(r"sha-?1(?![0-9])", hay):
+        return PqcStatus.REVIEW, "broken-hash", "Classically broken (collisions) — remediate regardless of quantum"
+    if any(t in hay for t in ("3des", "triple-des", "tripledes", "tdea", "des-ede", "des3")):
+        return PqcStatus.REVIEW, "3DES", "Withdrawn (SP 800-67); legacy decrypt only — review usage"
+    if "aes" in hay:
+        if "256" in hay or "192" in hay:
+            return PqcStatus.SAFE, "AES", "Grover-resistant at >=192-bit keys"
+        if "128" in hay:
+            return PqcStatus.REVIEW, "AES-128", "~64-bit post-Grover; below the CNSA 2.0 256-bit bar — review"
+        return PqcStatus.REVIEW, "AES", "Key size unspecified — AES-128 and AES-256 differ; review"
+    if "chacha" in hay:
+        return PqcStatus.SAFE, "ChaCha20", "256-bit stream cipher, Grover-resistant"
+    if re.search(r"\bdes\b", hay):
+        return PqcStatus.REVIEW, "DES", "56-bit — broken; remediate"
+    if any(t in hay for t in ("sha-512", "sha512", "sha-384", "sha384", "sha3-512", "sha3-384", "shake256")):
+        return PqcStatus.SAFE, "SHA-2/3", "Grover-resistant digest (>=384-bit)"
+    if any(t in hay for t in ("sha-256", "sha256", "sha3-256", "shake128", "sha-224", "sha224")):
+        # SHA-256 is SAFE: Grover does not speed up collision search and NIST keeps SHA-2 approved.
+        return PqcStatus.SAFE, "SHA-256", "Grover leaves ~128-bit; NIST keeps SHA-2 approved"
+    return None
+
+
+def _classify_identity(hay: str, tokens: set[str]) -> tuple[PqcStatus, str | None, str, bool]:
+    """Return ``(status, family, reason, is_pqc_safe_family)`` from algorithm identity."""
+    if any(s in hay for s in _PQC_SAFE_SUBSTRINGS):
+        return PqcStatus.SAFE, "PQC", "Standardized post-quantum algorithm (FIPS 203/204/205)", True
+    if any(s in hay for s in _PQC_REVIEW_SUBSTRINGS):
+        return PqcStatus.REVIEW, "PQC-candidate", "Selected/stateful PQC, not a finalized FIPS standard — review", False
+    if any(s in hay for s in _VULNERABLE_SUBSTRINGS) or (tokens & _VULNERABLE_TOKENS):
+        return (
+            PqcStatus.VULNERABLE,
+            "classical-asymmetric",
+            "Broken by Shor's algorithm (factoring / discrete log)",
+            False,
+        )
+    sym = _classify_symmetric_or_hash(hay)
+    if sym is not None:
+        status, family, reason = sym
+        return status, family, reason, False
+    return PqcStatus.UNKNOWN, None, "Algorithm not recognized", False
+
+
+def classify_crypto_asset(asset: CryptoAsset) -> PqcAssessment:
+    """Classify one crypto asset's post-quantum status from its identity.
+
+    Algorithm identity (name / algorithmFamily / curve) decides the verdict.
+    ``nistQuantumSecurityLevel`` is used only as a corroborating signal: it
+    promotes an otherwise-unrecognized asset to ``review`` (never ``safe``) and
+    raises a data-quality flag when it conflicts with the identity verdict.
+    """
+    hay = _haystack(asset)
+    tokens = _tokens(hay)
+    status, family, reason, is_pqc_safe = _classify_identity(hay, tokens)
+
+    level = asset.nist_quantum_security_level
+
+    if status is PqcStatus.UNKNOWN and level is not None and level >= 1:
+        return PqcAssessment(
+            status=PqcStatus.REVIEW,
+            family=family,
+            reason="Declares a NIST PQC security category but the algorithm is unrecognized — review",
+        )
+
+    data_quality_flag = None
+    if status is PqcStatus.VULNERABLE and level is not None and level >= 1:
+        data_quality_flag = (
+            f"Declares nistQuantumSecurityLevel {level} on a quantum-vulnerable algorithm — likely mislabeled"
+        )
+    elif status is PqcStatus.SAFE and is_pqc_safe and level == 0:
+        data_quality_flag = "PQC algorithm declares nistQuantumSecurityLevel 0 — likely mislabeled"
+
+    return PqcAssessment(status=status, family=family, reason=reason, data_quality_flag=data_quality_flag)
+
+
+def assess_inventory(inventory: CryptoInventory) -> PqcSummary:
+    """Classify every asset and roll up to an overall readiness verdict.
+
+    Overall (conservative, most-severe-wins): any vulnerable -> ``at_risk``;
+    else any review, or any *algorithm* asset we could not classify ->
+    ``needs_review``; else any safe -> ``ready``; else ``not_assessed``.
+    """
+    results = tuple(PqcResult(asset, classify_crypto_asset(asset)) for asset in inventory.assets)
+    counts = {status.value: 0 for status in PqcStatus}
+    for result in results:
+        counts[result.assessment.status.value] += 1
+
+    unclassified_algorithms = sum(
+        1 for r in results if r.assessment.status is PqcStatus.UNKNOWN and r.asset.asset_type == "algorithm"
+    )
+
+    if counts[PqcStatus.VULNERABLE.value]:
+        overall = OVERALL_AT_RISK
+    elif counts[PqcStatus.REVIEW.value] or unclassified_algorithms:
+        overall = OVERALL_NEEDS_REVIEW
+    elif counts[PqcStatus.SAFE.value]:
+        overall = OVERALL_READY
+    else:
+        overall = OVERALL_NOT_ASSESSED
+
+    return PqcSummary(overall=overall, counts=counts, results=results)

--- a/sbomify/apps/sboms/schemas.py
+++ b/sbomify/apps/sboms/schemas.py
@@ -114,6 +114,9 @@ class CryptoAssetSchema(Schema):
     certificate: dict[str, Any] | None = None
     protocol: dict[str, Any] | None = None
     related_material: dict[str, Any] | None = None
+    pqc_status: str | None = None
+    pqc_reason: str | None = None
+    pqc_data_quality_flag: str | None = None
 
 
 class CryptoInventorySchema(Schema):
@@ -123,6 +126,8 @@ class CryptoInventorySchema(Schema):
     component_id: str
     count: int
     by_asset_type: dict[str, int]
+    pqc_overall: str
+    pqc_counts: dict[str, int]
     assets: list[CryptoAssetSchema]
 
 

--- a/sbomify/apps/sboms/schemas.py
+++ b/sbomify/apps/sboms/schemas.py
@@ -27,6 +27,8 @@ __all__ = [
     "ComponentMetaData",
     "ComponentMetaDataUpdate",
     "ComponentSupplierContactSchema",
+    "CryptoAssetSchema",
+    "CryptoInventorySchema",
     "CustomLicenseSchema",
     "CycloneDXSupportedVersion",
     "LicenseSchema",
@@ -90,6 +92,38 @@ class SBOMResponseSchema(BaseModel):
     signature_blob_key: str | None = None
     signature_type: str | None = None
     provenance_blob_key: str | None = None
+
+
+class CryptoAssetSchema(Schema):
+    """One ``cryptographic-asset`` component, projected for the CBOM inventory."""
+
+    name: str | None = None
+    bom_ref: str | None = None
+    oid: str | None = None
+    asset_type: str | None = None
+    primitive: str | None = None
+    algorithm_family: str | None = None
+    parameter_set: str | None = None
+    curve: str | None = None
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: list[str] = Field(default_factory=list)
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+
+class CryptoInventorySchema(Schema):
+    """Derived cryptographic-asset inventory (CBOM) for a single SBOM."""
+
+    sbom_id: str
+    component_id: str
+    count: int
+    by_asset_type: dict[str, int]
+    assets: list[CryptoAssetSchema]
 
 
 class DashboardSBOMUploadInfo(Schema):

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -14,6 +14,7 @@ from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace
 from sbomify.apps.sboms.crypto_inventory import CryptoAsset, derive_crypto_inventory
 from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.pqc import assess_inventory
 
 log = logging.getLogger(__name__)
 
@@ -149,12 +150,23 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
         document = None
 
     inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)
+    summary = assess_inventory(inventory)
     return ServiceResult.success(
         {
             "sbom_id": str(sbom.id),
             "component_id": str(sbom.component.id),
             "count": inventory.count,
             "by_asset_type": inventory.by_asset_type,
-            "assets": [_serialize_crypto_asset(a) for a in inventory.assets],
+            "pqc_overall": summary.overall,
+            "pqc_counts": summary.counts,
+            "assets": [
+                {
+                    **_serialize_crypto_asset(result.asset),
+                    "pqc_status": result.assessment.status.value,
+                    "pqc_reason": result.assessment.reason,
+                    "pqc_data_quality_flag": result.assessment.data_quality_flag,
+                }
+                for result in summary.results
+            ],
         }
     )

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -138,7 +138,7 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
-    if raw is None:
+    if not raw:  # None or empty body == missing/corrupt artifact (matches download_sbom)
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     try:

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -144,6 +144,8 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
     try:
         document = json.loads(raw)
     except (ValueError, TypeError):
+        # ValueError covers JSONDecodeError and UnicodeDecodeError (non-UTF-8 bytes),
+        # so a corrupt artifact degrades to an empty inventory rather than a 500.
         document = None
 
     inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -11,6 +12,7 @@ from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, derive_crypto_inventory
 from sbomify.apps.sboms.models import SBOM
 
 log = logging.getLogger(__name__)
@@ -90,3 +92,67 @@ def get_sbom_detail(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[st
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_sbom(sbom))
+
+
+def _serialize_crypto_asset(asset: CryptoAsset) -> dict[str, Any]:
+    return {
+        "name": asset.name,
+        "bom_ref": asset.bom_ref,
+        "oid": asset.oid,
+        "asset_type": asset.asset_type,
+        "primitive": asset.primitive,
+        "algorithm_family": asset.algorithm_family,
+        "parameter_set": asset.parameter_set,
+        "curve": asset.curve,
+        "nist_quantum_security_level": asset.nist_quantum_security_level,
+        "classical_security_level": asset.classical_security_level,
+        "crypto_functions": list(asset.crypto_functions),
+        "mode": asset.mode,
+        "padding": asset.padding,
+        "execution_environment": asset.execution_environment,
+        "certificate": asset.certificate,
+        "protocol": asset.protocol,
+        "related_material": asset.related_material,
+    }
+
+
+def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[str, Any]]:
+    """Derive the cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Reads the immutable artifact from storage and projects its
+    ``cryptographic-asset`` components (ADR-004 — nothing is persisted or
+    mutated). Returns an empty inventory when the artifact carries no crypto
+    assets or is not a parseable CycloneDX document.
+    """
+    try:
+        sbom = SBOM.objects.select_related("component", "component__team").get(pk=sbom_id)
+    except SBOM.DoesNotExist:
+        return ServiceResult.failure("SBOM not found", status_code=404)
+
+    from sbomify.apps.core.services.access_control import check_component_access
+
+    if not check_component_access(request, sbom.component).has_access:
+        return ServiceResult.failure("Forbidden", status_code=403)
+
+    if not sbom.sbom_filename:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
+    if raw is None:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    try:
+        document = json.loads(raw)
+    except (ValueError, TypeError):
+        document = None
+
+    inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)
+    return ServiceResult.success(
+        {
+            "sbom_id": str(sbom.id),
+            "component_id": str(sbom.component.id),
+            "count": inventory.count,
+            "by_asset_type": inventory.by_asset_type,
+            "assets": [_serialize_crypto_asset(a) for a in inventory.assets],
+        }
+    )

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,0 +1,69 @@
+{% comment %}
+Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
+partial (no base template) and swapped into its own placeholder. Shows raw
+inventory facts derived from the immutable CycloneDX artifact — no post-quantum
+safe/vulnerable judgment (that is a later, separate increment).
+{% endcomment %}
+<section id="crypto-inventory-card" class="tw-card">
+    <div class="px-6 py-4 border-b border-border">
+        <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+            <i class="fas fa-lock text-primary"></i>
+            Cryptographic Assets
+            <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-border/50 text-text-muted">{{ crypto_inventory.count }}</span>
+        </h4>
+    </div>
+    <div class="p-6 space-y-6">
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            <div class="px-4 py-3 rounded-lg bg-border/30 text-center">
+                <div class="text-2xl font-bold text-text">{{ crypto_inventory.count }}</div>
+                <div class="text-xs text-text-muted uppercase tracking-wide mt-1">Total</div>
+            </div>
+            {% for asset_type, n in crypto_inventory.by_asset_type.items %}
+                <div class="px-4 py-3 rounded-lg bg-info/10 border border-info/20 text-center">
+                    <div class="text-2xl font-bold text-info">{{ n }}</div>
+                    <div class="text-xs text-info uppercase tracking-wide mt-1">{{ asset_type }}</div>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-left text-text-muted border-b border-border">
+                        <th class="py-2 pr-4 font-medium">Asset</th>
+                        <th class="py-2 pr-4 font-medium">Type</th>
+                        <th class="py-2 pr-4 font-medium">Primitive</th>
+                        <th class="py-2 pr-4 font-medium">Parameters</th>
+                        <th class="py-2 pr-4 font-medium">NIST Quantum Level</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for asset in crypto_inventory.assets %}
+                        <tr class="border-b border-border/50">
+                            <td class="py-2 pr-4 font-medium text-text">{{ asset.name|default:"—" }}</td>
+                            <td class="py-2 pr-4">
+                                <span class="tw-badge tw-badge-secondary">{{ asset.asset_type|default:"unknown" }}</span>
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">{{ asset.primitive|default:"—" }}</td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.algorithm_family %}{{ asset.algorithm_family }}{% endif %}
+                                {% if asset.parameter_set %}{{ asset.parameter_set }}{% endif %}
+                                {% if asset.curve %}· {{ asset.curve }}{% endif %}
+                                {% if not asset.algorithm_family and not asset.parameter_set and not asset.curve %}—{% endif %}
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.nist_quantum_security_level is not None %}
+                                    {{ asset.nist_quantum_security_level }}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="text-xs text-text-muted m-0">
+            Derived from the CycloneDX document. sbomify does not modify the uploaded artifact.
+        </p>
+    </div>
+</section>

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,9 +1,9 @@
 {% load pqc_extras %}
 {% comment %}
 Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
-partial (no base template) and swapped into its own placeholder. Shows raw
-inventory facts derived from the immutable CycloneDX artifact — no post-quantum
-safe/vulnerable judgment (that is a later, separate increment).
+partial (no base template) and swapped into its own placeholder. Shows the crypto
+assets derived from the immutable CycloneDX artifact, with each asset's and the
+inventory's overall post-quantum readiness verdict from the pqc module.
 {% endcomment %}
 <section id="crypto-inventory-card" class="tw-card">
     <div class="px-6 py-4 border-b border-border">

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,3 +1,4 @@
+{% load pqc_extras %}
 {% comment %}
 Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
 partial (no base template) and swapped into its own placeholder. Shows raw
@@ -10,6 +11,9 @@ safe/vulnerable judgment (that is a later, separate increment).
             <i class="fas fa-lock text-primary"></i>
             Cryptographic Assets
             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-border/50 text-text-muted">{{ crypto_inventory.count }}</span>
+            <span class="tw-badge tw-badge-{{ crypto_inventory.pqc_overall|pqc_overall_variant }} ml-auto">
+                {{ crypto_inventory.pqc_overall|pqc_overall_label }}
+            </span>
         </h4>
     </div>
     <div class="p-6 space-y-6">
@@ -30,6 +34,7 @@ safe/vulnerable judgment (that is a later, separate increment).
                 <thead>
                     <tr class="text-left text-text-muted border-b border-border">
                         <th class="py-2 pr-4 font-medium">Asset</th>
+                        <th class="py-2 pr-4 font-medium">Quantum readiness</th>
                         <th class="py-2 pr-4 font-medium">Type</th>
                         <th class="py-2 pr-4 font-medium">Primitive</th>
                         <th class="py-2 pr-4 font-medium">Parameters</th>
@@ -40,6 +45,13 @@ safe/vulnerable judgment (that is a later, separate increment).
                     {% for asset in crypto_inventory.assets %}
                         <tr class="border-b border-border/50">
                             <td class="py-2 pr-4 font-medium text-text">{{ asset.name|default:"—" }}</td>
+                            <td class="py-2 pr-4">
+                                <span class="tw-badge tw-badge-{{ asset.pqc_status|pqc_variant }}">{{ asset.pqc_status|pqc_label }}</span>
+                                {% if asset.pqc_data_quality_flag %}
+                                    <i class="fas fa-triangle-exclamation text-warning ml-1"
+                                       title="{{ asset.pqc_data_quality_flag }}"></i>
+                                {% endif %}
+                            </td>
                             <td class="py-2 pr-4">
                                 <span class="tw-badge tw-badge-secondary">{{ asset.asset_type|default:"unknown" }}</span>
                             </td>

--- a/sbomify/apps/sboms/templatetags/pqc_extras.py
+++ b/sbomify/apps/sboms/templatetags/pqc_extras.py
@@ -1,0 +1,41 @@
+"""Template filters mapping PQC classification values to display labels + badge variants."""
+
+from django import template
+
+register = template.Library()
+
+# Per-asset PQC status -> (human label, tw-badge variant)
+_STATUS_DISPLAY = {
+    "quantum_safe": ("Quantum-safe", "success"),
+    "quantum_vulnerable": ("Vulnerable", "danger"),
+    "review": ("Review", "warning"),
+    "unknown": ("Unknown", "secondary"),
+}
+
+# Inventory-level readiness -> (human label, tw-badge variant)
+_OVERALL_DISPLAY = {
+    "at_risk": ("At risk", "danger"),
+    "needs_review": ("Needs review", "warning"),
+    "ready": ("Quantum-ready", "success"),
+    "not_assessed": ("Not assessed", "secondary"),
+}
+
+
+@register.filter
+def pqc_label(status: str | None) -> str:
+    return _STATUS_DISPLAY.get(status or "", ("Unknown", "secondary"))[0]
+
+
+@register.filter
+def pqc_variant(status: str | None) -> str:
+    return _STATUS_DISPLAY.get(status or "", ("Unknown", "secondary"))[1]
+
+
+@register.filter
+def pqc_overall_label(overall: str | None) -> str:
+    return _OVERALL_DISPLAY.get(overall or "", ("Not assessed", "secondary"))[0]
+
+
+@register.filter
+def pqc_overall_variant(overall: str | None) -> str:
+    return _OVERALL_DISPLAY.get(overall or "", ("Not assessed", "secondary"))[1]

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -87,3 +87,32 @@ def test_non_crypto_sbom_yields_empty_inventory():
 def test_handles_empty_or_missing_components():
     assert derive_crypto_inventory({}).count == 0
     assert derive_crypto_inventory({"components": []}).count == 0
+
+
+def test_malformed_field_types_never_raise_and_stay_schema_clean():
+    """Garbage field types must not raise (incl. by_asset_type's Counter) nor break the str|None API schema."""
+    doc = {
+        "components": [
+            {
+                "type": "cryptographic-asset",
+                "name": ["not", "a", "string"],
+                "cryptoProperties": {
+                    "assetType": {"nested": "dict"},  # unhashable -> would break Counter
+                    "algorithmProperties": {
+                        "primitive": ["list"],  # non-str on a str field
+                        "parameterSetIdentifier": 768,  # scalar -> coerced to "768"
+                        "cryptoFunctions": ["keygen", {"x": 1}],  # mixed -> only str-able kept
+                    },
+                },
+            }
+        ]
+    }
+    inv = derive_crypto_inventory(doc)
+    assert inv.count == 1
+    assert inv.by_asset_type == {}  # non-string assetType dropped, no TypeError
+    asset = inv.assets[0]
+    assert asset.asset_type is None
+    assert asset.name is None  # non-string dropped
+    assert asset.primitive is None  # list dropped
+    assert asset.parameter_set == "768"  # scalar coerced to str
+    assert all(isinstance(f, str) for f in asset.crypto_functions)

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -1,0 +1,89 @@
+"""Tests for the CBOM crypto-asset inventory derivation (#1001 increment 1)."""
+
+import json
+from pathlib import Path
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory, derive_crypto_inventory
+
+_DATA = Path(__file__).parent / "test_data"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_DATA / name).read_text())
+
+
+def _by_name(inv: CryptoInventory, name: str) -> CryptoAsset:
+    return next(a for a in inv.assets if a.name == name)
+
+
+def test_derives_crypto_assets_from_cbom_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    assert isinstance(inv, CryptoInventory)
+    # 6 cryptographic-asset components; the plain library is excluded
+    assert inv.count == 6
+    assert all(isinstance(a, CryptoAsset) for a in inv.assets)
+    assert "left-pad" not in {a.name for a in inv.assets}
+    # asset-type breakdown (algorithm x3, certificate, protocol; broken entry -> None)
+    assert inv.by_asset_type.get("algorithm") == 3
+    assert inv.by_asset_type.get("certificate") == 1
+    assert inv.by_asset_type.get("protocol") == 1
+
+
+def test_projects_algorithm_fields_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    rsa = _by_name(inv, "RSA-2048")
+    assert rsa.asset_type == "algorithm"
+    assert rsa.bom_ref == "crypto-rsa2048"
+    assert rsa.oid == "1.2.840.113549.1.1.1"
+    assert rsa.primitive == "pke"
+    assert rsa.parameter_set == "2048"
+    assert rsa.nist_quantum_security_level == 0
+    assert "encrypt" in rsa.crypto_functions
+
+    ecdsa = _by_name(inv, "ECDSA-P256")
+    assert ecdsa.primitive == "signature"
+    assert ecdsa.curve == "secp256r1"
+
+    mlkem = _by_name(inv, "ML-KEM-768")
+    assert mlkem.primitive == "kem"
+    assert mlkem.nist_quantum_security_level == 3
+
+
+def test_projects_certificate_and_protocol_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    cert = _by_name(inv, "server-cert")
+    assert cert.asset_type == "certificate"
+    assert cert.certificate and cert.certificate.get("subjectName") == "CN=demo.example.com"
+
+    proto = _by_name(inv, "TLS")
+    assert proto.asset_type == "protocol"
+    assert proto.protocol and proto.protocol.get("version") == "1.3"
+
+
+def test_tolerates_missing_crypto_properties():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    broken = _by_name(inv, "broken-entry")
+    assert broken.asset_type is None
+    assert broken.primitive is None  # no crash
+
+
+def test_1_7_field_aliases_elliptic_curve_and_family():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.7.cdx.json"))
+    assert inv.count == 2
+    ecdsa = _by_name(inv, "ECDSA-P384")
+    assert ecdsa.curve == "secp384r1"  # 1.7 uses ellipticCurve
+    assert ecdsa.algorithm_family == "ecdsa"
+    mldsa = _by_name(inv, "ML-DSA-65")
+    assert mldsa.algorithm_family == "ml-dsa"
+    assert mldsa.primitive == "signature"
+
+
+def test_non_crypto_sbom_yields_empty_inventory():
+    inv = derive_crypto_inventory(_load("sbomify_syft.cdx.json"))
+    assert inv.count == 0
+    assert inv.assets == ()
+
+
+def test_handles_empty_or_missing_components():
+    assert derive_crypto_inventory({}).count == 0
+    assert derive_crypto_inventory({"components": []}).count == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -82,3 +82,12 @@ def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFi
     _mock_s3(mocker, b"{}")
     response = Client().get(_url(sample_sbom.id))  # no session, component is private
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    # Corrupt (non-UTF-8) bytes must degrade to an empty inventory, never a 500.
+    _mock_s3(mocker, b"\xff\xfe\x00not-valid-utf8")
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.json()["count"] == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -91,3 +91,15 @@ def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM,
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 200
     assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_inventory_includes_pqc_classification(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    body = _owner_client(sample_sbom).get(_url(sample_sbom.id)).json()
+
+    assert body["pqc_overall"] == "at_risk"  # RSA + ECDSA present
+    assert body["pqc_counts"]["quantum_vulnerable"] >= 1
+    by_name = {a["name"]: a for a in body["assets"]}
+    assert by_name["RSA-2048"]["pqc_status"] == "quantum_vulnerable"
+    assert by_name["ML-KEM-768"]["pqc_status"] == "quantum_safe"

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -65,8 +65,14 @@ def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa
 
 
 @pytest.mark.django_db
-def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
-    _mock_s3(mocker, None)
+@pytest.mark.parametrize("payload", [None, b""])
+def test_404_when_artifact_missing_from_storage(
+    sample_sbom: SBOM,  # noqa: F811
+    mocker: MockerFixture,
+    payload: bytes | None,
+):
+    # An empty object body is corruption/absence, not a crypto-free SBOM: 404, not an empty inventory.
+    _mock_s3(mocker, payload)
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 404
 

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -1,0 +1,78 @@
+"""API tests for the derived crypto-inventory endpoint (#1001 increment 2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _url(sbom_id: str) -> str:
+    return reverse("api-1:get_sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_returns_derived_crypto_inventory(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sbom_id"] == sample_sbom.id
+    assert body["count"] == 6
+    assert body["by_asset_type"]["algorithm"] == 3
+    names = {a["name"] for a in body["assets"]}
+    assert "RSA-2048" in names
+    assert "left-pad" not in names  # plain library excluded
+
+
+@pytest.mark.django_db
+def test_empty_inventory_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_url("doesnotexist1"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, None)
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = Client().get(_url(sample_sbom.id))  # no session, component is private
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
@@ -1,0 +1,102 @@
+"""Tests for the lazy-loaded crypto-inventory UI card (#1001 increment 3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM, Component
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _card_url(sbom_id: str) -> str:
+    return reverse("sboms:sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_card_renders_for_cbom_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Cryptographic Assets" in html
+    assert "RSA-2048" in html  # an algorithm asset name
+    assert "ML-KEM-768" in html
+    assert "left-pad" not in html  # plain library excluded
+    # raw NIST quantum level shown verbatim, including 0 (not hidden as falsy)
+    assert "algorithm" in html  # asset-type breakdown label
+
+
+@pytest.mark.django_db
+def test_card_is_a_partial_not_a_full_page(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    html = _owner_client(sample_sbom).get(_card_url(sample_sbom.id)).content.decode()
+    assert "<html" not in html.lower()
+    assert "<!doctype" not in html.lower()
+
+
+@pytest.mark.django_db
+def test_card_empty_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""  # nothing to show -> placeholder collapses
+
+
+@pytest.mark.django_db
+def test_card_empty_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_card_url("doesnotexist1"))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""
+
+
+@pytest.mark.django_db
+def test_card_does_not_leak_private_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))  # anon, component is private
+    assert response.status_code == 200
+    assert "RSA-2048" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_card_visible_on_public_component_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    sample_sbom.component.visibility = Component.Visibility.PUBLIC
+    sample_sbom.component.save()
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert "RSA-2048" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_item_page_wires_lazy_placeholder(sample_sbom: SBOM):  # noqa: F811
+    """The SBOM item detail page lazy-loads the card via hx-get (no S3 read at page render)."""
+    client = _owner_client(sample_sbom)
+    item_url = reverse("core:component_item", args=[sample_sbom.component.id, "sboms", sample_sbom.id])
+    response = client.get(item_url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert _card_url(sample_sbom.id) in html
+    assert 'hx-trigger="load"' in html

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
@@ -91,6 +91,15 @@ def test_card_visible_on_public_component_to_anonymous(sample_sbom: SBOM, mocker
 
 
 @pytest.mark.django_db
+def test_card_shows_pqc_readiness(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    html = _owner_client(sample_sbom).get(_card_url(sample_sbom.id)).content.decode()
+    assert "At risk" in html  # overall readiness badge (RSA/ECDSA vulnerable)
+    assert "Vulnerable" in html  # per-asset status
+    assert "Quantum-safe" in html  # ML-KEM
+
+
+@pytest.mark.django_db
 def test_item_page_wires_lazy_placeholder(sample_sbom: SBOM):  # noqa: F811
     """The SBOM item detail page lazy-loads the card via hx-get (no S3 read at page render)."""
     client = _owner_client(sample_sbom)

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
@@ -1,0 +1,35 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "1.0"}},
+  "components": [
+    {"type": "library", "name": "left-pad", "version": "1.3.0", "bom-ref": "lib-leftpad"},
+    {
+      "type": "cryptographic-asset", "name": "RSA-2048", "bom-ref": "crypto-rsa2048",
+      "cryptoProperties": {"assetType": "algorithm", "oid": "1.2.840.113549.1.1.1",
+        "algorithmProperties": {"primitive": "pke", "parameterSetIdentifier": "2048", "classicalSecurityLevel": 112, "nistQuantumSecurityLevel": 0, "cryptoFunctions": ["encrypt", "decrypt"]}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P256", "bom-ref": "crypto-ecdsa",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "curve": "secp256r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-KEM-768", "bom-ref": "crypto-mlkem",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "kem", "parameterSetIdentifier": "768", "nistQuantumSecurityLevel": 3}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "server-cert", "bom-ref": "crypto-cert",
+      "cryptoProperties": {"assetType": "certificate",
+        "certificateProperties": {"subjectName": "CN=demo.example.com", "issuerName": "CN=Demo CA", "certificateFormat": "X.509"}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "TLS", "bom-ref": "crypto-tls",
+      "cryptoProperties": {"assetType": "protocol",
+        "protocolProperties": {"type": "tls", "version": "1.3"}}
+    },
+    {"type": "cryptographic-asset", "name": "broken-entry", "bom-ref": "crypto-broken"}
+  ]
+}

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
@@ -1,0 +1,18 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "2.0"}},
+  "components": [
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P384", "bom-ref": "c-ecdsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ecdsa", "ellipticCurve": "secp384r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-DSA-65", "bom-ref": "c-mldsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ml-dsa", "parameterSetIdentifier": "65", "nistQuantumSecurityLevel": 3}}
+    }
+  ]
+}

--- a/sbomify/apps/sboms/tests/test_pqc.py
+++ b/sbomify/apps/sboms/tests/test_pqc.py
@@ -1,0 +1,169 @@
+"""Tests for the post-quantum (PQC) readiness classification (#1001 increment 4).
+
+The classification table is grounded in NIST guidance (FIPS 203/204/205, draft 206,
+NIST IR 8547, NSA CNSA 2.0) and adversarially verified. Key, sometimes
+counter-intuitive, decisions encoded here:
+
+- SHA-256 is SAFE (Grover does not speed up collision search; NIST keeps SHA-2
+  approved) — NOT "review".
+- ``nistQuantumSecurityLevel`` is a NIST strength-category floor, not a quantum-safe
+  flag: algorithm identity decides the verdict; the declared level only raises a
+  data-quality flag when it looks mislabeled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory
+from sbomify.apps.sboms.pqc import (
+    PqcStatus,
+    assess_inventory,
+    classify_crypto_asset,
+)
+
+
+def _algo(name: str | None, **kw) -> CryptoAsset:
+    return CryptoAsset(name=name, bom_ref=None, oid=None, asset_type="algorithm", **kw)
+
+
+# --- standardized PQC -> SAFE -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["ML-KEM-768", "Kyber768", "CRYSTALS-Kyber", "ML-DSA-65", "Dilithium3", "SLH-DSA-SHA2-128s", "SPHINCS+"],
+)
+def test_standardized_pqc_is_safe(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.SAFE
+
+
+# --- quantum-vulnerable asymmetric -> VULNERABLE ------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["RSA-2048", "ECDSA-P256", "Ed25519", "Ed448", "X25519", "DH-2048", "ECDH-P384", "DSA", "ElGamal"],
+)
+def test_shor_breakable_asymmetric_is_vulnerable(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.VULNERABLE
+
+
+def test_ecdsa_recognized_via_algorithm_family_1_7():
+    assert classify_crypto_asset(_algo(None, algorithm_family="ECDSA")).status is PqcStatus.VULNERABLE
+
+
+def test_elliptic_curve_recognized_via_curve_field():
+    asset = _algo(None, primitive="signature", curve="secp256r1")
+    assert classify_crypto_asset(asset).status is PqcStatus.VULNERABLE
+
+
+# --- symmetric / hash (size-dependent) ---------------------------------------
+
+
+def test_aes_256_is_safe():
+    assert classify_crypto_asset(_algo("AES-256-GCM")).status is PqcStatus.SAFE
+
+
+def test_aes_128_is_review():
+    assert classify_crypto_asset(_algo("AES-128-CBC")).status is PqcStatus.REVIEW
+
+
+def test_aes_without_key_size_is_review():
+    assert classify_crypto_asset(_algo("AES")).status is PqcStatus.REVIEW
+
+
+def test_chacha20_is_safe():
+    assert classify_crypto_asset(_algo("ChaCha20-Poly1305")).status is PqcStatus.SAFE
+
+
+def test_sha256_is_safe_not_review():
+    # Adversarially verified: Grover does not attack collision resistance; NIST keeps SHA-2 approved.
+    assert classify_crypto_asset(_algo("SHA-256")).status is PqcStatus.SAFE
+
+
+def test_sha512_is_safe():
+    assert classify_crypto_asset(_algo("SHA-512")).status is PqcStatus.SAFE
+
+
+@pytest.mark.parametrize("name", ["MD5", "SHA-1"])
+def test_classically_broken_hash_is_review(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.REVIEW
+
+
+# --- gray zone -> REVIEW ------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["3DES", "TripleDES", "Falcon-512", "FN-DSA", "HQC-128"])
+def test_gray_zone_is_review(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.REVIEW
+
+
+# --- unknown ------------------------------------------------------------------
+
+
+def test_unrecognized_algorithm_is_unknown():
+    assert classify_crypto_asset(_algo("FooCipher9000")).status is PqcStatus.UNKNOWN
+
+
+def test_certificate_without_algorithm_info_is_unknown():
+    cert = CryptoAsset(name="server-cert", bom_ref=None, oid=None, asset_type="certificate")
+    assert classify_crypto_asset(cert).status is PqcStatus.UNKNOWN
+
+
+# --- declared nistQuantumSecurityLevel = corroborating / data-quality only -----
+
+
+def test_vulnerable_family_with_declared_pqc_level_flags_mislabel_but_stays_vulnerable():
+    asset = _algo("RSA-2048", nist_quantum_security_level=3)
+    result = classify_crypto_asset(asset)
+    assert result.status is PqcStatus.VULNERABLE  # identity wins, not the integer
+    assert result.data_quality_flag is not None
+
+
+def test_pqc_family_declared_level_zero_flags_data_quality_but_stays_safe():
+    asset = _algo("ML-KEM-768", nist_quantum_security_level=0)
+    result = classify_crypto_asset(asset)
+    assert result.status is PqcStatus.SAFE
+    assert result.data_quality_flag is not None
+
+
+def test_unrecognized_with_declared_pqc_level_is_review_not_safe():
+    # The integer alone must never assert SAFE on an unrecognized algorithm.
+    asset = _algo("MysteryKEM", nist_quantum_security_level=5)
+    assert classify_crypto_asset(asset).status is PqcStatus.REVIEW
+
+
+# --- inventory summary --------------------------------------------------------
+
+
+def _inv(*assets: CryptoAsset) -> CryptoInventory:
+    return CryptoInventory(assets=tuple(assets))
+
+
+def test_summary_at_risk_when_any_vulnerable():
+    summary = assess_inventory(_inv(_algo("RSA-2048"), _algo("ML-KEM-768"), _algo("AES-256")))
+    assert summary.overall == "at_risk"
+    assert summary.counts[PqcStatus.VULNERABLE.value] == 1
+    assert summary.counts[PqcStatus.SAFE.value] == 2
+    assert len(summary.results) == 3
+
+
+def test_summary_ready_when_all_safe():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("AES-256"), _algo("SHA-512")))
+    assert summary.overall == "ready"
+
+
+def test_summary_needs_review_when_review_present_no_vulnerable():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("AES-128")))
+    assert summary.overall == "needs_review"
+
+
+def test_summary_needs_review_for_unclassifiable_algorithm():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("FooCipher9000")))
+    assert summary.overall == "needs_review"
+
+
+def test_summary_not_assessed_when_no_classifiable_assets():
+    summary = assess_inventory(_inv())
+    assert summary.overall == "not_assessed"

--- a/sbomify/apps/sboms/urls.py
+++ b/sbomify/apps/sboms/urls.py
@@ -2,7 +2,12 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 from django.views.generic import RedirectView
 
-from sbomify.apps.sboms.views import SbomDownloadView, SbomsTableView, SbomVulnerabilitiesView
+from sbomify.apps.sboms.views import (
+    SbomCryptoInventoryView,
+    SbomDownloadView,
+    SbomsTableView,
+    SbomVulnerabilitiesView,
+)
 
 app_name = "sboms"
 urlpatterns: list[URLPattern] = [
@@ -66,5 +71,10 @@ urlpatterns: list[URLPattern] = [
         SbomsTableView.as_view(),
         name="sboms_table_public",
         kwargs={"is_public_view": True},
+    ),
+    path(
+        "sbom/<str:sbom_id>/crypto-inventory",
+        SbomCryptoInventoryView.as_view(),
+        name="sbom_crypto_inventory",
     ),
 ]

--- a/sbomify/apps/sboms/views/__init__.py
+++ b/sbomify/apps/sboms/views/__init__.py
@@ -1,9 +1,11 @@
+from sbomify.apps.sboms.views.sbom_crypto_inventory import SbomCryptoInventoryView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_download import SbomDownloadView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_upload_cyclonedx import SbomUploadCycloneDxView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_vulnerabilities import SbomVulnerabilitiesView  # noqa: F401
 from sbomify.apps.sboms.views.sboms_table import SbomsTableView  # noqa: F401
 
 __all__ = [
+    "SbomCryptoInventoryView",
     "SbomDownloadView",
     "SbomUploadCycloneDxView",
     "SbomVulnerabilitiesView",

--- a/sbomify/apps/sboms/views/sbom_crypto_inventory.py
+++ b/sbomify/apps/sboms/views/sbom_crypto_inventory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+
+from sbomify.apps.sboms.services.sboms import get_crypto_inventory
+
+CARD_TEMPLATE = "sboms/components/crypto_inventory_card.html.j2"
+
+
+class SbomCryptoInventoryView(View):
+    """Lazy-loaded (hx-get) crypto-asset inventory card for one SBOM.
+
+    Rendered as an HTMX partial so the per-SBOM artifact read does not block the
+    detail-page render. Authorization is delegated to ``get_crypto_inventory``
+    (the same ``check_component_access`` used by the other SBOM read paths), so
+    the card works on both the private and public item pages without a login
+    mixin. Any failure or an empty inventory renders nothing — with
+    ``hx-swap="outerHTML"`` the placeholder simply collapses, never leaking
+    existence or erroring on an ordinary (non-crypto) SBOM.
+    """
+
+    def get(self, request: HttpRequest, sbom_id: str) -> HttpResponse:
+        result = get_crypto_inventory(request, sbom_id)
+        if not result.ok or not (result.value or {}).get("count"):
+            return HttpResponse("")
+        return render(request, CARD_TEMPLATE, {"crypto_inventory": result.value})


### PR DESCRIPTION
## Summary

Increment 4 of the CBOM epic (#1001): a **NIST-grounded post-quantum (PQC) readiness classifier**, plus surfacing the verdict in the crypto-inventory API and UI card.

> **Stacked on #1030** (increments 1–3). Because the base branch lives on a fork, GitHub shows #1030's commits here too — **review only the last two commits** and merge this **after #1030**:
> - `88e2875` — the pure `pqc.py` classification module + tests
> - `792396d` — surfacing it in the API + card

## What's in these commits

**Classification module (`pqc.py`)**
- `classify_crypto_asset(asset) -> PqcAssessment`: maps a crypto asset to **quantum-safe / quantum-vulnerable / review / unknown**.
- `assess_inventory(inventory) -> PqcSummary`: rolls up to an overall verdict — **at_risk / needs_review / ready / not_assessed** (most-severe-wins, conservative).
- Grounded in **FIPS 203/204/205, draft 206, NIST IR 8547, NSA CNSA 2.0**, and **adversarially verified** (a panel of skeptics tried to refute each edge-case call).

**Classification rules (the defensible calls)**
- Standardized PQC — ML-KEM / ML-DSA / SLH-DSA (incl. legacy Kyber/Dilithium/SPHINCS+) → **safe**.
- Shor-breakable public key — RSA, DSA, DH, ECDH, ECDSA, EdDSA (Ed25519/Ed448), X25519/X448, ElGamal, any EC → **vulnerable**.
- Symmetric/hash (Grover-weakened, not broken) — AES-192/256, ChaCha20, SHA-256/384/512, SHA-3 → **safe**. AES-128, 3DES, Falcon/FN-DSA (FIPS 206 not final), HQC, bare/unsized symmetric → **review**. MD5/SHA-1 → **review** (classically broken).
- **SHA-256 is classified safe, not flagged** — the adversarial pass caught that "Grover collision margin" is a category error (Grover does not speed up collision search) and NIST keeps SHA-2 approved. A naive conservative table gets this wrong.
- `nistQuantumSecurityLevel` is treated as a **strength-category floor, not a quantum-safe flag**: algorithm identity decides the verdict; the declared level only raises a **data-quality flag** when it looks mislabeled, and never asserts "safe" on its own.

**Surfacing**
- API: each asset gains `pqc_status` / `pqc_reason` / `pqc_data_quality_flag`; the inventory gains `pqc_overall` + per-status `pqc_counts`.
- UI: the crypto-inventory card shows an **overall readiness badge** and a per-asset **Quantum readiness** column (with a data-quality warning icon), via `pqc_extras` template filters.

## Tests

- `test_pqc.py` — 41 tests over the classification + summary (standardized PQC, Shor-breakable, AES key-size split, SHA-256-safe, gray zone, mislabel/data-quality, overall roll-up).
- API + card tests extended to assert the surfaced verdict.
- Full `sboms` suite green (462 passed); ruff + mypy + djlint clean.

## Not in scope (later increments)

- **Increment 5** — a PQC-readiness assessment plugin (persisted `AssessmentRun` results).
- **Increment 6** — CRA / trust-center surfacing.

Part of #1001.
