### PR TITLE
ci(cbom): self-publish sbomify's Cryptography BOM (CBOM)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -628,7 +628,7 @@ jobs:
   publish-cbom-production:
     name: Publish CBOM (production)
     needs: [docker-build]
-    if: startsWith(github.ref, 'refs/tags/v') && vars.CBOM_COMPONENT_ID_PRODUCTION != ''
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && vars.CBOM_COMPONENT_ID_PRODUCTION != ''
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -568,6 +568,102 @@ jobs:
           subject-path: '${{ github.workspace }}/${{ matrix.output_file }}'
 
   # =========================================================================
+  # Publish CBOM (Cryptography Bill of Materials)
+  #
+  # Uploads the committed, hand-maintained CycloneDX 1.6 CBOM
+  # (cbom/sbomify-backend.cbom.cdx.json) that inventories sbomify's own
+  # cryptographic usage. No off-the-shelf tool reliably generates a CBOM for
+  # sbomify's Python-via-wrappers stack (cdxgen detects Java/JS only; IBM
+  # CBOMkit keys on direct pyca/cryptography calls, which sbomify rarely makes),
+  # so the CBOM is maintained as code and CI signs + attests + uploads it via
+  # OIDC trusted publishing, exactly like the source SBOMs above.
+  #
+  # DORMANT until configured: each job runs only when its component repo
+  # variable is set. To enable, create a dedicated CBOM component in the
+  # sbomify workspace, give it an OIDC trusted-publishing binding to this repo,
+  # and set repo variable CBOM_COMPONENT_ID_STAGING / CBOM_COMPONENT_ID_PRODUCTION
+  # (optionally CBOM_PRODUCT_RELEASE_ID_* to tag a product release). A dedicated
+  # component is required because the action uploads with the default bom_type
+  # ("sbom"), which would collide with the Python Stack component's package SBOM.
+  # =========================================================================
+  publish-cbom-staging:
+    name: Publish CBOM (staging)
+    needs: [docker-build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && vars.CBOM_COMPONENT_ID_STAGING != ''
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Determine version
+        id: version
+        uses: ./.github/actions/determine-version
+
+      - name: Upload CBOM
+        uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
+        env:
+          API_BASE_URL: 'https://stage.sbomify.com'
+          COMPONENT_ID: ${{ vars.CBOM_COMPONENT_ID_STAGING }}
+          COMPONENT_NAME: 'Cryptography (CBOM)'
+          COMPONENT_VERSION: ${{ steps.version.outputs.version }}
+          SBOM_FILE: 'cbom/sbomify-backend.cbom.cdx.json'
+          PRODUCT_RELEASE: ${{ vars.CBOM_PRODUCT_RELEASE_ID_STAGING != '' && format('["{0}:{1}"]', vars.CBOM_PRODUCT_RELEASE_ID_STAGING, steps.version.outputs.version) || '' }}
+          SBOM_FORMAT: cyclonedx
+          AUGMENT: false
+          ENRICH: false
+          UPLOAD: true
+          OUTPUT_FILE: 'cbom-out.cdx.json'
+
+      - name: Attest CBOM
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: '${{ github.workspace }}/cbom-out.cdx.json'
+
+  publish-cbom-production:
+    name: Publish CBOM (production)
+    needs: [docker-build]
+    if: startsWith(github.ref, 'refs/tags/v') && vars.CBOM_COMPONENT_ID_PRODUCTION != ''
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Determine version
+        id: version
+        uses: ./.github/actions/determine-version
+
+      - name: Upload CBOM
+        uses: sbomify/sbomify-action@master # scorecard-ignore:pinned-dependencies -- self-dogfooding
+        env:
+          COMPONENT_ID: ${{ vars.CBOM_COMPONENT_ID_PRODUCTION }}
+          COMPONENT_NAME: 'Cryptography (CBOM)'
+          COMPONENT_VERSION: ${{ steps.version.outputs.version }}
+          SBOM_FILE: 'cbom/sbomify-backend.cbom.cdx.json'
+          PRODUCT_RELEASE: ${{ vars.CBOM_PRODUCT_RELEASE_ID_PRODUCTION != '' && format('["{0}:{1}"]', vars.CBOM_PRODUCT_RELEASE_ID_PRODUCTION, steps.version.outputs.version) || '' }}
+          SBOM_FORMAT: cyclonedx
+          AUGMENT: false
+          ENRICH: false
+          UPLOAD: true
+          OUTPUT_FILE: 'cbom-out.cdx.json'
+
+      - name: Attest CBOM
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: '${{ github.workspace }}/cbom-out.cdx.json'
+
+  # =========================================================================
   # Generate Container SBOMs (Staging) - master branch only
   # =========================================================================
   generate-container-sboms-staging:

--- a/cbom/sbomify-backend.cbom.cdx.json
+++ b/cbom/sbomify-backend.cbom.cdx.json
@@ -1,0 +1,114 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-06-18T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "sbomify-backend",
+      "description": "sbomify Python (Django) backend — Cryptography Bill of Materials"
+    },
+    "properties": [
+      {"name": "cdx:cbom:scope", "value": "first-party cryptographic usage of the sbomify backend"}
+    ]
+  },
+  "components": [
+    {
+      "type": "cryptographic-asset",
+      "name": "RSA-2048",
+      "bom-ref": "crypto/algorithm/rsa-2048",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "oid": "1.2.840.113549.1.1.1",
+        "algorithmProperties": {
+          "primitive": "signature",
+          "parameterSetIdentifier": "2048",
+          "classicalSecurityLevel": 112,
+          "nistQuantumSecurityLevel": 0,
+          "cryptoFunctions": ["verify"]
+        }
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/apps/oidc/utils.py#L279"}]},
+      "description": "RS256 verification of inbound GitHub Actions OIDC tokens (verify-side; key is GitHub's)."
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "ECDSA-P256",
+      "bom-ref": "crypto/algorithm/ecdsa-p256",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "oid": "1.2.840.10045.4.3.2",
+        "algorithmProperties": {
+          "primitive": "signature",
+          "curve": "P-256",
+          "classicalSecurityLevel": 128,
+          "nistQuantumSecurityLevel": 0,
+          "cryptoFunctions": ["verify"]
+        }
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/apps/plugins/builtins/verification.py#L241"}]},
+      "description": "Sigstore/cosign signature verification of user-uploaded SBOM attestations (ECDSA P-256 + SHA-256)."
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "HMAC-SHA-256",
+      "bom-ref": "crypto/algorithm/hmac-sha-256",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "algorithmProperties": {
+          "primitive": "mac",
+          "parameterSetIdentifier": "256",
+          "nistQuantumSecurityLevel": 5,
+          "cryptoFunctions": ["tag", "verify"]
+        }
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/apps/access_tokens/utils.py#L83"}]},
+      "description": "HS256 signing/verification of sbomify personal access tokens and OIDC-issued tokens (Django SECRET_KEY)."
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "SHA-256",
+      "bom-ref": "crypto/algorithm/sha-256",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "oid": "2.16.840.1.101.3.4.2.1",
+        "algorithmProperties": {
+          "primitive": "hash",
+          "parameterSetIdentifier": "256",
+          "nistQuantumSecurityLevel": 2,
+          "cryptoFunctions": ["digest"]
+        }
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/apps/core/object_store.py#L48"}]},
+      "description": "Content-addressing, integrity digests, and dedup/cache keys across storage and SBOM handling."
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "PBKDF2-HMAC-SHA256",
+      "bom-ref": "crypto/algorithm/pbkdf2-hmac-sha256",
+      "cryptoProperties": {
+        "assetType": "algorithm",
+        "algorithmProperties": {
+          "primitive": "kdf",
+          "parameterSetIdentifier": "256",
+          "nistQuantumSecurityLevel": 5,
+          "cryptoFunctions": ["keyderive"]
+        }
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/settings.py"}]},
+      "description": "Django default password hasher (PBKDF2-HMAC-SHA256); largely vestigial as auth is delegated to Keycloak."
+    },
+    {
+      "type": "cryptographic-asset",
+      "name": "TLS",
+      "bom-ref": "crypto/protocol/tls",
+      "cryptoProperties": {
+        "assetType": "protocol",
+        "protocolProperties": {"type": "tls", "version": "1.3"}
+      },
+      "evidence": {"occurrences": [{"location": "sbomify/apps/core/object_store.py#L13"}]},
+      "description": "TLS for outbound HTTPS (JWKS fetch, package registries) and S3/MinIO transport (boto3, AWS SigV4)."
+    }
+  ]
+}

--- a/cbom/sbomify-backend.cbom.cdx.json
+++ b/cbom/sbomify-backend.cbom.cdx.json
@@ -96,8 +96,8 @@
           "cryptoFunctions": ["keyderive"]
         }
       },
-      "evidence": {"occurrences": [{"location": "sbomify/settings.py"}]},
-      "description": "Django default password hasher (PBKDF2-HMAC-SHA256); largely vestigial as auth is delegated to Keycloak."
+      "evidence": {"occurrences": [{"location": "sbomify/settings.py#L484"}]},
+      "description": "Django default password hasher (PBKDF2-HMAC-SHA256), implied by django.contrib.auth + AUTH_PASSWORD_VALIDATORS; largely vestigial as auth is delegated to Keycloak."
     },
     {
       "type": "cryptographic-asset",


### PR DESCRIPTION
## Summary

Wire **CBOM self-publishing** into sbomify's CI so sbomify dogfoods a Cryptography Bill of Materials the same way it already self-publishes its SBOMs.

## Why it's hand-maintained (not tool-generated)

No off-the-shelf tool reliably generates a CBOM for sbomify's stack:
- **cdxgen** detects crypto in **Java + JS/TS only** — not Python source (sbomify is mostly Python).
- **IBM/PQCA CBOMkit** covers Python, but keys on **direct `pyca/cryptography`** calls; sbomify uses crypto through wrappers (`pyjwt`, `sigstore`, `hashlib`), which it largely won't see.

So the CBOM (`cbom/sbomify-backend.cbom.cdx.json`) is **maintained as code**, grounded in a file:line audit of the backend's actual cryptographic usage:

| Asset | Where | PQC verdict |
|---|---|---|
| RS256 / RSA-2048 | GitHub OIDC verify (`oidc/utils.py`) | 🔴 vulnerable |
| ECDSA-P256 + SHA-256 | Sigstore/cosign verify (`verification.py`) | 🔴 vulnerable |
| HS256 / HMAC-SHA-256 | PAT signing (`access_tokens/utils.py`) | 🟢 safe |
| SHA-256 | content addressing (`object_store.py`) | 🟢 safe |
| PBKDF2-HMAC-SHA256 | Django password hasher | 🟢 safe |
| TLS | outbound HTTPS / S3 transport | ⚪ protocol |

It **validates against the CycloneDX 1.6 upload schema** and classifies correctly through the new PQC readiness feature (overall: **at risk**).

## CI design

Two jobs in `ci-cd.yml` — `publish-cbom-staging` (master) and `publish-cbom-production` (tags) — mirror the existing source-SBOM jobs: checkout → determine-version → `sbomify/sbomify-action@master` with `SBOM_FILE` (not `LOCK_FILE`) → build-provenance attestation. They publish over **OIDC trusted publishing** (`id-token: write`, no token).

**They are dormant and cannot break CI** — each runs only when its component repo variable is set (`vars.CBOM_COMPONENT_ID_STAGING != ''`).

## To enable (maintainer, has sbomify-workspace access)

1. Create a **dedicated CBOM component** ("Cryptography (CBOM)") in the staging + production sbomify workspaces. *(A dedicated component is required: the action uploads with the default `bom_type` = `sbom`, which would collide with the Python Stack component's package SBOM on the uniqueness key.)*
2. Add an **OIDC trusted-publishing binding** from that component to this repo.
3. Set repo variables `CBOM_COMPONENT_ID_STAGING` / `CBOM_COMPONENT_ID_PRODUCTION` (and optionally `CBOM_PRODUCT_RELEASE_ID_*`).

## Notes

- The crypto-inventory **card + posture card** (PRs #1030/#1031) will render this CBOM once that feature deploys. The **assessment plugin** (#1032) needs the artifact tagged `bom_type=cbom`; the action uploads as `sbom`, so that surface awaits the separately-tracked CBOM-auto-detection follow-up. The cards work regardless.
- Independent of the feature stack — can merge on its own.
