### PR TITLE
fix(oidc): confine the bot to its bound component on release endpoints

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2780,14 +2780,16 @@ def create_release(request: HttpRequest, payload: ReleaseCreateSchema) -> Any:
     if not can(request, "release:create", product):
         return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
 
-    # Confine an OIDC bot to products that contain its bound component (no-op for PAT/session
-    # requests, whose bound_component_id is None). The bot's scopes are unset (full), so this
-    # is the only thing keeping it from creating releases on unrelated products.
-    from sbomify.apps.oidc.permissions import bound_component_id_for_request
+    # Confine an OIDC bot to products that contain its bound component. The bot's scopes are
+    # unset (full), so this is the only thing keeping it from creating releases on unrelated
+    # products. Fail closed for OIDC requests (an orphan bot with no binding must be denied,
+    # not treated as a no-op); a plain no-op only for non-OIDC (PAT/session) requests.
+    from sbomify.apps.oidc.permissions import bound_component_id_for_request, request_is_oidc_authed
 
-    bound_component_id = bound_component_id_for_request(request)
-    if bound_component_id is not None and not product.components.filter(id=bound_component_id).exists():
-        return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
+    if request_is_oidc_authed(request):
+        bound_component_id = bound_component_id_for_request(request)
+        if bound_component_id is None or not product.components.filter(id=bound_component_id).exists():
+            return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
 
     # Prevent creating releases with name "latest" manually
     if payload.name.lower() == LATEST_RELEASE_NAME.lower():

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2780,6 +2780,15 @@ def create_release(request: HttpRequest, payload: ReleaseCreateSchema) -> Any:
     if not can(request, "release:create", product):
         return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
 
+    # Confine an OIDC bot to products that contain its bound component (no-op for PAT/session
+    # requests, whose bound_component_id is None). The bot's scopes are unset (full), so this
+    # is the only thing keeping it from creating releases on unrelated products.
+    from sbomify.apps.oidc.permissions import bound_component_id_for_request
+
+    bound_component_id = bound_component_id_for_request(request)
+    if bound_component_id is not None and not product.components.filter(id=bound_component_id).exists():
+        return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
+
     # Prevent creating releases with name "latest" manually
     if payload.name.lower() == LATEST_RELEASE_NAME.lower():
         return 400, {
@@ -3404,6 +3413,11 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
             if str(sbom.component.team_id) != str(release.product.team_id):
                 return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
+            from sbomify.apps.oidc.permissions import is_authorised_for_component
+
+            if not is_authorised_for_component(request, sbom.component):
+                return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
+
             result = add_artifact_to_release(release, sbom=sbom, allow_replacement=False)
             if result.get("error"):
                 # Return 409 Conflict if artifact already exists (RESTful standard)
@@ -3440,6 +3454,11 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
 
             document = Document.objects.get(pk=payload.document_id)
             if str(document.component.team_id) != str(release.product.team_id):
+                return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
+
+            from sbomify.apps.oidc.permissions import is_authorised_for_component
+
+            if not is_authorised_for_component(request, document.component):
                 return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
             result = add_artifact_to_release(release, document=document, allow_replacement=False)

--- a/sbomify/apps/oidc/tests/test_permissions.py
+++ b/sbomify/apps/oidc/tests/test_permissions.py
@@ -823,6 +823,22 @@ class TestBotReleaseConfinement:
         )
         assert resp.status_code == 403
 
+    def test_bot_cannot_tag_unbound_document(
+        self, oidc_sbomify_token, bound_component, other_component, team_with_business_plan
+    ):
+        from sbomify.apps.documents.models import Document
+
+        _product, release = self._release_in(team_with_business_plan, bound_component)
+        other_doc = Document.objects.create(name="od", component=other_component)
+
+        resp = Client().post(
+            f"/api/v1/releases/{release.id}/artifacts",
+            data=json.dumps({"document_id": other_doc.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
+        )
+        assert resp.status_code == 403
+
     def test_bot_cannot_create_release_on_product_without_its_component(
         self, oidc_sbomify_token, bound_component, other_component, team_with_business_plan
     ):

--- a/sbomify/apps/oidc/tests/test_permissions.py
+++ b/sbomify/apps/oidc/tests/test_permissions.py
@@ -791,3 +791,69 @@ class TestPrivateRepoEndToEnd:
             HTTP_AUTHORIZATION=f"Bearer {sbomify_token}",
         )
         assert forbidden.status_code == 403, forbidden.content
+
+
+@pytest.mark.django_db
+class TestBotReleaseConfinement:
+    """The OIDC bot's component confinement must extend to the release endpoints, not just uploads."""
+
+    def _release_in(self, team, *component):
+        from sbomify.apps.core.models import Product, Release
+
+        product = Product.objects.create(name="prod-conf", team=team)
+        for comp in component:
+            product.components.add(comp)
+        return product, Release.objects.create(product=product, name="v1")
+
+    def test_bot_cannot_tag_unbound_component(
+        self, oidc_sbomify_token, bound_component, other_component, team_with_business_plan
+    ):
+        from sbomify.apps.sboms.models import SBOM
+
+        _product, release = self._release_in(team_with_business_plan, bound_component)
+        other_sbom = SBOM.objects.create(
+            name="o", component=other_component, format="cyclonedx", format_version="1.6"
+        )
+
+        resp = Client().post(
+            f"/api/v1/releases/{release.id}/artifacts",
+            data=json.dumps({"sbom_id": other_sbom.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
+        )
+        assert resp.status_code == 403
+
+    def test_bot_cannot_create_release_on_product_without_its_component(
+        self, oidc_sbomify_token, bound_component, other_component, team_with_business_plan
+    ):
+        from sbomify.apps.core.models import Product
+
+        # A product in the same workspace that does NOT contain the bot's bound component.
+        product = Product.objects.create(name="prod-unbound", team=team_with_business_plan)
+        product.components.add(other_component)
+
+        resp = Client().post(
+            "/api/v1/releases",
+            data=json.dumps({"product_id": product.id, "name": "v9"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
+        )
+        assert resp.status_code == 403
+
+    def test_bot_can_tag_its_bound_component(self, oidc_sbomify_token, bound_component, team_with_business_plan):
+        """Control: the bot IS allowed to tag its bound component — proving the deny cases above
+        are the confinement check, not a blanket can() denial."""
+        from sbomify.apps.sboms.models import SBOM
+
+        _product, release = self._release_in(team_with_business_plan, bound_component)
+        bound_sbom = SBOM.objects.create(
+            name="b", component=bound_component, format="cyclonedx", format_version="1.6"
+        )
+
+        resp = Client().post(
+            f"/api/v1/releases/{release.id}/artifacts",
+            data=json.dumps({"sbom_id": bound_sbom.id}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
+        )
+        assert resp.status_code == 201


### PR DESCRIPTION
## What

An OIDC bot's `AccessToken` is minted **unscoped** (`scopes=NULL` = full-capability), so its confinement to the pinned component is enforced solely by `is_authorised_for_component`. That helper was wired into the three artifact-**upload** endpoints but **not** `create_release` / `add_artifacts_to_release`, so a bot bound to component X could:

- create releases on any product in its workspace, and
- tag any other component's SBOM/document into a release.

## Fix

- **`add_artifacts_to_release`**: gate each tagged SBOM and document on `is_authorised_for_component(request, artifact.component)` (a no-op for PAT/session requests).
- **`create_release`**: for an OIDC request, require the product to contain `bound_component_id_for_request(request)`.

## Tests

`TestBotReleaseConfinement`: the bot is 403'd tagging an unbound component and creating a release on a product without its component, and — as a control proving the 403s are the confinement check and not a blanket `can()` denial — **is** allowed to tag its own bound component (201). OIDC permission + release-tagging suites (62) green.