### PR TITLE
fix(billing): cancel the real subscription on downgrade; harden the grace period

### DIFF
--- a/sbomify/apps/billing/apis.py
+++ b/sbomify/apps/billing/apis.py
@@ -124,11 +124,14 @@ def change_plan(request: HttpRequest, data: ChangePlanRequest) -> tuple[int, Any
 
 def _handle_community_downgrade(team: Team, stripe_client: Any) -> tuple[int, Any]:
     """Handle downgrade to community plan."""
-    customer_id = f"c_{team.key}"
-
     with transaction.atomic():
         team = Team.objects.select_for_update().get(pk=team.pk)
         billing_limits = team.billing_plan_limits or {}
+        # Use the stored Stripe customer id. Web checkout creates a random cus_..., so the
+        # f"c_{team.key}" form only matches the API-created path; hardcoding it made
+        # get_customer 404 for web-checkout teams, the StripeError branch downgraded locally,
+        # and the active subscription was never canceled (continued billing).
+        customer_id = billing_limits.get("stripe_customer_id") or f"c_{team.key}"
 
         try:
             customer = stripe_client.get_customer(customer_id)

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -838,6 +838,11 @@ def handle_payment_succeeded(invoice: Any, event: Any = None) -> None:
             billing_limits = (team.billing_plan_limits or {}).copy()
             billing_limits["subscription_status"] = "active"
             billing_limits["last_updated"] = timezone.now().isoformat()
+            # Payment recovered — clear the failure marker so the grace window resets for any
+            # future failure episode. The "keep first failure time" guard on the failed-payment
+            # webhook would otherwise reuse this stale timestamp and treat the next failure as
+            # already past grace.
+            billing_limits.pop("payment_failed_at", None)
             billing_limits["last_payment_amount"] = invoice.amount_paid / 100.0 if invoice.amount_paid else 0.0
             billing_limits["last_payment_currency"] = invoice.currency
             billing_limits["last_processed_webhook_id"] = webhook_id

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -196,6 +196,7 @@ def check_billing_limits(resource_type: str) -> Any:
                         # skip the grace check entirely and escape enforcement. Stamp it now so
                         # the grace window starts (persisted — team is select_for_update'd here).
                         failed_at_str = timezone.now().isoformat()
+                        billing_limits = billing_limits.copy()
                         billing_limits["payment_failed_at"] = failed_at_str
                         team.billing_plan_limits = billing_limits
                         team.save(update_fields=["billing_plan_limits"])
@@ -762,8 +763,10 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
             billing_limits["last_updated"] = timezone.now().isoformat()
             # Keep the FIRST failure time so the grace period counts down. Stripe retries the
             # invoice, and resetting this to now() on every failed-payment event kept the grace
-            # window from ever expiring.
-            billing_limits.setdefault("payment_failed_at", timezone.now().isoformat())
+            # window from ever expiring. Guard on falsy (not just absent) so a None/"" doesn't
+            # slip through, matching stripe_sync's handling.
+            if not billing_limits.get("payment_failed_at"):
+                billing_limits["payment_failed_at"] = timezone.now().isoformat()
             billing_limits["last_processed_webhook_id"] = webhook_id
             team.billing_plan_limits = billing_limits
             team.save()

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -191,25 +191,33 @@ def check_billing_limits(resource_type: str) -> Any:
                 if subscription_status == "past_due":
                     failed_at_str = billing_limits.get("payment_failed_at")
 
-                    if failed_at_str:
-                        try:
-                            failed_at = datetime.datetime.fromisoformat(failed_at_str.replace("Z", "+00:00"))
-                            delta = timezone.now() - failed_at
-                            grace_days = getattr(settings, "PAYMENT_GRACE_PERIOD_DAYS", 3)
-                            grace_period_seconds = grace_days * 24 * 60 * 60
+                    if not failed_at_str:
+                        # A past_due subscription with no recorded failure time would otherwise
+                        # skip the grace check entirely and escape enforcement. Stamp it now so
+                        # the grace window starts (persisted — team is select_for_update'd here).
+                        failed_at_str = timezone.now().isoformat()
+                        billing_limits["payment_failed_at"] = failed_at_str
+                        team.billing_plan_limits = billing_limits
+                        team.save(update_fields=["billing_plan_limits"])
 
-                            if delta.total_seconds() > grace_period_seconds:
-                                msg = (
-                                    "Payment failed. Grace period expired. "
-                                    "Please update payment method to create resources."
-                                )
-                                logger.warning("Blocking resource access: Grace period expired")
-                                return _billing_error_response(request, msg)
+                    try:
+                        failed_at = datetime.datetime.fromisoformat(failed_at_str.replace("Z", "+00:00"))
+                        delta = timezone.now() - failed_at
+                        grace_days = getattr(settings, "PAYMENT_GRACE_PERIOD_DAYS", 3)
+                        grace_period_seconds = grace_days * 24 * 60 * 60
 
-                        except (ValueError, TypeError):
-                            logger.error("Invalid payment_failed_at format")
-                            msg = "Payment failed. Unable to verify grace period. Please contact support."
+                        if delta.total_seconds() > grace_period_seconds:
+                            msg = (
+                                "Payment failed. Grace period expired. "
+                                "Please update payment method to create resources."
+                            )
+                            logger.warning("Blocking resource access: Grace period expired")
                             return _billing_error_response(request, msg)
+
+                    except (ValueError, TypeError):
+                        logger.error("Invalid payment_failed_at format")
+                        msg = "Payment failed. Unable to verify grace period. Please contact support."
+                        return _billing_error_response(request, msg)
 
             try:
                 plan = BillingPlan.objects.get(key=team.billing_plan)
@@ -752,7 +760,10 @@ def handle_payment_failed(invoice: Any, event: Any = None) -> None:
             billing_limits = (team.billing_plan_limits or {}).copy()
             billing_limits["subscription_status"] = "past_due"
             billing_limits["last_updated"] = timezone.now().isoformat()
-            billing_limits["payment_failed_at"] = timezone.now().isoformat()
+            # Keep the FIRST failure time so the grace period counts down. Stripe retries the
+            # invoice, and resetting this to now() on every failed-payment event kept the grace
+            # window from ever expiring.
+            billing_limits.setdefault("payment_failed_at", timezone.now().isoformat())
             billing_limits["last_processed_webhook_id"] = webhook_id
             team.billing_plan_limits = billing_limits
             team.save()

--- a/sbomify/apps/billing/tests/test_billing_integrity.py
+++ b/sbomify/apps/billing/tests/test_billing_integrity.py
@@ -1,0 +1,108 @@
+"""Billing integrity: community-downgrade cancels the real subscription, grace period is
+enforced and not reset on repeated failures."""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpResponseForbidden
+from django.utils import timezone
+
+from sbomify.apps.billing import billing_processing
+from sbomify.apps.billing.apis import _handle_community_downgrade
+from sbomify.apps.billing.models import BillingPlan
+from sbomify.apps.teams.models import Member, Team
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def test_community_downgrade_uses_stored_customer_id():
+    """Downgrade must use the stored Stripe customer id (web checkout creates a random cus_),
+    not f'c_{team.key}', so the active subscription is actually canceled instead of the plan
+    being downgraded locally while billing continues."""
+    BillingPlan.objects.create(key="business", name="Business")
+    team = Team.objects.create(
+        name="T",
+        key="wsdowngrade",
+        billing_plan="business",
+        billing_plan_limits={
+            "subscription_status": "active",
+            "stripe_customer_id": "cus_random123",
+            "stripe_subscription_id": "sub_abc",
+        },
+    )
+    stripe = MagicMock()
+    stripe.get_customer.return_value = MagicMock(id="cus_random123")
+    stripe.list_subscriptions.return_value = MagicMock(data=[MagicMock(id="sub_abc")])
+
+    status, _body = _handle_community_downgrade(team, stripe)
+
+    assert status == 200
+    stripe.get_customer.assert_called_once_with("cus_random123")  # not c_wsdowngrade
+    stripe.modify_subscription.assert_called_once_with("sub_abc", cancel_at_period_end=True)
+
+
+def test_payment_failed_does_not_reset_failure_time():
+    """Repeated failed-payment events keep the FIRST payment_failed_at so the grace window
+    can actually expire."""
+    BillingPlan.objects.create(key="business", name="Business", max_products=10)
+    original = (timezone.now() - datetime.timedelta(days=2)).isoformat()
+    team = Team.objects.create(
+        name="T",
+        key="test-team-reset",
+        billing_plan="business",
+        billing_plan_limits={
+            "subscription_status": "active",
+            "stripe_subscription_id": "sub_reset",
+            "stripe_customer_id": "cus_reset",
+            "payment_failed_at": original,
+        },
+    )
+
+    invoice = MagicMock()
+    invoice.subscription = "sub_reset"
+    invoice.id = "in_reset_1"
+    with patch("sbomify.apps.billing.billing_processing.email_notifications"):
+        billing_processing.handle_payment_failed(invoice)
+
+    team.refresh_from_db()
+    assert team.billing_plan_limits["subscription_status"] == "past_due"
+    assert team.billing_plan_limits["payment_failed_at"] == original  # not reset to now
+
+
+def test_past_due_without_failed_at_is_enforced():
+    """A past_due subscription with no payment_failed_at must not escape enforcement: it is
+    backfilled so the grace window starts and eventually blocks."""
+    BillingPlan.objects.create(key="business", name="Business", max_products=10)
+    team = Team.objects.create(
+        name="T",
+        key="test-team-nofail",
+        billing_plan="business",
+        billing_plan_limits={"subscription_status": "past_due"},  # no payment_failed_at
+    )
+    user = User.objects.create_user(username="nofail_user", email="nofail@example.com")
+    Member.objects.create(team=team, user=user, role="owner")
+
+    request = MagicMock()
+    request.method = "POST"
+    request.session = {"current_team": {"key": "test-team-nofail"}}
+    request.headers = {}
+    request.META = {}
+
+    @billing_processing.check_billing_limits("product")
+    def view(request):
+        return "success"
+
+    # First call backfills payment_failed_at to now -> within grace -> allowed, and persisted.
+    assert view(request) == "success"
+    team.refresh_from_db()
+    assert "payment_failed_at" in team.billing_plan_limits
+
+    # Age the backfilled stamp past the grace window -> blocked (no longer bypassed).
+    team.billing_plan_limits["payment_failed_at"] = (timezone.now() - datetime.timedelta(days=4)).isoformat()
+    team.save()
+    result = view(request)
+    assert isinstance(result, HttpResponseForbidden)
+    assert "Grace period expired" in result.content.decode()

--- a/sbomify/apps/billing/tests/test_billing_integrity.py
+++ b/sbomify/apps/billing/tests/test_billing_integrity.py
@@ -106,3 +106,44 @@ def test_past_due_without_failed_at_is_enforced():
     result = view(request)
     assert isinstance(result, HttpResponseForbidden)
     assert "Grace period expired" in result.content.decode()
+
+
+def test_payment_recovery_clears_failure_marker_so_grace_resets():
+    """A recovered payment clears payment_failed_at, so a LATER failure starts a fresh grace
+    window instead of reusing the old (already-expired) timestamp."""
+    BillingPlan.objects.create(key="business", name="Business", max_products=10)
+    old_failure = (timezone.now() - datetime.timedelta(days=10)).isoformat()  # long past grace
+    team = Team.objects.create(
+        name="T",
+        key="test-team-recover",
+        billing_plan="business",
+        billing_plan_limits={
+            "subscription_status": "past_due",
+            "stripe_subscription_id": "sub_rec",
+            "stripe_customer_id": "cus_rec",
+            "payment_failed_at": old_failure,
+        },
+    )
+
+    paid = MagicMock()
+    paid.subscription = "sub_rec"
+    paid.id = "in_paid_1"
+    paid.amount_paid = 1000
+    paid.currency = "usd"
+    with patch("sbomify.apps.billing.billing_processing.email_notifications"):
+        billing_processing.handle_payment_succeeded(paid)
+
+    team.refresh_from_db()
+    assert team.billing_plan_limits["subscription_status"] == "active"
+    assert "payment_failed_at" not in team.billing_plan_limits  # cleared on recovery
+
+    # A new failure now stamps a FRESH timestamp (not the old expired one).
+    failed = MagicMock()
+    failed.subscription = "sub_rec"
+    failed.id = "in_fail_2"
+    with patch("sbomify.apps.billing.billing_processing.email_notifications"):
+        billing_processing.handle_payment_failed(failed)
+
+    team.refresh_from_db()
+    new_failure = datetime.datetime.fromisoformat(team.billing_plan_limits["payment_failed_at"])
+    assert (timezone.now() - new_failure).total_seconds() < 10  # fresh, grace window restarts


### PR DESCRIPTION
## Three billing-integrity issues

### 1. Community downgrade doesn't cancel the subscription (continued billing) — high

`_handle_community_downgrade` used a hardcoded `customer_id = f"c_{team.key}"`. Web checkout creates a **random** `cus_...` customer (persisted in `billing_plan_limits["stripe_customer_id"]`), so `get_customer("c_<key>")` 404s → `StripeError` branch downgrades the plan locally **without** canceling the active subscription → the customer keeps being billed. Only the API-upgrade path uses `c_<key>`.

**Fix:** `customer_id = billing_limits.get("stripe_customer_id") or f"c_{team.key}"`.

### 2. Grace period never expires — medium

The failed-payment webhook set `payment_failed_at = now()` on **every** event. Stripe retries the invoice, so each retry reset the timer and the grace window never expired.

**Fix:** `setdefault` — keep the first failure time.

### 3. `past_due` with no `payment_failed_at` escapes enforcement — low

`check_billing_limits` only ran the grace check `if failed_at_str:`, so a `past_due` subscription without a recorded failure time skipped enforcement entirely.

**Fix:** backfill `payment_failed_at` when missing (persisted — the team row is `select_for_update`'d in that block) so the grace window starts and is enforced.

## Tests

`test_billing_integrity.py`: downgrade calls `get_customer` with the stored id and cancels the sub; a repeated failed-payment event keeps the original `payment_failed_at`; a `past_due` team with no timestamp is backfilled and then blocked once aged past grace. Broader billing suite (73) green.