### PR TITLE
feat(teams): bulk API-token revocation (#1061)

### DIFF
--- a/sbomify/apps/core/js/components/delete-modal.ts
+++ b/sbomify/apps/core/js/components/delete-modal.ts
@@ -374,10 +374,12 @@ export function registerDeleteModal() {
                         } else {
                             let detail = 'Failed to revoke the selected tokens.';
                             try {
-                                const data = (await response.json()) as { detail?: string };
-                                if (data?.detail) detail = data.detail;
+                                if ((response.headers.get('Content-Type') || '').includes('application/json')) {
+                                    const data = (await response.json()) as { detail?: string };
+                                    if (data?.detail) detail = data.detail;
+                                }
                             } catch {
-                                // Non-JSON body — keep the default message.
+                                // Non-JSON / unparseable body — keep the default message.
                             }
                             showError(detail);
                         }

--- a/sbomify/apps/core/js/components/delete-modal.ts
+++ b/sbomify/apps/core/js/components/delete-modal.ts
@@ -361,7 +361,14 @@ export function registerDeleteModal() {
                                 document.body.dispatchEvent(new CustomEvent(config.refreshEvent));
                             }
                         } else {
-                            showError('Failed to revoke the selected tokens.');
+                            let detail = 'Failed to revoke the selected tokens.';
+                            try {
+                                const data = (await response.json()) as { detail?: string };
+                                if (data?.detail) detail = data.detail;
+                            } catch {
+                                // Non-JSON body — keep the default message.
+                            }
+                            showError(detail);
                         }
                     } catch {
                         showError('Network error while revoking tokens.');

--- a/sbomify/apps/core/js/components/delete-modal.ts
+++ b/sbomify/apps/core/js/components/delete-modal.ts
@@ -40,11 +40,14 @@ interface BulkRevokeConfig {
 interface BulkRevokeData {
     selected: number[];
     showBulkModal: boolean;
+    showRevokeAllModal: boolean;
     isLoading: boolean;
     readonly countLabel: string;
     getCsrfToken(): string;
     toggleAll(checked: boolean, ids: number[]): void;
     revokeSelected(): Promise<void>;
+    revokeAll(): Promise<void>;
+    _revoke(body: Record<string, unknown>, label: string, modalKey: 'showBulkModal' | 'showRevokeAllModal'): Promise<void>;
 }
 
 declare global {
@@ -318,6 +321,7 @@ export function registerDeleteModal() {
             return {
                 selected: [],
                 showBulkModal: false,
+                showRevokeAllModal: false,
                 isLoading: false,
                 get countLabel(): string {
                     const n = this.selected.length;
@@ -337,13 +341,20 @@ export function registerDeleteModal() {
                     this.selected = checked ? [...ids] : [];
                 },
                 async revokeSelected(): Promise<void> {
-                    if (this.isLoading || this.selected.length === 0) return;
+                    if (this.selected.length === 0) return;
+                    await this._revoke({ token_ids: this.selected }, this.countLabel, 'showBulkModal');
+                },
+                async revokeAll(): Promise<void> {
+                    await this._revoke({ all: true }, 'all tokens', 'showRevokeAllModal');
+                },
+                async _revoke(body, label, modalKey): Promise<void> {
+                    if (this.isLoading) return;
                     this.isLoading = true;
                     const csrfToken = this.getCsrfToken();
                     if (!csrfToken) {
                         this.isLoading = false;
                         showError('Security error: Missing CSRF token. Please reload the page and try again.');
-                        this.showBulkModal = false;
+                        this[modalKey] = false;
                         return;
                     }
                     try {
@@ -351,11 +362,11 @@ export function registerDeleteModal() {
                             method: 'DELETE',
                             headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                             credentials: 'same-origin',
-                            body: JSON.stringify({ token_ids: this.selected }),
+                            body: JSON.stringify(body),
                         });
                         if (response.ok) {
-                            showSuccess(`Revoked ${this.countLabel}`);
-                            this.showBulkModal = false;
+                            showSuccess(`Revoked ${label}`);
+                            this[modalKey] = false;
                             this.selected = [];
                             if (config.refreshEvent) {
                                 document.body.dispatchEvent(new CustomEvent(config.refreshEvent));

--- a/sbomify/apps/core/js/components/delete-modal.ts
+++ b/sbomify/apps/core/js/components/delete-modal.ts
@@ -31,9 +31,26 @@ interface ModalObservers {
     mutationObserver: MutationObserver;
 }
 
+interface BulkRevokeConfig {
+    url: string;
+    csrfToken?: string;
+    refreshEvent?: string;
+}
+
+interface BulkRevokeData {
+    selected: number[];
+    showBulkModal: boolean;
+    isLoading: boolean;
+    readonly countLabel: string;
+    getCsrfToken(): string;
+    toggleAll(checked: boolean, ids: number[]): void;
+    revokeSelected(): Promise<void>;
+}
+
 declare global {
     interface Window {
         getDeleteModalData: (config: DeleteModalConfig) => DeleteModalData;
+        getBulkRevokeData: (config: BulkRevokeConfig) => BulkRevokeData;
         modalFocusTrap: ModalFocusTrap;
         handleTabKey: (event: KeyboardEvent) => void;
         handleModalOpen: (modalElement: HTMLElement, modalId: string) => void;
@@ -291,6 +308,67 @@ export function registerDeleteModal() {
                         this.isLoading = false;
                     }
                 }
+            };
+        };
+    }
+
+    // Bulk token revocation (#1061): one Alpine component over the whole token list.
+    if (!window.getBulkRevokeData) {
+        window.getBulkRevokeData = function (config: BulkRevokeConfig): BulkRevokeData {
+            return {
+                selected: [],
+                showBulkModal: false,
+                isLoading: false,
+                get countLabel(): string {
+                    const n = this.selected.length;
+                    return `${n} token${n === 1 ? '' : 's'}`;
+                },
+                getCsrfToken(): string {
+                    if (config.csrfToken && config.csrfToken.trim()) {
+                        return config.csrfToken.trim();
+                    }
+                    try {
+                        return getCsrfTokenFromModule();
+                    } catch {
+                        return '';
+                    }
+                },
+                toggleAll(checked: boolean, ids: number[]): void {
+                    this.selected = checked ? [...ids] : [];
+                },
+                async revokeSelected(): Promise<void> {
+                    if (this.isLoading || this.selected.length === 0) return;
+                    this.isLoading = true;
+                    const csrfToken = this.getCsrfToken();
+                    if (!csrfToken) {
+                        this.isLoading = false;
+                        showError('Security error: Missing CSRF token. Please reload the page and try again.');
+                        this.showBulkModal = false;
+                        return;
+                    }
+                    try {
+                        const response = await fetch(config.url, {
+                            method: 'DELETE',
+                            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+                            credentials: 'same-origin',
+                            body: JSON.stringify({ token_ids: this.selected }),
+                        });
+                        if (response.ok) {
+                            showSuccess(`Revoked ${this.countLabel}`);
+                            this.showBulkModal = false;
+                            this.selected = [];
+                            if (config.refreshEvent) {
+                                document.body.dispatchEvent(new CustomEvent(config.refreshEvent));
+                            }
+                        } else {
+                            showError('Failed to revoke the selected tokens.');
+                        }
+                    } catch {
+                        showError('Network error while revoking tokens.');
+                    } finally {
+                        this.isLoading = false;
+                    }
+                },
             };
         };
     }

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -119,7 +119,7 @@
                 </div>
             </div>
             {% if access_tokens or unscoped_tokens %}
-                <div x-data="getBulkRevokeData({ url: '{% url 'teams:team_tokens' team.key %}', csrfToken: '{{ csrf_token }}', refreshEvent: 'refreshTeamTokens' })">
+                <div x-data="window.getBulkRevokeData({ url: '{% url 'teams:team_tokens' team.key %}', csrfToken: '{{ csrf_token }}', refreshEvent: 'refreshTeamTokens' })">
                     {# Bulk-revoke toolbar #}
                     <div class="flex items-center justify-between mb-3 ml-11">
                         <label class="flex items-center gap-2 text-sm text-text-muted cursor-pointer">

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -127,13 +127,18 @@
                                    @change="toggleAll($event.target.checked, [{% for t in access_tokens %}{{ t.id }},{% endfor %}{% for t in unscoped_tokens %}{{ t.id }},{% endfor %}])">
                             Select all
                         </label>
-                        <button type="button"
-                                class="tw-btn-danger tw-btn-sm"
-                                x-show="selected.length"
-                                x-cloak
-                                @click="showBulkModal = true">
-                            Revoke selected (<span x-text="selected.length"></span>)
-                        </button>
+                        <div class="flex items-center gap-2">
+                            <button type="button"
+                                    class="tw-btn-danger tw-btn-sm"
+                                    x-show="selected.length"
+                                    x-cloak
+                                    @click="showBulkModal = true">
+                                Revoke selected (<span x-text="selected.length"></span>)
+                            </button>
+                            <button type="button"
+                                    class="tw-btn-ghost tw-btn-sm text-danger hover:bg-danger/10"
+                                    @click="showRevokeAllModal = true">Revoke all</button>
+                        </div>
                     </div>
                     <div class="space-y-3 ml-11">
                         {% for token in access_tokens %}
@@ -219,6 +224,7 @@
                     </div>
                     {# Bulk-revoke confirm modal #}
                     {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showBulkModal' title='Revoke Tokens' message='Are you sure you want to revoke' item_name_expression='countLabel' warning_message='This action cannot be undone. The selected tokens will stop working immediately.' confirm_text='Revoke' confirm_callback='revokeSelected()' %}
+                    {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showRevokeAllModal' title='Revoke All Tokens' message='Are you sure you want to revoke' item_name='all tokens in this workspace' warning_message='This action cannot be undone. Every token listed here, including unscoped legacy tokens, will stop working immediately.' confirm_text='Revoke all' confirm_callback='revokeAll()' %}
                 </div>
             {% else %}
                 <div class="tw-empty-state py-10">

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -119,77 +119,106 @@
                 </div>
             </div>
             {% if access_tokens or unscoped_tokens %}
-                <div class="space-y-3 ml-11">
-                    {% for token in access_tokens %}
-                        <div class="flex items-center gap-4 p-4 bg-background/30 rounded-lg border border-border/50"
-                             x-cloak
-                             x-data="{ showDeleteModal: false }">
-                            <div class="w-10 h-10 rounded-lg bg-primary/5 flex items-center justify-center flex-shrink-0">
-                                <i class="fas fa-key text-primary/60"></i>
+                <div x-data="getBulkRevokeData({ url: '{% url 'teams:team_tokens' team.key %}', csrfToken: '{{ csrf_token }}', refreshEvent: 'refreshTeamTokens' })">
+                    {# Bulk-revoke toolbar #}
+                    <div class="flex items-center justify-between mb-3 ml-11">
+                        <label class="flex items-center gap-2 text-sm text-text-muted cursor-pointer">
+                            <input type="checkbox"
+                                   @change="toggleAll($event.target.checked, [{% for t in access_tokens %}{{ t.id }},{% endfor %}{% for t in unscoped_tokens %}{{ t.id }},{% endfor %}])">
+                            Select all
+                        </label>
+                        <button type="button"
+                                class="tw-btn-danger tw-btn-sm"
+                                x-show="selected.length"
+                                x-cloak
+                                @click="showBulkModal = true">
+                            Revoke selected (<span x-text="selected.length"></span>)
+                        </button>
+                    </div>
+                    <div class="space-y-3 ml-11">
+                        {% for token in access_tokens %}
+                            <div class="flex items-center gap-4 p-4 bg-background/30 rounded-lg border border-border/50"
+                                 x-cloak
+                                 x-data="{ showDeleteModal: false }">
+                                <input type="checkbox"
+                                       value="{{ token.id }}"
+                                       x-model.number="selected"
+                                       class="flex-shrink-0"
+                                       aria-label="Select token">
+                                <div class="w-10 h-10 rounded-lg bg-primary/5 flex items-center justify-center flex-shrink-0">
+                                    <i class="fas fa-key text-primary/60"></i>
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                    <h6 class="font-medium text-text m-0 truncate">{{ token.description }}</h6>
+                                    <p class="text-sm text-text-muted m-0">
+                                        <i class="fas fa-clock text-xs mr-1"></i>
+                                        Created
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
+                                    </p>
+                                    <p class="text-sm text-text-muted m-0">
+                                        <i class="fas fa-clock-rotate-left text-xs mr-1" aria-hidden="true"></i>
+                                        Last used
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=token.last_used_at fallback='never' %}
+                                    </p>
+                                    {% include 'teams/components/token_expiry.html.j2' with token=token %}
+                                </div>
+                                <div class="flex-shrink-0">
+                                    <button type="button"
+                                            class="tw-btn-ghost tw-btn-sm text-text-muted hover:text-danger hover:bg-danger/10"
+                                            title="Delete token"
+                                            @click="showDeleteModal = true">
+                                        <i class="fas fa-trash"></i>
+                                    </button>
+                                </div>
+                                {% url 'core:delete_access_token' token_id=token.id as delete_url %}
+                                {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete Token' message='Are you sure you want to delete the token' item_name=token.description warning_message='This action cannot be undone. You will need to generate a new token.' confirm_text='Delete Token' hx_url=delete_url hx_method='delete' success_message='Token deleted successfully!' refresh_event='refreshTeamTokens' %}
                             </div>
-                            <div class="flex-1 min-w-0">
-                                <h6 class="font-medium text-text m-0 truncate">{{ token.description }}</h6>
-                                <p class="text-sm text-text-muted m-0">
-                                    <i class="fas fa-clock text-xs mr-1"></i>
-                                    Created
-                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
-                                </p>
-                                <p class="text-sm text-text-muted m-0">
-                                    <i class="fas fa-clock-rotate-left text-xs mr-1" aria-hidden="true"></i>
-                                    Last used
-                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.last_used_at fallback='never' %}
-                                </p>
-                                {% include 'teams/components/token_expiry.html.j2' with token=token %}
+                        {% endfor %}
+                        {% for token in unscoped_tokens %}
+                            <div class="flex items-center gap-4 p-4 bg-warning/5 rounded-lg border border-warning/30"
+                                 x-cloak
+                                 x-data="{ showDeleteModal: false }">
+                                <input type="checkbox"
+                                       value="{{ token.id }}"
+                                       x-model.number="selected"
+                                       class="flex-shrink-0"
+                                       aria-label="Select token">
+                                <div class="w-10 h-10 rounded-lg bg-warning/10 flex items-center justify-center flex-shrink-0">
+                                    <i class="fas fa-exclamation-circle text-warning"></i>
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                    <h6 class="font-medium text-text m-0 truncate">{{ token.description }}</h6>
+                                    <p class="text-sm text-warning m-0">
+                                        <i class="fas fa-globe text-xs mr-1"></i>
+                                        Unscoped — not tied to any workspace. Please replace with a scoped token.
+                                    </p>
+                                    <p class="text-sm text-text-muted m-0">
+                                        <i class="fas fa-clock text-xs mr-1"></i>
+                                        Created
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
+                                    </p>
+                                    <p class="text-sm text-text-muted m-0">
+                                        <i class="fas fa-clock-rotate-left text-xs mr-1" aria-hidden="true"></i>
+                                        Last used
+                                        {% include 'core/components/relative_time.html.j2' with timestamp=token.last_used_at fallback='never' %}
+                                    </p>
+                                    {% include 'teams/components/token_expiry.html.j2' with token=token %}
+                                </div>
+                                <div class="flex-shrink-0">
+                                    <button type="button"
+                                            class="tw-btn-ghost tw-btn-sm text-text-muted hover:text-danger hover:bg-danger/10"
+                                            title="Delete token"
+                                            @click="showDeleteModal = true">
+                                        <i class="fas fa-trash"></i>
+                                    </button>
+                                </div>
+                                {% url 'core:delete_access_token' token_id=token.id as delete_url %}
+                                {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete Token' message='Are you sure you want to delete the token' item_name=token.description warning_message='This action cannot be undone. You will need to generate a new token.' confirm_text='Delete Token' hx_url=delete_url hx_method='delete' success_message='Token deleted successfully!' refresh_event='refreshTeamTokens' %}
                             </div>
-                            <div class="flex-shrink-0">
-                                <button type="button"
-                                        class="tw-btn-ghost tw-btn-sm text-text-muted hover:text-danger hover:bg-danger/10"
-                                        title="Delete token"
-                                        @click="showDeleteModal = true">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                            </div>
-                            {% url 'core:delete_access_token' token_id=token.id as delete_url %}
-                            {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete Token' message='Are you sure you want to delete the token' item_name=token.description warning_message='This action cannot be undone. You will need to generate a new token.' confirm_text='Delete Token' hx_url=delete_url hx_method='delete' success_message='Token deleted successfully!' refresh_event='refreshTeamTokens' %}
-                        </div>
-                    {% endfor %}
-                    {% for token in unscoped_tokens %}
-                        <div class="flex items-center gap-4 p-4 bg-warning/5 rounded-lg border border-warning/30"
-                             x-cloak
-                             x-data="{ showDeleteModal: false }">
-                            <div class="w-10 h-10 rounded-lg bg-warning/10 flex items-center justify-center flex-shrink-0">
-                                <i class="fas fa-exclamation-circle text-warning"></i>
-                            </div>
-                            <div class="flex-1 min-w-0">
-                                <h6 class="font-medium text-text m-0 truncate">{{ token.description }}</h6>
-                                <p class="text-sm text-warning m-0">
-                                    <i class="fas fa-globe text-xs mr-1"></i>
-                                    Unscoped — not tied to any workspace. Please replace with a scoped token.
-                                </p>
-                                <p class="text-sm text-text-muted m-0">
-                                    <i class="fas fa-clock text-xs mr-1"></i>
-                                    Created
-                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.created_at %}
-                                </p>
-                                <p class="text-sm text-text-muted m-0">
-                                    <i class="fas fa-clock-rotate-left text-xs mr-1" aria-hidden="true"></i>
-                                    Last used
-                                    {% include 'core/components/relative_time.html.j2' with timestamp=token.last_used_at fallback='never' %}
-                                </p>
-                                {% include 'teams/components/token_expiry.html.j2' with token=token %}
-                            </div>
-                            <div class="flex-shrink-0">
-                                <button type="button"
-                                        class="tw-btn-ghost tw-btn-sm text-text-muted hover:text-danger hover:bg-danger/10"
-                                        title="Delete token"
-                                        @click="showDeleteModal = true">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                            </div>
-                            {% url 'core:delete_access_token' token_id=token.id as delete_url %}
-                            {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showDeleteModal' title='Delete Token' message='Are you sure you want to delete the token' item_name=token.description warning_message='This action cannot be undone. You will need to generate a new token.' confirm_text='Delete Token' hx_url=delete_url hx_method='delete' success_message='Token deleted successfully!' refresh_event='refreshTeamTokens' %}
-                        </div>
-                    {% endfor %}
+                        {% endfor %}
+                    </div>
+                    {# Bulk-revoke confirm modal #}
+                    {% include 'components/delete_confirmation_modal.html.j2' with modal_id='showBulkModal' title='Revoke Tokens' message='Are you sure you want to revoke' item_name_expression='countLabel' warning_message='This action cannot be undone. The selected tokens will stop working immediately.' confirm_text='Revoke' confirm_callback='revokeSelected()' %}
                 </div>
             {% else %}
                 <div class="tw-empty-state py-10">

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -149,7 +149,7 @@
                                        value="{{ token.id }}"
                                        x-model.number="selected"
                                        class="flex-shrink-0"
-                                       aria-label="Select token">
+                                       aria-label="Select token {{ token.description }}">
                                 <div class="w-10 h-10 rounded-lg bg-primary/5 flex items-center justify-center flex-shrink-0">
                                     <i class="fas fa-key text-primary/60"></i>
                                 </div>
@@ -187,7 +187,7 @@
                                        value="{{ token.id }}"
                                        x-model.number="selected"
                                        class="flex-shrink-0"
-                                       aria-label="Select token">
+                                       aria-label="Select token {{ token.description }}">
                                 <div class="w-10 h-10 rounded-lg bg-warning/10 flex items-center justify-center flex-shrink-0">
                                     <i class="fas fa-exclamation-circle text-warning"></i>
                                 </div>

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -473,3 +473,20 @@ class TestBulkTokenRevocation:
 
         assert resp.status_code == 200
         assert capture.call_count == 2
+
+    def test_cannot_revoke_token_from_another_workspace(self, client: Client, sample_team_with_owner_member):
+        """#1061: an owner/admin can't revoke their own token scoped to a DIFFERENT workspace
+        via this workspace's endpoint (it isn't shown on this page)."""
+        team_a = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        team_b = Team.objects.create(name="Team B")
+        team_b.key = number_to_random_token(team_b.pk)
+        team_b.save()
+        token_b = AccessToken.objects.create(user=user, encoded_token="enc-b", description="b", team=team_b)
+        setup_authenticated_client_session(client, team_a, user)
+
+        resp = client.delete(self._url(team_a), data=json.dumps({"token_ids": [token_b.id]}),
+                             content_type="application/json")
+
+        assert resp.status_code == 403
+        assert AccessToken.objects.filter(id=token_b.id).exists()

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -490,3 +490,13 @@ class TestBulkTokenRevocation:
 
         assert resp.status_code == 403
         assert AccessToken.objects.filter(id=token_b.id).exists()
+
+    def test_non_integer_token_ids_is_400(self, client: Client, sample_team_with_owner_member):
+        """#1061: non-integer token_ids are rejected with 400 (not a 500 from the id__in cast)."""
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": ["abc"]}),
+                             content_type="application/json")
+        assert resp.status_code == 400

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -1,5 +1,6 @@
 """Tests for team tokens view."""
 
+import json
 from datetime import timedelta
 
 import pytest
@@ -382,3 +383,93 @@ class TestTeamTokenExpiry:
 
         content = client.get(reverse("teams:team_tokens", kwargs={"team_key": team.key})).content.decode()
         assert "Expired" in content
+
+
+@pytest.mark.django_db
+class TestBulkTokenRevocation:
+    """Bulk revoke + revoke-all on TeamTokensView.delete (#1061)."""
+
+    def _url(self, team):
+        return reverse("teams:team_tokens", kwargs={"team_key": team.key})
+
+    def _tok(self, user, team, desc):
+        return AccessToken.objects.create(user=user, encoded_token=f"enc-{desc}", description=desc, team=team)
+
+    def test_bulk_revoke_selected(self, client: Client, sample_team_with_owner_member):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+        t1, t2, keep = (self._tok(user, team, d) for d in ("t1", "t2", "keep"))
+
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}),
+                             content_type="application/json")
+
+        assert resp.status_code == 200
+        assert not AccessToken.objects.filter(id__in=[t1.id, t2.id]).exists()
+        assert AccessToken.objects.filter(id=keep.id).exists()
+
+    def test_revoke_all_includes_unscoped(self, client: Client, sample_team_with_owner_member):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+        scoped = self._tok(user, team, "scoped")
+        unscoped = AccessToken.objects.create(user=user, encoded_token="enc-leg", description="legacy", team=None)
+
+        resp = client.delete(self._url(team), data=json.dumps({"all": True}), content_type="application/json")
+
+        assert resp.status_code == 200
+        assert not AccessToken.objects.filter(id__in=[scoped.id, unscoped.id]).exists()
+
+    def test_foreign_id_rejected_and_nothing_deleted(self, client: Client, sample_team_with_owner_member, guest_user):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+        mine = self._tok(user, team, "mine")
+        theirs = AccessToken.objects.create(user=guest_user, encoded_token="enc-theirs", description="theirs", team=None)
+
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [mine.id, theirs.id]}),
+                             content_type="application/json")
+
+        assert resp.status_code == 403
+        # Reject wholesale: neither mine nor theirs is deleted.
+        assert AccessToken.objects.filter(id__in=[mine.id, theirs.id]).count() == 2
+
+    def test_empty_selection_is_400(self, client: Client, sample_team_with_owner_member):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": []}), content_type="application/json")
+        assert resp.status_code == 400
+
+    def test_guest_cannot_bulk_revoke(self, client: Client, sample_team_with_owner_member):
+        from django.contrib.auth import get_user_model
+
+        team = sample_team_with_owner_member.team
+        owner = sample_team_with_owner_member.user
+        mine = self._tok(owner, team, "mine")
+
+        guest = get_user_model().objects.create_user(username="g", email="g@example.com", password="x")
+        Member.objects.create(team=team, user=guest, role="guest")
+        setup_authenticated_client_session(client, team, guest)
+
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [mine.id]}),
+                             content_type="application/json")
+        assert resp.status_code == 403
+        assert AccessToken.objects.filter(id=mine.id).exists()
+
+    def test_emits_posthog_per_scoped_token(
+        self, client: Client, sample_team_with_owner_member, mocker, django_capture_on_commit_callbacks
+    ):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+        t1, t2 = self._tok(user, team, "t1"), self._tok(user, team, "t2")
+        capture = mocker.patch("sbomify.apps.teams.views.team_tokens.capture_for_request")
+
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = client.delete(self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}),
+                                 content_type="application/json")
+
+        assert resp.status_code == 200
+        assert capture.call_count == 2

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -500,3 +500,16 @@ class TestBulkTokenRevocation:
         resp = client.delete(self._url(team), data=json.dumps({"token_ids": ["abc"]}),
                              content_type="application/json")
         assert resp.status_code == 400
+
+    def test_all_as_non_boolean_does_not_revoke_all(self, client: Client, sample_team_with_owner_member):
+        """#1061: a truthy non-boolean 'all' (e.g. the string 'true') must NOT trigger revoke-all."""
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+        mine = self._tok(user, team, "mine")
+
+        resp = client.delete(self._url(team), data=json.dumps({"all": "true"}),
+                             content_type="application/json")
+
+        assert resp.status_code == 400  # falls through to the token_ids path, which is absent
+        assert AccessToken.objects.filter(id=mine.id).exists()  # nothing revoked

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -80,11 +80,18 @@ class TestTeamTokensView:
         setup_authenticated_client_session(client, team, user)
 
         AccessToken.objects.create(
-            user=user, description="Used Token", encoded_token="used_tok", team=team,
+            user=user,
+            description="Used Token",
+            encoded_token="used_tok",
+            team=team,
             last_used_at=timezone.now() - timedelta(days=2),
         )
         AccessToken.objects.create(
-            user=user, description="Fresh Token", encoded_token="fresh_tok", team=team, last_used_at=None,
+            user=user,
+            description="Fresh Token",
+            encoded_token="fresh_tok",
+            team=team,
+            last_used_at=None,
         )
 
         response = client.get(reverse("teams:team_tokens", kwargs={"team_key": team.key}))
@@ -401,8 +408,9 @@ class TestBulkTokenRevocation:
         setup_authenticated_client_session(client, team, user)
         t1, t2, keep = (self._tok(user, team, d) for d in ("t1", "t2", "keep"))
 
-        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}),
-                             content_type="application/json")
+        resp = client.delete(
+            self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}), content_type="application/json"
+        )
 
         assert resp.status_code == 200
         assert not AccessToken.objects.filter(id__in=[t1.id, t2.id]).exists()
@@ -425,10 +433,13 @@ class TestBulkTokenRevocation:
         user = sample_team_with_owner_member.user
         setup_authenticated_client_session(client, team, user)
         mine = self._tok(user, team, "mine")
-        theirs = AccessToken.objects.create(user=guest_user, encoded_token="enc-theirs", description="theirs", team=None)
+        theirs = AccessToken.objects.create(
+            user=guest_user, encoded_token="enc-theirs", description="theirs", team=None
+        )
 
-        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [mine.id, theirs.id]}),
-                             content_type="application/json")
+        resp = client.delete(
+            self._url(team), data=json.dumps({"token_ids": [mine.id, theirs.id]}), content_type="application/json"
+        )
 
         assert resp.status_code == 403
         # Reject wholesale: neither mine nor theirs is deleted.
@@ -453,8 +464,9 @@ class TestBulkTokenRevocation:
         Member.objects.create(team=team, user=guest, role="guest")
         setup_authenticated_client_session(client, team, guest)
 
-        resp = client.delete(self._url(team), data=json.dumps({"token_ids": [mine.id]}),
-                             content_type="application/json")
+        resp = client.delete(
+            self._url(team), data=json.dumps({"token_ids": [mine.id]}), content_type="application/json"
+        )
         assert resp.status_code == 403
         assert AccessToken.objects.filter(id=mine.id).exists()
 
@@ -468,8 +480,9 @@ class TestBulkTokenRevocation:
         capture = mocker.patch("sbomify.apps.teams.views.team_tokens.capture_for_request")
 
         with django_capture_on_commit_callbacks(execute=True):
-            resp = client.delete(self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}),
-                                 content_type="application/json")
+            resp = client.delete(
+                self._url(team), data=json.dumps({"token_ids": [t1.id, t2.id]}), content_type="application/json"
+            )
 
         assert resp.status_code == 200
         assert capture.call_count == 2
@@ -485,8 +498,9 @@ class TestBulkTokenRevocation:
         token_b = AccessToken.objects.create(user=user, encoded_token="enc-b", description="b", team=team_b)
         setup_authenticated_client_session(client, team_a, user)
 
-        resp = client.delete(self._url(team_a), data=json.dumps({"token_ids": [token_b.id]}),
-                             content_type="application/json")
+        resp = client.delete(
+            self._url(team_a), data=json.dumps({"token_ids": [token_b.id]}), content_type="application/json"
+        )
 
         assert resp.status_code == 403
         assert AccessToken.objects.filter(id=token_b.id).exists()
@@ -497,8 +511,7 @@ class TestBulkTokenRevocation:
         user = sample_team_with_owner_member.user
         setup_authenticated_client_session(client, team, user)
 
-        resp = client.delete(self._url(team), data=json.dumps({"token_ids": ["abc"]}),
-                             content_type="application/json")
+        resp = client.delete(self._url(team), data=json.dumps({"token_ids": ["abc"]}), content_type="application/json")
         assert resp.status_code == 400
 
     def test_all_as_non_boolean_does_not_revoke_all(self, client: Client, sample_team_with_owner_member):
@@ -508,8 +521,16 @@ class TestBulkTokenRevocation:
         setup_authenticated_client_session(client, team, user)
         mine = self._tok(user, team, "mine")
 
-        resp = client.delete(self._url(team), data=json.dumps({"all": "true"}),
-                             content_type="application/json")
+        resp = client.delete(self._url(team), data=json.dumps({"all": "true"}), content_type="application/json")
 
         assert resp.status_code == 400  # falls through to the token_ids path, which is absent
         assert AccessToken.objects.filter(id=mine.id).exists()  # nothing revoked
+
+    def test_non_dict_payload_is_400(self, client: Client, sample_team_with_owner_member):
+        """#1061: a JSON body that isn't an object (e.g. a list) is rejected with 400, not a 500."""
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        resp = client.delete(self._url(team), data="[]", content_type="application/json")
+        assert resp.status_code == 400

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from datetime import timedelta
+from functools import partial
 from typing import Any, cast
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
-from django.http import HttpRequest, HttpResponse
+from django.db.models import Q
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.utils import timezone
 from django.views import View
@@ -119,3 +122,49 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             "teams/team_tokens.html.j2",
             self._get_team_tokens_context(team, request, {"new_encoded_access_token": access_token_str}),
         )
+
+    def delete(self, request: HttpRequest, team_key: str) -> HttpResponse:
+        """Bulk-revoke the caller's tokens (#1061).
+
+        Owner/admin gate + workspace scoping come from TeamRoleRequiredMixin + get_team.
+        Only the caller's own tokens are ever deleted: an explicit list with any id not
+        owned by the caller is rejected wholesale (mirrors the single-delete 403), and
+        revoke-all targets exactly what this page shows (this team's tokens + the
+        unscoped legacy ones).
+        """
+        status_code, team = get_team(request, team_key)
+        if status_code != 200:
+            return htmx_error_response(team.get("detail", "Unknown error"))
+
+        user = cast(User, request.user)
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"detail": "Invalid JSON"}, status=400)
+
+        tokens = AccessToken.objects.filter(user=user)
+        if payload.get("all"):
+            team_id = token_to_number(team.key)
+            tokens = tokens.filter(Q(team_id=team_id) | Q(team__isnull=True))
+        else:
+            ids = payload.get("token_ids")
+            if not isinstance(ids, list) or not ids:
+                return JsonResponse({"detail": "No tokens selected"}, status=400)
+            tokens = tokens.filter(id__in=ids)
+            # Any requested id not in the caller's own set (foreign or nonexistent) ->
+            # reject and delete nothing, same shape as the single-delete 403.
+            if tokens.count() != len(set(ids)):
+                return JsonResponse({"detail": "Not allowed"}, status=403)
+
+        # Capture scoped tokens' team keys before deletion for the PostHog event.
+        scoped_team_keys = [token.team.key for token in tokens.select_related("team") if token.team]
+        with transaction.atomic():
+            tokens.delete()
+
+        # Unscoped (team is None) deletions are intentionally not captured, matching
+        # the single-delete convention (workspace-keyed distinct_id). on_commit so a
+        # rollback doesn't emit; partial binds team_key per iteration (no late-binding).
+        for token_team_key in scoped_team_keys:
+            transaction.on_commit(partial(capture_for_request, request, "api_token:deleted", team_key=token_team_key))
+
+        return HttpResponse(status=200)

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -148,10 +148,16 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         # the caller's tokens in OTHER workspaces -- tokens this page never shows.
         team_id = token_to_number(team.key)
         tokens = AccessToken.objects.filter(user=user).filter(Q(team_id=team_id) | Q(team__isnull=True))
-        if not payload.get("all"):
+        if payload.get("all") is not True:
             ids = payload.get("token_ids")
-            if not isinstance(ids, list) or not ids:
-                return JsonResponse({"detail": "No tokens selected"}, status=400)
+            # Reject non-int ids (strings would crash the id__in cast) and require a real
+            # boolean for "all" (a truthy string like "false" must not mean revoke-all).
+            if (
+                not isinstance(ids, list)
+                or not ids
+                or not all(isinstance(i, int) and not isinstance(i, bool) for i in ids)
+            ):
+                return JsonResponse({"detail": "token_ids must be a non-empty list of integers"}, status=400)
             tokens = tokens.filter(id__in=ids)
             # Any requested id not in this page's scoped set (foreign user, other
             # workspace, or nonexistent) -> reject wholesale, same shape as single-delete.

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -134,7 +134,8 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         """
         status_code, team = get_team(request, team_key)
         if status_code != 200:
-            return htmx_error_response(team.get("detail", "Unknown error"))
+            # delete() is called via fetch (JSON), not HTMX -- return a JSON error.
+            return JsonResponse({"detail": team.get("detail", "Unknown error")}, status=status_code)
 
         user = cast(User, request.user)
         try:
@@ -142,17 +143,18 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         except json.JSONDecodeError:
             return JsonResponse({"detail": "Invalid JSON"}, status=400)
 
-        tokens = AccessToken.objects.filter(user=user)
-        if payload.get("all"):
-            team_id = token_to_number(team.key)
-            tokens = tokens.filter(Q(team_id=team_id) | Q(team__isnull=True))
-        else:
+        # Scope to exactly what this page manages: the caller's tokens in THIS workspace
+        # plus the unscoped legacy ones. Without the team filter, crafted ids could revoke
+        # the caller's tokens in OTHER workspaces -- tokens this page never shows.
+        team_id = token_to_number(team.key)
+        tokens = AccessToken.objects.filter(user=user).filter(Q(team_id=team_id) | Q(team__isnull=True))
+        if not payload.get("all"):
             ids = payload.get("token_ids")
             if not isinstance(ids, list) or not ids:
                 return JsonResponse({"detail": "No tokens selected"}, status=400)
             tokens = tokens.filter(id__in=ids)
-            # Any requested id not in the caller's own set (foreign or nonexistent) ->
-            # reject and delete nothing, same shape as the single-delete 403.
+            # Any requested id not in this page's scoped set (foreign user, other
+            # workspace, or nonexistent) -> reject wholesale, same shape as single-delete.
             if tokens.count() != len(set(ids)):
                 return JsonResponse({"detail": "Not allowed"}, status=403)
 

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -168,11 +168,13 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         scoped_team_keys = [token.team.key for token in tokens.select_related("team") if token.team]
         with transaction.atomic():
             tokens.delete()
-
-        # Unscoped (team is None) deletions are intentionally not captured, matching
-        # the single-delete convention (workspace-keyed distinct_id). on_commit so a
-        # rollback doesn't emit; partial binds team_key per iteration (no late-binding).
-        for token_team_key in scoped_team_keys:
-            transaction.on_commit(partial(capture_for_request, request, "api_token:deleted", team_key=token_team_key))
+            # Register inside the atomic block so the event is tied to THIS transaction
+            # (registered after it exits, on_commit fires immediately in autocommit mode).
+            # Unscoped (team is None) deletions are intentionally not captured, matching
+            # the single-delete convention; partial binds team_key per iteration.
+            for token_team_key in scoped_team_keys:
+                transaction.on_commit(
+                    partial(capture_for_request, request, "api_token:deleted", team_key=token_team_key)
+                )
 
         return HttpResponse(status=200)

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -142,6 +142,9 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             payload = json.loads(request.body or "{}")
         except json.JSONDecodeError:
             return JsonResponse({"detail": "Invalid JSON"}, status=400)
+        if not isinstance(payload, dict):
+            # json.loads can return a list/None/str; .get would then 500.
+            return JsonResponse({"detail": "Invalid JSON: expected an object"}, status=400)
 
         # Scope to exactly what this page manages: the caller's tokens in THIS workspace
         # plus the unscoped legacy ones. Without the team filter, crafted ids could revoke

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -168,7 +168,9 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                 return JsonResponse({"detail": "Not allowed"}, status=403)
 
         # Capture scoped tokens' team keys before deletion for the PostHog event.
-        scoped_team_keys = [token.team.key for token in tokens.select_related("team") if token.team]
+        # Team keys of the scoped tokens (one per token, duplicates kept) without
+        # loading model instances.
+        scoped_team_keys = list(tokens.filter(team__isnull=False).values_list("team__key", flat=True))
         with transaction.atomic():
             tokens.delete()
             # Register inside the atomic block so the event is tied to THIS transaction

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -149,7 +149,9 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         # Scope to exactly what this page manages: the caller's tokens in THIS workspace
         # plus the unscoped legacy ones. Without the team filter, crafted ids could revoke
         # the caller's tokens in OTHER workspaces -- tokens this page never shows.
-        team_id = token_to_number(team.key)
+        # Use the team_key path param (already a valid token) rather than the nullable
+        # team.key DB field, which would 500 on token_to_number if null.
+        team_id = token_to_number(team_key)
         tokens = AccessToken.objects.filter(user=user).filter(Q(team_id=team_id) | Q(team__isnull=True))
         if payload.get("all") is not True:
             ids = payload.get("token_ids")


### PR DESCRIPTION
## What

Multi-select bulk revoke and revoke-all for the workspace API-token list, so users stop deleting tokens one at a time. Closes #1061.

## Backend

A `delete()` handler on the existing `TeamTokensView` (served by the existing `teams:team_tokens` URL — no new route). The owner/admin gate and workspace scoping come free from `TeamRoleRequiredMixin` + `get_team`.

- **Ownership-safe:** the queryset is always filtered to `request.user`'s tokens. An explicit `token_ids` list containing any foreign or nonexistent id is rejected wholesale (`403`, deletes nothing), mirroring the single-delete `403`.
- **Revoke-all** targets exactly what the page shows: this team's tokens plus the unscoped legacy ones.
- Fires `api_token:deleted` per scoped token via `on_commit` (unscoped skipped, matching the single-delete convention).

## Frontend

Per-row checkboxes + a select-all toggle + a "Revoke selected (N)" button that opens the reused confirmation modal, all bound to a `getBulkRevokeData` Alpine component that `DELETE`s the selected ids and refreshes the list.

## Tests

Bulk revoke, revoke-all (incl. unscoped), foreign-id rejected wholesale, empty selection `400`, guest role `403`, and `api_token:deleted` emitted per scoped token. djlint + tsc + bun lint clean.

Closes #1061