### PR TITLE
fix(authz): route workspace read endpoints through can() to honour token scopes

### DIFF
--- a/sbomify/apps/billing/apis.py
+++ b/sbomify/apps/billing/apis.py
@@ -10,6 +10,7 @@ from ninja import Router
 from ninja.security import django_auth
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import User
 from sbomify.apps.core.queries import get_team_asset_counts
 from sbomify.apps.core.schemas import ErrorResponse
@@ -67,6 +68,9 @@ def get_usage(request: HttpRequest) -> tuple[int, Any]:
 
         if not team.members.filter(member__user=request.user).exists():
             return 403, {"detail": "You do not have access to this workspace"}
+
+        if not can(request, "workspace:read", team):
+            return 403, {"detail": "Forbidden"}
 
         counts = get_team_asset_counts(str(team.id))
 

--- a/sbomify/apps/billing/tests/test_api.py
+++ b/sbomify/apps/billing/tests/test_api.py
@@ -7,6 +7,8 @@ from django.contrib.auth.base_user import AbstractBaseUser
 from django.test import Client
 from django.urls import reverse
 
+from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.access_tokens.utils import create_personal_access_token
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.billing.tests.fixtures import (  # noqa: F401
     business_plan,
@@ -15,6 +17,7 @@ from sbomify.apps.billing.tests.fixtures import (  # noqa: F401
     mock_stripe,
     sample_user,
 )
+from sbomify.apps.core.authz import SCOPE_PRESETS
 from sbomify.apps.core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
 from sbomify.apps.sboms.models import SBOM, Component
 
@@ -90,6 +93,45 @@ def test_get_usage(
 
     assert data["products"] == 1
     assert data["components"] == 1
+
+
+@pytest.mark.django_db
+def test_get_usage_token_scope_gate(
+    client: Client,
+    sample_user: AbstractBaseUser,  # noqa: F811
+    team_with_business_plan: Team,  # noqa: F811
+):
+    """get_usage is a READ_MEMBER action gated by can("workspace:read", team).
+
+    A publish-only token must be rejected (403); a read_only token and a full
+    (unscoped) token must both pass (200). sample_user is already an owner member
+    of the team via the fixture, so only the token scope distinguishes the cases.
+    """
+
+    def tok(scopes: list[str] | None) -> str:
+        token_str = create_personal_access_token(sample_user)
+        AccessToken.objects.create(
+            user=sample_user,
+            encoded_token=token_str,
+            team=team_with_business_plan,
+            scopes=scopes,
+            description="scope-gate test token",
+        )
+        return token_str
+
+    url = f"{reverse('api-1:get_usage')}?team_key={team_with_business_plan.key}"
+
+    pub = tok(["artifact:publish"])
+    response = client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}")
+    assert response.status_code == 403, response.content
+
+    ro = tok(SCOPE_PRESETS["read_only"])
+    response = client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}")
+    assert response.status_code == 200, response.content
+
+    full = tok(None)
+    response = client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}")
+    assert response.status_code == 200, response.content
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/controls/apis.py
+++ b/sbomify/apps/controls/apis.py
@@ -56,6 +56,7 @@ from sbomify.apps.controls.services.status_service import (
     get_controls_detail,
     upsert_status,
 )
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import Product, User
 from sbomify.apps.core.schemas import ErrorResponse
 from sbomify.apps.core.utils import token_to_number
@@ -114,6 +115,9 @@ def list_catalogs(request: HttpRequest, include_inactive: bool = False) -> tuple
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     result = get_all_catalogs(team) if include_inactive else get_active_catalogs(team)
     if not result.ok:
         return 400, ErrorResponse(detail=result.error or "Unknown error")
@@ -239,6 +243,9 @@ def get_catalog(request: HttpRequest, catalog_id: str) -> tuple[int, Any]:
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     try:
         catalog = ControlCatalog.objects.get(id=catalog_id, team=team)
     except ControlCatalog.DoesNotExist:
@@ -329,6 +336,9 @@ def export_csv(request: HttpRequest, catalog_id: str, product_id: str | None = N
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     try:
         catalog = ControlCatalog.objects.get(id=catalog_id, team=team)
     except ControlCatalog.DoesNotExist:
@@ -363,6 +373,9 @@ def export_summary_csv(request: HttpRequest, catalog_id: str) -> HttpResponse | 
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     try:
         catalog = ControlCatalog.objects.get(id=catalog_id, team=team)
     except ControlCatalog.DoesNotExist:
@@ -394,6 +407,9 @@ def list_controls(request: HttpRequest, catalog_id: str, product_id: str | None 
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     try:
         catalog = ControlCatalog.objects.get(id=catalog_id, team=team)
     except ControlCatalog.DoesNotExist:
@@ -518,6 +534,9 @@ def list_control_mappings(request: HttpRequest, control_id: str) -> tuple[int, A
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     try:
         control = Control.objects.select_related("catalog").get(id=control_id, catalog__team=team)
     except Control.DoesNotExist:
@@ -665,6 +684,9 @@ def list_evidence(request: HttpRequest, control_id: str) -> tuple[int, Any]:
         return err
 
     assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
+
     control_status, cs_err = _resolve_control_status(control_id, team)
     if cs_err:
         return cs_err
@@ -803,6 +825,10 @@ def list_automation_mappings(request: HttpRequest) -> tuple[int, Any]:
     team, err = _get_user_team(request)
     if err:
         return err
+
+    assert team is not None
+    if not can(request, "workspace:read", team):
+        return 403, ErrorResponse(detail="Forbidden")
 
     return 200, AutomationMappingSchema(mappings=get_automation_mappings())
 

--- a/sbomify/apps/controls/tests/test_apis.py
+++ b/sbomify/apps/controls/tests/test_apis.py
@@ -295,6 +295,41 @@ class TestListControls:
 
 
 @pytest.mark.django_db
+class TestTokenReadScope:
+    """A controls read endpoint now routes through can(), so a narrow-scoped
+    token (no read scope) is denied — it previously bypassed the token-scope gate
+    and could enumerate private workspace controls data.
+    """
+
+    def test_list_catalogs_enforces_token_read_scope(self, sample_team_with_owner_member):
+        from django.test import Client
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+        from sbomify.apps.core.authz import SCOPE_PRESETS
+
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        url = "/api/v1/controls/catalogs/"
+
+        def tok(scopes):
+            s = create_personal_access_token(user)
+            AccessToken.objects.create(user=user, encoded_token=s, description="t", team=team, scopes=scopes)
+            return s
+
+        client = Client()
+        # publish-only token: no read scope -> 403 (was 200 before the fix)
+        pub = tok(["artifact:publish"])
+        assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}").status_code == 403
+        # read-only preset (includes workspace:read) -> 200
+        ro = tok(SCOPE_PRESETS["read_only"])
+        assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}").status_code == 200
+        # unscoped (full) token -> 200, unchanged
+        full = tok(None)
+        assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200
+
+
+@pytest.mark.django_db
 class TestPublicSummary:
     """Test public controls summary endpoint (no auth required)."""
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -679,6 +679,16 @@ def list_products(request: HttpRequest, page: int = Query(1), page_size: int = Q
         if not team_id:
             return 403, {"detail": "No current team selected", "error_code": ErrorCode.NO_CURRENT_TEAM}
 
+        # Route this internal read through can() so a narrow-scoped API token
+        # (e.g. a publish-only CI token) honours its scope: listing products
+        # exposes private workspace data, which a non-read token scope must not
+        # reach. No behaviour change for sessions or full/unscoped tokens —
+        # product:read is the READ_MEMBER tier every current member already
+        # satisfies; it only adds the token action-scope gate.
+        team = Team.objects.filter(id=team_id).first()
+        if team is not None and not can(request, "product:read", team):
+            return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
         products_queryset = optimize_product_queryset(Product.objects.filter(team_id=team_id))
         has_crud_permissions = _get_team_crud_permission(request, team_id)
 
@@ -2401,6 +2411,16 @@ def get_dashboard_summary(
     if is_internal_member:
         current_user: Any = request.user
         user_teams_qs = Team.objects.filter(member__user=current_user)
+        # Route this internal read through can() so a narrow-scoped API token
+        # (e.g. a publish-only CI token) honours its scope: the authenticated
+        # dashboard aggregates private workspace data, which a non-read token
+        # scope must not reach. No behaviour change for sessions or
+        # full/unscoped tokens — workspace:read is the READ_MEMBER tier every
+        # current member already satisfies; it only adds the token scope gate.
+        team_id = _get_user_team_id(request)
+        team = Team.objects.filter(id=team_id).first() if team_id else None
+        if team is not None and not can(request, "workspace:read", team):
+            return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
         # Base querysets for the user's teams
         products_qs = Product.objects.filter(team__in=user_teams_qs)
         components_qs = Component.objects.filter(team__in=user_teams_qs)
@@ -2555,6 +2575,17 @@ def list_all_releases(
                             "error_code": ErrorCode.FORBIDDEN,
                         }
 
+                    # Route this internal read through can() so a narrow-scoped
+                    # API token (e.g. a publish-only CI token) honours its scope:
+                    # listing releases of a private product exposes private
+                    # workspace data, which a non-read token scope must not
+                    # reach. No behaviour change for sessions or full/unscoped
+                    # tokens — release:read is the READ_MEMBER tier every current
+                    # member already satisfies; it only adds the token scope gate.
+                    team = Team.objects.filter(id=team_id).first()
+                    if team is not None and not can(request, "release:read", team):
+                        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
                     # Verify the product belongs to the user's team
                     if str(product.team.id) != team_id:
                         return 403, {"detail": "Product not found", "error_code": ErrorCode.PRODUCT_NOT_FOUND}
@@ -2573,6 +2604,16 @@ def list_all_releases(
                     "detail": "Guest members can only access public pages",
                     "error_code": ErrorCode.FORBIDDEN,
                 }
+
+            # Route this internal read through can() so a narrow-scoped API token
+            # (e.g. a publish-only CI token) honours its scope: listing all team
+            # releases exposes private workspace data, which a non-read token
+            # scope must not reach. No behaviour change for sessions or
+            # full/unscoped tokens — release:read is the READ_MEMBER tier every
+            # current member already satisfies; it only adds the token scope gate.
+            team = Team.objects.filter(id=team_id).first()
+            if team is not None and not can(request, "release:read", team):
+                return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
             # Build the base query for releases belonging to the user's team
             query = Release.objects.filter(product__team_id=team_id).select_related("product")

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2411,6 +2411,13 @@ def get_dashboard_summary(
     if is_internal_member:
         current_user: Any = request.user
         user_teams_qs = Team.objects.filter(member__user=current_user)
+        # A workspace-scoped API token must only see its own workspace's data:
+        # without this, a token bound to workspace A would still aggregate the
+        # user's other workspaces (B, C, …) into the dashboard. Sessions (no
+        # token_team) keep the all-workspaces view.
+        token_team = getattr(request, "token_team", None)
+        if token_team is not None:
+            user_teams_qs = user_teams_qs.filter(id=token_team.id)
         # Route this internal read through can() so a narrow-scoped API token
         # (e.g. a publish-only CI token) honours its scope: the authenticated
         # dashboard aggregates private workspace data, which a non-read token

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -3213,3 +3213,35 @@ def test_list_products_enforces_token_read_scope(sample_team_with_owner_member: 
     # unscoped (full) token -> 200, unchanged
     full = tok(None)
     assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200
+
+
+@pytest.mark.django_db
+def test_dashboard_summary_scoped_token_sees_only_its_workspace(
+    sample_team_with_owner_member: Member,  # noqa: F811
+):
+    """A workspace-bound token's dashboard must aggregate only that workspace —
+    not the user's other workspaces. Without the token_team filter, a token for
+    workspace A would also count workspace B's products/components."""
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.teams.models import Team
+
+    user = sample_team_with_owner_member.user
+    team_a = sample_team_with_owner_member.team
+    team_b = Team.objects.create(name="scope-gap-other-workspace")
+    Member.objects.create(user=user, team=team_b, role="owner")
+
+    Product.objects.create(name="ws-a-product", team=team_a)
+    Product.objects.create(name="ws-b-product-1", team=team_b)
+    Product.objects.create(name="ws-b-product-2", team=team_b)
+
+    # Token bound to workspace A only.
+    token_str = create_personal_access_token(user)
+    AccessToken.objects.create(user=user, encoded_token=token_str, description="ws-a", team=team_a)
+
+    url = reverse("api-1:get_dashboard_summary")
+    resp = Client().get(url, HTTP_AUTHORIZATION=f"Bearer {token_str}")
+    assert resp.status_code == 200
+    # Sanity: workspace B has products that must be excluded from A's token view.
+    assert Product.objects.filter(team=team_b).count() >= 2
+    assert resp.json()["total_products"] == Product.objects.filter(team=team_a).count()

--- a/sbomify/apps/core/tests/test_crud_apis.py
+++ b/sbomify/apps/core/tests/test_crud_apis.py
@@ -3181,3 +3181,35 @@ def test_list_components_enforces_token_read_scope(sample_team_with_owner_member
     # unscoped (full) token -> 200, unchanged
     full = tok(None)
     assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200
+
+
+@pytest.mark.django_db
+def test_list_products_enforces_token_read_scope(sample_team_with_owner_member: Member):  # noqa: F811
+    """#1029: the products-list endpoint now routes through can(), so a
+    narrow-scoped token (no read scope) is denied — it previously bypassed the
+    token-scope gate and could enumerate private workspace products.
+    """
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.core.authz import SCOPE_PRESETS
+
+    team = sample_team_with_owner_member.team
+    user = sample_team_with_owner_member.user
+    Product.objects.create(name="scope-gap-private-product", team=team)
+    url = reverse("api-1:list_products")
+
+    def tok(scopes):
+        s = create_personal_access_token(user)
+        AccessToken.objects.create(user=user, encoded_token=s, description="t", team=team, scopes=scopes)
+        return s
+
+    client = Client()
+    # publish-only token: no read scope -> 403 (was 200 before the fix)
+    pub = tok(["artifact:publish"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}").status_code == 403
+    # read-only preset (includes product:read) -> 200
+    ro = tok(SCOPE_PRESETS["read_only"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}").status_code == 200
+    # unscoped (full) token -> 200, unchanged
+    full = tok(None)
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -16,6 +16,7 @@ from ninja.security import django_auth
 from pydantic import BaseModel
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.models import User
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.posthog_service import capture_for_request
@@ -149,6 +150,9 @@ def get_team_branding(request: HttpRequest, team_key: str) -> tuple[int, Any]:
     if not Member.objects.filter(user=user, team=team).exists():
         logger.warning(f"User {user.username} is not a member of team {team_key}")
         return 403, {"detail": "Forbidden"}
+
+    if not can(request, "workspace:read", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     branding_data = _normalize_branding_payload(team.branding_info)
     branding_info = BrandingInfo(**branding_data)
@@ -708,6 +712,10 @@ def list_contact_profiles(request: HttpRequest, team_key: str) -> tuple[int, Any
     if error:
         return error
 
+    assert team is not None  # guaranteed when error is None
+    if not can(request, "workspace:read", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     # Allow all team members to view contact profiles (for use in component metadata)
     # Exclude component-private profiles as they're managed through component metadata
     profiles = (
@@ -1238,6 +1246,9 @@ def get_team(request: HttpRequest, team_key: str) -> tuple[int, Any]:
         return 403, {"detail": "Access denied"}
     if membership.role == "guest":
         return 403, {"detail": "Guest members can only access public pages"}
+
+    if not can(request, "workspace:read", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     return 200, _build_team_response(request, team)
 

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -1305,6 +1305,37 @@ def test_team_branding_api_rejects_non_member(
 
 
 @pytest.mark.django_db
+def test_get_team_branding_enforces_token_read_scope(sample_team_with_owner_member: Member):  # noqa: F811
+    """The branding endpoint routes through can(), so a narrow-scoped token (no
+    read scope) is denied — a publish-only token could previously read internal
+    workspace branding it had no scope for.
+    """
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.core.authz import SCOPE_PRESETS
+
+    team = sample_team_with_owner_member.team
+    user = sample_team_with_owner_member.user
+    url = f"/api/v1/workspaces/{team.key}/branding"
+
+    def tok(scopes):
+        s = create_personal_access_token(user)
+        AccessToken.objects.create(user=user, encoded_token=s, description="t", team=team, scopes=scopes)
+        return s
+
+    client = Client()
+    # publish-only token: no read scope -> 403
+    pub = tok(["artifact:publish"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}").status_code == 403
+    # read-only preset (includes workspace:read) -> 200
+    ro = tok(SCOPE_PRESETS["read_only"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}").status_code == 200
+    # unscoped (full) token -> 200, unchanged
+    full = tok(None)
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200
+
+
+@pytest.mark.django_db
 def test_team_branding_api_permissions(sample_team_with_guest_member: Member):  # noqa: F811
     client = Client()
 

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth
 from sbomify.apps.core.api.errors import api_error_response
+from sbomify.apps.core.authz import can
 from sbomify.apps.core.domain.exceptions import DomainError, NotFoundError, PermissionDeniedError
 from sbomify.apps.core.models import User
 from sbomify.apps.core.utils import token_to_number
@@ -124,6 +125,9 @@ def get_team_vulnerability_stats(
             require_team_member(cast(User, request.user), team, ["owner", "admin"])
         except DomainError as exc:
             return api_error_response(exc)
+
+        if not can(request, "workspace:read", team):
+            return 403, {"detail": "Access denied"}
 
         from sbomify.apps.core.models import Component
 
@@ -238,6 +242,9 @@ def get_team_vulnerability_timeseries(
             require_team_member(cast(User, request.user), team, ["owner", "admin"])
         except DomainError as exc:
             return api_error_response(exc)
+
+        if not can(request, "workspace:read", team):
+            return 403, {"detail": "Access denied"}
 
         end_date = timezone.now()
         start_date = end_date - timedelta(days=days)
@@ -378,6 +385,9 @@ def get_team_vulnerability_drill_down(
             require_team_member(cast(User, request.user), team, ["owner", "admin"])
         except DomainError as exc:
             return api_error_response(exc)
+
+        if not can(request, "workspace:read", team):
+            return 403, {"detail": "Access denied"}
 
         end_date = timezone.now()
         start_date = end_date - timedelta(days=days)
@@ -815,6 +825,9 @@ def get_team_products_releases(request: HttpRequest, team_key: str) -> Any:
 
         # Check if user is a member of this team
         if not Member.objects.filter(user=cast(User, request.user), team=team).exists():
+            return 403, {"detail": "Access denied"}
+
+        if not can(request, "product:read", team):
             return 403, {"detail": "Access denied"}
 
         from sbomify.apps.core.models import Product, Release

--- a/sbomify/apps/vulnerability_scanning/tests/test_apis.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_apis.py
@@ -1,6 +1,7 @@
 """Tests for vulnerability scanning API endpoints."""
 
 import pytest
+from django.test import Client
 
 from sbomify.apps.core.tests.shared_fixtures import (
     get_api_headers,
@@ -92,3 +93,34 @@ class TestVulnerabilityStatsAPI:
         assert "time_series" in data
         assert "summary" in data
         assert data["summary"]["date_range"]["days"] == 30
+
+
+@pytest.mark.django_db
+def test_vulnerability_stats_enforces_token_read_scope(team_with_member):
+    """The vulnerability-stats endpoint routes through can(), so a narrow-scoped
+    token (no read scope) is denied — a publish-only token can no longer
+    enumerate private workspace vulnerability data, while read-only and full
+    tokens still pass.
+    """
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.core.authz import SCOPE_PRESETS
+
+    team, user = team_with_member
+    url = f"/api/v1/vulnerability-scanning/workspaces/{team.key}/vulnerability-stats"
+
+    def tok(scopes):
+        s = create_personal_access_token(user)
+        AccessToken.objects.create(user=user, encoded_token=s, description="t", team=team, scopes=scopes)
+        return s
+
+    client = Client()
+    # publish-only token: no read scope -> 403
+    pub = tok(["artifact:publish"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {pub}").status_code == 403
+    # read-only preset (includes workspace:read) -> 200
+    ro = tok(SCOPE_PRESETS["read_only"])
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {ro}").status_code == 200
+    # unscoped (full) token -> 200, unchanged
+    full = tok(None)
+    assert client.get(url, HTTP_AUTHORIZATION=f"Bearer {full}").status_code == 200


### PR DESCRIPTION
## Summary

Completes the list/read **token-scope-gap sweep** started by `list_components` (#1029). Nineteen list/detail read endpoints resolved their workspace via the legacy membership / team-filter pattern and never routed through `can()`, so the API-token **action-scope gate** (which lives inside `can()`) was never applied. A narrow-scoped token — e.g. a publish-only CI token — could still read private workspace data its scope must not reach.

Each endpoint now calls `can(request, <read action>, team)` with a `READ_MEMBER`-tier action that **every current member already satisfies**. So the only behavioural change is:

- **publish-only / other non-read-scoped token → 403** (previously leaked data)
- session, full/unscoped token, read-only token → **unchanged** (still 200)

## Endpoints gated

| App | Endpoints | Action |
|-----|-----------|--------|
| core | `list_products` | `product:read` |
| core | `get_dashboard_summary` | `workspace:read` |
| core | `list_all_releases` (both team-scoped branches) | `release:read` |
| vulnerability_scanning | `vulnerability-stats`, `-timeseries`, `-drill-down` | `workspace:read` |
| vulnerability_scanning | `get_team_products_releases` | `product:read` |
| teams | `get_team`, `get_team_branding`, `list_contact_profiles` | `workspace:read` |
| billing | `get_usage` | `workspace:read` |
| controls | `list_catalogs`, `get_catalog`, `export_csv`, `export_summary_csv`, `list_controls`, `list_control_mappings`, `list_evidence`, `list_automation_mappings` | `workspace:read` |

**Untouched by design:** public/unauthenticated paths, the public-product branch of `list_all_releases`, and the vuln `trends`/`heatmap` endpoints (already gated on `workspace:manage`).

## Tests

Adds one token-scope regression test per app, asserting `publish-only → 403`, `read_only → 200`, `full/unscoped → 200`. Each new gate also reuses the endpoint's existing `403: ErrorResponse` response declaration and the same error-tuple shape as its existing membership check, so no new serialization path is introduced.

## Verification

- 5 new regression tests pass; 204 passed across the affected modules (the 2 failures are pre-existing `controls` 422-vs-400 POST-validation tests, unrelated to this change).
- `ruff check`, `ruff format`, and `mypy` clean on all production files.

Closes #1028