### PR TITLE
fix(authz): let the OIDC/CI bot publish releases

### DIFF
--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -763,7 +763,8 @@ def test_create_token_form_maps_scope_presets():
 
     f = CreateAccessTokenForm({"description": "x", "scope": "publish"})
     assert f.is_valid(), f.errors
-    assert f.scopes() == ["artifact:publish"]
+    assert f.scopes() == SCOPE_PRESETS["publish"]
+    assert "release:create" in f.scopes()  # the publish preset covers cutting a release
 
     f = CreateAccessTokenForm({"description": "x", "scope": "read_only"})
     assert f.is_valid(), f.errors

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2777,8 +2777,8 @@ def create_release(request: HttpRequest, payload: ReleaseCreateSchema) -> Any:
     except Product.DoesNotExist:
         return 404, {"detail": "Product not found", "error_code": ErrorCode.PRODUCT_NOT_FOUND}
 
-    if not can(request, "product:manage", product):
-        return 403, {"detail": "Only owners and admins can create releases", "error_code": ErrorCode.FORBIDDEN}
+    if not can(request, "release:create", product):
+        return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent creating releases with name "latest" manually
     if payload.name.lower() == LATEST_RELEASE_NAME.lower():
@@ -3380,8 +3380,11 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
     except Release.DoesNotExist:
         return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
 
-    if not can(request, "release:manage", release.product):
-        return 403, {"detail": "Only owners and admins can manage release artifacts", "error_code": ErrorCode.FORBIDDEN}
+    if not can(request, "release:tag", release.product):
+        return 403, {
+            "detail": "You do not have permission to add artifacts to this release",
+            "error_code": ErrorCode.FORBIDDEN,
+        }
 
     # Prevent adding artifacts to latest releases
     if release.is_latest:

--- a/sbomify/apps/core/authz.py
+++ b/sbomify/apps/core/authz.py
@@ -59,10 +59,23 @@ PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT, ROLE_GUEST)
 guests (so a low-trust member can contribute artifacts without management
 rights)."""
 
+RELEASE_PUBLISH: tuple[str, ...] = (ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
+"""Cut and tag a release — the release half of the CI publish workflow. Granted
+to OIDC/CI ``bot`` identities (the action creates a release and tags its uploaded
+artifacts to it) alongside owners and admins. Guests are excluded: they may
+contribute artifacts (``PUBLISH``) but not cut releases. Renaming or deleting a
+release stays the stricter ``MANAGE`` / ``DELETE`` tiers."""
+
 # Order mirrors the predominant call-site literal ``["guest", "owner", "admin"]``
 # (membership is order-independent, but the parity keeps the claim above honest).
 READ_MEMBER: tuple[str, ...] = (ROLE_GUEST, ROLE_OWNER, ROLE_ADMIN)
 """Any workspace member may read internal (non-public) workspace data."""
+
+READ_MEMBER_OR_BOT: tuple[str, ...] = (ROLE_GUEST, ROLE_OWNER, ROLE_ADMIN, ROLE_BOT)
+"""``READ_MEMBER`` plus the CI/OIDC ``bot``: reading releases is part of the
+publish workflow (the action checks whether a release already exists before
+creating it), so a bot must reach release reads that other internal reads still
+deny it."""
 
 
 @dataclass(frozen=True)
@@ -94,6 +107,10 @@ _ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
     "release:manage": MANAGE,
     "sbom:manage": MANAGE,
     "document:manage": MANAGE,
+    # release publishing — the CI/OIDC bot's job (create a release, tag artifacts
+    # to it). Owners and admins keep it; bots gain it; guests stay out.
+    "release:create": RELEASE_PUBLISH,
+    "release:tag": RELEASE_PUBLISH,
     # owner-only deletion of domain resources (#468) — stricter than MANAGE
     "product:delete": DELETE,
     "component:delete": DELETE,
@@ -106,7 +123,7 @@ _ROLE_ACTIONS: dict[str, tuple[str, ...]] = {
     "workspace:read": READ_MEMBER,
     "component:read_internal": READ_MEMBER,
     "product:read": READ_MEMBER,
-    "release:read": READ_MEMBER,
+    "release:read": READ_MEMBER_OR_BOT,
     "document:read": READ_MEMBER,
     "sbom:read": READ_MEMBER,
 }
@@ -140,12 +157,17 @@ def is_valid_scope(scope: str) -> bool:
 # drift from the action vocabulary above.
 SCOPE_PRESETS: dict[str, list[str] | None] = {
     "full": None,
-    "publish": ["artifact:publish"],
-    # READ_MEMBER role-based reads plus the ABAC component:access read path, so a
-    # read-only token can still read gated/public components (can() checks scope
-    # before ABAC).
+    # The CI publish workflow the action performs end to end: upload an artifact,
+    # then check / create / tag its release. Without the release actions a
+    # publish-scoped CI token uploads fine but 403s the moment it cuts a release.
+    "publish": ["artifact:publish", "release:read", "release:create", "release:tag"],
+    # Every read action (``<resource>:read`` / ``read_internal``) plus the ABAC
+    # component:access read path, so a read-only token can still read
+    # gated/public components (can() checks scope before ABAC). Keyed on the verb,
+    # not a tier identity, so a read action moving to a bot-inclusive tier (e.g.
+    # release:read) stays in the read-only preset.
     "read_only": sorted(
-        [action for action, tier in _ROLE_ACTIONS.items() if tier == READ_MEMBER] + list(_ABAC_ACTIONS)
+        [action for action in _ROLE_ACTIONS if action.split(":", 1)[1].startswith("read")] + list(_ABAC_ACTIONS)
     ),
 }
 

--- a/sbomify/apps/core/tests/test_authz.py
+++ b/sbomify/apps/core/tests/test_authz.py
@@ -63,6 +63,13 @@ _MATRIX = {
     "workspace:read": ("team", {"owner": True, "admin": True, "guest": True, "bot": False}),
     "component:administer": ("component", {"owner": True, "admin": False, "guest": False, "bot": False}),
     "product:read": ("product", {"owner": True, "admin": True, "guest": True, "bot": False}),
+    # CI/OIDC publish workflow: a release-cutting bot reads (to check existence),
+    # creates, and tags releases — but cannot rename or delete them. Guests stay
+    # out of create/tag (they may upload artifacts, not cut releases).
+    "release:read": ("product", {"owner": True, "admin": True, "guest": True, "bot": True}),
+    "release:create": ("product", {"owner": True, "admin": True, "guest": False, "bot": True}),
+    "release:tag": ("product", {"owner": True, "admin": True, "guest": False, "bot": True}),
+    "release:manage": ("product", {"owner": True, "admin": True, "guest": False, "bot": False}),
 }
 _CASES = [(a, role, exp[role]) for a, (_res, exp) in _MATRIX.items() for role in ("owner", "admin", "guest", "bot")]
 

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.authz import SCOPE_PRESETS
 from sbomify.apps.core.forms import CreateAccessTokenForm
 from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 from sbomify.apps.core.utils import number_to_random_token
@@ -118,7 +119,7 @@ class TestTeamTokensView:
             {"description": "CI Token", "scope": "publish"},
         )
         tok = AccessToken.objects.get(user=user, description="CI Token")
-        assert tok.scopes == ["artifact:publish"]
+        assert tok.scopes == SCOPE_PRESETS["publish"]
 
     def test_post_invalid_form_returns_error(self, client: Client, sample_team_with_owner_member):
         """Test that POST with invalid form returns error."""


### PR DESCRIPTION
## What

The OIDC/CI bot can create and tag releases. This fixes a 403 that failed every OIDC-authenticated CI run at the release step.

## Why it broke

`role="bot"` sits in the `PUBLISH` tier (upload artifacts) but not `MANAGE`. The action's release flow is read, create, tag, and `create_release` required `product:manage`, so the bot got `403 - Only owners and admins can create releases` after uploading the SBOM. sbomify's own CI reached "Creating release" because its product is public and the public read path skips the role check. A private product would 403 one step earlier, on the existence check.

## Change

- New `RELEASE_PUBLISH` (owner, admin, bot) tier for `release:create` and `release:tag`, plus `READ_MEMBER_OR_BOT` for `release:read`.
- `create_release` uses `release:create`; `add_artifacts_to_release` uses `release:tag`.
- Guests stay out of cutting releases. Rename and delete remain owner/admin-only.
- The `publish` token scope preset grants the full upload-and-release workflow. `read_only` keys on the read verb so `release:read` stays in it.

## Tests

Role-capability matrix extended for the three release actions across all roles. 285 tests in core authz, release, and oidc pass. ruff clean.
