### PR TITLE
fix(sboms): auto-detect CBOM content and tag bom_type=cbom on upload

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -75,6 +75,16 @@ def _validate_bom_type(bom_type: str) -> tuple[int, dict[str, Any]] | None:
     return None
 
 
+def _is_cbom(sbom_data: dict[str, Any]) -> bool:
+    """True when a CycloneDX document declares cryptographic-asset components, i.e. it is a CBOM."""
+    components = sbom_data.get("components")
+    if not isinstance(components, list):
+        return False
+    return any(
+        isinstance(c, dict) and (c.get("type") == "cryptographic-asset" or "cryptoProperties" in c) for c in components
+    )
+
+
 def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
     """Check if an IntegrityError is for the SBOM uniqueness constraint.
 
@@ -416,6 +426,11 @@ def sbom_upload_cyclonedx(
 
         sbom_version = sbom_dict.get("version", "")
         sbom_format = "cyclonedx"
+
+        # Auto-detect CBOM content (#1042): an action-published CBOM arrives with the
+        # default bom_type="sbom"; tag it cbom so the cbom-gated PQC plugin runs.
+        if bom_type == "sbom" and _is_cbom(sbom_data):
+            bom_type = "cbom"
 
         # Extract PURL qualifiers from metadata.component.purl
         cdx_purl = _extract_cdx_purl(payload)
@@ -1106,6 +1121,11 @@ def sbom_upload_file(
 
             sbom_version = sbom_dict.get("version", "")
             sbom_format = "cyclonedx"
+
+            # Auto-detect CBOM content (#1042): tag a crypto BOM uploaded with the
+            # default bom_type="sbom" as cbom so the cbom-gated PQC plugin runs.
+            if bom_type == "sbom" and _is_cbom(sbom_data):
+                bom_type = "cbom"
 
             # Extract PURL qualifiers from metadata.component.purl
             cdx_purl = _extract_cdx_purl(cdx_payload)

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -75,14 +75,24 @@ def _validate_bom_type(bom_type: str) -> tuple[int, dict[str, Any]] | None:
     return None
 
 
-def _is_cbom(sbom_data: dict[str, Any]) -> bool:
-    """True when a CycloneDX document declares cryptographic-asset components, i.e. it is a CBOM."""
-    components = sbom_data.get("components")
-    if not isinstance(components, list):
-        return False
-    return any(
-        isinstance(c, dict) and (c.get("type") == "cryptographic-asset" or "cryptoProperties" in c) for c in components
+def _is_crypto_component(component: Any) -> bool:
+    """A CycloneDX component is a crypto asset if typed as one or carrying cryptoProperties."""
+    return isinstance(component, dict) and (
+        component.get("type") == "cryptographic-asset" or "cryptoProperties" in component
     )
+
+
+def _is_cbom(sbom_data: dict[str, Any]) -> bool:
+    """True when a CycloneDX document declares cryptographic-asset content (a CBOM).
+
+    Checks both the top-level ``components`` array and ``metadata.component`` (which
+    is itself a Component and may carry the crypto indicators on its own).
+    """
+    components = sbom_data.get("components")
+    if isinstance(components, list) and any(_is_crypto_component(c) for c in components):
+        return True
+    metadata = sbom_data.get("metadata")
+    return isinstance(metadata, dict) and _is_crypto_component(metadata.get("component"))
 
 
 def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
@@ -428,8 +438,9 @@ def sbom_upload_cyclonedx(
         sbom_format = "cyclonedx"
 
         # Auto-detect CBOM content (#1042): an action-published CBOM arrives with the
-        # default bom_type="sbom"; tag it cbom so the cbom-gated PQC plugin runs.
-        if bom_type == "sbom" and _is_cbom(sbom_data):
+        # default bom_type; tag it cbom so the cbom-gated PQC plugin runs. Only when
+        # the caller omitted bom_type — an explicit ?bom_type=sbom is honored.
+        if "bom_type" not in request.GET and _is_cbom(sbom_data):
             bom_type = "cbom"
 
         # Extract PURL qualifiers from metadata.component.purl
@@ -1123,8 +1134,9 @@ def sbom_upload_file(
             sbom_format = "cyclonedx"
 
             # Auto-detect CBOM content (#1042): tag a crypto BOM uploaded with the
-            # default bom_type="sbom" as cbom so the cbom-gated PQC plugin runs.
-            if bom_type == "sbom" and _is_cbom(sbom_data):
+            # default bom_type as cbom so the cbom-gated PQC plugin runs. Only when
+            # the caller omitted bom_type — an explicit ?bom_type=sbom is honored.
+            if "bom_type" not in request.GET and _is_cbom(sbom_data):
                 bom_type = "cbom"
 
             # Extract PURL qualifiers from metadata.component.purl

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -3558,3 +3558,72 @@ def test_delete_sbom_api_admin_forbidden(sample_sbom: SBOM):  # noqa: F811
 
     assert response.status_code == 403
     assert SBOM.objects.filter(id=sample_sbom.id).exists()
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_autodetects_cbom_bom_type(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """A CycloneDX doc with cryptographic-asset components is auto-tagged bom_type=cbom (#1042)."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    cbom_path = pathlib.Path(__file__).parent.resolve() / "test_data/cbom_sample_1.6.cdx.json"
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url, data=open(cbom_path).read(), content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+    assert resp.status_code == 201
+    sbom = SBOM.objects.get(id=resp.json()["id"])
+    assert sbom.bom_type == "cbom"
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_non_crypto_stays_sbom(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """A plain CycloneDX SBOM is not reclassified by CBOM auto-detection (#1042)."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    path = pathlib.Path(__file__).parent.resolve() / "test_data/sbomify_trivy.cdx.json"
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url, data=open(path).read(), content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+    assert resp.status_code == 201
+    sbom = SBOM.objects.get(id=resp.json()["id"])
+    assert sbom.bom_type == "sbom"
+
+
+@pytest.mark.django_db
+def test_sbom_upload_file_autodetects_cbom(
+    sample_user,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """File-uploading a CycloneDX CBOM with the default bom_type tags it cbom (#1042)."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    cbom_path = pathlib.Path(__file__).parent.resolve() / "test_data/cbom_sample_1.6.cdx.json"
+    client = Client()
+    client.force_login(sample_user)
+    url = reverse("api-1:sbom_upload_file", kwargs={"component_id": sample_component.id})
+    with open(cbom_path, "rb") as f:
+        resp = client.post(url, data={"sbom_file": f}, format="multipart")
+
+    assert resp.status_code == 201
+    sbom = SBOM.objects.get(id=resp.json()["id"])
+    assert sbom.bom_type == "cbom"

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -3627,3 +3627,26 @@ def test_sbom_upload_file_autodetects_cbom(
     assert resp.status_code == 201
     sbom = SBOM.objects.get(id=resp.json()["id"])
     assert sbom.bom_type == "cbom"
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_explicit_sbom_not_reclassified(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """An explicit ?bom_type=sbom is honored even for crypto content (#1042)."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    cbom_path = pathlib.Path(__file__).parent.resolve() / "test_data/cbom_sample_1.6.cdx.json"
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id}) + "?bom_type=sbom"
+    resp = client.post(
+        url, data=open(cbom_path).read(), content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+    assert resp.status_code == 201
+    sbom = SBOM.objects.get(id=resp.json()["id"])
+    assert sbom.bom_type == "sbom"

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -3650,3 +3650,38 @@ def test_cyclonedx_upload_explicit_sbom_not_reclassified(
     assert resp.status_code == 201
     sbom = SBOM.objects.get(id=resp.json()["id"])
     assert sbom.bom_type == "sbom"
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_autodetects_cbom_from_metadata_component(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """CBOM detection fires when only metadata.component is a crypto asset (#1042)."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    doc = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "cryptographic-asset",
+                "name": "rsa-2048",
+                "bom-ref": "crypto-1",
+                "cryptoProperties": {"assetType": "algorithm"},
+            }
+        },
+        "components": [{"type": "library", "name": "libfoo", "version": "1.0"}],
+    }
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url, data=json.dumps(doc), content_type="application/json", **get_api_headers(sample_access_token)
+    )
+    assert resp.status_code == 201
+    sbom = SBOM.objects.get(id=resp.json()["id"])
+    assert sbom.bom_type == "cbom"

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -3575,7 +3575,7 @@ def test_cyclonedx_upload_autodetects_cbom_bom_type(
     client = Client()
     url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
     resp = client.post(
-        url, data=open(cbom_path).read(), content_type="application/json",
+        url, data=cbom_path.read_text(), content_type="application/json",
         **get_api_headers(sample_access_token),
     )
     assert resp.status_code == 201
@@ -3598,7 +3598,7 @@ def test_cyclonedx_upload_non_crypto_stays_sbom(
     client = Client()
     url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
     resp = client.post(
-        url, data=open(path).read(), content_type="application/json",
+        url, data=path.read_text(), content_type="application/json",
         **get_api_headers(sample_access_token),
     )
     assert resp.status_code == 201
@@ -3644,7 +3644,7 @@ def test_cyclonedx_upload_explicit_sbom_not_reclassified(
     client = Client()
     url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id}) + "?bom_type=sbom"
     resp = client.post(
-        url, data=open(cbom_path).read(), content_type="application/json",
+        url, data=cbom_path.read_text(), content_type="application/json",
         **get_api_headers(sample_access_token),
     )
     assert resp.status_code == 201


### PR DESCRIPTION
## What

A CycloneDX document with `cryptographic-asset` components is a CBOM, but the sbomify-action uploads with the default `bom_type="sbom"`. The `pqc-readiness` plugin is gated to `bom_type="cbom"`, so an action-published CBOM got the inventory/posture cards and the API but no persisted PQC `AssessmentRun`.

## Fix

Detect crypto content at upload (`components[].type == "cryptographic-asset"` or a component `cryptoProperties`) and override `sbom` → `cbom` when the caller used the default. Applied to both CycloneDX upload paths — the `artifact/cyclonedx` endpoint (used by the action) and the generic file upload. SPDX uploads and explicitly-typed uploads are unchanged.

## Tests

- CycloneDX CBOM via the artifact endpoint → `bom_type=cbom`
- CycloneDX CBOM via file upload → `bom_type=cbom`
- Plain CycloneDX SBOM → stays `sbom`

Closes #1042