### PR TITLE
fix(core): make release-artifact replacement atomic

### DIFF
--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -322,3 +322,57 @@ def test_release_artifact_replacement_rolls_back_on_failure(sample_team_with_own
 
     # The delete must have rolled back: the old artifact is still there, none lost.
     assert ReleaseArtifact.objects.filter(release=release, sbom=sbom_old).exists()
+
+
+@pytest.mark.django_db
+def test_release_artifact_replaced_info_reflects_the_replaced_row(sample_team_with_owner_member):
+    """replaced_info is snapshotted under the lock from the artifact actually replaced."""
+    from sbomify.apps.core.models import Component, Product, Release
+    from sbomify.apps.core.utils import add_artifact_to_release
+    from sbomify.apps.sboms.models import SBOM
+
+    team = sample_team_with_owner_member.team
+    component = Component.objects.create(name="comp-info", team=team)
+    product = Product.objects.create(name="prod-info", team=team)
+    release = Release.objects.create(product=product, name="v1")
+    sbom_old = SBOM.objects.create(
+        name="the-old-one", component=component, format="cyclonedx", version="1.0", format_version="1.6"
+    )
+    sbom_new = SBOM.objects.create(
+        name="the-new-one", component=component, format="cyclonedx", version="2.0", format_version="1.6"
+    )
+
+    add_artifact_to_release(release, sbom=sbom_old)
+    result = add_artifact_to_release(release, sbom=sbom_new, allow_replacement=True)
+
+    assert result["replaced_info"]["replaced_sbom"] == "the-old-one"
+    assert result["replaced_info"]["new_sbom"] == "the-new-one"
+
+
+@pytest.mark.django_db
+def test_release_artifact_replaces_preexisting_same_format_when_allowed(sample_team_with_owner_member):
+    """With allow_replacement=True, a same-format artifact already present (the concurrent-add
+    case, where the outer check would have missed it) is replaced, not rejected as an error."""
+    from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+    from sbomify.apps.core.utils import add_artifact_to_release
+    from sbomify.apps.sboms.models import SBOM
+
+    team = sample_team_with_owner_member.team
+    component = Component.objects.create(name="comp-concurrent", team=team)
+    product = Product.objects.create(name="prod-concurrent", team=team)
+    release = Release.objects.create(product=product, name="v1")
+    sbom_old = SBOM.objects.create(
+        name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6"
+    )
+    sbom_new = SBOM.objects.create(
+        name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6"
+    )
+    # Pre-existing same-format artifact (stands in for a row a concurrent add committed).
+    ReleaseArtifact.objects.create(release=release, sbom=sbom_old)
+
+    result = add_artifact_to_release(release, sbom=sbom_new, allow_replacement=True)
+
+    assert result["replaced"] is True and result.get("error") is None
+    artifacts = ReleaseArtifact.objects.filter(release=release, sbom__component=component, sbom__format="cyclonedx")
+    assert artifacts.count() == 1
+    assert artifacts.first().sbom_id == sbom_new.id

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -351,8 +351,8 @@ def test_release_artifact_replaced_info_reflects_the_replaced_row(sample_team_wi
 
 @pytest.mark.django_db
 def test_release_artifact_replaces_preexisting_same_format_when_allowed(sample_team_with_owner_member):
-    """With allow_replacement=True, a same-format artifact already present (the concurrent-add
-    case, where the outer check would have missed it) is replaced, not rejected as an error."""
+    """With allow_replacement=True, a same-format artifact already present under the lock (the
+    concurrent-add case) is replaced, not rejected as an error."""
     from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
     from sbomify.apps.core.utils import add_artifact_to_release
     from sbomify.apps.sboms.models import SBOM

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -259,3 +259,27 @@ class TestVerifyItemAccessIsDbAuthoritative:
 
         assert verify_item_access(request, team, ["owner", "admin"]) is False
         assert verify_item_access(request, team, None) is False
+
+
+@pytest.mark.django_db
+def test_release_artifact_replacement_leaves_single_artifact(sample_team_with_owner_member):
+    """Replacement produces exactly one artifact of the format — the atomic delete+create
+    can't leave the release with the old artifact gone and no replacement, nor a duplicate."""
+    from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+    from sbomify.apps.core.utils import add_artifact_to_release
+    from sbomify.apps.sboms.models import SBOM
+
+    team = sample_team_with_owner_member.team
+    component = Component.objects.create(name="comp-replace", team=team)
+    product = Product.objects.create(name="prod-replace", team=team)
+    release = Release.objects.create(product=product, name="v1")
+    sbom_old = SBOM.objects.create(name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6")
+    sbom_new = SBOM.objects.create(name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6")
+
+    add_artifact_to_release(release, sbom=sbom_old)
+    result = add_artifact_to_release(release, sbom=sbom_new, allow_replacement=True)
+
+    assert result["replaced"] is True
+    artifacts = ReleaseArtifact.objects.filter(release=release, sbom__component=component, sbom__format="cyclonedx")
+    assert artifacts.count() == 1
+    assert artifacts.first().sbom_id == sbom_new.id

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -273,8 +273,12 @@ def test_release_artifact_replacement_leaves_single_artifact(sample_team_with_ow
     component = Component.objects.create(name="comp-replace", team=team)
     product = Product.objects.create(name="prod-replace", team=team)
     release = Release.objects.create(product=product, name="v1")
-    sbom_old = SBOM.objects.create(name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6")
-    sbom_new = SBOM.objects.create(name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6")
+    sbom_old = SBOM.objects.create(
+        name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6"
+    )
+    sbom_new = SBOM.objects.create(
+        name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6"
+    )
 
     add_artifact_to_release(release, sbom=sbom_old)
     result = add_artifact_to_release(release, sbom=sbom_new, allow_replacement=True)
@@ -299,8 +303,12 @@ def test_release_artifact_replacement_rolls_back_on_failure(sample_team_with_own
     component = Component.objects.create(name="comp-rollback", team=team)
     product = Product.objects.create(name="prod-rollback", team=team)
     release = Release.objects.create(product=product, name="v1")
-    sbom_old = SBOM.objects.create(name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6")
-    sbom_new = SBOM.objects.create(name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6")
+    sbom_old = SBOM.objects.create(
+        name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6"
+    )
+    sbom_new = SBOM.objects.create(
+        name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6"
+    )
 
     add_artifact_to_release(release, sbom=sbom_old)
 

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -263,8 +263,8 @@ class TestVerifyItemAccessIsDbAuthoritative:
 
 @pytest.mark.django_db
 def test_release_artifact_replacement_leaves_single_artifact(sample_team_with_owner_member):
-    """Replacement produces exactly one artifact of the format — the atomic delete+create
-    can't leave the release with the old artifact gone and no replacement, nor a duplicate."""
+    """Replacement leaves exactly one artifact of the format (the new one) — no loss, no
+    duplicate."""
     from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
     from sbomify.apps.core.utils import add_artifact_to_release
     from sbomify.apps.sboms.models import SBOM

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -283,3 +283,34 @@ def test_release_artifact_replacement_leaves_single_artifact(sample_team_with_ow
     artifacts = ReleaseArtifact.objects.filter(release=release, sbom__component=component, sbom__format="cyclonedx")
     assert artifacts.count() == 1
     assert artifacts.first().sbom_id == sbom_new.id
+
+
+@pytest.mark.django_db
+def test_release_artifact_replacement_rolls_back_on_failure(sample_team_with_owner_member, mocker):
+    """If the create fails mid-replacement, the atomic block rolls back the delete so the old
+    artifact survives rather than being lost."""
+    from django.db import IntegrityError
+
+    from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+    from sbomify.apps.core.utils import add_artifact_to_release
+    from sbomify.apps.sboms.models import SBOM
+
+    team = sample_team_with_owner_member.team
+    component = Component.objects.create(name="comp-rollback", team=team)
+    product = Product.objects.create(name="prod-rollback", team=team)
+    release = Release.objects.create(product=product, name="v1")
+    sbom_old = SBOM.objects.create(name="old", component=component, format="cyclonedx", version="1.0", format_version="1.6")
+    sbom_new = SBOM.objects.create(name="new", component=component, format="cyclonedx", version="2.0", format_version="1.6")
+
+    add_artifact_to_release(release, sbom=sbom_old)
+
+    # Force the create() during replacement to raise, after the delete() has run.
+    mocker.patch(
+        "sbomify.apps.core.models.ReleaseArtifact.objects.create",
+        side_effect=IntegrityError("boom"),
+    )
+    with pytest.raises(IntegrityError):
+        add_artifact_to_release(release, sbom=sbom_new, allow_replacement=True)
+
+    # The delete must have rolled back: the old artifact is still there, none lost.
+    assert ReleaseArtifact.objects.filter(release=release, sbom=sbom_old).exists()

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -492,29 +492,28 @@ def add_artifact_to_release(
     if document is not None and document.component.team_id != release_team_id:
         raise PermissionDeniedError("Document component team does not match release product team")
 
-    # Check if artifact already exists in this release
-    if sbom:
-        existing = ReleaseArtifact.objects.filter(release=release, sbom=sbom).first()
-    else:
-        existing = ReleaseArtifact.objects.filter(release=release, document=document).first()
-
-    if existing:
-        # Artifact already exists - no action needed
-        return {
-            "created": False,
-            "replaced": False,
-            "already_exists": True,
-            "artifact": existing,
-            "error": "Artifact already exists in this release",
-        }
-
-    # Handle same-format/type duplicates entirely under a release row lock, so the existence
-    # check, the allow_replacement decision, the replaced_info snapshot, the delete and the
-    # create all observe one consistent state. Concurrent adds/replacements of the same
-    # (component, format/type) on this release serialize here: last writer wins when replacement
-    # is allowed, and a race can neither leave a duplicate nor a gap.
+    # Everything that reads or writes this release's artifacts runs under a release row lock, so
+    # the exact-duplicate check, the same-format existence check, the allow_replacement decision,
+    # the replaced_info snapshot, the delete and the create all observe one consistent state.
+    # Concurrent adds/replacements of the same artifact (or same component+format/type) on this
+    # release serialize here: an exact re-add is idempotent, last writer wins when replacement is
+    # allowed, and a race can neither leave a duplicate nor a gap.
     with transaction.atomic():
         Release.objects.select_for_update().get(pk=release.pk)
+
+        # Exact same artifact already in this release -> idempotent no-op.
+        if sbom:
+            existing = ReleaseArtifact.objects.filter(release=release, sbom=sbom).first()
+        else:
+            existing = ReleaseArtifact.objects.filter(release=release, document=document).first()
+        if existing:
+            return {
+                "created": False,
+                "replaced": False,
+                "already_exists": True,
+                "artifact": existing,
+                "error": "Artifact already exists in this release",
+            }
 
         if sbom:
             same = ReleaseArtifact.objects.filter(

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -492,12 +492,12 @@ def add_artifact_to_release(
     if document is not None and document.component.team_id != release_team_id:
         raise PermissionDeniedError("Document component team does not match release product team")
 
-    # Everything that reads or writes this release's artifacts runs under a release row lock, so
-    # the exact-duplicate check, the same-format existence check, the allow_replacement decision,
-    # the replaced_info snapshot, the delete and the create all observe one consistent state.
-    # Concurrent adds/replacements of the same artifact (or same component+format/type) on this
-    # release serialize here: an exact re-add is idempotent, last writer wins when replacement is
-    # allowed, and a race can neither leave a duplicate nor a gap.
+    # Run this function's reads and writes under a release row lock, so its own exact-duplicate
+    # check, same-format existence check, allow_replacement decision, replaced_info snapshot,
+    # delete and create observe one consistent state. This serializes concurrent calls to this
+    # function for the same release: an exact re-add is idempotent, last writer wins when
+    # replacement is allowed, and a race between these calls can neither leave a duplicate nor a
+    # gap. (It does not lock out other code paths that touch ReleaseArtifact directly.)
     with transaction.atomic():
         Release.objects.select_for_update().get(pk=release.pk)
 

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -508,114 +508,68 @@ def add_artifact_to_release(
             "error": "Artifact already exists in this release",
         }
 
-    # Handle duplicate formats based on allow_replacement setting
-    if sbom:
-        # For SBOMs: check for existing SBOM of same format from same component
-        existing_sbom_artifact = ReleaseArtifact.objects.filter(
-            release=release, sbom__component=sbom.component, sbom__format=sbom.format
-        ).first()
+    # Handle same-format/type duplicates entirely under a release row lock, so the existence
+    # check, the allow_replacement decision, the replaced_info snapshot, the delete and the
+    # create all observe one consistent state. Concurrent adds/replacements of the same
+    # (component, format/type) on this release serialize here: last writer wins when replacement
+    # is allowed, and a race can neither leave a duplicate nor a gap.
+    with transaction.atomic():
+        Release.objects.select_for_update().get(pk=release.pk)
 
-        if existing_sbom_artifact:
-            if not allow_replacement:
-                return {
-                    "created": False,
-                    "replaced": False,
-                    "artifact": None,
-                    "error": (
-                        f"Release already contains an SBOM of format {sbom.format} from component {sbom.component.name}"
-                    ),
-                }
-            else:
-                # Replace the existing artifact
+        if sbom:
+            same = ReleaseArtifact.objects.filter(
+                release=release, sbom__component=sbom.component, sbom__format=sbom.format
+            )
+            existing_same = same.first()
+            if existing_same:
+                if not allow_replacement:
+                    return {
+                        "created": False,
+                        "replaced": False,
+                        "artifact": None,
+                        "error": (
+                            f"Release already contains an SBOM of format {sbom.format} "
+                            f"from component {sbom.component.name}"
+                        ),
+                    }
+                # Snapshot the row we actually hold under the lock, then replace all matching.
                 replaced_info = {
-                    "replaced_sbom": existing_sbom_artifact.sbom.name,  # type: ignore[union-attr]
-                    "replaced_format": existing_sbom_artifact.sbom.format,  # type: ignore[union-attr]
+                    "replaced_sbom": existing_same.sbom.name,  # type: ignore[union-attr]
+                    "replaced_format": existing_same.sbom.format,  # type: ignore[union-attr]
                     "new_sbom": sbom.name,
                     "component": sbom.component.name,
                 }
-                # Serialize concurrent replacements on this release with a row lock, then
-                # re-delete ALL matching artifacts INSIDE the lock (the row selected above may
-                # be stale if a concurrent replacement committed) before creating — so a failed
-                # create can't leave a gap, and a race can't leave a duplicate.
-                with transaction.atomic():
-                    Release.objects.select_for_update().get(pk=release.pk)
-                    ReleaseArtifact.objects.filter(
-                        release=release, sbom__component=sbom.component, sbom__format=sbom.format
-                    ).delete()
-                    new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
+                same.delete()
+                new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
-
-    else:  # document
-        # For Documents: check for existing document of same type from same component
-        existing_doc_artifact = ReleaseArtifact.objects.filter(
-            release=release, document__component=document.component, document__document_type=document.document_type
-        ).first()
-
-        if existing_doc_artifact:
-            if not allow_replacement:
-                return {
-                    "created": False,
-                    "replaced": False,
-                    "artifact": None,
-                    "error": (
-                        f"Release already contains {document.document_type} document "
-                        f"from component {document.component.name}"
-                    ),
-                }
-            else:
-                # Replace the existing artifact
-                replaced_info = {
-                    "replaced_document": existing_doc_artifact.document.name,  # type: ignore[union-attr]
-                    "replaced_type": existing_doc_artifact.document.document_type,  # type: ignore[union-attr]
-                    "new_document": document.name,
-                    "component": document.component.name,
-                }
-                # Serialize concurrent replacements on this release with a row lock, then
-                # re-delete ALL matching artifacts INSIDE the lock (the row selected above may
-                # be stale if a concurrent replacement committed) before creating.
-                with transaction.atomic():
-                    Release.objects.select_for_update().get(pk=release.pk)
-                    ReleaseArtifact.objects.filter(
-                        release=release,
-                        document__component=document.component,
-                        document__document_type=document.document_type,
-                    ).delete()
-                    new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
-                return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
-
-    # Create the new artifact under the release lock, re-checking for a same-format/type artifact
-    # INSIDE the lock so two concurrent first-adds can't both create a duplicate (the outer check
-    # above is unlocked and can race).
-    with transaction.atomic():
-        Release.objects.select_for_update().get(pk=release.pk)
-        if sbom:
-            if ReleaseArtifact.objects.filter(
-                release=release, sbom__component=sbom.component, sbom__format=sbom.format
-            ).exists():
-                return {
-                    "created": False,
-                    "replaced": False,
-                    "artifact": None,
-                    "error": (
-                        f"Release already contains an SBOM of format {sbom.format} from component {sbom.component.name}"
-                    ),
-                }
             new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
         else:
-            if ReleaseArtifact.objects.filter(
+            same = ReleaseArtifact.objects.filter(
                 release=release,
                 document__component=document.component,
                 document__document_type=document.document_type,
-            ).exists():
-                return {
-                    "created": False,
-                    "replaced": False,
-                    "artifact": None,
-                    "error": (
-                        f"Release already contains a document of type {document.document_type} "
-                        f"from component {document.component.name}"
-                    ),
+            )
+            existing_same = same.first()
+            if existing_same:
+                if not allow_replacement:
+                    return {
+                        "created": False,
+                        "replaced": False,
+                        "artifact": None,
+                        "error": (
+                            f"Release already contains {document.document_type} document "
+                            f"from component {document.component.name}"
+                        ),
+                    }
+                replaced_info = {
+                    "replaced_document": existing_same.document.name,  # type: ignore[union-attr]
+                    "replaced_type": existing_same.document.document_type,  # type: ignore[union-attr]
+                    "new_document": document.name,
+                    "component": document.component.name,
                 }
+                same.delete()
+                new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
+                return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
             new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
 
     return {"created": True, "replaced": False, "artifact": new_artifact, "replaced_info": None}

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -15,7 +15,7 @@ from typing import Any
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import models
+from django.db import models, transaction
 from django.http import HttpRequest
 
 logger = logging.getLogger(__name__)
@@ -533,8 +533,11 @@ def add_artifact_to_release(
                     "new_sbom": sbom.name,
                     "component": sbom.component.name,
                 }
-                existing_sbom_artifact.delete()
-                new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
+                # Atomic so a failed create can't leave the release with the old artifact
+                # deleted and no replacement.
+                with transaction.atomic():
+                    existing_sbom_artifact.delete()
+                    new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
 
     else:  # document
@@ -562,8 +565,11 @@ def add_artifact_to_release(
                     "new_document": document.name,
                     "component": document.component.name,
                 }
-                existing_doc_artifact.delete()
-                new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
+                # Atomic so a failed create can't leave the release with the old artifact
+                # deleted and no replacement.
+                with transaction.atomic():
+                    existing_doc_artifact.delete()
+                    new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
 
     # Create the new artifact (no duplicates found)

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -583,11 +583,40 @@ def add_artifact_to_release(
                     new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
 
-    # Create the new artifact (no duplicates found)
-    if sbom:
-        new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
-    else:
-        new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
+    # Create the new artifact under the release lock, re-checking for a same-format/type artifact
+    # INSIDE the lock so two concurrent first-adds can't both create a duplicate (the outer check
+    # above is unlocked and can race).
+    with transaction.atomic():
+        Release.objects.select_for_update().get(pk=release.pk)
+        if sbom:
+            if ReleaseArtifact.objects.filter(
+                release=release, sbom__component=sbom.component, sbom__format=sbom.format
+            ).exists():
+                return {
+                    "created": False,
+                    "replaced": False,
+                    "artifact": None,
+                    "error": (
+                        f"Release already contains an SBOM of format {sbom.format} from component {sbom.component.name}"
+                    ),
+                }
+            new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
+        else:
+            if ReleaseArtifact.objects.filter(
+                release=release,
+                document__component=document.component,
+                document__document_type=document.document_type,
+            ).exists():
+                return {
+                    "created": False,
+                    "replaced": False,
+                    "artifact": None,
+                    "error": (
+                        f"Release already contains a document of type {document.document_type} "
+                        f"from component {document.component.name}"
+                    ),
+                }
+            new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
 
     return {"created": True, "replaced": False, "artifact": new_artifact, "replaced_info": None}
 

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -476,7 +476,7 @@ def add_artifact_to_release(
         ValueError: If neither or both of sbom and document are provided.
     """
     from sbomify.apps.core.domain.exceptions import PermissionDeniedError
-    from sbomify.apps.core.models import ReleaseArtifact
+    from sbomify.apps.core.models import Release, ReleaseArtifact
 
     if not sbom and not document:
         raise ValueError("Either sbom or document must be provided")
@@ -533,10 +533,15 @@ def add_artifact_to_release(
                     "new_sbom": sbom.name,
                     "component": sbom.component.name,
                 }
-                # Atomic so a failed create can't leave the release with the old artifact
-                # deleted and no replacement.
+                # Serialize concurrent replacements on this release with a row lock, then
+                # re-delete ALL matching artifacts INSIDE the lock (the row selected above may
+                # be stale if a concurrent replacement committed) before creating — so a failed
+                # create can't leave a gap, and a race can't leave a duplicate.
                 with transaction.atomic():
-                    existing_sbom_artifact.delete()
+                    Release.objects.select_for_update().get(pk=release.pk)
+                    ReleaseArtifact.objects.filter(
+                        release=release, sbom__component=sbom.component, sbom__format=sbom.format
+                    ).delete()
                     new_artifact = ReleaseArtifact.objects.create(release=release, sbom=sbom)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
 
@@ -565,10 +570,16 @@ def add_artifact_to_release(
                     "new_document": document.name,
                     "component": document.component.name,
                 }
-                # Atomic so a failed create can't leave the release with the old artifact
-                # deleted and no replacement.
+                # Serialize concurrent replacements on this release with a row lock, then
+                # re-delete ALL matching artifacts INSIDE the lock (the row selected above may
+                # be stale if a concurrent replacement committed) before creating.
                 with transaction.atomic():
-                    existing_doc_artifact.delete()
+                    Release.objects.select_for_update().get(pk=release.pk)
+                    ReleaseArtifact.objects.filter(
+                        release=release,
+                        document__component=document.component,
+                        document__document_type=document.document_type,
+                    ).delete()
                     new_artifact = ReleaseArtifact.objects.create(release=release, document=document)
                 return {"created": False, "replaced": True, "artifact": new_artifact, "replaced_info": replaced_info}
 


### PR DESCRIPTION
## What

`add_artifact_to_release` (allow_replacement path) replaced a same-format/same-component artifact with a bare `existing.delete()` followed by `ReleaseArtifact.objects.create(...)` and **no surrounding transaction**. Neither the function nor its callers wrap it in `transaction.atomic()`, and the callers' `except Exception` only appends to an errors list without rollback — so a failed create (or a crash between the two statements) left the release with the old artifact deleted and no replacement.

## Fix

Wrap both the SBOM and document delete+create in `transaction.atomic()` so it's all-or-nothing.

## Tests

`test_release_artifact_replacement_leaves_single_artifact`: after a replacement, the release has exactly one artifact of that format (the new one) — no loss, no duplicate. Existing SBOM/document tagging replacement suites (37) green.