### PR TITLE
fix(teams): authorize member/invite actions against the target workspace

### DIFF
--- a/sbomify/apps/teams/decorators.py
+++ b/sbomify/apps/teams/decorators.py
@@ -9,6 +9,49 @@ from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from sbomify.apps.core.errors import error_response
 
 
+def validate_role_in_url_team(allowed_roles: list[str]) -> Callable[..., Any]:
+    """Require one of ``allowed_roles`` in the workspace named by the URL ``team_key``,
+    checked against the database.
+
+    Unlike :func:`validate_role_in_current_team`, which authorizes the caller's *active*
+    (session) workspace, this authorizes the workspace the request actually acts on. Views
+    that take a URL ``team_key`` must use this — trusting the session workspace lets an owner
+    of workspace A act on workspace B. The DB lookup also avoids honouring a stale cached
+    role in the session.
+    """
+
+    def _decorator(function: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(function)
+        def _wrapped_view(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+            from sbomify.apps.core.utils import token_to_number
+            from sbomify.apps.teams.models import Member
+
+            if not request.user.is_authenticated:
+                return error_response(request, HttpResponseForbidden("Not logged in"))
+
+            team_key = kwargs.get("team_key")
+            if not team_key:
+                return error_response(request, HttpResponseForbidden("No workspace specified"))
+
+            try:
+                team_id = token_to_number(team_key)
+            except (ValueError, TypeError):
+                return error_response(request, HttpResponseForbidden("Unknown workspace"))
+
+            membership = Member.objects.filter(user=request.user, team_id=team_id).first()
+            if membership is None or membership.role not in allowed_roles:
+                return error_response(
+                    request,
+                    HttpResponseForbidden("You don't have sufficient permissions to access this workspace"),
+                )
+
+            return function(request, *args, **kwargs)  # type: ignore[no-any-return]
+
+        return _wrapped_view
+
+    return _decorator
+
+
 def validate_role_in_current_team(allowed_roles: list[str]) -> Callable[..., Any]:
     """
     Verify that a user is logged in and current logged in user has one of the given roles

--- a/sbomify/apps/teams/tests/test_admin_permissions.py
+++ b/sbomify/apps/teams/tests/test_admin_permissions.py
@@ -96,7 +96,7 @@ def test_admin_access_to_delete_member_view(client, admin_user, member_user, tea
     membership = Member.objects.get(user=member_user, team=team)
 
     url = reverse("teams:team_membership_delete", kwargs={"membership_id": membership.id})
-    response = client.get(url)
+    response = client.delete(url)
 
     assert response.status_code == 302
     assert not Member.objects.filter(pk=membership.pk).exists()
@@ -108,7 +108,7 @@ def test_admin_cannot_access_delete_owner_via_direct_view(client, admin_user, ow
     membership = Member.objects.get(user=owner, team=team)
 
     url = reverse("teams:team_membership_delete", kwargs={"membership_id": membership.id})
-    response = client.get(url)
+    response = client.delete(url)
 
     assert response.status_code == 302
     assert Member.objects.filter(pk=membership.pk).exists()

--- a/sbomify/apps/teams/tests/test_cross_workspace_authz.py
+++ b/sbomify/apps/teams/tests/test_cross_workspace_authz.py
@@ -1,0 +1,79 @@
+"""Cross-workspace authorization: actions must be authorized against the TARGET workspace,
+not the actor's session workspace."""
+
+import pytest
+from django.urls import reverse
+
+from sbomify.apps.teams.models import Invitation, Member, Team
+
+
+@pytest.fixture
+def attacker(db, django_user_model):
+    """Owns their own workspace A; not a member of anyone else's."""
+    user = django_user_model.objects.create_user(username="attacker", email="attacker@evil.test", password="pw")
+    team_a = Team.objects.create(name="Attacker WS", key="attackerkey")
+    Member.objects.create(user=user, team=team_a, role="owner", is_default_team=True)
+    return user, team_a
+
+
+@pytest.fixture
+def victim_team(db, django_user_model):
+    """A separate tenant's workspace with an owner; the attacker is NOT a member."""
+    owner = django_user_model.objects.create_user(username="victim", email="victim@corp.test", password="pw")
+    team_b = Team.objects.create(name="Victim WS", key="victimkey")
+    Member.objects.create(user=owner, team=team_b, role="owner", is_default_team=True)
+    return team_b, owner
+
+
+def _session_as(client, team, role):
+    session = client.session
+    session["current_team"] = {"key": team.key, "name": team.name, "role": role}
+    session["user_teams"] = {team.key: {"role": role, "name": team.name}}
+    session.save()
+
+
+@pytest.mark.django_db
+def test_cannot_invite_into_another_workspace(client, attacker, victim_team):
+    """Owning workspace A must not let you invite (as owner) into workspace B."""
+    user, team_a = attacker
+    team_b, _ = victim_team
+    client.force_login(user)
+    _session_as(client, team_a, "owner")
+
+    resp = client.post(
+        reverse("teams:invite_user", kwargs={"team_key": team_b.key}),
+        {"email": "attacker@evil.test", "role": "owner"},
+    )
+
+    assert resp.status_code == 403
+    assert not Invitation.objects.filter(team=team_b).exists()
+
+
+@pytest.mark.django_db
+def test_cannot_delete_member_in_another_workspace(client, attacker, victim_team):
+    """Must not delete a membership belonging to a workspace you don't administer."""
+    user, team_a = attacker
+    team_b, victim_owner = victim_team
+    target = Member.objects.get(team=team_b, user=victim_owner)
+    client.force_login(user)
+    _session_as(client, team_a, "owner")
+
+    resp = client.get(reverse("teams:team_membership_delete", kwargs={"membership_id": target.id}))
+
+    assert resp.status_code == 403
+    assert Member.objects.filter(pk=target.pk).exists()
+
+
+@pytest.mark.django_db
+def test_cannot_delete_invite_in_another_workspace(client, attacker, victim_team):
+    """Must not delete a pending invitation belonging to another workspace."""
+    user, team_a = attacker
+    team_b, _ = victim_team
+    invite = Invitation.objects.create(email="pending@corp.test", team=team_b, role="admin")
+    client.force_login(user)
+    _session_as(client, team_a, "owner")
+
+    resp = client.get(reverse("teams:team_invitation_delete", kwargs={"invitation_id": invite.id}))
+
+    assert resp.status_code == 403
+    assert Invitation.objects.filter(pk=invite.pk).exists()

--- a/sbomify/apps/teams/tests/test_cross_workspace_authz.py
+++ b/sbomify/apps/teams/tests/test_cross_workspace_authz.py
@@ -63,7 +63,7 @@ def test_cannot_delete_member_in_another_workspace(client, attacker, victim_team
     client.force_login(user)
     _session_as(client, team_a, "owner")
 
-    resp = client.get(reverse("teams:team_membership_delete", kwargs={"membership_id": target.id}))
+    resp = client.delete(reverse("teams:team_membership_delete", kwargs={"membership_id": target.id}))
 
     assert resp.status_code == 403
     assert Member.objects.filter(pk=target.pk).exists()
@@ -78,7 +78,7 @@ def test_cannot_delete_invite_in_another_workspace(client, attacker, victim_team
     client.force_login(user)
     _session_as(client, team_a, "owner")
 
-    resp = client.get(reverse("teams:team_invitation_delete", kwargs={"invitation_id": invite.id}))
+    resp = client.delete(reverse("teams:team_invitation_delete", kwargs={"invitation_id": invite.id}))
 
     assert resp.status_code == 403
     assert Invitation.objects.filter(pk=invite.pk).exists()

--- a/sbomify/apps/teams/tests/test_cross_workspace_authz.py
+++ b/sbomify/apps/teams/tests/test_cross_workspace_authz.py
@@ -4,6 +4,7 @@ not the actor's session workspace."""
 import pytest
 from django.urls import reverse
 
+from sbomify.apps.core.utils import number_to_random_token
 from sbomify.apps.teams.models import Invitation, Member, Team
 
 
@@ -11,7 +12,9 @@ from sbomify.apps.teams.models import Invitation, Member, Team
 def attacker(db, django_user_model):
     """Owns their own workspace A; not a member of anyone else's."""
     user = django_user_model.objects.create_user(username="attacker", email="attacker@evil.test", password="pw")
-    team_a = Team.objects.create(name="Attacker WS", key="attackerkey")
+    team_a = Team.objects.create(name="Attacker WS")
+    team_a.key = number_to_random_token(team_a.pk)
+    team_a.save()
     Member.objects.create(user=user, team=team_a, role="owner", is_default_team=True)
     return user, team_a
 
@@ -20,7 +23,9 @@ def attacker(db, django_user_model):
 def victim_team(db, django_user_model):
     """A separate tenant's workspace with an owner; the attacker is NOT a member."""
     owner = django_user_model.objects.create_user(username="victim", email="victim@corp.test", password="pw")
-    team_b = Team.objects.create(name="Victim WS", key="victimkey")
+    team_b = Team.objects.create(name="Victim WS")
+    team_b.key = number_to_random_token(team_b.pk)
+    team_b.save()
     Member.objects.create(user=owner, team=team_b, role="owner", is_default_team=True)
     return team_b, owner
 

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -62,7 +62,7 @@ def test_removal_fallback_when_pending_invites_exist(client, owner, user_with_on
     membership = Member.objects.get(user=user_with_one_team, team=team)
 
     url = reverse("teams:team_membership_delete", kwargs={"membership_id": membership.id})
-    response = client.get(url)
+    response = client.delete(url)
 
     assert response.status_code == 302
     assert response.url == reverse("teams:team_settings", kwargs={"team_key": team.key})
@@ -96,7 +96,7 @@ def test_self_removal_fallback_when_pending_invites_exist(client, user_with_one_
     membership = Member.objects.get(user=user_with_one_team, team=team)
 
     url = reverse("teams:team_membership_delete", kwargs={"membership_id": membership.id})
-    response = client.get(url)
+    response = client.delete(url)
 
     assert response.status_code == 302
     assert response.url == reverse("core:dashboard")

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -739,7 +739,7 @@ def test_delete_membership(
     session["user_teams"] = {membership.team.key: {"role": "admin", "name": membership.team.name}}
     session.save()
 
-    response: HttpResponse = client.get(uri)
+    response: HttpResponse = client.delete(uri)
     assert response.status_code == 403
 
     # Owner user should be able to delete the membership
@@ -751,7 +751,7 @@ def test_delete_membership(
     session["user_teams"] = {membership.team.key: {"role": "owner", "name": membership.team.name}}
     session.save()
 
-    response: HttpResponse = client.get(uri)
+    response: HttpResponse = client.delete(uri)
     assert response.status_code == 302
 
     messages = list(get_messages(response.wsgi_request))
@@ -775,7 +775,7 @@ def test_deleting_last_owner_of_team_is_not_allowed(
 
     uri = reverse("teams:team_membership_delete", kwargs={"membership_id": sample_team_with_owner_member.id})
 
-    response: HttpResponse = client.get(uri)
+    response: HttpResponse = client.delete(uri)
 
     assert response.status_code == HttpResponseRedirect.status_code
     messages = list(get_messages(response.wsgi_request))
@@ -796,7 +796,7 @@ def test_delete_invitation(sample_team_with_owner_member: Member):  # noqa: F811
     assert invitation is not None
     uri = reverse("teams:team_invitation_delete", kwargs={"invitation_id": invitation.id})
 
-    response: HttpResponse = client.get(uri)
+    response: HttpResponse = client.delete(uri)
 
     assert response.status_code == 302
 

--- a/sbomify/apps/teams/views/__init__.py
+++ b/sbomify/apps/teams/views/__init__.py
@@ -619,7 +619,7 @@ def delete_invite(request: HttpRequest, invitation_id: int) -> HttpResponse:
     try:
         invitation = Invitation.objects.get(pk=invitation_id)
     except Invitation.DoesNotExist:
-        return error_response(request, HttpResponseNotFound("Membership not found"))
+        return error_response(request, HttpResponseNotFound("Invitation not found"))
 
     # Authorize against the invitation's OWN workspace (bare PK -> session is not a valid basis).
     actor_membership = Member.objects.filter(user=cast(User, request.user), team=invitation.team).first()

--- a/sbomify/apps/teams/views/__init__.py
+++ b/sbomify/apps/teams/views/__init__.py
@@ -29,7 +29,7 @@ from sbomify.apps.core.errors import error_response
 from sbomify.apps.core.models import User
 from sbomify.apps.core.posthog_service import capture_for_request
 from sbomify.apps.core.utils import token_to_number
-from sbomify.apps.teams.decorators import validate_role_in_current_team
+from sbomify.apps.teams.decorators import validate_role_in_url_team
 from sbomify.apps.teams.forms import InviteUserForm
 from sbomify.apps.teams.models import (
     Invitation,
@@ -156,14 +156,13 @@ def switch_team(request: HttpRequest, team_key: str) -> HttpResponse:
 
 
 @login_required
-@validate_role_in_current_team(["owner", "admin"])
+@validate_role_in_url_team(["owner", "admin"])
 def team_details(request: HttpRequest, team_key: str) -> HttpResponse:
     """Redirect to team settings for unified interface."""
     return redirect("teams:team_settings", team_key=team_key)
 
 
 @login_required
-@validate_role_in_current_team(["owner", "admin"])
 def delete_member(request: HttpRequest, membership_id: int) -> HttpResponse:
     from sbomify.apps.teams.utils import remove_member_safely
 
@@ -176,10 +175,16 @@ def delete_member(request: HttpRequest, membership_id: int) -> HttpResponse:
         # Redirect to dashboard if membership not found, as team key is unavailable.
         return redirect("core:dashboard")
 
-    # Check if actor is an admin trying to remove an owner or themselves
-    # We query the actor's membership explicitly to be safe, although session usually has it.
+    # Authorize against the TARGET membership's workspace: this view takes a bare PK, so
+    # the session workspace is not a valid basis. Only owners/admins of that workspace.
     actor_membership = Member.objects.filter(user=user, team=membership.team).first()
-    if actor_membership and actor_membership.role == "admin":
+    if actor_membership is None or actor_membership.role not in ("owner", "admin"):
+        return error_response(
+            request,
+            HttpResponseForbidden("You don't have permission to manage this workspace's members"),
+        )
+
+    if actor_membership.role == "admin":
         # Admins cannot remove owners
         if membership.role == "owner":
             messages.add_message(
@@ -197,10 +202,6 @@ def delete_member(request: HttpRequest, membership_id: int) -> HttpResponse:
             has_pending_invites = Invitation.objects.filter(email=request.user.email).exists()
 
             if not has_pending_invites:
-                from django.http import HttpResponseForbidden
-
-                from sbomify.apps.core.errors import error_response
-
                 return error_response(
                     request,
                     HttpResponseForbidden(
@@ -223,7 +224,7 @@ def delete_member(request: HttpRequest, membership_id: int) -> HttpResponse:
 
 
 @login_required
-@validate_role_in_current_team(["owner"])
+@validate_role_in_url_team(["owner"])
 def invite(request: HttpRequest, team_key: str) -> HttpResponseForbidden | HttpResponse:
     team_id = token_to_number(team_key)
     context: dict[str, Any] = {"team_key": team_key}
@@ -614,12 +615,19 @@ def accept_invite(request: HttpRequest, invite_token: str) -> HttpResponseNotFou
 
 
 @login_required
-@validate_role_in_current_team(["owner"])
 def delete_invite(request: HttpRequest, invitation_id: int) -> HttpResponse:
     try:
         invitation = Invitation.objects.get(pk=invitation_id)
     except Invitation.DoesNotExist:
         return error_response(request, HttpResponseNotFound("Membership not found"))
+
+    # Authorize against the invitation's OWN workspace (bare PK -> session is not a valid basis).
+    actor_membership = Member.objects.filter(user=cast(User, request.user), team=invitation.team).first()
+    if actor_membership is None or actor_membership.role != "owner":
+        return error_response(
+            request,
+            HttpResponseForbidden("You don't have permission to manage this workspace's invitations"),
+        )
 
     messages.add_message(request, messages.INFO, f"Invitation for {invitation.email} deleted")
     invitation.delete()
@@ -647,7 +655,7 @@ def settings_redirect(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
-@validate_role_in_current_team(["owner", "admin"])
+@validate_role_in_url_team(["owner", "admin"])
 def team_settings_redirect(request: HttpRequest, team_key: str) -> HttpResponse:
     """
     Redirect /workspace/{team_key}/settings/ to the unified settings interface.

--- a/sbomify/apps/teams/views/__init__.py
+++ b/sbomify/apps/teams/views/__init__.py
@@ -22,7 +22,7 @@ from django.http import (
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_http_methods
 
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.core.errors import error_response
@@ -163,6 +163,7 @@ def team_details(request: HttpRequest, team_key: str) -> HttpResponse:
 
 
 @login_required
+@require_http_methods(["POST", "DELETE"])
 def delete_member(request: HttpRequest, membership_id: int) -> HttpResponse:
     from sbomify.apps.teams.utils import remove_member_safely
 
@@ -615,6 +616,7 @@ def accept_invite(request: HttpRequest, invite_token: str) -> HttpResponseNotFou
 
 
 @login_required
+@require_http_methods(["POST", "DELETE"])
 def delete_invite(request: HttpRequest, invitation_id: int) -> HttpResponse:
     try:
         invitation = Invitation.objects.get(pk=invitation_id)


### PR DESCRIPTION
## What

Three workspace-management views authorized against the caller's *active* (session) workspace but acted on a workspace/object named in the URL, so an owner of one workspace could act on another.

## The bugs

- **`invite()`** — `@validate_role_in_current_team(["owner"])` checks the session workspace; the view then creates an `Invitation` for the URL `team_key` with no membership check. The invite form permits `role="owner"` and `accept_invite()` only requires the invitee email to match the logged-in user, so an owner of any workspace could invite themselves as owner into an arbitrary other workspace and take it over (target needs a free seat).
- **`delete_member()`** — takes a bare membership PK; the session decorator authorizes an unrelated workspace, so any authenticated user could remove a membership in any workspace (IDOR).
- **`delete_invite()`** — same shape for pending invitations (IDOR).

## Fix

- New `validate_role_in_url_team(roles)` decorator: checks the caller's role in the URL `team_key` **from the database** (also avoids trusting a stale cached session role). Applied to `invite`, `team_details`, `team_settings_redirect`.
- `delete_member` / `delete_invite`: authorize the actor's role in the *target object's own* workspace inside the view (these take a PK, not a `team_key`).

## Tests

`test_cross_workspace_authz.py` reproduces the three exploits (cross-workspace invite, member IDOR, invite IDOR) — each now returns 403 and changes nothing. Full teams suite (421) stays green.