### PR TITLE
fix(authz): enforce token workspace scope for gated component reads

### DIFF
--- a/sbomify/apps/core/services/access_control.py
+++ b/sbomify/apps/core/services/access_control.py
@@ -159,6 +159,18 @@ def check_component_access(
                 requires_access_request=True,
             )
 
+        # A workspace-scoped token must not reach a component outside its workspace, even when
+        # the user's own membership/NDA would otherwise grant gated access (mirror the scope
+        # gate in verify_item_access that the PRIVATE branch below relies on).
+        token_team = getattr(request, "token_team", None)
+        if token_team is not None and team is not None and team.id != token_team.id:
+            return ComponentAccessResult(
+                has_access=False,
+                reason="token_workspace_scope",
+                requires_authentication=True,
+                requires_access_request=False,
+            )
+
         # Check if user has gated access
         has_access, needs_nda_re_sign = _check_gated_access(request.user, team)
         if has_access:

--- a/sbomify/apps/core/tests/test_access_control_service.py
+++ b/sbomify/apps/core/tests/test_access_control_service.py
@@ -212,7 +212,6 @@ class TestCheckComponentAccess:
         factory = RequestFactory()
         request = factory.get("/")
         request.user = sample_user
-        type(request.user).is_authenticated = PropertyMock(return_value=True)
         request.token_team = other_team  # PAT scoped to a different workspace
 
         result = check_component_access(request, gated_component)
@@ -231,7 +230,6 @@ class TestCheckComponentAccess:
         factory = RequestFactory()
         request = factory.get("/")
         request.user = sample_user
-        type(request.user).is_authenticated = PropertyMock(return_value=True)
         request.token_team = team_with_business_plan  # scoped to the SAME workspace
 
         result = check_component_access(request, gated_component)

--- a/sbomify/apps/core/tests/test_access_control_service.py
+++ b/sbomify/apps/core/tests/test_access_control_service.py
@@ -23,7 +23,7 @@ from sbomify.apps.core.services.access_control import (
 from sbomify.apps.documents.access_models import AccessRequest, NDASignature
 from sbomify.apps.documents.models import Document
 from sbomify.apps.sboms.models import Component
-from sbomify.apps.teams.models import Member
+from sbomify.apps.teams.models import Member, Team
 
 
 @pytest.fixture
@@ -193,6 +193,46 @@ class TestCheckComponentAccess:
         request.user = sample_user
         # Mock is_authenticated property
         type(request.user).is_authenticated = PropertyMock(return_value=True)
+
+        result = check_component_access(request, gated_component)
+
+        assert result.has_access is True
+        assert result.reason == "gated_access_granted"
+
+    def test_gated_component_denied_for_out_of_scope_token(
+        self, sample_user, team_with_business_plan, gated_component
+    ):
+        """A workspace-scoped token must not read a gated component in a DIFFERENT workspace,
+        even when the user's own membership would otherwise grant gated access."""
+        Member.objects.get_or_create(
+            user=sample_user, team=team_with_business_plan, defaults={"role": "owner"}
+        )
+        other_team = Team.objects.create(name="Other WS", key="otherwsscopekey")
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = sample_user
+        type(request.user).is_authenticated = PropertyMock(return_value=True)
+        request.token_team = other_team  # PAT scoped to a different workspace
+
+        result = check_component_access(request, gated_component)
+
+        assert result.has_access is False
+        assert result.reason == "token_workspace_scope"
+
+    def test_gated_component_allowed_for_in_scope_token(
+        self, sample_user, team_with_business_plan, gated_component
+    ):
+        """A token scoped to the component's own workspace still grants gated access."""
+        Member.objects.get_or_create(
+            user=sample_user, team=team_with_business_plan, defaults={"role": "owner"}
+        )
+
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = sample_user
+        type(request.user).is_authenticated = PropertyMock(return_value=True)
+        request.token_team = team_with_business_plan  # scoped to the SAME workspace
 
         result = check_component_access(request, gated_component)
 


### PR DESCRIPTION
## What

A PAT scoped to workspace A could read **gated** artifacts (SBOMs, documents, crypto inventories) in *other* workspaces its owner can reach — defeating the token-workspace-scoping boundary.

## Root cause

`can("component:access")` (the ABAC branch) delegates gated components to `check_component_access`. Its `GATED` path grants access purely on the user's own membership / approved AccessRequest / signed NDA (`_check_gated_access`) and **never consults `request.token_team`**. The `PRIVATE` path, by contrast, routes through `verify_item_access`, which *does* enforce the token's workspace scope — so a scoped token was correctly denied a private component in another workspace but wrongly allowed a gated one.

Reachable via `get_crypto_inventory`, `get_sbom_detail`, `get_document_detail`, and the signature/provenance downloads (all process a PAT). Extends the earlier artifact-read scoping fix (#1037), which routed those endpoints through `can()` but couldn't close the gap inside the gated branch itself.

## Fix

Mirror the `verify_item_access` scope gate in the `GATED` branch: deny when `request.token_team` is set and the component's team differs. Unscoped tokens and session requests (`token_team is None`) are unaffected.

## Tests

`test_gated_component_denied_for_out_of_scope_token` (denied) and `test_gated_component_allowed_for_in_scope_token` (still granted). Full access-control + authz + documents suites (300+) green.