### PR TITLE
feat(cbom): PQC assessment plugin + component posture card (#1001 incr 5+6, stacked on #1031)

### DIFF
--- a/sbomify/apps/core/templates/core/component_details_private_sbom.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_private_sbom.html.j2
@@ -20,6 +20,10 @@
             <p class="mt-3 text-text-muted">Loading vulnerability trends...</p>
         </div>
     </div>
+    {# Post-Quantum posture — lazy-loaded; collapses when the latest artifact has no crypto assets #}
+    <div hx-get="{% url 'sboms:component_crypto_posture' component_id=component.id %}"
+         hx-trigger="load"
+         hx-swap="outerHTML"></div>
 {% endblock %}
 {% block upload_section %}
     {% if component.has_crud_permissions %}

--- a/sbomify/apps/core/templates/core/component_details_public_sbom.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_public_sbom.html.j2
@@ -3,6 +3,11 @@
 {% block meta_description_suffix %}View SBOMs associated with this component.{% endblock %}
 {% block table_icon %}<i class="fas fa-file-code text-primary"></i>{% endblock %}
 {% block table_section %}
+    {# Post-Quantum posture — lazy-loaded; collapses when the latest artifact has no crypto assets #}
+    <div class="mb-6"
+         hx-get="{% url 'sboms:component_crypto_posture' component_id=component.id %}"
+         hx-trigger="load"
+         hx-swap="outerHTML"></div>
     <div id="sboms-table-container"
          hx-get="{% url 'sboms:sboms_table_public' component.id %}"
          hx-trigger="load, refreshSbomsTable from:body"

--- a/sbomify/apps/core/templates/core/component_item.html.j2
+++ b/sbomify/apps/core/templates/core/component_item.html.j2
@@ -197,6 +197,10 @@
                     </div>
                 </div>
             {% endif %}
+            {# Cryptographic Assets (CBOM) — lazy-loaded; collapses when there are none #}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
             {# Assessment Results Section #}
             {% if assessment_runs %}
                 <div>

--- a/sbomify/apps/core/templates/core/component_item_public.html.j2
+++ b/sbomify/apps/core/templates/core/component_item_public.html.j2
@@ -111,6 +111,12 @@
                 </a>
             </div>
         </div>
+        {# Cryptographic Assets (CBOM) — lazy-loaded for SBOM artifacts; collapses when there are none #}
+        {% if component.component_type == 'bom' %}
+            <div hx-get="{% url 'sboms:sbom_crypto_inventory' sbom_id=item.id %}"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"></div>
+        {% endif %}
     </div>
 {% endblock %}
 {% block scripts %}

--- a/sbomify/apps/plugins/apps.py
+++ b/sbomify/apps/plugins/apps.py
@@ -230,6 +230,29 @@ class PluginsConfig(AppConfig):
             },
         )
 
+        # PQC Readiness Plugin (post-quantum classification of CBOM crypto assets)
+        from .builtins.pqc import PqcReadinessPlugin
+
+        _register(
+            "pqc-readiness",
+            {
+                "display_name": "Post-Quantum Readiness",
+                "description": (
+                    "Classifies the cryptographic assets in a CycloneDX CBOM for post-quantum "
+                    "readiness. Each algorithm is graded quantum-safe, quantum-vulnerable, or "
+                    "needs-review against NIST guidance (FIPS 203/204/205, NIST IR 8547, NSA "
+                    "CNSA 2.0). Applies only to CBOM artifacts (bom_type 'cbom')."
+                ),
+                "category": "compliance",
+                "version": PqcReadinessPlugin.VERSION,
+                "plugin_class_path": "sbomify.apps.plugins.builtins.pqc.PqcReadinessPlugin",
+                "is_enabled": True,
+                "is_beta": True,
+                "is_builtin": True,
+                "default_config": {},
+            },
+        )
+
         # Reconcile: disable builtin plugins no longer in codebase
         if not registered_builtin_names:
             return

--- a/sbomify/apps/plugins/builtins/pqc.py
+++ b/sbomify/apps/plugins/builtins/pqc.py
@@ -1,0 +1,171 @@
+"""Post-quantum (PQC) readiness assessment plugin for CycloneDX CBOM artifacts.
+
+Adapts the pure crypto-inventory derivation + PQC classifier (in the ``sboms``
+app) to the ADR-003 assessment framework: it reads the immutable artifact the
+orchestrator hands it, derives the cryptographic-asset inventory, classifies
+each asset's post-quantum readiness, and emits one compliance Finding per asset.
+
+Gated to ``supported_bom_types=["cbom"]`` — every other builtin pins ``["sbom"]``,
+so CBOM artifacts trigger no assessments without this. Results persist as
+immutable ``AssessmentRun`` records and render in the existing compliance card.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sbomify.apps.plugins.sdk import (
+    AssessmentCategory,
+    AssessmentPlugin,
+    AssessmentResult,
+    AssessmentSummary,
+    Finding,
+    PluginMetadata,
+    ScanMode,
+)
+from sbomify.apps.plugins.sdk.base import SBOMContext
+from sbomify.apps.sboms.crypto_inventory import derive_crypto_inventory
+from sbomify.apps.sboms.pqc import PqcResult, PqcStatus, assess_inventory
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_NAME = "pqc-readiness"
+
+# PQC verdict -> (compliance Finding.status, cosmetic severity). Compliance findings
+# key off status; severity is only cosmetic.
+_VERDICT = {
+    PqcStatus.SAFE: ("pass", "info"),
+    PqcStatus.VULNERABLE: ("fail", "high"),
+    PqcStatus.REVIEW: ("warning", "medium"),
+    PqcStatus.UNKNOWN: ("warning", "medium"),
+}
+
+_LABELS = {
+    PqcStatus.SAFE: "Quantum-safe",
+    PqcStatus.VULNERABLE: "Quantum-vulnerable",
+    PqcStatus.REVIEW: "Needs review",
+    PqcStatus.UNKNOWN: "Unrecognized algorithm",
+}
+_REMEDIATION = {
+    PqcStatus.VULNERABLE: (
+        "Migrate to a NIST-standardized post-quantum algorithm — ML-KEM (FIPS 203) for key establishment, "
+        "ML-DSA (FIPS 204) or SLH-DSA (FIPS 205) for signatures."
+    ),
+    PqcStatus.REVIEW: (
+        "Review against your cryptographic policy (e.g. NSA CNSA 2.0): confirm key size, standardization status, "
+        "and intended use before relying on this algorithm."
+    ),
+    PqcStatus.UNKNOWN: "Could not classify this algorithm automatically — verify its post-quantum status manually.",
+}
+
+
+class PqcReadinessPlugin(AssessmentPlugin):
+    """Classify a CBOM's cryptographic assets for post-quantum readiness."""
+
+    VERSION = "1.0.0"
+    STANDARD_NAME = "NIST Post-Quantum Cryptography Migration"
+    STANDARD_VERSION = "NIST IR 8547"
+    STANDARD_URL = "https://csrc.nist.gov/pubs/ir/8547/ipd"
+
+    def get_metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name=_PLUGIN_NAME,
+            version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE,
+            scan_mode=ScanMode.ONE_SHOT,
+            supported_bom_types=["cbom"],
+        )
+
+    def assess(
+        self,
+        sbom_id: str,
+        sbom_path: Path,
+        dependency_status: dict[str, Any] | None = None,
+        context: SBOMContext | None = None,
+    ) -> AssessmentResult:
+        try:
+            document = json.loads(sbom_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError) as exc:
+            return self._error_result(f"Invalid JSON: {exc}")
+        except OSError as exc:  # pragma: no cover - defensive
+            return self._error_result(f"Failed to read SBOM: {exc}")
+
+        if not isinstance(document, dict):
+            return self._error_result("SBOM is not a JSON object")
+
+        summary = assess_inventory(derive_crypto_inventory(document))
+        findings = [self._finding(index, result) for index, result in enumerate(summary.results)]
+        if not findings:
+            findings = [
+                Finding(
+                    id=f"{_PLUGIN_NAME}:no-assets",
+                    title="No cryptographic assets found",
+                    description="This CBOM declares no cryptographic-asset components to assess.",
+                    status="warning",
+                    severity="medium",
+                )
+            ]
+
+        return AssessmentResult(
+            plugin_name=_PLUGIN_NAME,
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=self._summary(findings),
+            findings=findings,
+            metadata={
+                "standard_name": self.STANDARD_NAME,
+                "standard_version": self.STANDARD_VERSION,
+                "standard_url": self.STANDARD_URL,
+                "pqc_overall": summary.overall,
+            },
+        )
+
+    def _finding(self, index: int, result: PqcResult) -> Finding:
+        asset, verdict = result.asset, result.assessment
+        status, severity = _VERDICT.get(verdict.status, ("warning", "medium"))
+        description = verdict.reason
+        if verdict.data_quality_flag:
+            description = f"{description}. {verdict.data_quality_flag}"
+        ref = asset.bom_ref or asset.name or f"asset-{index}"
+        return Finding(
+            id=f"{_PLUGIN_NAME}:{ref}",
+            title=f"{asset.name or 'Unnamed asset'} — {_LABELS.get(verdict.status, 'Unknown')}",
+            description=description,
+            status=status,
+            severity=severity,
+            remediation=_REMEDIATION.get(verdict.status),
+            metadata={"pqc_status": verdict.status.value, "asset_type": asset.asset_type},
+        )
+
+    def _summary(self, findings: list[Finding]) -> AssessmentSummary:
+        return AssessmentSummary(
+            total_findings=len(findings),
+            pass_count=sum(1 for f in findings if f.status == "pass"),
+            fail_count=sum(1 for f in findings if f.status == "fail"),
+            warning_count=sum(1 for f in findings if f.status == "warning"),
+            error_count=sum(1 for f in findings if f.status == "error"),
+        )
+
+    def _error_result(self, message: str) -> AssessmentResult:
+        return AssessmentResult(
+            plugin_name=_PLUGIN_NAME,
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=AssessmentSummary(total_findings=1, error_count=1),
+            findings=[
+                Finding(
+                    id=f"{_PLUGIN_NAME}:error",
+                    title="PQC assessment error",
+                    description=message,
+                    status="error",
+                    severity="high",
+                )
+            ],
+            metadata={"error": True},
+        )

--- a/sbomify/apps/plugins/builtins/pqc.py
+++ b/sbomify/apps/plugins/builtins/pqc.py
@@ -165,6 +165,7 @@ class PqcReadinessPlugin(AssessmentPlugin):
             fail_count=sum(1 for f in findings if f.status == "fail"),
             warning_count=sum(1 for f in findings if f.status == "warning"),
             error_count=sum(1 for f in findings if f.status == "error"),
+            info_count=sum(1 for f in findings if f.status == "info"),
         )
 
     def _error_result(self, message: str) -> AssessmentResult:

--- a/sbomify/apps/plugins/builtins/pqc.py
+++ b/sbomify/apps/plugins/builtins/pqc.py
@@ -127,14 +127,30 @@ class PqcReadinessPlugin(AssessmentPlugin):
 
     def _finding(self, index: int, result: PqcResult) -> Finding:
         asset, verdict = result.asset, result.assessment
+        name = asset.name or "Unnamed asset"
+        finding_id = f"{_PLUGIN_NAME}:{asset.bom_ref or asset.name or f'asset-{index}'}"
+
+        # A non-algorithm asset (certificate / protocol / related material) that the classifier
+        # could not grade is "not assessed" — it is not an "unrecognized algorithm", so don't give
+        # it an algorithm label or algorithm remediation.
+        if verdict.status is PqcStatus.UNKNOWN and asset.asset_type is not None and asset.asset_type != "algorithm":
+            kind = asset.asset_type.replace("-", " ")
+            return Finding(
+                id=finding_id,
+                title=f"{name} — {kind} (not assessed)",
+                description=f"{kind.capitalize()} assets are not assessed for post-quantum readiness by this check.",
+                status="info",
+                severity="info",
+                metadata={"pqc_status": verdict.status.value, "asset_type": asset.asset_type},
+            )
+
         status, severity = _VERDICT.get(verdict.status, ("warning", "medium"))
         description = verdict.reason
         if verdict.data_quality_flag:
             description = f"{description}. {verdict.data_quality_flag}"
-        ref = asset.bom_ref or asset.name or f"asset-{index}"
         return Finding(
-            id=f"{_PLUGIN_NAME}:{ref}",
-            title=f"{asset.name or 'Unnamed asset'} — {_LABELS.get(verdict.status, 'Unknown')}",
+            id=finding_id,
+            title=f"{name} — {_LABELS.get(verdict.status, 'Unknown')}",
             description=description,
             status=status,
             severity=severity,

--- a/sbomify/apps/plugins/sdk/results.py
+++ b/sbomify/apps/plugins/sdk/results.py
@@ -140,6 +140,7 @@ class AssessmentSummary:
         fail_count: Number of findings with status "fail".
         warning_count: Number of findings with status "warning".
         error_count: Number of findings with status "error".
+        info_count: Number of findings with status "info".
         by_severity: Severity counts dict (e.g., {"critical": 0, "high": 1}).
     """
 
@@ -148,6 +149,7 @@ class AssessmentSummary:
     fail_count: int = 0
     warning_count: int = 0
     error_count: int = 0
+    info_count: int = 0
     by_severity: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/sbomify/apps/plugins/tests/test_builtin_reconciliation.py
+++ b/sbomify/apps/plugins/tests/test_builtin_reconciliation.py
@@ -73,6 +73,7 @@ class TestBuiltinReconciliation:
             "sbom-verification",
             "osv",
             "dependency-track",
+            "pqc-readiness",
         }
         assert set(builtins.values_list("name", flat=True)) == expected_names
 

--- a/sbomify/apps/plugins/tests/test_pqc_plugin.py
+++ b/sbomify/apps/plugins/tests/test_pqc_plugin.py
@@ -80,6 +80,18 @@ def test_named_algorithm_inside_certificate_still_classified(tmp_path: Path):
     assert finding.status == "fail"  # RSA -> quantum-vulnerable
 
 
+def test_summary_counts_include_info_and_sum_to_total(tmp_path: Path):
+    # A cert produces a status="info" finding; the summary must count it so the
+    # per-status counts sum to total_findings.
+    doc = _cbom(_crypto("RSA-2048", primitive="pke"), _crypto("server-cert", asset_type="certificate"))
+    summary = _assess(doc, tmp_path).summary
+    assert summary.info_count == 1
+    assert (
+        summary.pass_count + summary.fail_count + summary.warning_count + summary.error_count + summary.info_count
+        == summary.total_findings
+    )
+
+
 def test_assess_empty_cbom_warns(tmp_path: Path):
     result = _assess(_cbom(), tmp_path)
     assert result.summary.total_findings == 1

--- a/sbomify/apps/plugins/tests/test_pqc_plugin.py
+++ b/sbomify/apps/plugins/tests/test_pqc_plugin.py
@@ -1,0 +1,89 @@
+"""Tests for the PQC-readiness assessment plugin (#1001 increment 5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sbomify.apps.plugins.builtins.pqc import PqcReadinessPlugin
+from sbomify.apps.plugins.sdk import AssessmentCategory
+
+
+def _crypto(name: str, asset_type: str = "algorithm", **algo) -> dict:
+    comp = {
+        "type": "cryptographic-asset",
+        "name": name,
+        "bom-ref": name.lower(),
+        "cryptoProperties": {"assetType": asset_type},
+    }
+    if algo:
+        comp["cryptoProperties"]["algorithmProperties"] = algo
+    return comp
+
+
+def _cbom(*components: dict) -> dict:
+    return {"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1, "components": list(components)}
+
+
+def _assess(doc: dict, tmp_path: Path):
+    path = tmp_path / "cbom.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return PqcReadinessPlugin().assess("test-sbom-id", path)
+
+
+def test_metadata_gates_on_cbom():
+    metadata = PqcReadinessPlugin().get_metadata()
+    assert metadata.name == "pqc-readiness"
+    assert metadata.category is AssessmentCategory.COMPLIANCE
+    # Critical: existing plugins pin ["sbom"], so without this the plugin never runs on a CBOM.
+    assert metadata.supported_bom_types == ["cbom"]
+
+
+def test_assess_classifies_each_crypto_asset(tmp_path: Path):
+    doc = _cbom(
+        _crypto("RSA-2048", primitive="pke"),
+        _crypto("ML-KEM-768", primitive="kem"),
+        _crypto("AES-128-GCM", primitive="ae"),
+    )
+    result = _assess(doc, tmp_path)
+
+    assert result.plugin_name == "pqc-readiness"
+    assert result.category == AssessmentCategory.COMPLIANCE.value
+    assert result.summary.total_findings == 3
+    assert result.summary.fail_count == 1  # RSA
+    assert result.summary.pass_count == 1  # ML-KEM
+    assert result.summary.warning_count == 1  # AES-128
+
+    by_status = {f.status for f in result.findings}
+    assert by_status == {"pass", "fail", "warning"}
+    rsa = next(f for f in result.findings if "RSA" in f.title)
+    assert rsa.status == "fail"
+    assert rsa.remediation  # migration guidance present
+    assert rsa.metadata and rsa.metadata["pqc_status"] == "quantum_vulnerable"
+
+
+def test_assess_empty_cbom_warns(tmp_path: Path):
+    result = _assess(_cbom(), tmp_path)
+    assert result.summary.total_findings == 1
+    assert result.findings[0].status == "warning"
+
+
+def test_assess_invalid_json_returns_error_not_raise(tmp_path: Path):
+    path = tmp_path / "broken.json"
+    path.write_text("{not json", encoding="utf-8")
+    result = PqcReadinessPlugin().assess("test-sbom-id", path)
+    assert result.summary.error_count == 1
+    assert result.findings[0].status == "error"
+
+
+def test_result_serializes_to_json(tmp_path: Path):
+    result = _assess(_cbom(_crypto("RSA-2048", primitive="pke")), tmp_path)
+    # The UI consumes result.to_dict() as JSON; it must round-trip.
+    payload = json.dumps(result.to_dict())
+    assert json.loads(payload)["category"] == "compliance"
+
+
+def test_metadata_block_includes_standard_reference(tmp_path: Path):
+    result = _assess(_cbom(_crypto("RSA-2048", primitive="pke")), tmp_path)
+    assert result.metadata and result.metadata["standard_name"]
+    assert result.metadata["pqc_overall"] == "at_risk"

--- a/sbomify/apps/plugins/tests/test_pqc_plugin.py
+++ b/sbomify/apps/plugins/tests/test_pqc_plugin.py
@@ -62,6 +62,24 @@ def test_assess_classifies_each_crypto_asset(tmp_path: Path):
     assert rsa.metadata and rsa.metadata["pqc_status"] == "quantum_vulnerable"
 
 
+def test_non_algorithm_asset_is_not_labelled_unrecognized_algorithm(tmp_path: Path):
+    # A certificate/protocol the classifier can't grade is "not assessed", not an "unrecognized algorithm".
+    doc = _cbom(_crypto("server-cert", asset_type="certificate"))
+    finding = _assess(doc, tmp_path).findings[0]
+    assert finding.status == "info"
+    assert "not assessed" in finding.title.lower()
+    assert "certificate" in finding.title.lower()
+    assert "algorithm" not in finding.title.lower()
+    assert finding.remediation is None
+
+
+def test_named_algorithm_inside_certificate_still_classified(tmp_path: Path):
+    # If a non-algorithm asset's name does identify an algorithm, keep the real verdict.
+    doc = _cbom(_crypto("RSA-2048-signing-cert", asset_type="certificate"))
+    finding = _assess(doc, tmp_path).findings[0]
+    assert finding.status == "fail"  # RSA -> quantum-vulnerable
+
+
 def test_assess_empty_cbom_warns(tmp_path: Path):
     result = _assess(_cbom(), tmp_path)
     assert result.summary.total_findings == 1

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -36,6 +36,7 @@ from sbomify.apps.teams.models import ContactProfile
 from .models import SBOM, Component, Product
 from .schemas import (
     ComponentMetaData,
+    CryptoInventorySchema,
     CycloneDXSupportedVersion,
     SBOMResponseSchema,
     SBOMUploadRequest,
@@ -52,7 +53,7 @@ from .schemas import (
     validate_cyclonedx_sbom,
     validate_spdx_sbom,
 )
-from .services.sboms import delete_sbom_record, get_sbom_detail
+from .services.sboms import delete_sbom_record, get_crypto_inventory, get_sbom_detail
 
 log = logging.getLogger(__name__)
 
@@ -727,6 +728,24 @@ def get_cyclonedx_component_metadata(
 def get_sbom(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
     """Get a specific SBOM by ID."""
     result = get_sbom_detail(request, sbom_id)
+    if not result.ok:
+        return result.status_code or 400, {"detail": result.error or "Invalid request"}
+
+    return 200, result.value or {}
+
+
+@router.get(
+    "/{sbom_id}/crypto-inventory",
+    response={200: CryptoInventorySchema, 403: ErrorResponse, 404: ErrorResponse},
+    auth=None,  # Allow unauthenticated access for public SBOMs
+)
+def get_sbom_crypto_inventory(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
+    """Return the derived cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Projects the ``cryptographic-asset`` components of the stored CycloneDX
+    artifact. Non-crypto SBOMs return an empty inventory rather than an error.
+    """
+    result = get_crypto_inventory(request, sbom_id)
     if not result.ok:
         return result.status_code or 400, {"detail": result.error or "Invalid request"}
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -739,6 +739,7 @@ def get_sbom(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
     response={200: CryptoInventorySchema, 403: ErrorResponse, 404: ErrorResponse},
     auth=None,  # Allow unauthenticated access for public SBOMs
 )
+@decorate_view(optional_auth)
 def get_sbom_crypto_inventory(request: HttpRequest, sbom_id: str) -> tuple[int, dict[str, Any]]:
     """Return the derived cryptographic-asset (CBOM) inventory for an SBOM.
 

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -81,25 +81,45 @@ def _dict_or_none(value: Any) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Coerce a CycloneDX scalar to ``str`` (keep hashable, schema-clean).
+
+    A spec-conformant value is already a string. A scalar (int/float/bool) is
+    stringified so data is not lost. Anything else (dict/list) is dropped to
+    ``None`` — it would be unhashable for ``by_asset_type`` and would violate the
+    ``str | None`` API schema, both of which the module promises never to raise on.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):  # bool is an int subclass — fine
+        return str(value)
+    return None
+
+
+def _str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(v) for v in value if isinstance(v, (str, int, float)))
+
+
 def _project_asset(component: dict[str, Any]) -> CryptoAsset:
     crypto = _dict_or_none(component.get("cryptoProperties")) or {}
     algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
-    functions = algo.get("cryptoFunctions")
     return CryptoAsset(
-        name=component.get("name"),
-        bom_ref=component.get("bom-ref"),
-        oid=crypto.get("oid") or component.get("oid"),
-        asset_type=crypto.get("assetType"),
-        primitive=algo.get("primitive"),
-        algorithm_family=algo.get("algorithmFamily"),
-        parameter_set=algo.get("parameterSetIdentifier"),
-        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        name=_str_or_none(component.get("name")),
+        bom_ref=_str_or_none(component.get("bom-ref")),
+        oid=_str_or_none(crypto.get("oid") or component.get("oid")),
+        asset_type=_str_or_none(crypto.get("assetType")),
+        primitive=_str_or_none(algo.get("primitive")),
+        algorithm_family=_str_or_none(algo.get("algorithmFamily")),
+        parameter_set=_str_or_none(algo.get("parameterSetIdentifier")),
+        curve=_str_or_none(algo.get("curve") or algo.get("ellipticCurve")),
         nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
         classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
-        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
-        mode=algo.get("mode"),
-        padding=algo.get("padding"),
-        execution_environment=algo.get("executionEnvironment"),
+        crypto_functions=_str_tuple(algo.get("cryptoFunctions")),
+        mode=_str_or_none(algo.get("mode")),
+        padding=_str_or_none(algo.get("padding")),
+        execution_environment=_str_or_none(algo.get("executionEnvironment")),
         certificate=_dict_or_none(crypto.get("certificateProperties")),
         protocol=_dict_or_none(crypto.get("protocolProperties")),
         related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),

--- a/sbomify/apps/sboms/crypto_inventory.py
+++ b/sbomify/apps/sboms/crypto_inventory.py
@@ -1,0 +1,126 @@
+"""Derive a crypto-asset inventory (CBOM) from a CycloneDX document.
+
+CycloneDX 1.6+ represents cryptographic assets as ``components[]`` entries with
+``type == "cryptographic-asset"`` and a ``cryptoProperties`` object (algorithm /
+certificate / protocol / related-crypto-material). sbomify stores the raw
+artifact immutably in S3 and never extracts these (ADR-004), so the inventory is
+**derived on read** from the stored document — there is no separate persisted
+copy to keep in sync.
+
+``derive_crypto_inventory`` is a pure function over the parsed JSON: it filters
+the crypto-asset components and projects the PQC-relevant fields into plain
+dataclasses. It tolerates both CycloneDX 1.6 and 1.7 field spellings (1.7
+renamed ``curve`` -> ``ellipticCurve`` and added ``algorithmFamily``) and
+malformed/partial entries. It does not validate the document — callers upload
+through the schema validator; this only reads.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+CRYPTO_ASSET_TYPE = "cryptographic-asset"
+
+
+@dataclass(frozen=True)
+class CryptoAsset:
+    """One ``cryptographic-asset`` component, projected for inventory + PQC use."""
+
+    name: str | None
+    bom_ref: str | None
+    oid: str | None
+    asset_type: str | None  # algorithm | certificate | protocol | related-crypto-material
+
+    # algorithmProperties projection (the fields PQC readiness keys on)
+    primitive: str | None = None
+    algorithm_family: str | None = None  # CycloneDX 1.7
+    parameter_set: str | None = None
+    curve: str | None = None  # 1.6 "curve" / 1.7 "ellipticCurve"
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: tuple[str, ...] = ()
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+
+    # other asset-type sub-objects kept as-is (raw); less central to PQC scoring
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+    # full cryptoProperties for any downstream field this projection omits
+    raw: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CryptoInventory:
+    """The crypto assets derived from a single CycloneDX document."""
+
+    assets: tuple[CryptoAsset, ...] = ()
+
+    @property
+    def count(self) -> int:
+        return len(self.assets)
+
+    @property
+    def by_asset_type(self) -> dict[str, int]:
+        """Count of assets per ``assetType`` (entries with no assetType omitted)."""
+        return dict(Counter(a.asset_type for a in self.assets if a.asset_type))
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _dict_or_none(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _project_asset(component: dict[str, Any]) -> CryptoAsset:
+    crypto = _dict_or_none(component.get("cryptoProperties")) or {}
+    algo = _dict_or_none(crypto.get("algorithmProperties")) or {}
+    functions = algo.get("cryptoFunctions")
+    return CryptoAsset(
+        name=component.get("name"),
+        bom_ref=component.get("bom-ref"),
+        oid=crypto.get("oid") or component.get("oid"),
+        asset_type=crypto.get("assetType"),
+        primitive=algo.get("primitive"),
+        algorithm_family=algo.get("algorithmFamily"),
+        parameter_set=algo.get("parameterSetIdentifier"),
+        curve=algo.get("curve") or algo.get("ellipticCurve"),
+        nist_quantum_security_level=_as_int(algo.get("nistQuantumSecurityLevel")),
+        classical_security_level=_as_int(algo.get("classicalSecurityLevel")),
+        crypto_functions=tuple(functions) if isinstance(functions, (list, tuple)) else (),
+        mode=algo.get("mode"),
+        padding=algo.get("padding"),
+        execution_environment=algo.get("executionEnvironment"),
+        certificate=_dict_or_none(crypto.get("certificateProperties")),
+        protocol=_dict_or_none(crypto.get("protocolProperties")),
+        related_material=_dict_or_none(crypto.get("relatedCryptoMaterialProperties")),
+        raw=crypto or None,
+    )
+
+
+def derive_crypto_inventory(sbom_json: dict[str, Any] | None) -> CryptoInventory:
+    """Project the ``cryptographic-asset`` components of a CycloneDX doc.
+
+    Returns an empty inventory for a non-dict input, a document with no
+    ``components``, or one with no crypto assets. Never raises on partial data.
+    """
+    if not isinstance(sbom_json, dict):
+        return CryptoInventory()
+    components = sbom_json.get("components")
+    if not isinstance(components, list):
+        return CryptoInventory()
+    assets = tuple(
+        _project_asset(component)
+        for component in components
+        if isinstance(component, dict) and component.get("type") == CRYPTO_ASSET_TYPE
+    )
+    return CryptoInventory(assets=assets)

--- a/sbomify/apps/sboms/pqc.py
+++ b/sbomify/apps/sboms/pqc.py
@@ -1,0 +1,228 @@
+"""Post-quantum (PQC) readiness classification for crypto assets.
+
+Classifies a :class:`~sbomify.apps.sboms.crypto_inventory.CryptoAsset` as
+quantum-safe, quantum-vulnerable, needs-review, or unknown, and aggregates an
+inventory into an overall readiness verdict.
+
+The table is grounded in NIST guidance — FIPS 203 (ML-KEM), 204 (ML-DSA),
+205 (SLH-DSA), draft 206 (FN-DSA/Falcon), NIST IR 8547, and NSA CNSA 2.0 — and
+was adversarially verified. Notable, sometimes counter-intuitive, rules:
+
+- Standardized PQC (ML-KEM/ML-DSA/SLH-DSA, incl. legacy names Kyber/Dilithium/
+  SPHINCS+) is SAFE. Selected-but-not-yet-finalized PQC (FN-DSA/Falcon, HQC) and
+  stateful special-use schemes (XMSS/LMS) are REVIEW.
+- Shor-breakable public-key crypto (RSA, DSA, DH, ECDH, ECDSA, EdDSA incl.
+  Ed25519/Ed448, X25519/X448, ElGamal, any EC) is VULNERABLE.
+- Symmetric/hash are only Grover-weakened, not broken: AES-192/256, ChaCha20,
+  SHA-256/384/512, SHA-3 are SAFE; **SHA-256 is SAFE — Grover does not attack
+  collision resistance and NIST keeps SHA-2 approved**. AES-128 (~64-bit
+  post-Grover), 3DES (withdrawn; legacy-decrypt only) and bare/unsized symmetric
+  are REVIEW. MD5/SHA-1 are classically broken -> REVIEW.
+- ``nistQuantumSecurityLevel`` is a NIST *strength-category floor*, not a
+  quantum-safe flag. Algorithm identity decides the verdict; the declared level
+  only raises a ``data_quality_flag`` when it looks mislabeled, and never on its
+  own asserts SAFE for an unrecognized algorithm.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory
+
+
+class PqcStatus(str, Enum):
+    SAFE = "quantum_safe"
+    VULNERABLE = "quantum_vulnerable"
+    REVIEW = "review"
+    UNKNOWN = "unknown"
+
+
+# Overall inventory readiness verdicts.
+OVERALL_AT_RISK = "at_risk"
+OVERALL_NEEDS_REVIEW = "needs_review"
+OVERALL_READY = "ready"
+OVERALL_NOT_ASSESSED = "not_assessed"
+
+
+@dataclass(frozen=True)
+class PqcAssessment:
+    status: PqcStatus
+    family: str | None
+    reason: str
+    data_quality_flag: str | None = None
+
+
+@dataclass(frozen=True)
+class PqcResult:
+    asset: CryptoAsset
+    assessment: PqcAssessment
+
+
+@dataclass(frozen=True)
+class PqcSummary:
+    overall: str
+    counts: dict[str, int]
+    results: tuple[PqcResult, ...]
+
+
+# Substrings distinctive enough to match once the PQC families have been ruled
+# out first (e.g. "dsa" here only reaches ECDSA/DSA/EdDSA, since ML-DSA/SLH-DSA/
+# FN-DSA are matched earlier).
+_VULNERABLE_SUBSTRINGS = (
+    "rsa",
+    "ecdsa",
+    "eddsa",
+    "ed25519",
+    "ed448",
+    "ecdh",
+    "x25519",
+    "x448",
+    "elgamal",
+    "ecmqv",
+    "ecies",
+    "diffie",
+    "hellman",
+    "ffdh",
+    "dsa",
+    "secp",
+    "sect",
+    "brainpool",
+    "prime256v1",
+    "curve25519",
+    "curve448",
+    "nistp",
+)
+# Short tokens matched whole to avoid false positives.
+_VULNERABLE_TOKENS = frozenset({"dh", "dhe", "ec", "ecc", "mqv", "p-256", "p-384", "p-521", "p256", "p384", "p521"})
+
+_PQC_SAFE_SUBSTRINGS = ("ml-kem", "mlkem", "kyber", "ml-dsa", "mldsa", "dilithium", "slh-dsa", "slhdsa", "sphincs")
+# PQC-adjacent but not a finalized FIPS standard, or stateful special-use.
+_PQC_REVIEW_SUBSTRINGS = (
+    "fn-dsa",
+    "falcon",
+    "hqc",
+    "bike",
+    "mceliece",
+    "frodo",
+    "ntru",
+    "saber",
+    "xmss",
+    "lms",
+    "hss",
+)
+
+
+def _haystack(asset: CryptoAsset) -> str:
+    parts = [asset.name, asset.algorithm_family, asset.curve]
+    return " ".join(p for p in parts if isinstance(p, str)).lower()
+
+
+def _tokens(haystack: str) -> set[str]:
+    return set(re.split(r"[^a-z0-9]+", haystack))
+
+
+def _classify_symmetric_or_hash(hay: str) -> tuple[PqcStatus, str, str] | None:
+    """Symmetric ciphers and hashes (Grover-weakened, not Shor-broken), or None."""
+    if "md5" in hay or re.search(r"sha-?1(?![0-9])", hay):
+        return PqcStatus.REVIEW, "broken-hash", "Classically broken (collisions) — remediate regardless of quantum"
+    if any(t in hay for t in ("3des", "triple-des", "tripledes", "tdea", "des-ede", "des3")):
+        return PqcStatus.REVIEW, "3DES", "Withdrawn (SP 800-67); legacy decrypt only — review usage"
+    if "aes" in hay:
+        if "256" in hay or "192" in hay:
+            return PqcStatus.SAFE, "AES", "Grover-resistant at >=192-bit keys"
+        if "128" in hay:
+            return PqcStatus.REVIEW, "AES-128", "~64-bit post-Grover; below the CNSA 2.0 256-bit bar — review"
+        return PqcStatus.REVIEW, "AES", "Key size unspecified — AES-128 and AES-256 differ; review"
+    if "chacha" in hay:
+        return PqcStatus.SAFE, "ChaCha20", "256-bit stream cipher, Grover-resistant"
+    if re.search(r"\bdes\b", hay):
+        return PqcStatus.REVIEW, "DES", "56-bit — broken; remediate"
+    if any(t in hay for t in ("sha-512", "sha512", "sha-384", "sha384", "sha3-512", "sha3-384", "shake256")):
+        return PqcStatus.SAFE, "SHA-2/3", "Grover-resistant digest (>=384-bit)"
+    if any(t in hay for t in ("sha-256", "sha256", "sha3-256", "shake128", "sha-224", "sha224")):
+        # SHA-256 is SAFE: Grover does not speed up collision search and NIST keeps SHA-2 approved.
+        return PqcStatus.SAFE, "SHA-256", "Grover leaves ~128-bit; NIST keeps SHA-2 approved"
+    return None
+
+
+def _classify_identity(hay: str, tokens: set[str]) -> tuple[PqcStatus, str | None, str, bool]:
+    """Return ``(status, family, reason, is_pqc_safe_family)`` from algorithm identity."""
+    if any(s in hay for s in _PQC_SAFE_SUBSTRINGS):
+        return PqcStatus.SAFE, "PQC", "Standardized post-quantum algorithm (FIPS 203/204/205)", True
+    if any(s in hay for s in _PQC_REVIEW_SUBSTRINGS):
+        return PqcStatus.REVIEW, "PQC-candidate", "Selected/stateful PQC, not a finalized FIPS standard — review", False
+    if any(s in hay for s in _VULNERABLE_SUBSTRINGS) or (tokens & _VULNERABLE_TOKENS):
+        return (
+            PqcStatus.VULNERABLE,
+            "classical-asymmetric",
+            "Broken by Shor's algorithm (factoring / discrete log)",
+            False,
+        )
+    sym = _classify_symmetric_or_hash(hay)
+    if sym is not None:
+        status, family, reason = sym
+        return status, family, reason, False
+    return PqcStatus.UNKNOWN, None, "Algorithm not recognized", False
+
+
+def classify_crypto_asset(asset: CryptoAsset) -> PqcAssessment:
+    """Classify one crypto asset's post-quantum status from its identity.
+
+    Algorithm identity (name / algorithmFamily / curve) decides the verdict.
+    ``nistQuantumSecurityLevel`` is used only as a corroborating signal: it
+    promotes an otherwise-unrecognized asset to ``review`` (never ``safe``) and
+    raises a data-quality flag when it conflicts with the identity verdict.
+    """
+    hay = _haystack(asset)
+    tokens = _tokens(hay)
+    status, family, reason, is_pqc_safe = _classify_identity(hay, tokens)
+
+    level = asset.nist_quantum_security_level
+
+    if status is PqcStatus.UNKNOWN and level is not None and level >= 1:
+        return PqcAssessment(
+            status=PqcStatus.REVIEW,
+            family=family,
+            reason="Declares a NIST PQC security category but the algorithm is unrecognized — review",
+        )
+
+    data_quality_flag = None
+    if status is PqcStatus.VULNERABLE and level is not None and level >= 1:
+        data_quality_flag = (
+            f"Declares nistQuantumSecurityLevel {level} on a quantum-vulnerable algorithm — likely mislabeled"
+        )
+    elif status is PqcStatus.SAFE and is_pqc_safe and level == 0:
+        data_quality_flag = "PQC algorithm declares nistQuantumSecurityLevel 0 — likely mislabeled"
+
+    return PqcAssessment(status=status, family=family, reason=reason, data_quality_flag=data_quality_flag)
+
+
+def assess_inventory(inventory: CryptoInventory) -> PqcSummary:
+    """Classify every asset and roll up to an overall readiness verdict.
+
+    Overall (conservative, most-severe-wins): any vulnerable -> ``at_risk``;
+    else any review, or any *algorithm* asset we could not classify ->
+    ``needs_review``; else any safe -> ``ready``; else ``not_assessed``.
+    """
+    results = tuple(PqcResult(asset, classify_crypto_asset(asset)) for asset in inventory.assets)
+    counts = {status.value: 0 for status in PqcStatus}
+    for result in results:
+        counts[result.assessment.status.value] += 1
+
+    unclassified_algorithms = sum(
+        1 for r in results if r.assessment.status is PqcStatus.UNKNOWN and r.asset.asset_type == "algorithm"
+    )
+
+    if counts[PqcStatus.VULNERABLE.value]:
+        overall = OVERALL_AT_RISK
+    elif counts[PqcStatus.REVIEW.value] or unclassified_algorithms:
+        overall = OVERALL_NEEDS_REVIEW
+    elif counts[PqcStatus.SAFE.value]:
+        overall = OVERALL_READY
+    else:
+        overall = OVERALL_NOT_ASSESSED
+
+    return PqcSummary(overall=overall, counts=counts, results=results)

--- a/sbomify/apps/sboms/schemas.py
+++ b/sbomify/apps/sboms/schemas.py
@@ -114,6 +114,9 @@ class CryptoAssetSchema(Schema):
     certificate: dict[str, Any] | None = None
     protocol: dict[str, Any] | None = None
     related_material: dict[str, Any] | None = None
+    pqc_status: str | None = None
+    pqc_reason: str | None = None
+    pqc_data_quality_flag: str | None = None
 
 
 class CryptoInventorySchema(Schema):
@@ -123,6 +126,8 @@ class CryptoInventorySchema(Schema):
     component_id: str
     count: int
     by_asset_type: dict[str, int]
+    pqc_overall: str
+    pqc_counts: dict[str, int]
     assets: list[CryptoAssetSchema]
 
 

--- a/sbomify/apps/sboms/schemas.py
+++ b/sbomify/apps/sboms/schemas.py
@@ -27,6 +27,8 @@ __all__ = [
     "ComponentMetaData",
     "ComponentMetaDataUpdate",
     "ComponentSupplierContactSchema",
+    "CryptoAssetSchema",
+    "CryptoInventorySchema",
     "CustomLicenseSchema",
     "CycloneDXSupportedVersion",
     "LicenseSchema",
@@ -90,6 +92,38 @@ class SBOMResponseSchema(BaseModel):
     signature_blob_key: str | None = None
     signature_type: str | None = None
     provenance_blob_key: str | None = None
+
+
+class CryptoAssetSchema(Schema):
+    """One ``cryptographic-asset`` component, projected for the CBOM inventory."""
+
+    name: str | None = None
+    bom_ref: str | None = None
+    oid: str | None = None
+    asset_type: str | None = None
+    primitive: str | None = None
+    algorithm_family: str | None = None
+    parameter_set: str | None = None
+    curve: str | None = None
+    nist_quantum_security_level: int | None = None
+    classical_security_level: int | None = None
+    crypto_functions: list[str] = Field(default_factory=list)
+    mode: str | None = None
+    padding: str | None = None
+    execution_environment: str | None = None
+    certificate: dict[str, Any] | None = None
+    protocol: dict[str, Any] | None = None
+    related_material: dict[str, Any] | None = None
+
+
+class CryptoInventorySchema(Schema):
+    """Derived cryptographic-asset inventory (CBOM) for a single SBOM."""
+
+    sbom_id: str
+    component_id: str
+    count: int
+    by_asset_type: dict[str, int]
+    assets: list[CryptoAssetSchema]
 
 
 class DashboardSBOMUploadInfo(Schema):

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -14,6 +14,7 @@ from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace
 from sbomify.apps.sboms.crypto_inventory import CryptoAsset, derive_crypto_inventory
 from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.pqc import assess_inventory
 
 log = logging.getLogger(__name__)
 
@@ -149,12 +150,23 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
         document = None
 
     inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)
+    summary = assess_inventory(inventory)
     return ServiceResult.success(
         {
             "sbom_id": str(sbom.id),
             "component_id": str(sbom.component.id),
             "count": inventory.count,
             "by_asset_type": inventory.by_asset_type,
-            "assets": [_serialize_crypto_asset(a) for a in inventory.assets],
+            "pqc_overall": summary.overall,
+            "pqc_counts": summary.counts,
+            "assets": [
+                {
+                    **_serialize_crypto_asset(result.asset),
+                    "pqc_status": result.assessment.status.value,
+                    "pqc_reason": result.assessment.reason,
+                    "pqc_data_quality_flag": result.assessment.data_quality_flag,
+                }
+                for result in summary.results
+            ],
         }
     )

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -138,7 +138,7 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
-    if raw is None:
+    if not raw:  # None or empty body == missing/corrupt artifact (matches download_sbom)
         return ServiceResult.failure("SBOM file not found", status_code=404)
 
     try:

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -144,6 +144,8 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
     try:
         document = json.loads(raw)
     except (ValueError, TypeError):
+        # ValueError covers JSONDecodeError and UnicodeDecodeError (non-UTF-8 bytes),
+        # so a corrupt artifact degrades to an empty inventory rather than a 500.
         document = None
 
     inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -11,6 +12,7 @@ from sbomify.apps.core.authz import can
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.core.utils import broadcast_to_workspace
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, derive_crypto_inventory
 from sbomify.apps.sboms.models import SBOM
 
 log = logging.getLogger(__name__)
@@ -90,3 +92,67 @@ def get_sbom_detail(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[st
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_sbom(sbom))
+
+
+def _serialize_crypto_asset(asset: CryptoAsset) -> dict[str, Any]:
+    return {
+        "name": asset.name,
+        "bom_ref": asset.bom_ref,
+        "oid": asset.oid,
+        "asset_type": asset.asset_type,
+        "primitive": asset.primitive,
+        "algorithm_family": asset.algorithm_family,
+        "parameter_set": asset.parameter_set,
+        "curve": asset.curve,
+        "nist_quantum_security_level": asset.nist_quantum_security_level,
+        "classical_security_level": asset.classical_security_level,
+        "crypto_functions": list(asset.crypto_functions),
+        "mode": asset.mode,
+        "padding": asset.padding,
+        "execution_environment": asset.execution_environment,
+        "certificate": asset.certificate,
+        "protocol": asset.protocol,
+        "related_material": asset.related_material,
+    }
+
+
+def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[str, Any]]:
+    """Derive the cryptographic-asset (CBOM) inventory for an SBOM.
+
+    Reads the immutable artifact from storage and projects its
+    ``cryptographic-asset`` components (ADR-004 — nothing is persisted or
+    mutated). Returns an empty inventory when the artifact carries no crypto
+    assets or is not a parseable CycloneDX document.
+    """
+    try:
+        sbom = SBOM.objects.select_related("component", "component__team").get(pk=sbom_id)
+    except SBOM.DoesNotExist:
+        return ServiceResult.failure("SBOM not found", status_code=404)
+
+    from sbomify.apps.core.services.access_control import check_component_access
+
+    if not check_component_access(request, sbom.component).has_access:
+        return ServiceResult.failure("Forbidden", status_code=403)
+
+    if not sbom.sbom_filename:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    raw = S3Client("SBOMS").get_sbom_data(sbom.sbom_filename)
+    if raw is None:
+        return ServiceResult.failure("SBOM file not found", status_code=404)
+
+    try:
+        document = json.loads(raw)
+    except (ValueError, TypeError):
+        document = None
+
+    inventory = derive_crypto_inventory(document if isinstance(document, dict) else None)
+    return ServiceResult.success(
+        {
+            "sbom_id": str(sbom.id),
+            "component_id": str(sbom.component.id),
+            "count": inventory.count,
+            "by_asset_type": inventory.by_asset_type,
+            "assets": [_serialize_crypto_asset(a) for a in inventory.assets],
+        }
+    )

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,0 +1,69 @@
+{% comment %}
+Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
+partial (no base template) and swapped into its own placeholder. Shows raw
+inventory facts derived from the immutable CycloneDX artifact — no post-quantum
+safe/vulnerable judgment (that is a later, separate increment).
+{% endcomment %}
+<section id="crypto-inventory-card" class="tw-card">
+    <div class="px-6 py-4 border-b border-border">
+        <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+            <i class="fas fa-lock text-primary"></i>
+            Cryptographic Assets
+            <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-border/50 text-text-muted">{{ crypto_inventory.count }}</span>
+        </h4>
+    </div>
+    <div class="p-6 space-y-6">
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            <div class="px-4 py-3 rounded-lg bg-border/30 text-center">
+                <div class="text-2xl font-bold text-text">{{ crypto_inventory.count }}</div>
+                <div class="text-xs text-text-muted uppercase tracking-wide mt-1">Total</div>
+            </div>
+            {% for asset_type, n in crypto_inventory.by_asset_type.items %}
+                <div class="px-4 py-3 rounded-lg bg-info/10 border border-info/20 text-center">
+                    <div class="text-2xl font-bold text-info">{{ n }}</div>
+                    <div class="text-xs text-info uppercase tracking-wide mt-1">{{ asset_type }}</div>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-left text-text-muted border-b border-border">
+                        <th class="py-2 pr-4 font-medium">Asset</th>
+                        <th class="py-2 pr-4 font-medium">Type</th>
+                        <th class="py-2 pr-4 font-medium">Primitive</th>
+                        <th class="py-2 pr-4 font-medium">Parameters</th>
+                        <th class="py-2 pr-4 font-medium">NIST Quantum Level</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for asset in crypto_inventory.assets %}
+                        <tr class="border-b border-border/50">
+                            <td class="py-2 pr-4 font-medium text-text">{{ asset.name|default:"—" }}</td>
+                            <td class="py-2 pr-4">
+                                <span class="tw-badge tw-badge-secondary">{{ asset.asset_type|default:"unknown" }}</span>
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">{{ asset.primitive|default:"—" }}</td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.algorithm_family %}{{ asset.algorithm_family }}{% endif %}
+                                {% if asset.parameter_set %}{{ asset.parameter_set }}{% endif %}
+                                {% if asset.curve %}· {{ asset.curve }}{% endif %}
+                                {% if not asset.algorithm_family and not asset.parameter_set and not asset.curve %}—{% endif %}
+                            </td>
+                            <td class="py-2 pr-4 text-text-muted">
+                                {% if asset.nist_quantum_security_level is not None %}
+                                    {{ asset.nist_quantum_security_level }}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="text-xs text-text-muted m-0">
+            Derived from the CycloneDX document. sbomify does not modify the uploaded artifact.
+        </p>
+    </div>
+</section>

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -58,8 +58,14 @@ inventory's overall post-quantum readiness verdict from the pqc module.
                             <td class="py-2 pr-4 text-text-muted">{{ asset.primitive|default:"—" }}</td>
                             <td class="py-2 pr-4 text-text-muted">
                                 {% if asset.algorithm_family %}{{ asset.algorithm_family }}{% endif %}
-                                {% if asset.parameter_set %}{{ asset.parameter_set }}{% endif %}
-                                {% if asset.curve %}· {{ asset.curve }}{% endif %}
+                                {% if asset.parameter_set %}
+                                    {% if asset.algorithm_family %}·{% endif %}
+                                    {{ asset.parameter_set }}
+                                {% endif %}
+                                {% if asset.curve %}
+                                    {% if asset.algorithm_family or asset.parameter_set %}·{% endif %}
+                                    {{ asset.curve }}
+                                {% endif %}
                                 {% if not asset.algorithm_family and not asset.parameter_set and not asset.curve %}—{% endif %}
                             </td>
                             <td class="py-2 pr-4 text-text-muted">

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,9 +1,9 @@
 {% load pqc_extras %}
 {% comment %}
 Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
-partial (no base template) and swapped into its own placeholder. Shows raw
-inventory facts derived from the immutable CycloneDX artifact — no post-quantum
-safe/vulnerable judgment (that is a later, separate increment).
+partial (no base template) and swapped into its own placeholder. Shows the crypto
+assets derived from the immutable CycloneDX artifact, with each asset's and the
+inventory's overall post-quantum readiness verdict from the pqc module.
 {% endcomment %}
 <section id="crypto-inventory-card" class="tw-card">
     <div class="px-6 py-4 border-b border-border">

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_inventory_card.html.j2
@@ -1,3 +1,4 @@
+{% load pqc_extras %}
 {% comment %}
 Lazy-loaded crypto-asset (CBOM) inventory card. Rendered as a standalone HTMX
 partial (no base template) and swapped into its own placeholder. Shows raw
@@ -10,6 +11,9 @@ safe/vulnerable judgment (that is a later, separate increment).
             <i class="fas fa-lock text-primary"></i>
             Cryptographic Assets
             <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-border/50 text-text-muted">{{ crypto_inventory.count }}</span>
+            <span class="tw-badge tw-badge-{{ crypto_inventory.pqc_overall|pqc_overall_variant }} ml-auto">
+                {{ crypto_inventory.pqc_overall|pqc_overall_label }}
+            </span>
         </h4>
     </div>
     <div class="p-6 space-y-6">
@@ -30,6 +34,7 @@ safe/vulnerable judgment (that is a later, separate increment).
                 <thead>
                     <tr class="text-left text-text-muted border-b border-border">
                         <th class="py-2 pr-4 font-medium">Asset</th>
+                        <th class="py-2 pr-4 font-medium">Quantum readiness</th>
                         <th class="py-2 pr-4 font-medium">Type</th>
                         <th class="py-2 pr-4 font-medium">Primitive</th>
                         <th class="py-2 pr-4 font-medium">Parameters</th>
@@ -40,6 +45,13 @@ safe/vulnerable judgment (that is a later, separate increment).
                     {% for asset in crypto_inventory.assets %}
                         <tr class="border-b border-border/50">
                             <td class="py-2 pr-4 font-medium text-text">{{ asset.name|default:"—" }}</td>
+                            <td class="py-2 pr-4">
+                                <span class="tw-badge tw-badge-{{ asset.pqc_status|pqc_variant }}">{{ asset.pqc_status|pqc_label }}</span>
+                                {% if asset.pqc_data_quality_flag %}
+                                    <i class="fas fa-triangle-exclamation text-warning ml-1"
+                                       title="{{ asset.pqc_data_quality_flag }}"></i>
+                                {% endif %}
+                            </td>
                             <td class="py-2 pr-4">
                                 <span class="tw-badge tw-badge-secondary">{{ asset.asset_type|default:"unknown" }}</span>
                             </td>

--- a/sbomify/apps/sboms/templates/sboms/components/crypto_posture_card.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/crypto_posture_card.html.j2
@@ -1,0 +1,39 @@
+{% load pqc_extras %}
+{% comment %}
+Lazy-loaded component-level post-quantum posture card (HTMX partial, no base
+template). Summarizes the overall PQC readiness of the component's most recent
+artifact and links through to the per-SBOM cryptographic-asset detail. Renders
+nothing (placeholder collapses) when the latest artifact has no crypto assets.
+{% endcomment %}
+<section id="crypto-posture-card" class="tw-card">
+    <div class="px-6 py-4 border-b border-border flex items-center justify-between gap-2">
+        <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+            <i class="fas fa-shield-halved text-primary"></i>
+            Post-Quantum Posture
+        </h4>
+        <span class="tw-badge tw-badge-{{ posture.pqc_overall|pqc_overall_variant }}">
+            {{ posture.pqc_overall|pqc_overall_label }}
+        </span>
+    </div>
+    <div class="p-6 space-y-4">
+        <div class="grid grid-cols-3 gap-3">
+            <div class="px-4 py-3 rounded-lg bg-danger/10 border border-danger/20 text-center">
+                <div class="text-2xl font-bold text-danger">{{ posture.pqc_counts.quantum_vulnerable|default:0 }}</div>
+                <div class="text-xs text-danger uppercase tracking-wide mt-1">Vulnerable</div>
+            </div>
+            <div class="px-4 py-3 rounded-lg bg-warning/10 border border-warning/20 text-center">
+                <div class="text-2xl font-bold text-warning">{{ posture.pqc_counts.review|default:0 }}</div>
+                <div class="text-xs text-warning uppercase tracking-wide mt-1">Review</div>
+            </div>
+            <div class="px-4 py-3 rounded-lg bg-success/10 border border-success/20 text-center">
+                <div class="text-2xl font-bold text-success">{{ posture.pqc_counts.quantum_safe|default:0 }}</div>
+                <div class="text-xs text-success uppercase tracking-wide mt-1">Quantum-safe</div>
+            </div>
+        </div>
+        <a href="{% url 'core:component_item' component_id 'sboms' sbom_id %}"
+           class="text-sm text-primary hover:underline inline-flex items-center gap-1">
+            View {{ posture.count }} cryptographic asset{{ posture.count|pluralize }}
+            <i class="fas fa-arrow-right text-xs"></i>
+        </a>
+    </div>
+</section>

--- a/sbomify/apps/sboms/templatetags/pqc_extras.py
+++ b/sbomify/apps/sboms/templatetags/pqc_extras.py
@@ -1,0 +1,41 @@
+"""Template filters mapping PQC classification values to display labels + badge variants."""
+
+from django import template
+
+register = template.Library()
+
+# Per-asset PQC status -> (human label, tw-badge variant)
+_STATUS_DISPLAY = {
+    "quantum_safe": ("Quantum-safe", "success"),
+    "quantum_vulnerable": ("Vulnerable", "danger"),
+    "review": ("Review", "warning"),
+    "unknown": ("Unknown", "secondary"),
+}
+
+# Inventory-level readiness -> (human label, tw-badge variant)
+_OVERALL_DISPLAY = {
+    "at_risk": ("At risk", "danger"),
+    "needs_review": ("Needs review", "warning"),
+    "ready": ("Quantum-ready", "success"),
+    "not_assessed": ("Not assessed", "secondary"),
+}
+
+
+@register.filter
+def pqc_label(status: str | None) -> str:
+    return _STATUS_DISPLAY.get(status or "", ("Unknown", "secondary"))[0]
+
+
+@register.filter
+def pqc_variant(status: str | None) -> str:
+    return _STATUS_DISPLAY.get(status or "", ("Unknown", "secondary"))[1]
+
+
+@register.filter
+def pqc_overall_label(overall: str | None) -> str:
+    return _OVERALL_DISPLAY.get(overall or "", ("Not assessed", "secondary"))[0]
+
+
+@register.filter
+def pqc_overall_variant(overall: str | None) -> str:
+    return _OVERALL_DISPLAY.get(overall or "", ("Not assessed", "secondary"))[1]

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -87,3 +87,32 @@ def test_non_crypto_sbom_yields_empty_inventory():
 def test_handles_empty_or_missing_components():
     assert derive_crypto_inventory({}).count == 0
     assert derive_crypto_inventory({"components": []}).count == 0
+
+
+def test_malformed_field_types_never_raise_and_stay_schema_clean():
+    """Garbage field types must not raise (incl. by_asset_type's Counter) nor break the str|None API schema."""
+    doc = {
+        "components": [
+            {
+                "type": "cryptographic-asset",
+                "name": ["not", "a", "string"],
+                "cryptoProperties": {
+                    "assetType": {"nested": "dict"},  # unhashable -> would break Counter
+                    "algorithmProperties": {
+                        "primitive": ["list"],  # non-str on a str field
+                        "parameterSetIdentifier": 768,  # scalar -> coerced to "768"
+                        "cryptoFunctions": ["keygen", {"x": 1}],  # mixed -> only str-able kept
+                    },
+                },
+            }
+        ]
+    }
+    inv = derive_crypto_inventory(doc)
+    assert inv.count == 1
+    assert inv.by_asset_type == {}  # non-string assetType dropped, no TypeError
+    asset = inv.assets[0]
+    assert asset.asset_type is None
+    assert asset.name is None  # non-string dropped
+    assert asset.primitive is None  # list dropped
+    assert asset.parameter_set == "768"  # scalar coerced to str
+    assert all(isinstance(f, str) for f in asset.crypto_functions)

--- a/sbomify/apps/sboms/tests/test_crypto_inventory.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory.py
@@ -1,0 +1,89 @@
+"""Tests for the CBOM crypto-asset inventory derivation (#1001 increment 1)."""
+
+import json
+from pathlib import Path
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory, derive_crypto_inventory
+
+_DATA = Path(__file__).parent / "test_data"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_DATA / name).read_text())
+
+
+def _by_name(inv: CryptoInventory, name: str) -> CryptoAsset:
+    return next(a for a in inv.assets if a.name == name)
+
+
+def test_derives_crypto_assets_from_cbom_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    assert isinstance(inv, CryptoInventory)
+    # 6 cryptographic-asset components; the plain library is excluded
+    assert inv.count == 6
+    assert all(isinstance(a, CryptoAsset) for a in inv.assets)
+    assert "left-pad" not in {a.name for a in inv.assets}
+    # asset-type breakdown (algorithm x3, certificate, protocol; broken entry -> None)
+    assert inv.by_asset_type.get("algorithm") == 3
+    assert inv.by_asset_type.get("certificate") == 1
+    assert inv.by_asset_type.get("protocol") == 1
+
+
+def test_projects_algorithm_fields_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    rsa = _by_name(inv, "RSA-2048")
+    assert rsa.asset_type == "algorithm"
+    assert rsa.bom_ref == "crypto-rsa2048"
+    assert rsa.oid == "1.2.840.113549.1.1.1"
+    assert rsa.primitive == "pke"
+    assert rsa.parameter_set == "2048"
+    assert rsa.nist_quantum_security_level == 0
+    assert "encrypt" in rsa.crypto_functions
+
+    ecdsa = _by_name(inv, "ECDSA-P256")
+    assert ecdsa.primitive == "signature"
+    assert ecdsa.curve == "secp256r1"
+
+    mlkem = _by_name(inv, "ML-KEM-768")
+    assert mlkem.primitive == "kem"
+    assert mlkem.nist_quantum_security_level == 3
+
+
+def test_projects_certificate_and_protocol_1_6():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    cert = _by_name(inv, "server-cert")
+    assert cert.asset_type == "certificate"
+    assert cert.certificate and cert.certificate.get("subjectName") == "CN=demo.example.com"
+
+    proto = _by_name(inv, "TLS")
+    assert proto.asset_type == "protocol"
+    assert proto.protocol and proto.protocol.get("version") == "1.3"
+
+
+def test_tolerates_missing_crypto_properties():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.6.cdx.json"))
+    broken = _by_name(inv, "broken-entry")
+    assert broken.asset_type is None
+    assert broken.primitive is None  # no crash
+
+
+def test_1_7_field_aliases_elliptic_curve_and_family():
+    inv = derive_crypto_inventory(_load("cbom_sample_1.7.cdx.json"))
+    assert inv.count == 2
+    ecdsa = _by_name(inv, "ECDSA-P384")
+    assert ecdsa.curve == "secp384r1"  # 1.7 uses ellipticCurve
+    assert ecdsa.algorithm_family == "ecdsa"
+    mldsa = _by_name(inv, "ML-DSA-65")
+    assert mldsa.algorithm_family == "ml-dsa"
+    assert mldsa.primitive == "signature"
+
+
+def test_non_crypto_sbom_yields_empty_inventory():
+    inv = derive_crypto_inventory(_load("sbomify_syft.cdx.json"))
+    assert inv.count == 0
+    assert inv.assets == ()
+
+
+def test_handles_empty_or_missing_components():
+    assert derive_crypto_inventory({}).count == 0
+    assert derive_crypto_inventory({"components": []}).count == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -82,3 +82,12 @@ def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFi
     _mock_s3(mocker, b"{}")
     response = Client().get(_url(sample_sbom.id))  # no session, component is private
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    # Corrupt (non-UTF-8) bytes must degrade to an empty inventory, never a 500.
+    _mock_s3(mocker, b"\xff\xfe\x00not-valid-utf8")
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.json()["count"] == 0

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -91,3 +91,15 @@ def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM,
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 200
     assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_inventory_includes_pqc_classification(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    body = _owner_client(sample_sbom).get(_url(sample_sbom.id)).json()
+
+    assert body["pqc_overall"] == "at_risk"  # RSA + ECDSA present
+    assert body["pqc_counts"]["quantum_vulnerable"] >= 1
+    by_name = {a["name"]: a for a in body["assets"]}
+    assert by_name["RSA-2048"]["pqc_status"] == "quantum_vulnerable"
+    assert by_name["ML-KEM-768"]["pqc_status"] == "quantum_safe"

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -10,8 +10,10 @@ from django.test import Client
 from django.urls import reverse
 from pytest_mock.plugin import MockerFixture
 
+from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
 from ..models import SBOM
-from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .fixtures import sample_access_token, sample_component, sample_sbom  # noqa: F401
 from .test_views import setup_test_session
 
 _DATA = Path(__file__).parent / "test_data"
@@ -91,6 +93,19 @@ def test_invalid_utf8_artifact_yields_empty_inventory_not_500(sample_sbom: SBOM,
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 200
     assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_personal_access_token_reads_private_inventory(
+    sample_sbom: SBOM,  # noqa: F811
+    sample_access_token,  # noqa: F811
+    mocker: MockerFixture,
+):
+    # auth=None must still honor a PAT (via optional_auth) for private SBOMs — no session, bearer only.
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_url(sample_sbom.id), **get_api_headers(sample_access_token))
+    assert response.status_code == 200
+    assert response.json()["count"] == 6
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -65,8 +65,14 @@ def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa
 
 
 @pytest.mark.django_db
-def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
-    _mock_s3(mocker, None)
+@pytest.mark.parametrize("payload", [None, b""])
+def test_404_when_artifact_missing_from_storage(
+    sample_sbom: SBOM,  # noqa: F811
+    mocker: MockerFixture,
+    payload: bytes | None,
+):
+    # An empty object body is corruption/absence, not a crypto-free SBOM: 404, not an empty inventory.
+    _mock_s3(mocker, payload)
     response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
     assert response.status_code == 404
 

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -1,0 +1,78 @@
+"""API tests for the derived crypto-inventory endpoint (#1001 increment 2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _url(sbom_id: str) -> str:
+    return reverse("api-1:get_sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_returns_derived_crypto_inventory(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sbom_id"] == sample_sbom.id
+    assert body["count"] == 6
+    assert body["by_asset_type"]["algorithm"] == 3
+    names = {a["name"] for a in body["assets"]}
+    assert "RSA-2048" in names
+    assert "left-pad" not in names  # plain library excluded
+
+
+@pytest.mark.django_db
+def test_empty_inventory_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.django_db
+def test_404_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_url("doesnotexist1"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_404_when_artifact_missing_from_storage(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, None)
+    response = _owner_client(sample_sbom).get(_url(sample_sbom.id))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_403_for_private_sbom_without_access(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = Client().get(_url(sample_sbom.id))  # no session, component is private
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
@@ -1,0 +1,102 @@
+"""Tests for the lazy-loaded crypto-inventory UI card (#1001 increment 3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM, Component
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _card_url(sbom_id: str) -> str:
+    return reverse("sboms:sbom_crypto_inventory", kwargs={"sbom_id": sbom_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_card_renders_for_cbom_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Cryptographic Assets" in html
+    assert "RSA-2048" in html  # an algorithm asset name
+    assert "ML-KEM-768" in html
+    assert "left-pad" not in html  # plain library excluded
+    # raw NIST quantum level shown verbatim, including 0 (not hidden as falsy)
+    assert "algorithm" in html  # asset-type breakdown label
+
+
+@pytest.mark.django_db
+def test_card_is_a_partial_not_a_full_page(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    html = _owner_client(sample_sbom).get(_card_url(sample_sbom.id)).content.decode()
+    assert "<html" not in html.lower()
+    assert "<!doctype" not in html.lower()
+
+
+@pytest.mark.django_db
+def test_card_empty_for_non_crypto_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""  # nothing to show -> placeholder collapses
+
+
+@pytest.mark.django_db
+def test_card_empty_for_unknown_sbom(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, b"{}")
+    response = _owner_client(sample_sbom).get(_card_url("doesnotexist1"))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""
+
+
+@pytest.mark.django_db
+def test_card_does_not_leak_private_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))  # anon, component is private
+    assert response.status_code == 200
+    assert "RSA-2048" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_card_visible_on_public_component_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    sample_sbom.component.visibility = Component.Visibility.PUBLIC
+    sample_sbom.component.save()
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_card_url(sample_sbom.id))
+    assert response.status_code == 200
+    assert "RSA-2048" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_item_page_wires_lazy_placeholder(sample_sbom: SBOM):  # noqa: F811
+    """The SBOM item detail page lazy-loads the card via hx-get (no S3 read at page render)."""
+    client = _owner_client(sample_sbom)
+    item_url = reverse("core:component_item", args=[sample_sbom.component.id, "sboms", sample_sbom.id])
+    response = client.get(item_url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert _card_url(sample_sbom.id) in html
+    assert 'hx-trigger="load"' in html

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_card.py
@@ -91,6 +91,15 @@ def test_card_visible_on_public_component_to_anonymous(sample_sbom: SBOM, mocker
 
 
 @pytest.mark.django_db
+def test_card_shows_pqc_readiness(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    html = _owner_client(sample_sbom).get(_card_url(sample_sbom.id)).content.decode()
+    assert "At risk" in html  # overall readiness badge (RSA/ECDSA vulnerable)
+    assert "Vulnerable" in html  # per-asset status
+    assert "Quantum-safe" in html  # ML-KEM
+
+
+@pytest.mark.django_db
 def test_item_page_wires_lazy_placeholder(sample_sbom: SBOM):  # noqa: F811
     """The SBOM item detail page lazy-loads the card via hx-get (no S3 read at page render)."""
     client = _owner_client(sample_sbom)

--- a/sbomify/apps/sboms/tests/test_crypto_posture_card.py
+++ b/sbomify/apps/sboms/tests/test_crypto_posture_card.py
@@ -1,0 +1,74 @@
+"""Tests for the component-level post-quantum posture card (#1001 increment 6)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from pytest_mock.plugin import MockerFixture
+
+from ..models import SBOM, Component
+from .fixtures import sample_component, sample_sbom  # noqa: F401
+from .test_views import setup_test_session
+
+_DATA = Path(__file__).parent / "test_data"
+_S3_TARGET = "sbomify.apps.sboms.services.sboms.S3Client"
+
+
+def _posture_url(component_id: str) -> str:
+    return reverse("sboms:component_crypto_posture", kwargs={"component_id": component_id})
+
+
+def _mock_s3(mocker: MockerFixture, payload: bytes | None) -> None:
+    mocker.patch(_S3_TARGET).return_value.get_sbom_data.return_value = payload
+
+
+def _owner_client(sbom: SBOM) -> Client:
+    client = Client()
+    team = sbom.component.team
+    setup_test_session(client, team, team.members.first())
+    return client
+
+
+@pytest.mark.django_db
+def test_posture_renders_for_component_with_crypto(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    component_id = sample_sbom.component.id
+    response = _owner_client(sample_sbom).get(_posture_url(component_id))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Post-Quantum Posture" in html
+    assert "At risk" in html  # RSA/ECDSA vulnerable -> overall at_risk
+    # links through to the per-SBOM crypto detail
+    assert reverse("core:component_item", args=[component_id, "sboms", sample_sbom.id]) in html
+
+
+@pytest.mark.django_db
+def test_posture_collapses_for_non_crypto(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, json.dumps({"specVersion": "1.6", "components": [{"type": "library", "name": "x"}]}).encode())
+    response = _owner_client(sample_sbom).get(_posture_url(sample_sbom.component.id))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""
+
+
+@pytest.mark.django_db
+def test_posture_collapses_for_component_without_sboms(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    component = Component.objects.create(name="No SBOMs", team=team, component_type=Component.ComponentType.BOM)
+    client = Client()
+    setup_test_session(client, team, sample_team_with_owner_member.user)
+    response = client.get(_posture_url(component.id))
+    assert response.status_code == 200
+    assert response.content.decode().strip() == ""
+
+
+@pytest.mark.django_db
+def test_posture_does_not_leak_private_to_anonymous(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    response = Client().get(_posture_url(sample_sbom.component.id))  # anon, component private
+    assert response.status_code == 200
+    assert "At risk" not in response.content.decode()

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.6.cdx.json
@@ -1,0 +1,35 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "1.0"}},
+  "components": [
+    {"type": "library", "name": "left-pad", "version": "1.3.0", "bom-ref": "lib-leftpad"},
+    {
+      "type": "cryptographic-asset", "name": "RSA-2048", "bom-ref": "crypto-rsa2048",
+      "cryptoProperties": {"assetType": "algorithm", "oid": "1.2.840.113549.1.1.1",
+        "algorithmProperties": {"primitive": "pke", "parameterSetIdentifier": "2048", "classicalSecurityLevel": 112, "nistQuantumSecurityLevel": 0, "cryptoFunctions": ["encrypt", "decrypt"]}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P256", "bom-ref": "crypto-ecdsa",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "curve": "secp256r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-KEM-768", "bom-ref": "crypto-mlkem",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "kem", "parameterSetIdentifier": "768", "nistQuantumSecurityLevel": 3}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "server-cert", "bom-ref": "crypto-cert",
+      "cryptoProperties": {"assetType": "certificate",
+        "certificateProperties": {"subjectName": "CN=demo.example.com", "issuerName": "CN=Demo CA", "certificateFormat": "X.509"}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "TLS", "bom-ref": "crypto-tls",
+      "cryptoProperties": {"assetType": "protocol",
+        "protocolProperties": {"type": "tls", "version": "1.3"}}
+    },
+    {"type": "cryptographic-asset", "name": "broken-entry", "bom-ref": "crypto-broken"}
+  ]
+}

--- a/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
+++ b/sbomify/apps/sboms/tests/test_data/cbom_sample_1.7.cdx.json
@@ -1,0 +1,18 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "metadata": {"timestamp": "2026-01-01T00:00:00Z", "component": {"type": "application", "name": "demo-app", "version": "2.0"}},
+  "components": [
+    {
+      "type": "cryptographic-asset", "name": "ECDSA-P384", "bom-ref": "c-ecdsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ecdsa", "ellipticCurve": "secp384r1", "nistQuantumSecurityLevel": 0}}
+    },
+    {
+      "type": "cryptographic-asset", "name": "ML-DSA-65", "bom-ref": "c-mldsa17",
+      "cryptoProperties": {"assetType": "algorithm",
+        "algorithmProperties": {"primitive": "signature", "algorithmFamily": "ml-dsa", "parameterSetIdentifier": "65", "nistQuantumSecurityLevel": 3}}
+    }
+  ]
+}

--- a/sbomify/apps/sboms/tests/test_pqc.py
+++ b/sbomify/apps/sboms/tests/test_pqc.py
@@ -1,0 +1,169 @@
+"""Tests for the post-quantum (PQC) readiness classification (#1001 increment 4).
+
+The classification table is grounded in NIST guidance (FIPS 203/204/205, draft 206,
+NIST IR 8547, NSA CNSA 2.0) and adversarially verified. Key, sometimes
+counter-intuitive, decisions encoded here:
+
+- SHA-256 is SAFE (Grover does not speed up collision search; NIST keeps SHA-2
+  approved) — NOT "review".
+- ``nistQuantumSecurityLevel`` is a NIST strength-category floor, not a quantum-safe
+  flag: algorithm identity decides the verdict; the declared level only raises a
+  data-quality flag when it looks mislabeled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.sboms.crypto_inventory import CryptoAsset, CryptoInventory
+from sbomify.apps.sboms.pqc import (
+    PqcStatus,
+    assess_inventory,
+    classify_crypto_asset,
+)
+
+
+def _algo(name: str | None, **kw) -> CryptoAsset:
+    return CryptoAsset(name=name, bom_ref=None, oid=None, asset_type="algorithm", **kw)
+
+
+# --- standardized PQC -> SAFE -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["ML-KEM-768", "Kyber768", "CRYSTALS-Kyber", "ML-DSA-65", "Dilithium3", "SLH-DSA-SHA2-128s", "SPHINCS+"],
+)
+def test_standardized_pqc_is_safe(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.SAFE
+
+
+# --- quantum-vulnerable asymmetric -> VULNERABLE ------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["RSA-2048", "ECDSA-P256", "Ed25519", "Ed448", "X25519", "DH-2048", "ECDH-P384", "DSA", "ElGamal"],
+)
+def test_shor_breakable_asymmetric_is_vulnerable(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.VULNERABLE
+
+
+def test_ecdsa_recognized_via_algorithm_family_1_7():
+    assert classify_crypto_asset(_algo(None, algorithm_family="ECDSA")).status is PqcStatus.VULNERABLE
+
+
+def test_elliptic_curve_recognized_via_curve_field():
+    asset = _algo(None, primitive="signature", curve="secp256r1")
+    assert classify_crypto_asset(asset).status is PqcStatus.VULNERABLE
+
+
+# --- symmetric / hash (size-dependent) ---------------------------------------
+
+
+def test_aes_256_is_safe():
+    assert classify_crypto_asset(_algo("AES-256-GCM")).status is PqcStatus.SAFE
+
+
+def test_aes_128_is_review():
+    assert classify_crypto_asset(_algo("AES-128-CBC")).status is PqcStatus.REVIEW
+
+
+def test_aes_without_key_size_is_review():
+    assert classify_crypto_asset(_algo("AES")).status is PqcStatus.REVIEW
+
+
+def test_chacha20_is_safe():
+    assert classify_crypto_asset(_algo("ChaCha20-Poly1305")).status is PqcStatus.SAFE
+
+
+def test_sha256_is_safe_not_review():
+    # Adversarially verified: Grover does not attack collision resistance; NIST keeps SHA-2 approved.
+    assert classify_crypto_asset(_algo("SHA-256")).status is PqcStatus.SAFE
+
+
+def test_sha512_is_safe():
+    assert classify_crypto_asset(_algo("SHA-512")).status is PqcStatus.SAFE
+
+
+@pytest.mark.parametrize("name", ["MD5", "SHA-1"])
+def test_classically_broken_hash_is_review(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.REVIEW
+
+
+# --- gray zone -> REVIEW ------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["3DES", "TripleDES", "Falcon-512", "FN-DSA", "HQC-128"])
+def test_gray_zone_is_review(name):
+    assert classify_crypto_asset(_algo(name)).status is PqcStatus.REVIEW
+
+
+# --- unknown ------------------------------------------------------------------
+
+
+def test_unrecognized_algorithm_is_unknown():
+    assert classify_crypto_asset(_algo("FooCipher9000")).status is PqcStatus.UNKNOWN
+
+
+def test_certificate_without_algorithm_info_is_unknown():
+    cert = CryptoAsset(name="server-cert", bom_ref=None, oid=None, asset_type="certificate")
+    assert classify_crypto_asset(cert).status is PqcStatus.UNKNOWN
+
+
+# --- declared nistQuantumSecurityLevel = corroborating / data-quality only -----
+
+
+def test_vulnerable_family_with_declared_pqc_level_flags_mislabel_but_stays_vulnerable():
+    asset = _algo("RSA-2048", nist_quantum_security_level=3)
+    result = classify_crypto_asset(asset)
+    assert result.status is PqcStatus.VULNERABLE  # identity wins, not the integer
+    assert result.data_quality_flag is not None
+
+
+def test_pqc_family_declared_level_zero_flags_data_quality_but_stays_safe():
+    asset = _algo("ML-KEM-768", nist_quantum_security_level=0)
+    result = classify_crypto_asset(asset)
+    assert result.status is PqcStatus.SAFE
+    assert result.data_quality_flag is not None
+
+
+def test_unrecognized_with_declared_pqc_level_is_review_not_safe():
+    # The integer alone must never assert SAFE on an unrecognized algorithm.
+    asset = _algo("MysteryKEM", nist_quantum_security_level=5)
+    assert classify_crypto_asset(asset).status is PqcStatus.REVIEW
+
+
+# --- inventory summary --------------------------------------------------------
+
+
+def _inv(*assets: CryptoAsset) -> CryptoInventory:
+    return CryptoInventory(assets=tuple(assets))
+
+
+def test_summary_at_risk_when_any_vulnerable():
+    summary = assess_inventory(_inv(_algo("RSA-2048"), _algo("ML-KEM-768"), _algo("AES-256")))
+    assert summary.overall == "at_risk"
+    assert summary.counts[PqcStatus.VULNERABLE.value] == 1
+    assert summary.counts[PqcStatus.SAFE.value] == 2
+    assert len(summary.results) == 3
+
+
+def test_summary_ready_when_all_safe():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("AES-256"), _algo("SHA-512")))
+    assert summary.overall == "ready"
+
+
+def test_summary_needs_review_when_review_present_no_vulnerable():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("AES-128")))
+    assert summary.overall == "needs_review"
+
+
+def test_summary_needs_review_for_unclassifiable_algorithm():
+    summary = assess_inventory(_inv(_algo("ML-KEM-768"), _algo("FooCipher9000")))
+    assert summary.overall == "needs_review"
+
+
+def test_summary_not_assessed_when_no_classifiable_assets():
+    summary = assess_inventory(_inv())
+    assert summary.overall == "not_assessed"

--- a/sbomify/apps/sboms/urls.py
+++ b/sbomify/apps/sboms/urls.py
@@ -3,6 +3,7 @@ from django.urls.resolvers import URLPattern
 from django.views.generic import RedirectView
 
 from sbomify.apps.sboms.views import (
+    ComponentCryptoPostureView,
     SbomCryptoInventoryView,
     SbomDownloadView,
     SbomsTableView,
@@ -76,5 +77,10 @@ urlpatterns: list[URLPattern] = [
         "sbom/<str:sbom_id>/crypto-inventory",
         SbomCryptoInventoryView.as_view(),
         name="sbom_crypto_inventory",
+    ),
+    path(
+        "component/<str:component_id>/crypto-posture",
+        ComponentCryptoPostureView.as_view(),
+        name="component_crypto_posture",
     ),
 ]

--- a/sbomify/apps/sboms/urls.py
+++ b/sbomify/apps/sboms/urls.py
@@ -2,7 +2,12 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 from django.views.generic import RedirectView
 
-from sbomify.apps.sboms.views import SbomDownloadView, SbomsTableView, SbomVulnerabilitiesView
+from sbomify.apps.sboms.views import (
+    SbomCryptoInventoryView,
+    SbomDownloadView,
+    SbomsTableView,
+    SbomVulnerabilitiesView,
+)
 
 app_name = "sboms"
 urlpatterns: list[URLPattern] = [
@@ -66,5 +71,10 @@ urlpatterns: list[URLPattern] = [
         SbomsTableView.as_view(),
         name="sboms_table_public",
         kwargs={"is_public_view": True},
+    ),
+    path(
+        "sbom/<str:sbom_id>/crypto-inventory",
+        SbomCryptoInventoryView.as_view(),
+        name="sbom_crypto_inventory",
     ),
 ]

--- a/sbomify/apps/sboms/views/__init__.py
+++ b/sbomify/apps/sboms/views/__init__.py
@@ -1,3 +1,4 @@
+from sbomify.apps.sboms.views.component_crypto_posture import ComponentCryptoPostureView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_crypto_inventory import SbomCryptoInventoryView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_download import SbomDownloadView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_upload_cyclonedx import SbomUploadCycloneDxView  # noqa: F401
@@ -5,6 +6,7 @@ from sbomify.apps.sboms.views.sbom_vulnerabilities import SbomVulnerabilitiesVie
 from sbomify.apps.sboms.views.sboms_table import SbomsTableView  # noqa: F401
 
 __all__ = [
+    "ComponentCryptoPostureView",
     "SbomCryptoInventoryView",
     "SbomDownloadView",
     "SbomUploadCycloneDxView",

--- a/sbomify/apps/sboms/views/__init__.py
+++ b/sbomify/apps/sboms/views/__init__.py
@@ -1,9 +1,11 @@
+from sbomify.apps.sboms.views.sbom_crypto_inventory import SbomCryptoInventoryView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_download import SbomDownloadView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_upload_cyclonedx import SbomUploadCycloneDxView  # noqa: F401
 from sbomify.apps.sboms.views.sbom_vulnerabilities import SbomVulnerabilitiesView  # noqa: F401
 from sbomify.apps.sboms.views.sboms_table import SbomsTableView  # noqa: F401
 
 __all__ = [
+    "SbomCryptoInventoryView",
     "SbomDownloadView",
     "SbomUploadCycloneDxView",
     "SbomVulnerabilitiesView",

--- a/sbomify/apps/sboms/views/component_crypto_posture.py
+++ b/sbomify/apps/sboms/views/component_crypto_posture.py
@@ -22,16 +22,18 @@ class ComponentCryptoPostureView(View):
     """
 
     def get(self, request: HttpRequest, component_id: str) -> HttpResponse:
-        latest = SBOM.objects.filter(component_id=component_id).order_by("-created_at").first()
-        if latest is None:
+        latest_id = (
+            SBOM.objects.filter(component_id=component_id).order_by("-created_at").values_list("id", flat=True).first()
+        )
+        if latest_id is None:
             return HttpResponse("")
 
-        result = get_crypto_inventory(request, latest.id)
+        result = get_crypto_inventory(request, latest_id)
         if not result.ok or not (result.value or {}).get("count"):
             return HttpResponse("")
 
         return render(
             request,
             POSTURE_TEMPLATE,
-            {"posture": result.value, "component_id": component_id, "sbom_id": latest.id},
+            {"posture": result.value, "component_id": component_id, "sbom_id": latest_id},
         )

--- a/sbomify/apps/sboms/views/component_crypto_posture.py
+++ b/sbomify/apps/sboms/views/component_crypto_posture.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.services.sboms import get_crypto_inventory
+
+POSTURE_TEMPLATE = "sboms/components/crypto_posture_card.html.j2"
+
+
+class ComponentCryptoPostureView(View):
+    """Lazy-loaded (hx-get) component-level post-quantum posture card.
+
+    Shows the overall PQC readiness of the component's most recent artifact, as
+    an at-a-glance signal on the component detail page (private and public).
+    Like the per-SBOM card it is an HTMX partial: a single S3 read happens after
+    page render, authorization is delegated to ``get_crypto_inventory`` (so no
+    private leak on the public page), and any failure or a crypto-free artifact
+    renders nothing — the placeholder simply collapses.
+    """
+
+    def get(self, request: HttpRequest, component_id: str) -> HttpResponse:
+        latest = SBOM.objects.filter(component_id=component_id).order_by("-created_at").first()
+        if latest is None:
+            return HttpResponse("")
+
+        result = get_crypto_inventory(request, latest.id)
+        if not result.ok or not (result.value or {}).get("count"):
+            return HttpResponse("")
+
+        return render(
+            request,
+            POSTURE_TEMPLATE,
+            {"posture": result.value, "component_id": component_id, "sbom_id": latest.id},
+        )

--- a/sbomify/apps/sboms/views/sbom_crypto_inventory.py
+++ b/sbomify/apps/sboms/views/sbom_crypto_inventory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+
+from sbomify.apps.sboms.services.sboms import get_crypto_inventory
+
+CARD_TEMPLATE = "sboms/components/crypto_inventory_card.html.j2"
+
+
+class SbomCryptoInventoryView(View):
+    """Lazy-loaded (hx-get) crypto-asset inventory card for one SBOM.
+
+    Rendered as an HTMX partial so the per-SBOM artifact read does not block the
+    detail-page render. Authorization is delegated to ``get_crypto_inventory``
+    (the same ``check_component_access`` used by the other SBOM read paths), so
+    the card works on both the private and public item pages without a login
+    mixin. Any failure or an empty inventory renders nothing — with
+    ``hx-swap="outerHTML"`` the placeholder simply collapses, never leaking
+    existence or erroring on an ordinary (non-crypto) SBOM.
+    """
+
+    def get(self, request: HttpRequest, sbom_id: str) -> HttpResponse:
+        result = get_crypto_inventory(request, sbom_id)
+        if not result.ok or not (result.value or {}).get("count"):
+            return HttpResponse("")
+        return render(request, CARD_TEMPLATE, {"crypto_inventory": result.value})


### PR DESCRIPTION
## Summary

Increments **5 and 6** of the CBOM epic (#1001): run the PQC classifier through the assessment framework (increment 5), and surface readiness one level up on the component / trust-center pages (increment 6).

> **Stacked on #1031 → #1030.** GitHub shows the whole stack; **review the last three commits** and merge **after #1030 and #1031**:
> - `cc907f9` — the assessment plugin
> - `2a04943` — plugin fix (not-assessed labelling, per Copilot)
> - `8ff8b60` — the component posture card

## Increment 5 — assessment plugin (`builtins/pqc.py`)

- `PqcReadinessPlugin(AssessmentPlugin)` (ADR-003): reads the artifact the orchestrator hands it, reuses `derive_crypto_inventory` + `assess_inventory`, and emits **one compliance `Finding` per crypto asset** (quantum-safe → pass, quantum-vulnerable → fail, review/unknown → warning) with migration remediation + a NIST IR 8547 standard reference. Renders in the existing compliance card with **no template changes**. Non-algorithm assets (certificates/protocols) it can't grade are an informational "not assessed", not a mislabeled "unrecognized algorithm".
- **The load-bearing line:** `supported_bom_types=["cbom"]`. Every other builtin pins `["sbom"]`, so CBOM artifacts triggered **zero** assessments before this. Registered in `apps.py`; runs through the existing on-upload pipeline.

## Increment 6 — component posture card (`views/component_crypto_posture.py`)

- A lazy HTMX **Post-Quantum Posture** card on the component detail page (private) and public component / trust-center page: overall readiness badge + vulnerable/review/safe counts, linking to the per-SBOM detail.
- Reuses `get_crypto_inventory` (auth via `check_component_access` — no private leak on the public page); one S3 read after page render; collapses when the latest artifact has no crypto.

## Tests

- `test_pqc_plugin.py` (8), `test_crypto_posture_card.py` (4). Full `plugins` suite green (745+); ruff + mypy + bandit + djlint clean.

## Known follow-up (flagged, not silently shipped)

`bom_type` is an explicit upload parameter (default `"sbom"`), so the **plugin** fires for CBOM-tagged uploads. Automatic CBOM detection on upload is deliberately separate (auto-tagging a hybrid artifact would also pull it out of `latest_sbom`'s `bom_type="sbom"` vuln pipeline). The **posture card** sidesteps this by keying off the latest artifact of any bom_type.

Completes the planned 6-increment decomposition of #1001 (derive → API → card → classify → plugin → surface).
