### PR TITLE
fix(controls): return 400 not 422 for invalid status / evidence_type

### DIFF
--- a/sbomify/apps/controls/schemas.py
+++ b/sbomify/apps/controls/schemas.py
@@ -5,6 +5,14 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from sbomify.apps.controls.models import ControlEvidence, ControlStatus
+
+# Valid value sets, sourced from the model TextChoices so the API docs (and the
+# 400 messages keyed off the same choices) cannot drift from what the endpoints
+# actually accept.
+_STATUS_VALUES = ", ".join(choice[0] for choice in ControlStatus.Status.choices)
+_EVIDENCE_TYPE_VALUES = ", ".join(choice[0] for choice in ControlEvidence.EvidenceType.choices)
+
 
 class CatalogSchema(BaseModel):
     """Schema for ControlCatalog API responses."""
@@ -44,7 +52,7 @@ class ControlWithStatusSchema(ControlSchema):
 class StatusUpdateSchema(BaseModel):
     """Schema for updating a single control status."""
 
-    status: str = Field(..., description="One of: compliant, partial, not_implemented, not_applicable")
+    status: str = Field(..., description=f"One of: {_STATUS_VALUES}")
     product_id: str | None = None
     notes: str = ""
 
@@ -53,7 +61,7 @@ class BulkStatusUpdateItemSchema(BaseModel):
     """Schema for a single item in a bulk status update."""
 
     control_id: str
-    status: str = Field(..., description="One of: compliant, partial, not_implemented, not_applicable")
+    status: str = Field(..., description=f"One of: {_STATUS_VALUES}")
     product_id: str | None = None
     notes: str = ""
 
@@ -178,7 +186,7 @@ class ControlEvidenceSchema(BaseModel):
 class CreateEvidenceSchema(BaseModel):
     """Schema for creating evidence on a control."""
 
-    evidence_type: str = Field(..., description="One of: url, document, note")
+    evidence_type: str = Field(..., description=f"One of: {_EVIDENCE_TYPE_VALUES}")
     title: str
     url: str = ""
     document_id: str = ""

--- a/sbomify/apps/controls/schemas.py
+++ b/sbomify/apps/controls/schemas.py
@@ -7,11 +7,11 @@ from pydantic import BaseModel, Field
 
 from sbomify.apps.controls.models import ControlEvidence, ControlStatus
 
-# Valid value sets, sourced from the model TextChoices so the API docs (and the
-# 400 messages keyed off the same choices) cannot drift from what the endpoints
-# actually accept.
-_STATUS_VALUES = ", ".join(choice[0] for choice in ControlStatus.Status.choices)
-_EVIDENCE_TYPE_VALUES = ", ".join(choice[0] for choice in ControlEvidence.EvidenceType.choices)
+# Field-description constants, sourced from the model TextChoices so the API docs
+# (and the 400 messages keyed off the same choices) cannot drift from what the
+# endpoints actually accept. Single constant per field, reused across schemas.
+_STATUS_DESCRIPTION = "One of: " + ", ".join(choice[0] for choice in ControlStatus.Status.choices)
+_EVIDENCE_TYPE_DESCRIPTION = "One of: " + ", ".join(choice[0] for choice in ControlEvidence.EvidenceType.choices)
 
 
 class CatalogSchema(BaseModel):
@@ -52,7 +52,7 @@ class ControlWithStatusSchema(ControlSchema):
 class StatusUpdateSchema(BaseModel):
     """Schema for updating a single control status."""
 
-    status: str = Field(..., description=f"One of: {_STATUS_VALUES}")
+    status: str = Field(..., description=_STATUS_DESCRIPTION)
     product_id: str | None = None
     notes: str = ""
 
@@ -61,7 +61,7 @@ class BulkStatusUpdateItemSchema(BaseModel):
     """Schema for a single item in a bulk status update."""
 
     control_id: str
-    status: str = Field(..., description=f"One of: {_STATUS_VALUES}")
+    status: str = Field(..., description=_STATUS_DESCRIPTION)
     product_id: str | None = None
     notes: str = ""
 
@@ -186,7 +186,7 @@ class ControlEvidenceSchema(BaseModel):
 class CreateEvidenceSchema(BaseModel):
     """Schema for creating evidence on a control."""
 
-    evidence_type: str = Field(..., description=f"One of: {_EVIDENCE_TYPE_VALUES}")
+    evidence_type: str = Field(..., description=_EVIDENCE_TYPE_DESCRIPTION)
     title: str
     url: str = ""
     document_id: str = ""

--- a/sbomify/apps/controls/schemas.py
+++ b/sbomify/apps/controls/schemas.py
@@ -44,7 +44,7 @@ class ControlWithStatusSchema(ControlSchema):
 class StatusUpdateSchema(BaseModel):
     """Schema for updating a single control status."""
 
-    status: Literal["compliant", "partial", "not_implemented", "not_applicable"]
+    status: str = Field(..., description="One of: compliant, partial, not_implemented, not_applicable")
     product_id: str | None = None
     notes: str = ""
 
@@ -53,7 +53,7 @@ class BulkStatusUpdateItemSchema(BaseModel):
     """Schema for a single item in a bulk status update."""
 
     control_id: str
-    status: Literal["compliant", "partial", "not_implemented", "not_applicable"]
+    status: str = Field(..., description="One of: compliant, partial, not_implemented, not_applicable")
     product_id: str | None = None
     notes: str = ""
 
@@ -178,7 +178,7 @@ class ControlEvidenceSchema(BaseModel):
 class CreateEvidenceSchema(BaseModel):
     """Schema for creating evidence on a control."""
 
-    evidence_type: Literal["url", "document", "note"]
+    evidence_type: str = Field(..., description="One of: url, document, note")
     title: str
     url: str = ""
     document_id: str = ""


### PR DESCRIPTION
## What

`PUT /controls/controls/{id}/status/`, the bulk status endpoint, and `POST .../evidence/` now return **400** with a friendly message for invalid `status` / `evidence_type`, instead of django-ninja's schema **422**.

## Why

The fields were typed as pydantic `Literal[...]`, so ninja rejected out-of-enum values at the request-parse boundary (422) before the endpoint body ran. The 400 validation already existed downstream and was unreachable dead code:
- `status` — `status_service.upsert_status` / `bulk_update_statuses` (`Invalid status '…'. Must be one of: …`)
- `evidence_type` — explicit guard in `add_evidence`

## Change

Relax the three `Literal[...]` fields to `str` (keeping the valid set in the OpenAPI `description`), so the request parses and the existing 400 paths fire. No endpoint, service, or model changes; no migration.

## Tests

The three pre-existing tests that asserted 400 now pass (were 422). Full `controls` api + evidence suites green (28). ruff clean.

Closes #1006
