### PR TITLE
feat(access-tokens): expose X-RateLimit-* headers on token API responses (#1076)

### DIFF
--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -1167,7 +1167,7 @@ def test_throttle_no_ratelimit_for_anonymous():
     req = RequestFactory().get("/api/v1/x")  # no access_token_record
 
     assert throttle.allow_request(req) is True
-    assert getattr(req, "_ratelimit", None) is None
+    assert getattr(req, "_access_token_ratelimit", None) is None
 
 
 def test_ratelimit_headers_middleware_sets_headers():

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -1153,7 +1153,7 @@ def test_throttle_stashes_ratelimit_on_request():
     req.access_token_record = SimpleNamespace(pk=4242)
 
     assert throttle.allow_request(req) is True
-    limit, remaining, reset = req._ratelimit
+    limit, remaining, reset = req._access_token_ratelimit
     assert limit == 5
     assert remaining == 4  # one request consumed
     assert reset > 0
@@ -1177,7 +1177,7 @@ def test_ratelimit_headers_middleware_sets_headers():
     from sbomify.apps.access_tokens.throttling import RateLimitHeadersMiddleware
 
     req = RequestFactory().get("/api/v1/x")
-    req._ratelimit = (100, 97, 1234567890)
+    req._access_token_ratelimit = (100, 97, 1234567890)
     resp = RateLimitHeadersMiddleware(lambda r: HttpResponse("ok"))(req)
 
     assert resp["X-RateLimit-Limit"] == "100"
@@ -1193,3 +1193,20 @@ def test_ratelimit_headers_middleware_noop_without_stash():
 
     resp = RateLimitHeadersMiddleware(lambda r: HttpResponse("ok"))(RequestFactory().get("/"))
     assert "X-RateLimit-Limit" not in resp
+
+
+@pytest.mark.django_db
+def test_api_response_carries_ratelimit_headers(sample_product, sample_access_token):  # noqa: F811
+    """#1076: a real PAT-authenticated API request carries the X-RateLimit-* headers end to end."""
+    from django.core.cache import cache
+    from django.urls import reverse
+
+    from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+    cache.clear()
+    resp = Client().get(reverse("api-1:list_products"), **get_api_headers(sample_access_token))
+
+    assert resp.status_code == 200
+    assert int(resp["X-RateLimit-Limit"]) > 0
+    assert int(resp["X-RateLimit-Remaining"]) >= 0
+    assert int(resp["X-RateLimit-Reset"]) > 0

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -1137,3 +1137,59 @@ def test_throttled_handler_sets_retry_after():
     resp_no_wait = _on_throttled(req, Throttled(wait=None))
     assert resp_no_wait.status_code == 429
     assert "Retry-After" not in resp_no_wait
+
+
+def test_throttle_stashes_ratelimit_on_request():
+    """#1076: allow_request records the token's limit/remaining/reset on the request."""
+    from types import SimpleNamespace
+
+    from django.core.cache import cache
+
+    from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+
+    cache.clear()
+    throttle = AccessTokenRateThrottle(rate="5/min")
+    req = RequestFactory().get("/api/v1/x")
+    req.access_token_record = SimpleNamespace(pk=4242)
+
+    assert throttle.allow_request(req) is True
+    limit, remaining, reset = req._ratelimit
+    assert limit == 5
+    assert remaining == 4  # one request consumed
+    assert reset > 0
+
+
+def test_throttle_no_ratelimit_for_anonymous():
+    """#1076: session/anonymous requests carry no token, so no headers are stashed."""
+    from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+
+    throttle = AccessTokenRateThrottle(rate="5/min")
+    req = RequestFactory().get("/api/v1/x")  # no access_token_record
+
+    assert throttle.allow_request(req) is True
+    assert getattr(req, "_ratelimit", None) is None
+
+
+def test_ratelimit_headers_middleware_sets_headers():
+    """#1076: the middleware surfaces the stashed budget as X-RateLimit-* headers."""
+    from django.http import HttpResponse
+
+    from sbomify.apps.access_tokens.throttling import RateLimitHeadersMiddleware
+
+    req = RequestFactory().get("/api/v1/x")
+    req._ratelimit = (100, 97, 1234567890)
+    resp = RateLimitHeadersMiddleware(lambda r: HttpResponse("ok"))(req)
+
+    assert resp["X-RateLimit-Limit"] == "100"
+    assert resp["X-RateLimit-Remaining"] == "97"
+    assert resp["X-RateLimit-Reset"] == "1234567890"
+
+
+def test_ratelimit_headers_middleware_noop_without_stash():
+    """#1076: no stashed budget (web/anonymous) -> no rate-limit headers added."""
+    from django.http import HttpResponse
+
+    from sbomify.apps.access_tokens.throttling import RateLimitHeadersMiddleware
+
+    resp = RateLimitHeadersMiddleware(lambda r: HttpResponse("ok"))(RequestFactory().get("/"))
+    assert "X-RateLimit-Limit" not in resp

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from django.conf import settings
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
 from ninja.throttling import SimpleRateThrottle
 
 
@@ -23,3 +25,43 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         if record is None:
             return None
         return f"throttle_access_token_{record.pk}"
+
+    def allow_request(self, request: HttpRequest) -> bool:
+        allowed = super().allow_request(request)
+        # key is None for session/anonymous requests -> no token budget to report.
+        if getattr(self, "key", None) is None:
+            return allowed
+        # ponytail: reads the shared instance's per-request state right after super();
+        # a concurrent request could clobber it, but these headers are informational.
+        limit = self.num_requests or 0
+        duration = self.duration or 0
+        remaining = max(0, limit - len(self.history))
+        reset = int((self.history[-1] if self.history else self.now) + duration)
+        budget = (limit, remaining, reset)
+        # When several throttles apply (global + heavy), report the strictest budget.
+        current = getattr(request, "_ratelimit", None)
+        if current is None or remaining < current[1]:
+            setattr(request, "_ratelimit", budget)
+        return allowed
+
+
+class RateLimitHeadersMiddleware:
+    """Surface the per-token throttle budget as X-RateLimit-* response headers (#1076).
+
+    ``AccessTokenRateThrottle.allow_request`` stashes ``(limit, remaining, reset)`` on the
+    request for PAT-authenticated API calls; this middleware copies it onto the response so
+    clients can pace themselves instead of only learning the limit from a 429.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+        budget = getattr(request, "_ratelimit", None)
+        if budget is not None:
+            limit, remaining, reset = budget
+            response["X-RateLimit-Limit"] = str(limit)
+            response["X-RateLimit-Remaining"] = str(remaining)
+            response["X-RateLimit-Reset"] = str(reset)
+        return response

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from math import ceil
 
@@ -29,17 +30,21 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
 
     def allow_request(self, request: HttpRequest) -> bool:
         allowed = super().allow_request(request)
-        # key is None for session/anonymous requests -> no token budget to report.
-        if getattr(self, "key", None) is None:
-            return allowed
-        # Read the shared throttle instance's per-request state right after super().
-        # A concurrent request on the same instance could clobber it between these two
-        # lines; the headers are informational, so an occasional stale value is acceptable.
-        limit = self.num_requests or 0
+        # Ninja reuses one throttle instance across requests, so its per-request scratch
+        # (self.key/history/now) is unsafe to read here. Compute the budget from local
+        # state and this request's own token instead: get_cache_key() is a pure function
+        # of the request, so a fresh cache read for that key can't be corrupted by a
+        # concurrent request on the shared instance.
+        key = self.get_cache_key(request)
+        if key is None:
+            return allowed  # session/anonymous -> no token budget to report
+        now = time.time()
         duration = self.duration or 0
-        remaining = max(0, limit - len(self.history))
+        limit = self.num_requests or 0
+        history = [ts for ts in self.cache.get(key, []) if ts > now - duration]
+        remaining = max(0, limit - len(history))
         # ceil so the reset is never reported earlier than a slot actually frees.
-        reset = ceil((self.history[-1] if self.history else self.now) + duration)
+        reset = ceil((history[-1] if history else now) + duration)
         budget = (limit, remaining, reset)
         # When several throttles apply (global + heavy), report the one the client hits
         # first: fewest remaining, then soonest reset.

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from math import ceil
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -36,12 +37,14 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         limit = self.num_requests or 0
         duration = self.duration or 0
         remaining = max(0, limit - len(self.history))
-        reset = int((self.history[-1] if self.history else self.now) + duration)
+        # ceil so the reset is never reported earlier than a slot actually frees.
+        reset = ceil((self.history[-1] if self.history else self.now) + duration)
         budget = (limit, remaining, reset)
-        # When several throttles apply (global + heavy), report the strictest budget.
-        current = getattr(request, "_ratelimit", None)
-        if current is None or remaining < current[1]:
-            setattr(request, "_ratelimit", budget)
+        # When several throttles apply (global + heavy), report the one the client hits
+        # first: fewest remaining, then soonest reset.
+        current = getattr(request, "_access_token_ratelimit", None)
+        if current is None or (remaining, reset) < (current[1], current[2]):
+            setattr(request, "_access_token_ratelimit", budget)
         return allowed
 
 
@@ -58,7 +61,7 @@ class RateLimitHeadersMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        budget = getattr(request, "_ratelimit", None)
+        budget = getattr(request, "_access_token_ratelimit", None)
         if budget is not None:
             limit, remaining, reset = budget
             response["X-RateLimit-Limit"] = str(limit)

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -32,8 +32,9 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         # key is None for session/anonymous requests -> no token budget to report.
         if getattr(self, "key", None) is None:
             return allowed
-        # ponytail: reads the shared instance's per-request state right after super();
-        # a concurrent request could clobber it, but these headers are informational.
+        # Read the shared throttle instance's per-request state right after super().
+        # A concurrent request on the same instance could clobber it between these two
+        # lines; the headers are informational, so an occasional stale value is acceptable.
         limit = self.num_requests or 0
         duration = self.duration or 0
         remaining = max(0, limit - len(self.history))

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -152,6 +152,9 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Outer enough to see the final API response; copies the per-token throttle budget
+    # stashed on the request onto X-RateLimit-* headers.
+    "sbomify.apps.access_tokens.throttling.RateLimitHeadersMiddleware",
     "sbomify.apps.core.middleware.DynamicHostValidationMiddleware",
     "sbomify.apps.core.middleware.CustomDomainContextMiddleware",
     "sbomify.apps.core.middleware.RealIPMiddleware",

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -147,6 +147,7 @@ DJANGO_VITE = {
 # Ensure WhiteNoise is configured
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "sbomify.apps.access_tokens.throttling.RateLimitHeadersMiddleware",
     "sbomify.apps.core.middleware.DynamicHostValidationMiddleware",
     "sbomify.apps.core.middleware.CustomDomainContextMiddleware",
     "sbomify.apps.core.middleware.RealIPMiddleware",


### PR DESCRIPTION
## What

PAT-authenticated API responses now carry rate-limit headers so clients can pace themselves instead of only learning the limit from a `429`:

- `X-RateLimit-Limit` — the per-token window cap
- `X-RateLimit-Remaining` — requests left in the current window
- `X-RateLimit-Reset` — epoch seconds when the oldest request in the window ages out (a slot frees)

## How

`AccessTokenRateThrottle.allow_request` stashes `(limit, remaining, reset)` on the request after the throttle runs; `RateLimitHeadersMiddleware` copies it onto the response. Session/anonymous requests carry no resolved token, so they get no headers. When several throttles apply to one operation (the global limit plus the heavy upload limit from #1070), the strictest remaining wins.

## Notes

- Stacks on #1068 (the throttle infra); its commits show in this diff until #1068 merges.
- `X-RateLimit-Reset` is a sliding-window estimate (oldest-in-window + duration), not a fixed calendar boundary.

Closes #1076