### PR TITLE
fix(email): set Reply-To to the submitter on inbound notifications

### DIFF
--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -97,13 +97,14 @@ Submitted by user: {user_email} ({user_name})
 Submitted at: {submitted_at}
 """
 
-        # Send email to sales team
+        # Send email to sales team. Reply-to is the prospect so a reply reaches
+        # them rather than bouncing back to the sales inbox.
         sales_email = EmailMessage(
             subject=subject,
             body=message_content,
             from_email=settings.DEFAULT_FROM_EMAIL,
             to=[settings.ENTERPRISE_SALES_EMAIL],
-            reply_to=[settings.ENTERPRISE_SALES_EMAIL],
+            reply_to=[str(email)] if email else [settings.ENTERPRISE_SALES_EMAIL],
         )
         sales_email.send(fail_silently=False)
 

--- a/sbomify/apps/billing/tests/test_enterprise_contact_turnstile.py
+++ b/sbomify/apps/billing/tests/test_enterprise_contact_turnstile.py
@@ -110,3 +110,38 @@ class TestEnterpriseContactTurnstile:
                 
                 # Task should be called
                 assert mock_task.send.called
+
+
+@pytest.mark.django_db
+def test_enterprise_inquiry_replies_to_submitter(settings):
+    """The sales-team notification must reply to the inquirer, not to ourselves,
+    so a reply reaches the prospect instead of the sales inbox."""
+    from django.core import mail
+
+    from sbomify.apps.billing.tasks import send_enterprise_inquiry_email
+
+    mail.outbox = []
+    form_data = {
+        "company_name": "Acme",
+        "company_size_display": "50-100",
+        "industry": "Tech",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "email": "jane@acme.example",
+        "primary_use_case_display": "Compliance",
+        "message": "We need enterprise.",
+        "newsletter_signup": False,
+    }
+
+    send_enterprise_inquiry_email(form_data, is_public=True)
+
+    assert len(mail.outbox) == 2
+    sales_notification, user_confirmation = mail.outbox[0], mail.outbox[1]
+
+    # Notification to the sales team -> reply goes to the prospect.
+    assert sales_notification.to == [settings.ENTERPRISE_SALES_EMAIL]
+    assert sales_notification.reply_to == ["jane@acme.example"]
+
+    # Confirmation to the prospect -> reply still reaches the sales team.
+    assert user_confirmation.to == ["jane@acme.example"]
+    assert user_confirmation.reply_to == [settings.ENTERPRISE_SALES_EMAIL]

--- a/sbomify/apps/documents/access_apis.py
+++ b/sbomify/apps/documents/access_apis.py
@@ -112,7 +112,8 @@ def _notify_admins_of_access_request(access_request: AccessRequest, team: Team, 
                     body=render_to_string("documents/emails/access_request_notification.txt", email_context),
                     from_email=settings.DEFAULT_FROM_EMAIL,
                     to=[admin_member.user.email],
-                    reply_to=["hello@sbomify.com"],
+                    # Reply-to the requester so an admin's reply reaches them, not our own inbox.
+                    reply_to=[requester_email or "hello@sbomify.com"],
                 )
                 email.attach_alternative(
                     render_to_string("documents/emails/access_request_notification.html.j2", email_context),

--- a/sbomify/apps/documents/tests/test_access_requests.py
+++ b/sbomify/apps/documents/tests/test_access_requests.py
@@ -1438,3 +1438,30 @@ class TestGuestMemberExclusion:
         
         assert guest_user.email not in member_emails
         assert sample_user.email in member_emails
+
+
+@pytest.mark.django_db
+def test_access_request_notification_replies_to_requester(team_with_business_plan, sample_user, guest_user):
+    """The 'new access request' notification to admins must reply to the requester,
+    not to hello@sbomify.com, so admins reply to the person asking for access."""
+    from django.core import mail
+
+    from sbomify.apps.documents.access_apis import (
+        _notify_admins_of_access_request as notify_api,
+    )
+    from sbomify.apps.documents.views.access_requests import (
+        _notify_admins_of_access_request as notify_view,
+    )
+
+    Member.objects.get_or_create(user=sample_user, team=team_with_business_plan, defaults={"role": "owner"})
+    access_request = AccessRequest.objects.create(
+        team=team_with_business_plan, user=guest_user, status=AccessRequest.Status.PENDING
+    )
+
+    for notify in (notify_view, notify_api):
+        mail.outbox = []
+        notify(access_request, team_with_business_plan)
+        assert mail.outbox, "expected an admin notification email"
+        message = mail.outbox[0]
+        assert message.to == [sample_user.email]
+        assert message.reply_to == [guest_user.email]

--- a/sbomify/apps/documents/views/access_requests.py
+++ b/sbomify/apps/documents/views/access_requests.py
@@ -211,7 +211,8 @@ def _notify_admins_of_access_request(access_request: AccessRequest, team: Team, 
                     body=render_to_string("documents/emails/access_request_notification.txt", email_context),
                     from_email=settings.DEFAULT_FROM_EMAIL,
                     to=[admin_member.user.email],
-                    reply_to=["hello@sbomify.com"],
+                    # Reply-to the requester so an admin's reply reaches them, not our own inbox.
+                    reply_to=[requester_email or "hello@sbomify.com"],
                 )
                 email.attach_alternative(
                     render_to_string("documents/emails/access_request_notification.html.j2", email_context),


### PR DESCRIPTION
## What

Support tickets and form submissions notified our own team with Reply-To pointing back at a sbomify address. A reply from the shared inbox went to us, not the person who filed the ticket.

Now the inbound notifications reply to the submitter:

- Enterprise inquiry to the sales team -> the prospect's email (`billing/tasks`)
- New access-request notification to admins -> the requester's email (`documents/access_apis.py` + `documents/views/access_requests.py`)

Emails to the user (access decisions, welcome, invites) are unchanged and still reply to `hello@sbomify.com`. The support-contact form already did this.

## Tests

Regression tests check that the notification replies to the submitter and the user confirmation still replies to us. Both failed before the change (Reply-To was `hello@sbomify.com`) and pass after.