### PR TITLE
fix(plugins): authorize team plugin-settings against the URL workspace (IDOR)

### DIFF
--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -1,15 +1,16 @@
 """API endpoints for the plugins framework."""
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from django.db.models import OuterRef, Subquery
 from django.http import HttpRequest
 from ninja import Router
 from pydantic import BaseModel
 
+from sbomify.apps.core.models import User
 from sbomify.apps.sboms.models import SBOM
-from sbomify.apps.teams.models import Team
+from sbomify.apps.teams.models import Member, Team
 
 from .models import AssessmentRun, RegisteredPlugin, TeamPluginSettings
 from .schemas import (
@@ -478,6 +479,11 @@ def get_team_plugin_settings(request: HttpRequest, team_key: str) -> tuple[int, 
     except Team.DoesNotExist:
         return 404, {"detail": "Team not found"}
 
+    # Authorize against the URL team (see update_team_plugin_settings) rather than trusting the
+    # caller's session-scoped guard.
+    if not Member.objects.filter(user=cast(User, request.user), team=team, role__in=("owner", "admin")).exists():
+        return 403, {"detail": "You don't have permission to view this workspace's plugins"}
+
     # Get or create team plugin settings
     settings, _ = TeamPluginSettings.objects.get_or_create(team=team)
 
@@ -526,6 +532,12 @@ def update_team_plugin_settings(
         team = Team.objects.get(key=team_key)
     except Team.DoesNotExist:
         return 404, {"detail": "Team not found"}
+
+    # Authorize against the URL team. The calling view's TeamRoleRequiredMixin only checks the
+    # actor's role in their SESSION workspace, so without this an owner/admin of workspace A
+    # could rewrite an unrelated workspace B's plugin settings (cross-workspace IDOR).
+    if not Member.objects.filter(user=cast(User, request.user), team=team, role__in=("owner", "admin")).exists():
+        return 403, {"detail": "You don't have permission to manage this workspace's plugins"}
 
     # Validate that all enabled plugins are registered and enabled
     available_plugins = set(RegisteredPlugin.objects.filter(is_enabled=True).values_list("name", flat=True))

--- a/sbomify/apps/plugins/tests/test_plugin_config.py
+++ b/sbomify/apps/plugins/tests/test_plugin_config.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.plugins.apis import (
@@ -13,7 +14,7 @@ from sbomify.apps.plugins.apis import (
 )
 from sbomify.apps.plugins.models import RegisteredPlugin, TeamPluginSettings
 from sbomify.apps.plugins.sdk.enums import AssessmentCategory
-from sbomify.apps.teams.models import Team
+from sbomify.apps.teams.models import Member, Team
 
 
 @pytest.fixture
@@ -29,6 +30,9 @@ def test_team(db) -> Team:
         },
     )
     team = Team.objects.create(name="Config Test Team", billing_plan="business")
+    owner = get_user_model().objects.create_user(username=f"cfg-owner-{team.pk}", email=f"cfg{team.pk}@t.test")
+    Member.objects.create(team=team, user=owner, role="owner")
+    team.owner = owner
     yield team
     team.delete()
 
@@ -46,6 +50,9 @@ def enterprise_team(db) -> Team:
         },
     )
     team = Team.objects.create(name="Enterprise Test Team", billing_plan="enterprise")
+    owner = get_user_model().objects.create_user(username=f"ent-owner-{team.pk}", email=f"ent{team.pk}@t.test")
+    Member.objects.create(team=team, user=owner, role="owner")
+    team.owner = owner
     yield team
     team.delete()
 
@@ -337,7 +344,7 @@ class TestPluginSettingsWithSchema:
         from django.test import RequestFactory
 
         request = RequestFactory().get("/")
-        request.user = type("User", (), {"is_authenticated": True})()
+        request.user = test_team.owner
 
         status_code, data = get_team_plugin_settings(request, test_team.key)
 
@@ -364,7 +371,7 @@ class TestPluginSettingsWithSchema:
         from django.test import RequestFactory
 
         request = RequestFactory().get("/")
-        request.user = type("User", (), {"is_authenticated": True})()
+        request.user = test_team.owner
 
         try:
             status_code, data = get_team_plugin_settings(request, test_team.key)
@@ -405,7 +412,7 @@ class TestViewPostPluginConfig:
         )
 
         request = RequestFactory().post("/")
-        request.user = type("User", (), {"is_authenticated": True})()
+        request.user = enterprise_team.owner
 
         status_code, result = update_team_plugin_settings(request, enterprise_team.key, payload)
 
@@ -426,7 +433,7 @@ class TestViewPostPluginConfig:
         )
 
         request = RequestFactory().post("/")
-        request.user = type("User", (), {"is_authenticated": True})()
+        request.user = test_team.owner
 
         status_code, result = update_team_plugin_settings(request, test_team.key, payload)
 
@@ -442,7 +449,7 @@ class TestViewPostPluginConfig:
         from sbomify.apps.plugins.apis import UpdateTeamPluginSettingsRequest, update_team_plugin_settings
 
         request = RequestFactory().post("/")
-        request.user = type("User", (), {"is_authenticated": True})()
+        request.user = enterprise_team.owner
 
         server_id = str(uuid.uuid4())
         payload = UpdateTeamPluginSettingsRequest(

--- a/sbomify/apps/plugins/tests/test_plugin_settings_authz.py
+++ b/sbomify/apps/plugins/tests/test_plugin_settings_authz.py
@@ -1,0 +1,29 @@
+"""Plugin settings must be authorized against the URL workspace, not the caller's session
+workspace (cross-workspace IDOR class)."""
+
+import pytest
+from django.test import RequestFactory
+
+from sbomify.apps.core.utils import number_to_random_token
+from sbomify.apps.plugins.apis import UpdateTeamPluginSettingsRequest, update_team_plugin_settings
+from sbomify.apps.teams.models import Team
+
+
+@pytest.mark.django_db
+def test_plugin_settings_write_denies_cross_workspace(sample_team_with_owner_member):
+    """A user who owns their own workspace must not update another workspace's plugin settings."""
+    attacker = sample_team_with_owner_member.user  # owner of their own workspace only
+    victim = Team.objects.create(name="Victim WS")
+    victim.key = number_to_random_token(victim.pk)
+    victim.save()
+
+    req = RequestFactory().post("/")
+    req.user = attacker
+    payload = UpdateTeamPluginSettingsRequest(enabled_plugins=[], plugin_configs=None)
+
+    status, _body = update_team_plugin_settings(req, victim.key, payload)
+    assert status == 403
+
+    # Control: the attacker CAN update their own workspace's settings.
+    own_status, _ = update_team_plugin_settings(req, sample_team_with_owner_member.team.key, payload)
+    assert own_status == 200


### PR DESCRIPTION
## What

`update_team_plugin_settings` / `get_team_plugin_settings` resolved the target workspace purely from the URL `team_key` (`Team.objects.get(key=team_key)`) and performed **no actor authorization**. `TeamPluginSettingsView`'s only guard, `TeamRoleRequiredMixin`, checks the caller's role in their **session** workspace (`request.session["current_team"]["key"]`), not the URL team — and the **POST** handler, unlike GET, never calls `get_team()`.

So any owner/admin of workspace A (their session workspace) could `POST /workspace/plugins/settings/<B_key>` and enable/disable another tenant's security/compliance plugins or rewrite their `plugin_configs` — a cross-workspace **write IDOR**. Workspace keys appear in public URLs, so victim keys are obtainable.

This is the same class as this session's teams-view fixes (#1081), in a sibling call-site the original audit missed. A multi-dimensional review (security + architecture lenses) surfaced it.

## Fix

Require owner/admin membership of the **URL** team inside both service functions before reading/writing, so the service is self-protecting regardless of caller.

## Tests

`test_plugin_settings_write_denies_cross_workspace`: an owner of workspace A is 403'd updating workspace B and allowed for their own. Existing plugin-config tests updated to use real owner members. Full plugins suite (749) green.