### PR TITLE
fix(plugins): gate assessment reads by component access; fail closed on scan errors

### DIFF
--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -6,8 +6,11 @@ from typing import Any
 from django.db.models import OuterRef, Subquery
 from django.http import HttpRequest
 from ninja import Router
+from ninja.decorators import decorate_view
 from pydantic import BaseModel
 
+from sbomify.apps.access_tokens.auth import optional_auth
+from sbomify.apps.core.authz import can
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Team
 
@@ -21,6 +24,14 @@ from .schemas import (
 from .sdk.enums import RunStatus
 
 router = Router(tags=["plugins"])
+
+
+def _readable_sbom(request: HttpRequest, sbom_id: str) -> SBOM | None:
+    """Return the SBOM when the caller may read its component (public or authorized), else None."""
+    sbom = SBOM.objects.select_related("component").filter(id=sbom_id).first()
+    if sbom is None or not can(request, "component:access", sbom.component):
+        return None
+    return sbom
 
 
 def _is_run_skipped(run: AssessmentRun) -> bool:
@@ -70,6 +81,10 @@ def _is_run_failing(run: AssessmentRun) -> bool:
         return False
 
     if run.category == "security":
+        # An operational scan error (error_count > 0, no by_severity) must not read as a clean
+        # pass — the scanner produced no verdict, so the posture is unknown, not good.
+        if summary.get("error_count", 0) > 0:
+            return True
         by_severity = summary.get("by_severity") or {}
         total_from_severity: int = sum(
             by_severity.get(sev, 0) for sev in ("critical", "high", "medium", "low", "info", "unknown")
@@ -216,14 +231,17 @@ def _compute_status_summary(runs: list[AssessmentRun]) -> AssessmentStatusSummar
     )
 
 
-@router.get("/assessments/{sbom_id}", response=SBOMAssessmentsResponse)
+@router.get("/assessments/{sbom_id}", response=SBOMAssessmentsResponse, auth=None)
+@decorate_view(optional_auth)
 def get_sbom_assessments(request: HttpRequest, sbom_id: str) -> SBOMAssessmentsResponse:
     """Get all assessment runs for an SBOM.
 
     Returns both the latest run per plugin and the full history.
     """
-    # Verify SBOM exists
-    if not SBOM.objects.filter(id=sbom_id).exists():
+    # Only expose results for an SBOM whose component the caller may read (public, or an
+    # authorized member/token). Otherwise return the empty "no assessments" shape so neither
+    # the findings nor the SBOM's existence leak.
+    if _readable_sbom(request, sbom_id) is None:
         return SBOMAssessmentsResponse(
             sbom_id=sbom_id,
             status_summary=AssessmentStatusSummary(overall_status="no_assessments"),
@@ -261,12 +279,25 @@ def get_sbom_assessments(request: HttpRequest, sbom_id: str) -> SBOMAssessmentsR
     )
 
 
-@router.get("/assessments/{sbom_id}/badge", response=AssessmentBadgeData)
+@router.get("/assessments/{sbom_id}/badge", response=AssessmentBadgeData, auth=None)
+@decorate_view(optional_auth)
 def get_sbom_assessment_badge(request: HttpRequest, sbom_id: str) -> AssessmentBadgeData:
     """Get minimal assessment data for badge display.
 
     Returns only what's needed for the assessment badge component.
     """
+    if _readable_sbom(request, sbom_id) is None:
+        empty = _compute_status_summary([])
+        return AssessmentBadgeData(
+            sbom_id=sbom_id,
+            overall_status=empty.overall_status,
+            total_assessments=0,
+            passing_count=0,
+            failing_count=0,
+            pending_count=0,
+            skipped_count=0,
+            plugins=[],
+        )
     # Fetch only the latest run per plugin_name via Subquery/OuterRef —
     # bounded to ``enabled plugins per SBOM`` rather than the full run
     # history. Under the scan-once-per-SBOM model there's one run per

--- a/sbomify/apps/plugins/orchestrator.py
+++ b/sbomify/apps/plugins/orchestrator.py
@@ -672,6 +672,10 @@ class PluginOrchestrator:
             return False
 
         if run.category == "security":
+            # A scan that errored out (error_count > 0, no by_severity) verified nothing, so it
+            # is not passing — otherwise a broken scanner silently satisfies a dependency gate.
+            if summary.get("error_count", 0) > 0:
+                return False
             by_severity = summary.get("by_severity") or {}
             total_from_severity: int = sum(
                 by_severity.get(sev, 0) for sev in ("critical", "high", "medium", "low", "info", "unknown")

--- a/sbomify/apps/plugins/tests/test_cisa_integration.py
+++ b/sbomify/apps/plugins/tests/test_cisa_integration.py
@@ -43,6 +43,7 @@ class TestCISAPluginIntegration:
             name="test-component",
             team=team,
             component_type="bom",
+            visibility=Component.Visibility.PUBLIC,
         )
 
     @pytest.fixture
@@ -340,6 +341,7 @@ class TestCISAPluginAPIIntegration(TestCase):
             name="api-test-component",
             team=self.team,
             component_type="bom",
+            visibility=Component.Visibility.PUBLIC,
         )
         RegisteredPlugin.objects.update_or_create(
             name="cisa-minimum-elements-2025",

--- a/sbomify/apps/plugins/tests/test_ntia_integration.py
+++ b/sbomify/apps/plugins/tests/test_ntia_integration.py
@@ -43,6 +43,7 @@ class TestNTIAPluginIntegration:
             name="test-component",
             team=team,
             component_type="bom",
+            visibility=Component.Visibility.PUBLIC,
         )
 
     @pytest.fixture
@@ -295,6 +296,7 @@ class TestNTIAPluginAPIIntegration(TestCase):
             name="api-test-component",
             team=self.team,
             component_type="bom",
+            visibility=Component.Visibility.PUBLIC,
         )
         RegisteredPlugin.objects.update_or_create(
             name="ntia-minimum-elements-2021",

--- a/sbomify/apps/plugins/tests/test_plugins_security.py
+++ b/sbomify/apps/plugins/tests/test_plugins_security.py
@@ -1,0 +1,89 @@
+"""Plugins security: fail-closed on scanner error, and access control on assessment reads."""
+
+import pytest
+from django.test import Client
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.plugins.apis import _is_run_failing
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+
+
+def _run(sbom, summary):
+    full_summary = {"total_findings": 0, "pass_count": 0, "fail_count": 0, "warning_count": 0, "error_count": 0}
+    full_summary.update(summary)
+    return AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name="osv",
+        plugin_version="1.0.0",
+        plugin_config_hash="h",
+        category="security",
+        run_reason="on_upload",
+        status="completed",
+        result={
+            "plugin_name": "osv",
+            "plugin_version": "1.0.0",
+            "category": "security",
+            "assessed_at": "2026-07-01T00:00:00Z",
+            "summary": full_summary,
+            "findings": [],
+        },
+    )
+
+
+def _sbom(team, visibility):
+    component = Component.objects.create(
+        name=f"comp-{visibility}", team=team, visibility=visibility, component_type="bom"
+    )
+    return SBOM.objects.create(name="s", component=component, format="cyclonedx", format_version="1.6")
+
+
+@pytest.mark.django_db
+def test_errored_security_run_is_failing(sample_team_with_owner_member):
+    """An errored security scan (error_count>0, no by_severity) must read as failing, not clean."""
+    sbom = _sbom(sample_team_with_owner_member.team, Component.Visibility.PUBLIC)
+    errored = _run(sbom, {"total_findings": 1, "error_count": 1})  # no by_severity
+    clean = _run(sbom, {"total_findings": 0, "error_count": 0, "by_severity": {}})
+
+    assert _is_run_failing(errored) is True
+    assert _is_run_failing(clean) is False
+
+
+@pytest.mark.django_db
+def test_assessments_not_leaked_for_private_sbom(sample_team_with_owner_member):
+    """An anonymous caller must not read a private SBOM's assessment findings."""
+    sbom = _sbom(sample_team_with_owner_member.team, Component.Visibility.PRIVATE)
+    _run(sbom, {"total_findings": 3, "by_severity": {"high": 3}})
+
+    resp = Client().get(f"/api/v1/plugins/assessments/{sbom.id}")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["all_runs"] == []
+    assert data["status_summary"]["overall_status"] == "no_assessments"
+
+
+@pytest.mark.django_db
+def test_assessments_visible_for_public_sbom(sample_team_with_owner_member):
+    """A public SBOM's assessments remain readable anonymously (badges/public pages)."""
+    sbom = _sbom(sample_team_with_owner_member.team, Component.Visibility.PUBLIC)
+    _run(sbom, {"total_findings": 3, "by_severity": {"high": 3}})
+
+    resp = Client().get(f"/api/v1/plugins/assessments/{sbom.id}")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["all_runs"]) == 1
+
+
+@pytest.mark.django_db
+def test_badge_not_leaked_for_private_sbom(sample_team_with_owner_member):
+    """The badge endpoint is gated the same way as the assessments endpoint."""
+    sbom = _sbom(sample_team_with_owner_member.team, Component.Visibility.PRIVATE)
+    _run(sbom, {"total_findings": 3, "by_severity": {"high": 3}})
+
+    resp = Client().get(f"/api/v1/plugins/assessments/{sbom.id}/badge")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["overall_status"] == "no_assessments"
+    assert data["plugins"] == []

--- a/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
+++ b/sbomify/apps/plugins/tests/test_release_dependent_trigger.py
@@ -463,7 +463,7 @@ class TestReleaseArtifactSignalHandler:
         # Disconnect the SBOM upload signal so only the ReleaseArtifact handler fires
         post_save.disconnect(trigger_plugin_assessments, sender=SBOM)
         try:
-            component = Component.objects.create(name="c", team=team)
+            component = Component.objects.create(name="c", team=team, visibility=Component.Visibility.PUBLIC)
             sbom = SBOM.objects.create(name="s", component=component, format="cyclonedx")
         finally:
             post_save.connect(trigger_plugin_assessments, sender=SBOM)
@@ -588,7 +588,7 @@ class TestSkippedRunsNotCountedAsPassing:
         team = sample_team_with_owner_member.team
         post_save.disconnect(trigger_plugin_assessments, sender=SBOM)
         try:
-            component = Component.objects.create(name="c", team=team)
+            component = Component.objects.create(name="c", team=team, visibility=Component.Visibility.PUBLIC)
             sbom = SBOM.objects.create(name="s", component=component, format="cyclonedx")
         finally:
             post_save.connect(trigger_plugin_assessments, sender=SBOM)


### PR DESCRIPTION
## Two issues in the plugins framework

### 1. Unauthenticated access to assessment/vulnerability results

The plugins `Router` had no auth, and `get_sbom_assessments` / `get_sbom_assessment_badge` gated only on `SBOM.objects.filter(id=sbom_id).exists()`. Anyone could read **any** SBOM's assessment findings (CVE ids, severities, CVSS, affected purls) and posture badge — including **private** components.

**Fix:** gate both endpoints on `can("component:access", sbom.component)` via `@decorate_view(optional_auth)`. Public SBOMs stay readable (badges/public pages); non-public require authorization. When not readable, return the empty "no assessments" shape so neither the findings nor the SBOM's existence leak.

### 2. Scanner errors reported as a passing scan (fail-open)

For `category == "security"` runs, pass/fail was decided purely from `summary.by_severity`, ignoring `error_count`. An operational scanner failure returns `_create_error_result` (a normal `AssessmentResult` with `error_count=1` and **no** `by_severity`), so a broken OSV / Dependency-Track scan read as a **clean pass** in both the UI badge (`_is_run_failing`) and the dependency gate (`orchestrator._is_passing`).

**Fix:** treat `error_count > 0` as failing / not-passing in both.

## Tests

`test_plugins_security.py` — errored security run is failing; private SBOM assessments + badge are not leaked anonymously; public SBOM assessments still visible. Existing integration tests that read private assessments via a mock request now use public components (they verify serialization, not access control). Full plugins suite (752) green.