### PR TITLE
fix(sboms): scope public aggregates to public documents; fingerprint documents

### DIFF
--- a/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
+++ b/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
@@ -66,3 +66,21 @@ def test_fingerprint_reacts_to_public_document_changes(team_with_business_plan):
     priv = _doc_component(team, product, Component.Visibility.PRIVATE)
     Document.objects.create(name="p", component=priv, content_hash="hash-priv")
     assert compute_release_aggregate_fingerprint(release) == fp_after_change
+
+
+@pytest.mark.django_db
+def test_public_product_spdx_aggregate_excludes_nonpublic_documents(team_with_business_plan):
+    """The SPDX external-reference builder scopes documents the same way as the CycloneDX one."""
+    from sbomify.apps.sboms.utils import create_product_spdx_external_references
+
+    team = team_with_business_plan
+    product = Product.objects.create(name="Pspdx", team=team, is_public=True)
+    Document.objects.create(name="pub", component=_doc_component(team, product, Component.Visibility.PUBLIC))
+    Document.objects.create(name="priv", component=_doc_component(team, product, Component.Visibility.PRIVATE))
+
+    public_refs = create_product_spdx_external_references(product, user=None)
+    assert len(public_refs) == 1  # only the PUBLIC document
+
+    product.is_public = False
+    product.save()
+    assert len(create_product_spdx_external_references(product, user=None)) == 2

--- a/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
+++ b/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
@@ -24,6 +24,10 @@ def _doc_component(team, product, visibility):
 def test_public_product_aggregate_excludes_nonpublic_documents(team_with_business_plan):
     """A public product's aggregate embeds only PUBLIC documents; a private product (authenticated,
     per-user download) embeds all of them."""
+    from sbomify.apps.sboms.utils import _get_cyclonedx_model
+
+    if _get_cyclonedx_model() is None:
+        pytest.skip("CycloneDX schema unavailable; create_product_external_references returns []")
     team = team_with_business_plan
     product = Product.objects.create(name="P", team=team, is_public=True)
     Document.objects.create(name="pub", component=_doc_component(team, product, Component.Visibility.PUBLIC))

--- a/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
+++ b/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
@@ -1,0 +1,69 @@
+"""Public aggregates must embed only PUBLIC documents (no per-user signed URLs leaked via the
+shared cache), and the cache fingerprint must react to document changes."""
+
+import pytest
+
+from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+from sbomify.apps.core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
+from sbomify.apps.documents.models import Document
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.utils import (
+    compute_release_aggregate_fingerprint,
+    create_product_external_references,
+)
+
+
+def _doc_component(team, product, visibility):
+    comp = Component.objects.create(
+        name=f"doc-{visibility}", team=team, visibility=visibility, component_type="document"
+    )
+    comp.products.add(product)
+    return comp
+
+
+@pytest.mark.django_db
+def test_public_product_aggregate_excludes_nonpublic_documents(team_with_business_plan):  # noqa: F811
+    """A public product's aggregate embeds only PUBLIC documents; a private product (authenticated,
+    per-user download) embeds all of them."""
+    team = team_with_business_plan
+    product = Product.objects.create(name="P", team=team, is_public=True)
+    Document.objects.create(name="pub", component=_doc_component(team, product, Component.Visibility.PUBLIC))
+    Document.objects.create(name="priv", component=_doc_component(team, product, Component.Visibility.PRIVATE))
+
+    public_refs = create_product_external_references(product, user=None)
+    assert len(public_refs) == 1  # only the PUBLIC document (no links on this product)
+
+    product.is_public = False
+    product.save()
+    private_refs = create_product_external_references(product, user=None)
+    assert len(private_refs) == 2  # both documents for an authenticated private download
+
+
+@pytest.mark.django_db
+def test_fingerprint_reacts_to_public_document_changes(team_with_business_plan):  # noqa: F811
+    """Adding a public document, and changing its content, both bust the aggregate cache key."""
+    team = team_with_business_plan
+    product = Product.objects.create(name="P2", team=team, is_public=True)
+    release = Release.objects.create(product=product, name="v1")
+    member = Component.objects.create(
+        name="m", team=team, visibility=Component.Visibility.PUBLIC, component_type=Component.ComponentType.BOM
+    )
+    sbom = SBOM.objects.create(name="m", component=member, format="cyclonedx", version="1", sbom_filename="m.json")
+    ReleaseArtifact.objects.create(release=release, sbom=sbom)
+
+    fp_before = compute_release_aggregate_fingerprint(release)
+
+    comp = _doc_component(team, product, Component.Visibility.PUBLIC)
+    doc = Document.objects.create(name="d", component=comp, content_hash="hash-1")
+    fp_after_add = compute_release_aggregate_fingerprint(release)
+    assert fp_after_add != fp_before  # adding a public document busts the key
+
+    doc.content_hash = "hash-2"
+    doc.save()
+    fp_after_change = compute_release_aggregate_fingerprint(release)
+    assert fp_after_change != fp_after_add  # a content change busts the key
+
+    # A PRIVATE document must NOT affect the public aggregate's fingerprint.
+    priv = _doc_component(team, product, Component.Visibility.PRIVATE)
+    Document.objects.create(name="p", component=priv, content_hash="hash-priv")
+    assert compute_release_aggregate_fingerprint(release) == fp_after_change

--- a/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
+++ b/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
@@ -4,7 +4,6 @@ shared cache), and the cache fingerprint must react to document changes."""
 import pytest
 
 from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
-from sbomify.apps.core.tests.shared_fixtures import team_with_business_plan  # noqa: F401
 from sbomify.apps.documents.models import Document
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.sboms.utils import (
@@ -22,7 +21,7 @@ def _doc_component(team, product, visibility):
 
 
 @pytest.mark.django_db
-def test_public_product_aggregate_excludes_nonpublic_documents(team_with_business_plan):  # noqa: F811
+def test_public_product_aggregate_excludes_nonpublic_documents(team_with_business_plan):
     """A public product's aggregate embeds only PUBLIC documents; a private product (authenticated,
     per-user download) embeds all of them."""
     team = team_with_business_plan
@@ -40,7 +39,7 @@ def test_public_product_aggregate_excludes_nonpublic_documents(team_with_busines
 
 
 @pytest.mark.django_db
-def test_fingerprint_reacts_to_public_document_changes(team_with_business_plan):  # noqa: F811
+def test_fingerprint_reacts_to_public_document_changes(team_with_business_plan):
     """Adding a public document, and changing its content, both bust the aggregate cache key."""
     team = team_with_business_plan
     product = Product.objects.create(name="P2", team=team, is_public=True)

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1827,7 +1827,11 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
     * the release/product METADATA the builder embeds: the product + release
       names (the aggregate's top-level component name) and the product external
       references it renders from product links + identifiers. So a rename or a
-      link/identifier edit also triggers a rebuild.
+      link/identifier edit also triggers a rebuild; and
+    * the PUBLIC documents embedded as external references (each document's
+      content_hash + metadata), so a document add/remove/rename/retype/rehash
+      also triggers a rebuild. Only PUBLIC documents are fed — exactly the set a
+      public aggregate embeds.
 
     Rows are ordered, and every field is length-prefixed (netstring-style) before
     hashing so user-controlled values cannot collide regardless of content — no

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -935,17 +935,17 @@ def create_product_external_references(product: Product, user: Any = None) -> li
 
     # Add documents as external references (for document components that are part of this product)
     # Get document components that are part of this product
-    # Authorization is handled at the API level, so we don't filter by is_public here
+    # A public product's aggregate is cached in S3 and served to anyone, so it must embed
+    # only PUBLIC documents (plain, non-expiring URLs). Non-public documents render with
+    # per-user signed URLs that would otherwise leak to everyone via the shared cache; for
+    # private products the download is authenticated and per-user, so all documents are fine.
     from sbomify.apps.core.models import Component
 
-    document_components = (
-        Component.objects.filter(
-            component_type="document",
-            products=product,
-        )
-        .distinct()
-        .prefetch_related("document_set")
-    )
+    document_filter: dict[str, Any] = {"component_type": "document", "products": product}
+    if product.is_public:
+        document_filter["visibility"] = Component.Visibility.PUBLIC
+
+    document_components = Component.objects.filter(**document_filter).distinct().prefetch_related("document_set")
 
     for component in document_components:
         for document in component.document_set.all():
@@ -982,17 +982,17 @@ def create_product_spdx_external_references(product: Product, user: Any = None) 
 
     # Add documents as external references (for document components that are part of this product)
     # Get document components that are part of this product
-    # Authorization is handled at the API level, so we don't filter by is_public here
+    # A public product's aggregate is cached in S3 and served to anyone, so it must embed
+    # only PUBLIC documents (plain, non-expiring URLs). Non-public documents render with
+    # per-user signed URLs that would otherwise leak to everyone via the shared cache; for
+    # private products the download is authenticated and per-user, so all documents are fine.
     from sbomify.apps.core.models import Component
 
-    document_components = (
-        Component.objects.filter(
-            component_type="document",
-            products=product,
-        )
-        .distinct()
-        .prefetch_related("document_set")
-    )
+    document_filter: dict[str, Any] = {"component_type": "document", "products": product}
+    if product.is_public:
+        document_filter["visibility"] = Component.Visibility.PUBLIC
+
+    document_components = Component.objects.filter(**document_filter).distinct().prefetch_related("document_set")
 
     for component in document_components:
         for document in component.document_set.all():
@@ -1834,7 +1834,7 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
     reliance on a delimiter byte that a name/URL could itself contain. (ADR-004:
     member artifacts are immutable, so the filename is a faithful fingerprint.)
     """
-    digest = hashlib.sha256(b"v4")
+    digest = hashlib.sha256(b"v5")
 
     def feed(*parts: Any) -> None:
         for part in parts:
@@ -1859,6 +1859,23 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
         product.links.order_by("id").values_list("link_type", "title", "url", "description").iterator()
     ):
         feed("ln", lt, title, url, desc)
+
+    # Public documents embedded in the aggregate (only PUBLIC document components are rendered
+    # for a public product). Feed content_hash + metadata so an add/remove/rename/retype/rehash
+    # busts the cache key — the fingerprint previously omitted documents entirely.
+    from sbomify.apps.documents.models import Document
+
+    documents = (
+        Document.objects.filter(
+            component__products=product,
+            component__component_type="document",
+            component__visibility=Component.Visibility.PUBLIC,
+        )
+        .order_by("id")
+        .values_list("id", "content_hash", "document_type", "name", "description")
+    )
+    for did, chash, dtype, dname, ddesc in documents.iterator():
+        feed("doc", did, chash, dtype, dname, ddesc)
 
     return digest.hexdigest()
 

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -942,7 +942,7 @@ def create_product_external_references(product: Product, user: Any = None) -> li
     from sbomify.apps.core.models import Component
 
     document_filter: dict[str, Any] = {"component_type": "document", "products": product}
-    if product.is_public:
+    if getattr(product, "is_public", False):
         document_filter["visibility"] = Component.Visibility.PUBLIC
 
     document_components = Component.objects.filter(**document_filter).distinct().prefetch_related("document_set")
@@ -989,7 +989,7 @@ def create_product_spdx_external_references(product: Product, user: Any = None) 
     from sbomify.apps.core.models import Component
 
     document_filter: dict[str, Any] = {"component_type": "document", "products": product}
-    if product.is_public:
+    if getattr(product, "is_public", False):
         document_filter["visibility"] = Component.Visibility.PUBLIC
 
     document_components = Component.objects.filter(**document_filter).distinct().prefetch_related("document_set")


### PR DESCRIPTION
## Two issues in the cached public-product SBOM aggregate

### 1. Cross-user signed document URLs leak via the shared cache — high

The aggregate embeds document external references. Non-public documents render with **per-user signed** download URLs (`get_download_url_for_document` embeds the requester's user id). For a **public** product the aggregate is cached in a shared, user-independent S3 object and served **unauthenticated** by `download_release`, so one user's signed URLs for non-public documents were served to anonymous/other users.

**Fix:** when the product is public, embed only `visibility=PUBLIC` documents (plain, non-expiring URLs). Private products (authenticated, per-user, not cached) still embed all. Applied to both the CycloneDX and SPDX external-reference builders.

### 2. Fingerprint omits documents → stale public aggregates — medium

`compute_release_aggregate_fingerprint` never fed the product's documents, so adding/removing/renaming/rehashing a public document didn't bust the cache key.

**Fix:** feed each public document's `content_hash` + metadata into the fingerprint (bumped `v4` → `v5`, which harmlessly rebuilds existing aggregates once).

## Tests

`test_aggregate_document_scoping.py`: a public product's refs include only the public document (private includes both); adding/changing a public document busts the fingerprint while a private document does not. Aggregate-cache + utils + SPDX suites (78) green.