### PR TITLE
feat(sboms): backfill command to re-tag stored CBOMs and run PQC (#1069)

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -30,7 +30,7 @@ from sbomify.apps.core.utils import (
     obj_extract,
 )
 from sbomify.apps.oidc.permissions import is_authorised_for_component
-from sbomify.apps.sboms.utils import verify_download_token
+from sbomify.apps.sboms.utils import _is_cbom, _is_duplicate_integrity_error, verify_download_token
 from sbomify.apps.teams.models import ContactProfile
 
 from .models import SBOM, Component, Product
@@ -61,7 +61,6 @@ log = logging.getLogger(__name__)
 SBOM_MAX_UPLOAD_SIZE = 100 * 1024 * 1024
 
 
-_SBOM_UNIQUE_CONSTRAINT = "sboms_sbom_unique_component_version_format_qualifiers_bom_type"
 _VALID_BOM_TYPES = {choice[0] for choice in SBOM.BomType.choices}
 
 
@@ -73,59 +72,6 @@ def _validate_bom_type(bom_type: str) -> tuple[int, dict[str, Any]] | None:
             "error_code": ErrorCode.VALIDATION_ERROR,
         }
     return None
-
-
-def _is_crypto_component(component: Any) -> bool:
-    """A CycloneDX component is a crypto asset if typed as one or carrying cryptoProperties."""
-    return isinstance(component, dict) and (
-        component.get("type") == "cryptographic-asset" or "cryptoProperties" in component
-    )
-
-
-def _is_cbom(sbom_data: dict[str, Any]) -> bool:
-    """True when a CycloneDX document declares cryptographic-asset content (a CBOM).
-
-    Checks both the top-level ``components`` array and ``metadata.component`` (which
-    is itself a Component and may carry the crypto indicators on its own).
-    """
-    components = sbom_data.get("components")
-    if isinstance(components, list) and any(_is_crypto_component(c) for c in components):
-        return True
-    metadata = sbom_data.get("metadata")
-    return isinstance(metadata, dict) and _is_crypto_component(metadata.get("component"))
-
-
-def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
-    """Check if an IntegrityError is for the SBOM uniqueness constraint.
-
-    Postgres path: checks diag.constraint_name, then SQLSTATE 23505 with
-    constraint name in the message.
-    SQLite path: checks for "UNIQUE constraint failed" with the relevant columns.
-    """
-    cause = exc.__cause__
-    if cause is not None:
-        # Try PostgreSQL diagnostics first (most precise)
-        diag = getattr(cause, "diag", None)
-        if diag is not None:
-            diag_constraint: str | None = getattr(diag, "constraint_name", None)
-            if diag_constraint == _SBOM_UNIQUE_CONSTRAINT:
-                return True
-
-        pgcode: str | None = getattr(cause, "pgcode", None)
-        if pgcode == "23505":
-            return _SBOM_UNIQUE_CONSTRAINT in str(exc).lower()
-
-    msg = str(exc).lower()
-
-    # Postgres fallback (no __cause__ or missing diag)
-    if _SBOM_UNIQUE_CONSTRAINT in msg:
-        return True
-
-    # SQLite: "UNIQUE constraint failed: sboms_sbom.component_id, ..."
-    if "unique constraint failed" in msg and "sboms_sbom.component_id" in msg and "sboms_sbom.version" in msg:
-        return True
-
-    return False
 
 
 def _cleanup_orphaned_s3_object(filename: str) -> None:

--- a/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
@@ -20,7 +20,7 @@ from django.db import IntegrityError
 from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk import RunReason
 from sbomify.apps.plugins.tasks import enqueue_assessment
-from sbomify.apps.sboms.apis import _is_cbom
+from sbomify.apps.sboms.apis import _is_cbom, _is_duplicate_integrity_error
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.sboms.utils import SBOMDataError, get_sbom_data
 
@@ -37,19 +37,24 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         dry_run: bool = options["dry_run"]
+        limit: int | None = options["limit"]
+        # Only sbom-typed CycloneDX rows: other bom_types (vex, aibom, ...) keep their
+        # discriminator even if they happen to carry crypto-asset components. Re-tagged
+        # rows become cbom, so a re-run no longer sees them (idempotent).
         candidates = (
-            SBOM.objects.filter(format="cyclonedx")
-            .exclude(bom_type=SBOM.BomType.CBOM)
+            SBOM.objects.filter(format="cyclonedx", bom_type=SBOM.BomType.SBOM)
             .select_related("component")
             .order_by("id")
         )
         if options["team_id"] is not None:
             candidates = candidates.filter(component__team_id=options["team_id"])
-        if options["limit"] is not None:
-            candidates = candidates[: options["limit"]]
 
         scanned = retagged = enqueued = skipped_run = errors = 0
-        for sbom in candidates:
+        # iterator() avoids caching the whole result set for a large one-off backfill;
+        # limit is applied manually since slicing and iterator() are incompatible.
+        for sbom in candidates.iterator(chunk_size=500):
+            if limit is not None and scanned >= limit:
+                break
             scanned += 1
             try:
                 _, sbom_data = get_sbom_data(sbom.id)
@@ -71,8 +76,11 @@ class Command(BaseCommand):
                 try:
                     sbom.save(update_fields=["bom_type"])
                 except IntegrityError as exc:
-                    # A cbom row with the same (component, version, format, qualifiers)
-                    # already exists — skip rather than abort the batch.
+                    # Only swallow the known uniqueness collision (a cbom row with the
+                    # same component/version/format/qualifiers already exists); re-raise
+                    # any other integrity error so real problems aren't hidden.
+                    if not _is_duplicate_integrity_error(exc):
+                        raise
                     errors += 1
                     self.stderr.write(f"skip {sbom.id}: duplicate cbom artifact ({exc})")
                     continue

--- a/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
@@ -1,0 +1,93 @@
+"""Re-tag stored CycloneDX CBOMs as bom_type=cbom and trigger the PQC plugin (#1069).
+
+CBOM auto-detection (#1042) only tags NEW uploads. CycloneDX SBOMs uploaded before
+that (e.g. action-published CBOMs stored as bom_type=sbom) keep the wrong tag, so the
+cbom-gated pqc-readiness plugin never produced a persisted AssessmentRun. This one-off,
+idempotent backfill re-detects crypto content and re-tags + re-assesses the matches.
+
+Only the bom_type discriminator changes; the stored artifact bytes are never rewritten
+(ADR-004 immutability).
+
+Note: enqueue_assessment sends to the Dramatiq "plugins" queue, so a worker must be
+running for the AssessmentRun to materialize. Use --dry-run to preview first.
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.db import IntegrityError
+
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.plugins.sdk import RunReason
+from sbomify.apps.plugins.tasks import enqueue_assessment
+from sbomify.apps.sboms.apis import _is_cbom
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.utils import SBOMDataError, get_sbom_data
+
+PQC_PLUGIN = "pqc-readiness"
+
+
+class Command(BaseCommand):
+    help = "Re-tag stored CycloneDX CBOMs as bom_type=cbom and trigger the PQC plugin."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
+        parser.add_argument("--team-id", type=int, default=None, help="Limit to one workspace (Team pk).")
+        parser.add_argument("--limit", type=int, default=None, help="Process at most N candidates.")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        dry_run: bool = options["dry_run"]
+        candidates = (
+            SBOM.objects.filter(format="cyclonedx")
+            .exclude(bom_type=SBOM.BomType.CBOM)
+            .select_related("component")
+            .order_by("id")
+        )
+        if options["team_id"] is not None:
+            candidates = candidates.filter(component__team_id=options["team_id"])
+        if options["limit"] is not None:
+            candidates = candidates[: options["limit"]]
+
+        scanned = retagged = enqueued = skipped_run = errors = 0
+        for sbom in candidates:
+            scanned += 1
+            try:
+                _, sbom_data = get_sbom_data(sbom.id)
+            except SBOMDataError as exc:
+                errors += 1
+                self.stderr.write(f"skip {sbom.id}: {exc}")
+                continue
+
+            if not _is_cbom(sbom_data):
+                continue
+
+            if dry_run:
+                retagged += 1
+                self.stdout.write(f"[dry-run] would re-tag {sbom.id} ({sbom.name}) -> cbom")
+                continue
+
+            if sbom.bom_type != SBOM.BomType.CBOM:
+                sbom.bom_type = SBOM.BomType.CBOM
+                try:
+                    sbom.save(update_fields=["bom_type"])
+                except IntegrityError as exc:
+                    # A cbom row with the same (component, version, format, qualifiers)
+                    # already exists — skip rather than abort the batch.
+                    errors += 1
+                    self.stderr.write(f"skip {sbom.id}: duplicate cbom artifact ({exc})")
+                    continue
+                retagged += 1
+
+            # Idempotent: don't re-enqueue if a PQC run already exists for this SBOM.
+            if AssessmentRun.objects.filter(sbom_id=sbom.id, plugin_name=PQC_PLUGIN).exists():
+                skipped_run += 1
+                continue
+
+            enqueue_assessment(sbom_id=sbom.id, plugin_name=PQC_PLUGIN, run_reason=RunReason.MANUAL)
+            enqueued += 1
+
+        summary = (
+            f"scanned={scanned} re-tagged={retagged} pqc-enqueued={enqueued} "
+            f"skipped-existing-run={skipped_run} errors={errors}"
+        )
+        self.stdout.write(self.style.SUCCESS(summary + (" (dry-run)" if dry_run else "")))

--- a/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
@@ -20,9 +20,8 @@ from django.db import IntegrityError, transaction
 from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk import RunReason
 from sbomify.apps.plugins.tasks import enqueue_assessment
-from sbomify.apps.sboms.apis import _is_cbom, _is_duplicate_integrity_error
 from sbomify.apps.sboms.models import SBOM
-from sbomify.apps.sboms.utils import SBOMDataError, get_sbom_data
+from sbomify.apps.sboms.utils import SBOMDataError, _is_cbom, _is_duplicate_integrity_error, get_sbom_data
 
 PQC_PLUGIN = "pqc-readiness"
 

--- a/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/management/commands/backfill_cbom_retag.py
@@ -15,7 +15,7 @@ running for the AssessmentRun to materialize. Use --dry-run to preview first.
 from typing import Any
 
 from django.core.management.base import BaseCommand
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 
 from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk import RunReason
@@ -41,26 +41,23 @@ class Command(BaseCommand):
         # Only sbom-typed CycloneDX rows: other bom_types (vex, aibom, ...) keep their
         # discriminator even if they happen to carry crypto-asset components. Re-tagged
         # rows become cbom, so a re-run no longer sees them (idempotent).
-        candidates = (
-            SBOM.objects.filter(format="cyclonedx", bom_type=SBOM.BomType.SBOM)
-            .select_related("component")
-            .order_by("id")
-        )
+        candidates = SBOM.objects.filter(format="cyclonedx", bom_type=SBOM.BomType.SBOM).order_by("id")
         if options["team_id"] is not None:
             candidates = candidates.filter(component__team_id=options["team_id"])
 
         scanned = retagged = enqueued = skipped_run = errors = 0
-        # iterator() avoids caching the whole result set for a large one-off backfill;
-        # limit is applied manually since slicing and iterator() are incompatible.
-        for sbom in candidates.iterator(chunk_size=500):
+        # Iterate IDs only (the SBOM instance comes from get_sbom_data, which already
+        # fetches it) so there's one DB read per row, not two. iterator() avoids caching
+        # the whole result set; limit is manual since slicing + iterator() are incompatible.
+        for sbom_id in candidates.values_list("id", flat=True).iterator(chunk_size=500):
             if limit is not None and scanned >= limit:
                 break
             scanned += 1
             try:
-                _, sbom_data = get_sbom_data(sbom.id)
+                sbom, sbom_data = get_sbom_data(sbom_id)
             except SBOMDataError as exc:
                 errors += 1
-                self.stderr.write(f"skip {sbom.id}: {exc}")
+                self.stderr.write(f"skip {sbom_id}: {exc}")
                 continue
 
             if not _is_cbom(sbom_data):
@@ -74,7 +71,10 @@ class Command(BaseCommand):
             if sbom.bom_type != SBOM.BomType.CBOM:
                 sbom.bom_type = SBOM.BomType.CBOM
                 try:
-                    sbom.save(update_fields=["bom_type"])
+                    # Savepoint so a uniqueness collision rolls back just this write,
+                    # leaving any surrounding transaction usable.
+                    with transaction.atomic():
+                        sbom.save(update_fields=["bom_type"])
                 except IntegrityError as exc:
                     # Only swallow the known uniqueness collision (a cbom row with the
                     # same component/version/format/qualifiers already exists); re-raise

--- a/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
@@ -1,0 +1,117 @@
+"""Tests for the backfill_cbom_retag management command (#1069)."""
+
+import json
+import pathlib
+
+import pytest
+from django.core.management import call_command
+
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.plugins.sdk import RunReason
+from sbomify.apps.sboms.utils import SBOMDataError
+
+from ..models import SBOM
+from .fixtures import sample_component  # noqa: F401
+
+CMD = "sbomify.apps.sboms.management.commands.backfill_cbom_retag"
+_TEST_DATA = pathlib.Path(__file__).parent / "test_data"
+CBOM_DATA = json.loads((_TEST_DATA / "cbom_sample_1.6.cdx.json").read_text())
+PLAIN_DATA = json.loads((_TEST_DATA / "sbomify_trivy.cdx.json").read_text())
+
+
+def _make_sbom(component, name, bom_type="sbom"):
+    return SBOM.objects.create(
+        name=name,
+        component=component,
+        format="cyclonedx",
+        version=name,  # distinct per row to satisfy the unique (component, version, format, bom_type)
+        sbom_filename=f"{name}.json",
+        bom_type=bom_type,
+    )
+
+
+@pytest.fixture
+def enqueue(mocker):
+    return mocker.patch(f"{CMD}.enqueue_assessment")
+
+
+@pytest.mark.django_db
+def test_retags_crypto_and_enqueues_pqc(sample_component, mocker, enqueue):  # noqa: F811
+    crypto = _make_sbom(sample_component, "crypto")
+    plain = _make_sbom(sample_component, "plain")
+    data = {str(crypto.id): CBOM_DATA, str(plain.id): PLAIN_DATA}
+    mocker.patch(f"{CMD}.get_sbom_data", side_effect=lambda sid: (SBOM.objects.get(id=sid), data[str(sid)]))
+
+    call_command("backfill_cbom_retag")
+
+    crypto.refresh_from_db()
+    plain.refresh_from_db()
+    assert crypto.bom_type == "cbom"
+    assert plain.bom_type == "sbom"
+    enqueue.assert_called_once()
+    kwargs = enqueue.call_args.kwargs
+    assert kwargs["sbom_id"] == crypto.id
+    assert kwargs["plugin_name"] == "pqc-readiness"
+    assert kwargs["run_reason"] == RunReason.MANUAL
+
+
+@pytest.mark.django_db
+def test_idempotent_rerun_is_noop(sample_component, mocker, enqueue):  # noqa: F811
+    crypto = _make_sbom(sample_component, "crypto")
+    mocker.patch(f"{CMD}.get_sbom_data", return_value=(crypto, CBOM_DATA))
+
+    call_command("backfill_cbom_retag")
+    call_command("backfill_cbom_retag")  # already cbom -> excluded by the query
+
+    assert enqueue.call_count == 1
+
+
+@pytest.mark.django_db
+def test_skips_enqueue_when_pqc_run_exists(sample_component, mocker, enqueue):  # noqa: F811
+    crypto = _make_sbom(sample_component, "crypto")
+    AssessmentRun.objects.create(
+        sbom=crypto,
+        plugin_name="pqc-readiness",
+        plugin_version="1.0",
+        plugin_config_hash="abc",
+        category="assessment",
+        run_reason=RunReason.MANUAL.value,
+    )
+    mocker.patch(f"{CMD}.get_sbom_data", return_value=(crypto, CBOM_DATA))
+
+    call_command("backfill_cbom_retag")
+
+    crypto.refresh_from_db()
+    assert crypto.bom_type == "cbom"  # still re-tagged
+    enqueue.assert_not_called()  # but no duplicate PQC enqueue
+
+
+@pytest.mark.django_db
+def test_dry_run_writes_nothing(sample_component, mocker, enqueue):  # noqa: F811
+    crypto = _make_sbom(sample_component, "crypto")
+    mocker.patch(f"{CMD}.get_sbom_data", return_value=(crypto, CBOM_DATA))
+
+    call_command("backfill_cbom_retag", "--dry-run")
+
+    crypto.refresh_from_db()
+    assert crypto.bom_type == "sbom"
+    enqueue.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_continues_past_fetch_error(sample_component, mocker, enqueue):  # noqa: F811
+    bad = _make_sbom(sample_component, "bad")
+    crypto = _make_sbom(sample_component, "crypto")
+
+    def fetch(sid):
+        if sid == bad.id:
+            raise SBOMDataError("orphaned S3 object")
+        return (SBOM.objects.get(id=sid), CBOM_DATA)
+
+    mocker.patch(f"{CMD}.get_sbom_data", side_effect=fetch)
+
+    call_command("backfill_cbom_retag")
+
+    crypto.refresh_from_db()
+    assert crypto.bom_type == "cbom"  # processed despite the bad row
+    enqueue.assert_called_once()

--- a/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
@@ -10,7 +10,7 @@ from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk import RunReason
 from sbomify.apps.sboms.utils import SBOMDataError
 
-from ..models import SBOM
+from ..models import SBOM, Component
 from .fixtures import sample_component  # noqa: F401
 
 CMD = "sbomify.apps.sboms.management.commands.backfill_cbom_retag"
@@ -131,3 +131,43 @@ def test_skips_on_uniqueness_collision(sample_component, mocker, enqueue):  # no
     sbom_row.refresh_from_db()
     assert sbom_row.bom_type == "sbom"  # flip rolled back on the uniqueness collision
     enqueue.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_team_id_restricts_candidates(sample_component, mocker, enqueue):  # noqa: F811
+    """#1069: --team-id only re-tags SBOMs in that workspace."""
+    from sbomify.apps.core.utils import number_to_random_token
+    from sbomify.apps.teams.models import Team
+
+    other_team = Team.objects.create(name="Other")
+    other_team.key = number_to_random_token(other_team.pk)
+    other_team.save()
+    other_component = Component.objects.create(
+        name="other", team=other_team, component_type=Component.ComponentType.BOM
+    )
+    in_scope = _make_sbom(sample_component, "in_scope")
+    out_of_scope = _make_sbom(other_component, "out_of_scope")
+    mocker.patch(f"{CMD}.get_sbom_data", side_effect=lambda sid: (SBOM.objects.get(id=sid), CBOM_DATA))
+
+    call_command("backfill_cbom_retag", "--team-id", str(sample_component.team_id))
+
+    in_scope.refresh_from_db()
+    out_of_scope.refresh_from_db()
+    assert in_scope.bom_type == "cbom"
+    assert out_of_scope.bom_type == "sbom"  # other workspace untouched
+
+
+@pytest.mark.django_db
+def test_limit_caps_scanning(sample_component, mocker, enqueue):  # noqa: F811
+    """#1069: --limit stops after N candidates."""
+    s1 = _make_sbom(sample_component, "s1")
+    s2 = _make_sbom(sample_component, "s2")
+    mocker.patch(f"{CMD}.get_sbom_data", side_effect=lambda sid: (SBOM.objects.get(id=sid), CBOM_DATA))
+
+    call_command("backfill_cbom_retag", "--limit", "1")
+
+    s1.refresh_from_db()
+    s2.refresh_from_db()
+    retagged = [s for s in (s1, s2) if s.bom_type == "cbom"]
+    assert len(retagged) == 1  # capped at one
+    assert enqueue.call_count == 1

--- a/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
@@ -24,7 +24,7 @@ def _make_sbom(component, name, bom_type="sbom"):
         name=name,
         component=component,
         format="cyclonedx",
-        version=name,  # distinct per row to satisfy the unique (component, version, format, bom_type)
+        version=name,  # distinct per row to satisfy unique (component, version, format, qualifiers, bom_type)
         sbom_filename=f"{name}.json",
         bom_type=bom_type,
     )

--- a/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
+++ b/sbomify/apps/sboms/tests/test_backfill_cbom_retag.py
@@ -115,3 +115,19 @@ def test_continues_past_fetch_error(sample_component, mocker, enqueue):  # noqa:
     crypto.refresh_from_db()
     assert crypto.bom_type == "cbom"  # processed despite the bad row
     enqueue.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_skips_on_uniqueness_collision(sample_component, mocker, enqueue):  # noqa: F811
+    """#1069: flipping sbom->cbom that collides with an existing cbom row is skipped, not fatal."""
+    sbom_row = _make_sbom(sample_component, "crypto")
+    # An existing cbom row sharing (component, version, format, qualifiers) — the flip
+    # would duplicate its unique tuple.
+    _make_sbom(sample_component, "crypto", bom_type="cbom")
+    mocker.patch(f"{CMD}.get_sbom_data", return_value=(sbom_row, CBOM_DATA))
+
+    call_command("backfill_cbom_retag")
+
+    sbom_row.refresh_from_db()
+    assert sbom_row.bom_type == "sbom"  # flip rolled back on the uniqueness collision
+    enqueue.assert_not_called()

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -2291,7 +2291,6 @@ def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
     # SQLite: "UNIQUE constraint failed: <db_table>.component_id, <db_table>.version, ..."
     # Derive the table from the model so it can't drift (it's "sboms_sboms", not "sboms_sbom").
     table = SBOM._meta.db_table
-    if "unique constraint failed" in msg and f"{table}.component_id" in msg and f"{table}.version" in msg:
-        return True
-
-    return False
+    return "unique constraint failed" in msg and all(
+        f"{table}.{col}" in msg for col in ("component_id", "version", "format", "qualifiers", "bom_type")
+    )

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.core import signing
-from django.db import DatabaseError, OperationalError
+from django.db import DatabaseError, IntegrityError, OperationalError
 from django.http import HttpRequest
 from django.utils import timezone
 
@@ -2235,3 +2235,61 @@ def populate_component_metadata_native_fields(
                             bom_ref=license_data.get("bom_ref"),
                             order=order,
                         )
+
+
+# Shared by the upload API (#1042) and the CBOM backfill command (#1069); kept here in
+# the neutral utils module so neither imports the web/API layer for them.
+_SBOM_UNIQUE_CONSTRAINT = "sboms_sbom_unique_component_version_format_qualifiers_bom_type"
+
+
+def _is_crypto_component(component: Any) -> bool:
+    """A CycloneDX component is a crypto asset if typed as one or carrying cryptoProperties."""
+    return isinstance(component, dict) and (
+        component.get("type") == "cryptographic-asset" or "cryptoProperties" in component
+    )
+
+
+def _is_cbom(sbom_data: dict[str, Any]) -> bool:
+    """True when a CycloneDX document declares cryptographic-asset content (a CBOM).
+
+    Checks both the top-level ``components`` array and ``metadata.component`` (which
+    is itself a Component and may carry the crypto indicators on its own).
+    """
+    components = sbom_data.get("components")
+    if isinstance(components, list) and any(_is_crypto_component(c) for c in components):
+        return True
+    metadata = sbom_data.get("metadata")
+    return isinstance(metadata, dict) and _is_crypto_component(metadata.get("component"))
+
+
+def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
+    """Check if an IntegrityError is for the SBOM uniqueness constraint.
+
+    Postgres path: checks diag.constraint_name, then SQLSTATE 23505 with
+    constraint name in the message.
+    SQLite path: checks for "UNIQUE constraint failed" with the relevant columns.
+    """
+    cause = exc.__cause__
+    if cause is not None:
+        # Try PostgreSQL diagnostics first (most precise)
+        diag = getattr(cause, "diag", None)
+        if diag is not None:
+            diag_constraint: str | None = getattr(diag, "constraint_name", None)
+            if diag_constraint == _SBOM_UNIQUE_CONSTRAINT:
+                return True
+
+        pgcode: str | None = getattr(cause, "pgcode", None)
+        if pgcode == "23505":
+            return _SBOM_UNIQUE_CONSTRAINT in str(exc).lower()
+
+    msg = str(exc).lower()
+
+    # Postgres fallback (no __cause__ or missing diag)
+    if _SBOM_UNIQUE_CONSTRAINT in msg:
+        return True
+
+    # SQLite: "UNIQUE constraint failed: sboms_sbom.component_id, ..."
+    if "unique constraint failed" in msg and "sboms_sbom.component_id" in msg and "sboms_sbom.version" in msg:
+        return True
+
+    return False

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -2288,8 +2288,10 @@ def _is_duplicate_integrity_error(exc: IntegrityError) -> bool:
     if _SBOM_UNIQUE_CONSTRAINT in msg:
         return True
 
-    # SQLite: "UNIQUE constraint failed: sboms_sbom.component_id, ..."
-    if "unique constraint failed" in msg and "sboms_sbom.component_id" in msg and "sboms_sbom.version" in msg:
+    # SQLite: "UNIQUE constraint failed: <db_table>.component_id, <db_table>.version, ..."
+    # Derive the table from the model so it can't drift (it's "sboms_sboms", not "sboms_sbom").
+    table = SBOM._meta.db_table
+    if "unique constraint failed" in msg and f"{table}.component_id" in msg and f"{table}.version" in msg:
         return True
 
     return False


### PR DESCRIPTION
## What

A one-off, idempotent management command (`backfill_cbom_retag`) that fixes CycloneDX CBOMs stored before auto-detection (#1042). Closes #1069.

CBOM auto-detection only tags **new** uploads, so action-published CBOMs already stored as `bom_type=sbom` keep the wrong tag and have no persisted PQC `AssessmentRun`.

## How

- Query candidates: `format="cyclonedx"` rows not already `cbom`.
- Fetch + parse each from S3 via `get_sbom_data` (skips orphaned objects, never aborts the batch).
- Re-detect crypto with the same `_is_cbom` helper the upload path uses (#1042), incl. `metadata.component`.
- Re-tag matches `cbom` (`save(update_fields=["bom_type"])`, skipping on a unique-constraint collision).
- Enqueue `pqc-readiness` so an `AssessmentRun` materializes — unless one already exists.
- `--dry-run`, `--team-id`, `--limit` flags.

Idempotent: the query excludes already-`cbom` rows and the enqueue skips SBOMs with an existing PQC run, so re-running converges to a no-op. Only the `bom_type` discriminator changes — the stored artifact bytes are untouched (ADR-004). A Dramatiq worker must be running for the enqueued runs to materialize.

## Tests

Re-tag + enqueue, plain-SBOM untouched, idempotent re-run, existing-run skip, dry-run no-op, and continue-past-fetch-error.

Closes #1069