### PR TITLE
fix(authz): enforce token read scope on PAT-reachable artifact reads

### DIFF
--- a/sbomify/apps/documents/services/documents.py
+++ b/sbomify/apps/documents/services/documents.py
@@ -41,12 +41,12 @@ def get_document_detail(request: HttpRequest, document_id: str) -> ServiceResult
 
     component = document.component
 
-    # Use centralized access control
-    from sbomify.apps.core.services.access_control import check_component_access
-
-    access_result = check_component_access(request, component)
-
-    if not access_result.has_access:
+    # Route through the authz front door so a scoped API token's read scope is
+    # honoured — this endpoint runs under PAT auth, and check_component_access
+    # alone enforces visibility/NDA but not the token action-scope (that gate
+    # lives in can()). component:access is the ABAC read action; no change for
+    # sessions, anonymous callers, or full/read-only tokens.
+    if not can(request, "component:access", component).allowed:
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_document(document))

--- a/sbomify/apps/documents/services/documents.py
+++ b/sbomify/apps/documents/services/documents.py
@@ -46,7 +46,7 @@ def get_document_detail(request: HttpRequest, document_id: str) -> ServiceResult
     # alone enforces visibility/NDA but not the token action-scope (that gate
     # lives in can()). component:access is the ABAC read action; no change for
     # sessions, anonymous callers, or full/read-only tokens.
-    if not can(request, "component:access", component).allowed:
+    if not can(request, "component:access", component):
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_document(document))

--- a/sbomify/apps/documents/tests/test_apis.py
+++ b/sbomify/apps/documents/tests/test_apis.py
@@ -804,3 +804,23 @@ def test_download_document_default_content_type(
     assert response.status_code == 200
     assert response.content == b"test document content"
     assert response["Content-Type"] == "application/octet-stream"
+
+
+@pytest.mark.django_db
+def test_get_document_denied_for_publish_only_token(sample_document):
+    """get_document runs under PAT auth, so a publish-only token must be denied a
+    private document's metadata (scope gate), not served it."""
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+
+    team = sample_document.component.team
+    owner = Member.objects.filter(team=team, role="owner").first()
+    assert owner is not None
+    token_str = create_personal_access_token(owner.user)
+    AccessToken.objects.create(
+        user=owner.user, encoded_token=token_str, description="publish-only", team=team, scopes=["artifact:publish"]
+    )
+
+    url = reverse("api-1:get_document", kwargs={"document_id": sample_document.id})
+    response = Client().get(url, HTTP_AUTHORIZATION=f"Bearer {token_str}")
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -1233,7 +1233,7 @@ def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = Fals
         if not can(request, "sbom:manage", sbom.component):
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     else:
-        if not can(request, "component:access", sbom.component).allowed:
+        if not can(request, "component:access", sbom.component):
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     return sbom
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -1222,7 +1222,9 @@ def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = Fals
     """Look up an SBOM and verify access. Returns SBOM or (status, error_dict).
 
     For write=True (uploads), requires owner/admin via can("sbom:manage", ...).
-    For write=False (downloads), uses check_component_access to support public SBOMs.
+    For write=False (downloads), uses can("component:access", ...): the same
+    visibility/NDA logic as check_component_access plus the API-token scope gate,
+    so public SBOMs stay downloadable while a non-read-scoped token is denied.
     """
     sbom = SBOM.objects.select_related("component", "component__team").filter(pk=sbom_id).first()
     if sbom is None:
@@ -1231,8 +1233,7 @@ def _get_sbom_or_error(request: HttpRequest, sbom_id: str, *, write: bool = Fals
         if not can(request, "sbom:manage", sbom.component):
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     else:
-        access = check_component_access(request, sbom.component)
-        if not access.has_access:
+        if not can(request, "component:access", sbom.component).allowed:
             return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
     return sbom
 

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -84,12 +84,14 @@ def get_sbom_detail(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[st
 
     component = sbom.component
 
-    # Use centralized access control
-    from sbomify.apps.core.services.access_control import check_component_access
+    # Route through the authz front door so a scoped API token's read scope is
+    # honoured — check_component_access alone enforces visibility/NDA but not the
+    # token action-scope (that gate lives in can()). component:access is the ABAC
+    # read action; no change for sessions, anonymous callers, or full/read-only
+    # tokens, only non-read-scoped tokens are newly denied.
+    from sbomify.apps.core.authz import can
 
-    access_result = check_component_access(request, component)
-
-    if not access_result.has_access:
+    if not can(request, "component:access", component).allowed:
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_sbom(sbom))
@@ -130,9 +132,12 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
     except SBOM.DoesNotExist:
         return ServiceResult.failure("SBOM not found", status_code=404)
 
-    from sbomify.apps.core.services.access_control import check_component_access
+    # Route through can() so a scoped API token's read scope is honoured (this
+    # endpoint runs optional_auth, so a PAT reaches it). component:access is the
+    # ABAC read action; no change for sessions / full / read-only tokens.
+    from sbomify.apps.core.authz import can
 
-    if not check_component_access(request, sbom.component).has_access:
+    if not can(request, "component:access", sbom.component).allowed:
         return ServiceResult.failure("Forbidden", status_code=403)
 
     if not sbom.sbom_filename:

--- a/sbomify/apps/sboms/services/sboms.py
+++ b/sbomify/apps/sboms/services/sboms.py
@@ -91,7 +91,7 @@ def get_sbom_detail(request: HttpRequest, sbom_id: str) -> ServiceResult[dict[st
     # tokens, only non-read-scoped tokens are newly denied.
     from sbomify.apps.core.authz import can
 
-    if not can(request, "component:access", component).allowed:
+    if not can(request, "component:access", component):
         return ServiceResult.failure("Forbidden", status_code=403)
 
     return ServiceResult.success(serialize_sbom(sbom))
@@ -137,7 +137,7 @@ def get_crypto_inventory(request: HttpRequest, sbom_id: str) -> ServiceResult[di
     # ABAC read action; no change for sessions / full / read-only tokens.
     from sbomify.apps.core.authz import can
 
-    if not can(request, "component:access", sbom.component).allowed:
+    if not can(request, "component:access", sbom.component):
         return ServiceResult.failure("Forbidden", status_code=403)
 
     if not sbom.sbom_filename:

--- a/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
+++ b/sbomify/apps/sboms/tests/test_crypto_inventory_api.py
@@ -118,3 +118,24 @@ def test_inventory_includes_pqc_classification(sample_sbom: SBOM, mocker: Mocker
     by_name = {a["name"]: a for a in body["assets"]}
     assert by_name["RSA-2048"]["pqc_status"] == "quantum_vulnerable"
     assert by_name["ML-KEM-768"]["pqc_status"] == "quantum_safe"
+
+
+@pytest.mark.django_db
+def test_publish_only_token_denied_private_inventory(sample_sbom: SBOM, mocker: MockerFixture):  # noqa: F811
+    # optional_auth processes the PAT, so the token scope must be honoured: a
+    # publish-only token must NOT read a private SBOM's crypto inventory.
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.teams.models import Member
+
+    _mock_s3(mocker, (_DATA / "cbom_sample_1.6.cdx.json").read_bytes())
+    team = sample_sbom.component.team
+    owner = Member.objects.filter(team=team, role="owner").first()
+    assert owner is not None
+    token_str = create_personal_access_token(owner.user)
+    AccessToken.objects.create(
+        user=owner.user, encoded_token=token_str, description="publish-only", team=team, scopes=["artifact:publish"]
+    )
+
+    response = Client().get(_url(sample_sbom.id), HTTP_AUTHORIZATION=f"Bearer {token_str}")
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/tests/test_signature_provenance_apis.py
+++ b/sbomify/apps/sboms/tests/test_signature_provenance_apis.py
@@ -540,3 +540,25 @@ def test_provenance_download_not_attached(
 
     assert response.status_code == 404
     assert "No provenance attached" in response.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_download_signature_denied_for_publish_only_token(sbom_with_hash: SBOM):
+    """The download endpoints run optional_auth, so a publish-only token must be
+    denied a private SBOM's signature (scope gate), not served it."""
+    from sbomify.apps.access_tokens.utils import create_personal_access_token
+    from sbomify.apps.teams.models import Member
+
+    team = sbom_with_hash.component.team
+    owner = Member.objects.filter(team=team, role="owner").first()
+    assert owner is not None
+    token_str = create_personal_access_token(owner.user)
+    token = AccessToken.objects.create(
+        user=owner.user, encoded_token=token_str, description="publish-only", team=team, scopes=["artifact:publish"]
+    )
+
+    client = Client()
+    url = f"/api/v1/sboms/sbom/{sbom_with_hash.id}/signature"
+    response = client.get(url, **get_api_headers(token))
+
+    assert response.status_code == 403

--- a/sbomify/apps/sboms/tests/test_signature_provenance_apis.py
+++ b/sbomify/apps/sboms/tests/test_signature_provenance_apis.py
@@ -543,9 +543,16 @@ def test_provenance_download_not_attached(
 
 
 @pytest.mark.django_db
-def test_download_signature_denied_for_publish_only_token(sbom_with_hash: SBOM):
-    """The download endpoints run optional_auth, so a publish-only token must be
-    denied a private SBOM's signature (scope gate), not served it."""
+@pytest.mark.parametrize("artifact", ["signature", "provenance"])
+def test_download_denied_for_publish_only_token(
+    sbom_with_hash: SBOM,
+    mocker: MockerFixture,
+    artifact: str,
+):
+    """Both download endpoints run optional_auth, so a publish-only token must be
+    denied a private SBOM's signature/provenance (scope gate), not served it. The
+    scope check precedes any S3 access, so boto3 is stubbed only as a guard."""
+    mocker.patch("boto3.resource")
     from sbomify.apps.access_tokens.utils import create_personal_access_token
     from sbomify.apps.teams.models import Member
 
@@ -558,7 +565,7 @@ def test_download_signature_denied_for_publish_only_token(sbom_with_hash: SBOM):
     )
 
     client = Client()
-    url = f"/api/v1/sboms/sbom/{sbom_with_hash.id}/signature"
+    url = f"/api/v1/sboms/sbom/{sbom_with_hash.id}/{artifact}"
     response = client.get(url, **get_api_headers(token))
 
     assert response.status_code == 403


### PR DESCRIPTION
## Summary

Follow-up to the #1028/#1029 scope-gap sweep, on the **artifact/component-ABAC** read path rather than the team-filter path.

The API-token **action-scope** gate (#215) is enforced only inside `can()` — `check_component_access` / `verify_item_access` enforce visibility/role but **not** token scope. Four artifact **read** paths called `check_component_access` directly *and* are reachable by a processed Personal Access Token (router PAT auth or `optional_auth`), so a **publish-only** token could read **private** artifact content/metadata its scope must not reach:

| Endpoint | Auth path | Underlying read | Leak |
|----------|-----------|-----------------|------|
| `GET /sboms/{id}/crypto-inventory` | `optional_auth` | `get_crypto_inventory()` | private CBOM inventory |
| `GET /sboms/sbom/{id}/signature` | `optional_auth` | `_get_sbom_or_error(write=False)` | private signature blob |
| `GET /sboms/sbom/{id}/provenance` | `optional_auth` | `_get_sbom_or_error(write=False)` | private provenance blob |
| `GET /documents/{id}` | router PAT auth | `get_document_detail()` | private document metadata |

## Fix

Each read now goes through the front door:

```python
if not can(request, "component:access", component).allowed:
    return 403
```

`component:access` is the ABAC read action — `can()` runs the **same** visibility / NDA / access-request logic as `check_component_access` *plus* the scope gate. Behaviour is identical for sessions, anonymous callers, full tokens, and read-only tokens (the `read_only` preset includes `component:access`); only non-read-scoped tokens are newly denied. `get_sbom_detail` is migrated too for consistency — it isn't PAT-reachable today (`get_sbom` is plain `auth=None`, so a bearer token is ignored), but adding `optional_auth` later (as was done for crypto-inventory) would otherwise silently reopen the gap.

**Not touched:** `GET /sboms/{id}/download` and `GET /documents/{id}/download` — plain `auth=None` with no `optional_auth`, so a PAT is never parsed and the caller is anonymous; `check_component_access` already denies private content there.

## Tests (TDD)

Added a `publish-only token → 403` regression test for each exploitable endpoint. Each was confirmed **RED** before the fix (crypto-inventory & document returned 200; signature passed access then 404'd on the missing blob) and **GREEN** after.

## Verification

- 3 new tests pass; **287 passed** across the affected `sboms` + `documents` suites (no regressions — full/session/anonymous unchanged).
- `ruff check`, `ruff format`, `mypy` clean on all production files.

Closes #1037