### PR TITLE
docs: API access-token best practices + legacy-token rotation guide (#1062)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,8 @@ process, involving the following steps:
 - Audit code to find any potential similar problems.
 - Prepare fixes for all releases still under maintenance. These fixes
   will be released as fast as possible to pub.dev where applicable.
+
+## API access tokens
+
+For using and rotating API access tokens safely (scoping, expiry, rotation, and the
+legacy unscoped-token migration), see [docs/access-tokens.md](docs/access-tokens.md).

--- a/docs/access-tokens.md
+++ b/docs/access-tokens.md
@@ -7,7 +7,7 @@ unscoped tokens. The authoritative field semantics live in the `AccessToken` mod
 
 ## The model
 
-A token is workspace-scoped, action-scoped, and expiring:
+A token carries workspace scoping, optional action scopes, and an optional expiry:
 
 - **Workspace** (`team`): the token acts only within that workspace. Legacy tokens
   predating workspace scoping have `team = NULL` and are **not** restricted to one
@@ -20,8 +20,9 @@ A token is workspace-scoped, action-scoped, and expiring:
 - **Last seen** (`last_used_at`): stamped on use, throttled (accurate to minutes), for
   spotting stale or leaked tokens.
 
-New PATs created in the UI are workspace-scoped, action-scoped, and 90-day-expiring by
-default.
+New PATs created in the UI are workspace-scoped and 90-day-expiring by default, but the
+access-scope selector defaults to **full** (unscoped) access. Narrow the action scope
+explicitly to limit what the token can do.
 
 ## Best practices
 

--- a/docs/access-tokens.md
+++ b/docs/access-tokens.md
@@ -17,7 +17,7 @@ A token carries workspace scoping, optional action scopes, and an optional expir
   only narrows access; the user's workspace role and the resource's attributes still
   apply. `NULL` means unscoped (full capability).
 - **Expiry** (`expires_at`): new PATs default to 90 days. `NULL` means never expires.
-- **Last seen** (`last_used_at`): stamped on use, throttled (accurate to minutes), for
+- **Last seen** (`last_used_at`): stamped on use, throttled (accurate to within a few minutes), for
   spotting stale or leaked tokens.
 
 New PATs created in the UI are workspace-scoped and 90-day-expiring by default, but the

--- a/docs/access-tokens.md
+++ b/docs/access-tokens.md
@@ -1,0 +1,73 @@
+# API access tokens
+
+Personal access tokens (PATs) authenticate programmatic API requests. This is the
+operator and contributor reference for using them safely and for rotating the legacy
+unscoped tokens. The authoritative field semantics live in the `AccessToken` model
+`help_text` (`sbomify/apps/access_tokens/models.py`); this page does not duplicate them.
+
+## The model
+
+A token is workspace-scoped, action-scoped, and expiring:
+
+- **Workspace** (`team`): the token acts only within that workspace.
+- **Action scopes** (`scopes`): a list of `can()` actions the token may perform. A scope
+  only narrows access; the user's workspace role and the resource's attributes still
+  apply. `NULL` means unscoped (full capability).
+- **Expiry** (`expires_at`): new PATs default to 90 days. `NULL` means never expires.
+- **Last seen** (`last_used_at`): stamped on use, throttled (accurate to minutes), for
+  spotting stale or leaked tokens.
+
+New PATs created in the UI are workspace-scoped, action-scoped, and 90-day-expiring by
+default.
+
+## Best practices
+
+1. **Least privilege.** Scope every token to one workspace and the smallest set of
+   action scopes the integration needs. Over-scoping is the only risk; a scope can never
+   grant more than the user already has.
+2. **Always set an expiry.** Keep the 90-day default. A never-expiring token is a
+   deliberate, monitored exception, not a default.
+3. **Rotate on a schedule and on suspected leak.** For machine credentials, rotate
+   regularly so a stolen token works only briefly. (NIST SP 800-63B drops periodic
+   rotation for human passwords; that ruling does not cover API tokens.)
+4. **One token per consumer.** A separate token per CI pipeline or integration shrinks
+   the blast radius of a leak and makes `last_used_at` attributable to a single consumer.
+5. **Store securely, never in version control.** Treat tokens like passwords. Keep them
+   in the CI secret store or a secret manager, gitignore env files, and enable secret
+   scanning.
+6. **Revoke by deleting.** sbomify has no separate revoke step; deleting a token revokes
+   it. Delete immediately on suspected compromise.
+7. **Watch `last_used_at`.** Use it to find unused or leaked tokens and delete them.
+8. **Prefer OIDC trusted publishing for CI.** sbomify's OIDC-issued tokens are
+   short-lived (about 15 minutes), which removes the long-lived secret entirely. Use a
+   long-lived PAT only when OIDC is not available.
+
+On IP allow-listing: org-level IP restrictions break with CI runners on rotating IP
+pools (GitHub advises against allow-listing hosted runners), so do not rely on them for
+CI tokens. sbomify has no per-token IP restriction; scoping, expiry, and OIDC are the
+durable controls.
+
+## Rotating a legacy token
+
+Tokens created before token scoping shipped have `scopes = NULL` and `expires_at = NULL`
+(full, never-expiring access). They stay valid until you rotate them; there is no forced
+cutover or auto-expiry, since that would break existing CI. Rotate at your convenience:
+
+1. Create a new token scoped to the specific workspace, with only the action scopes the
+   integration needs, and an expiry (the 90-day default is fine).
+2. Update the CI job or integration to use the new token (via the secret store, never
+   committed).
+3. Confirm the new token's `last_used_at` starts advancing.
+4. Confirm the old token's `last_used_at` has stopped advancing. This is how you find
+   which integration still depends on a legacy token.
+5. Delete the old token.
+
+The token list flags unscoped tokens and surfaces `last_used_at` for self-service
+rotation.
+
+## References
+
+- GitHub, [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- GitHub, [Introducing fine-grained personal access tokens](https://github.blog/security/application-security/introducing-fine-grained-personal-access-tokens-for-github/)
+- GitLab, [Personal access tokens](https://docs.gitlab.com/user/profile/personal_access_tokens/)
+- OWASP, [Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)

--- a/docs/access-tokens.md
+++ b/docs/access-tokens.md
@@ -9,7 +9,10 @@ unscoped tokens. The authoritative field semantics live in the `AccessToken` mod
 
 A token is workspace-scoped, action-scoped, and expiring:
 
-- **Workspace** (`team`): the token acts only within that workspace.
+- **Workspace** (`team`): the token acts only within that workspace. Legacy tokens
+  predating workspace scoping have `team = NULL` and are **not** restricted to one
+  workspace; they work across every workspace the user belongs to. Rotate these (see
+  below) so each token is pinned to a single workspace.
 - **Action scopes** (`scopes`): a list of `can()` actions the token may perform. A scope
   only narrows access; the user's workspace role and the resource's attributes still
   apply. `NULL` means unscoped (full capability).
@@ -49,9 +52,11 @@ durable controls.
 
 ## Rotating a legacy token
 
-Tokens created before token scoping shipped have `scopes = NULL` and `expires_at = NULL`
-(full, never-expiring access). They stay valid until you rotate them; there is no forced
-cutover or auto-expiry, since that would break existing CI. Rotate at your convenience:
+Tokens created before token scoping shipped have `scopes = NULL`, `expires_at = NULL`,
+and often `team = NULL` (full, never-expiring access that is also not pinned to a single
+workspace, so it reaches every workspace the holder belongs to). They stay valid until
+you rotate them; there is no forced cutover or auto-expiry, since that would break
+existing CI. Rotate at your convenience:
 
 1. Create a new token scoped to the specific workspace, with only the action scopes the
    integration needs, and an expiry (the 90-day default is fine).


### PR DESCRIPTION
## What

`docs/access-tokens.md` — the operator/contributor reference the issue asks for. Closes #1062.

## Contents

- **The model**: workspace + action scopes, expiry, `last_used_at`, and the `NULL` semantics — pointing to the `AccessToken` model `help_text` for field detail rather than duplicating it.
- **Best practices**: least-privilege scoping, always-expire, rotation (with the NIST-vs-OWASP nuance: NIST's no-rotation ruling is for human passwords, not API tokens), one-token-per-consumer, secure storage, revoke-by-delete, monitor `last_used_at`, and prefer OIDC trusted publishing. Plus the IP-allow-list caveat (breaks with rotating CI runner IPs; sbomify has no per-token IP restriction).
- **Rotation runbook**: the replace-and-delete path for legacy unscoped/never-expiring tokens, using `last_used_at` to confirm the cutover before deleting the old one. No forced cutover or auto-expiry (that would break existing CI), so it frames this as "rotate at your convenience."

## Placement

Lives in `docs/` next to `billing.md` / `deployment.md` (committed operator references), grounded in cited GitHub/GitLab/OWASP guidance. All four reference URLs verified `200`.

Closes #1062