### PR TITLE
fix(tls): exempt internal API from SSL redirect so on-demand certs work

### DIFF
--- a/sbomify/apps/teams/tests/test_internal_apis.py
+++ b/sbomify/apps/teams/tests/test_internal_apis.py
@@ -1,5 +1,6 @@
 # skip_file  # nosec
 """Tests for internal API endpoints (no auth required - secured at proxy level)."""
+
 from __future__ import annotations
 
 import pytest
@@ -334,3 +335,35 @@ def test_check_domain_allowed_no_auth_required():
     # Should not return 401 (unauthorized) - either 200 or 404
     assert response.status_code in [200, 404]
     assert response.status_code != 401
+
+
+@pytest.mark.django_db
+@override_settings(
+    SECURE_SSL_REDIRECT=True,
+    SECURE_REDIRECT_EXEMPT=[r"^UuPha8mu/", r"^api/v1/internal/"],
+    APP_BASE_URL="https://app.example.com",
+)
+def test_check_domain_allowed_not_redirected_under_ssl_redirect():
+    """Regression for the on-demand TLS ask endpoint (PR #1051).
+
+    Caddy probes this endpoint directly over plain HTTP (container-to-container,
+    no X-Forwarded-Proto header). With SECURE_SSL_REDIRECT=True it must NOT be
+    301-redirected to https — Caddy refuses to follow redirects on the ask
+    endpoint and would deny the certificate. The fix exempts ^api/v1/internal/
+    from SECURE_REDIRECT_EXEMPT.
+
+    The Client is constructed inside the override so SecurityMiddleware compiles
+    the exempt list (done once in __init__) from the overridden settings.
+    """
+    client = Client()
+
+    # Sanity: the override is actually live — a non-exempt path over plain HTTP
+    # is redirected. Without this, a stale middleware instance reading
+    # SECURE_SSL_REDIRECT=False would make the assertion below pass vacuously.
+    redirected = client.get("/", secure=False)
+    assert redirected.status_code in (301, 302)
+    assert redirected.headers["Location"].startswith("https://")
+
+    # The ask endpoint is exempt, so it answers directly instead of redirecting.
+    response = client.get("/api/v1/internal/domains?domain=app.example.com", secure=False)
+    assert response.status_code == 200

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -837,9 +837,12 @@ else:
     CSRF_COOKIE_SAMESITE = "Strict"
 
     # Defense-in-depth behind Caddy's edge HTTP->HTTPS redirect. Exempt the internal
-    # health check, which is probed over plain HTTP without an X-Forwarded-Proto header.
+    # endpoints, which are probed over plain HTTP (container-to-container, no
+    # X-Forwarded-Proto header): the Django health check, and the on-demand-TLS "ask"
+    # endpoint Caddy hits to decide whether to issue a certificate for a custom/trust
+    # center domain. A 301 here makes Caddy refuse the redirect and deny the cert.
     SECURE_SSL_REDIRECT = True
-    SECURE_REDIRECT_EXEMPT = [r"^UuPha8mu/"]
+    SECURE_REDIRECT_EXEMPT = [r"^UuPha8mu/", r"^api/v1/internal/"]
 
     # HSTS (Caddy sets it at the edge too; harmless to assert at the app for direct hits).
     SECURE_HSTS_SECONDS = 31536000  # 1 year


### PR DESCRIPTION
## Problem

Trust center custom domains and subdomains (e.g. `luc.trustctr.com`) stopped getting HTTPS certificates. Caddy logs:

```
failed to get permission for on-demand certificate domain=luc.trustctr.com
error: Get "https://sbomify-backend:8000/api/v1/internal/domains?domain=luc.trustctr.com": following http redirects is not allowed
```

## Root cause

Caddy's on-demand-TLS `ask` directive calls `http://sbomify-backend:8000/api/v1/internal/domains` **directly, container-to-container over plain HTTP** — bypassing Caddy's TLS edge, so there's no `X-Forwarded-Proto: https` header on the request.

PR #922 added `SECURE_SSL_REDIRECT = True` and exempted only the Django health check (`^UuPha8mu/`). The internal ask endpoint is probed the same plain-HTTP way, so Django answers it with a `301` to `https://...`. Caddy refuses to follow redirects on the ask endpoint and therefore **denies the certificate** — the request never even reaches the allow/deny logic in `check_domain_allowed`.

## Fix

Add `^api/v1/internal/` to `SECURE_REDIRECT_EXEMPT` alongside the health check.

Safe because the entire `/api/v1/internal/*` tree is already locked down to private/Docker client IPs at the Caddy edge (returns `403` for anything else), so exempting it from the app-level HTTPS redirect exposes nothing.

## Verifying after deploy

From inside the network this should return `200`/`404`, not a `301`:

```bash
curl -si "http://sbomify-backend:8000/api/v1/internal/domains?domain=luc.trustctr.com"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)