### PR TITLE
fix(documents): prevent stored XSS via inline document serving

### DIFF
--- a/sbomify/apps/documents/access_apis.py
+++ b/sbomify/apps/documents/access_apis.py
@@ -380,7 +380,9 @@ def get_nda_for_signing(request: HttpRequest, team_key: str, request_id: str) ->
                 response = HttpResponse(document_data)
                 apply_safe_download_headers(
                     response,
-                    content_type=company_nda.content_type,
+                    # NDA content_type may be blank for legacy records; fall back
+                    # to PDF so the inline preview/signing flow keeps working.
+                    content_type=company_nda.content_type or "application/pdf",
                     filename=f"{company_nda.name}.pdf",
                     inline=True,
                 )

--- a/sbomify/apps/documents/access_apis.py
+++ b/sbomify/apps/documents/access_apis.py
@@ -32,6 +32,7 @@ from .access_schemas import (
     NDASignatureResponse,
     NDASignRequest,
 )
+from .content_safety import apply_safe_download_headers
 
 User = get_user_model()
 log = logging.getLogger(__name__)
@@ -376,8 +377,13 @@ def get_nda_for_signing(request: HttpRequest, team_key: str, request_id: str) ->
             document_data = s3.get_document_data(company_nda.document_filename)
 
             if document_data:
-                response = HttpResponse(document_data, content_type=company_nda.content_type or "application/pdf")
-                response["Content-Disposition"] = f'inline; filename="{company_nda.name}.pdf"'
+                response = HttpResponse(document_data)
+                apply_safe_download_headers(
+                    response,
+                    content_type=company_nda.content_type,
+                    filename=f"{company_nda.name}.pdf",
+                    inline=True,
+                )
                 return response
             else:
                 return 404, {"detail": "NDA document file not found"}

--- a/sbomify/apps/documents/content_safety.py
+++ b/sbomify/apps/documents/content_safety.py
@@ -1,0 +1,74 @@
+"""Helpers to serve user-uploaded document bytes without enabling stored XSS.
+
+A document's content and its ``content_type`` are attacker-controlled: the
+browser-supplied MIME type is stored verbatim at upload time. Serving such
+content inline with a script-capable type lets an attacker who controls a
+public/gated component execute JavaScript on the sbomify origin.
+
+We therefore only ever render a small allowlist of inert content types inline;
+everything else is forced to download as an attachment, and every response
+carries ``X-Content-Type-Options: nosniff`` so browsers cannot sniff a download
+back into active content.
+"""
+
+from __future__ import annotations
+
+from django.http import HttpResponse
+
+# Content types browsers render but that cannot execute script. Deliberately
+# excludes text/html, image/svg+xml and application/xhtml+xml (all can carry
+# script) and anything not on the list is served as an attachment instead.
+INLINE_SAFE_CONTENT_TYPES = frozenset(
+    {
+        "application/pdf",
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "text/plain",
+    }
+)
+
+_ATTACHMENT_CONTENT_TYPE = "application/octet-stream"
+
+
+def _normalize_content_type(content_type: str | None) -> str:
+    return (content_type or "").split(";", 1)[0].strip().lower()
+
+
+def _sanitize_filename(filename: str | None) -> str:
+    # Django already rejects CR/LF in header values; strip quotes/newlines so the
+    # value cannot break out of the quoted filename parameter.
+    name = (filename or "download").replace("\r", "").replace("\n", "").replace('"', "")
+    return name or "download"
+
+
+def apply_safe_download_headers(
+    response: HttpResponse,
+    *,
+    content_type: str | None,
+    filename: str | None,
+    inline: bool,
+) -> HttpResponse:
+    """Set safe Content-Type / Content-Disposition / nosniff headers on ``response``.
+
+    ``inline`` is honoured only for inert content types; every other type is
+    served as an attachment regardless of what the caller requested.
+    """
+    normalized = _normalize_content_type(content_type)
+    serve_inline = inline and normalized in INLINE_SAFE_CONTENT_TYPES
+
+    if serve_inline:
+        response["Content-Type"] = normalized
+        # Allow same-origin iframe embedding (e.g. NDA preview) for inline views.
+        response["X-Frame-Options"] = "SAMEORIGIN"
+        disposition = "inline"
+    else:
+        # As an attachment the browser downloads rather than renders the bytes, so
+        # even a script-capable type is inert here; nosniff (below) blocks sniffing.
+        response["Content-Type"] = normalized or _ATTACHMENT_CONTENT_TYPE
+        disposition = "attachment"
+
+    response["Content-Disposition"] = f'{disposition}; filename="{_sanitize_filename(filename)}"'
+    response["X-Content-Type-Options"] = "nosniff"
+    return response

--- a/sbomify/apps/documents/content_safety.py
+++ b/sbomify/apps/documents/content_safety.py
@@ -63,9 +63,16 @@ def apply_safe_download_headers(
         # Allow same-origin iframe embedding (e.g. NDA preview) for inline views.
         response["X-Frame-Options"] = "SAMEORIGIN"
         disposition = "inline"
+    elif inline:
+        # Inline was requested but denied because the type is not inert. Don't
+        # echo the (attacker-controlled) type back — force an inert one so a
+        # client/proxy that mishandles Content-Disposition can't render it.
+        response["Content-Type"] = _ATTACHMENT_CONTENT_TYPE
+        disposition = "attachment"
     else:
-        # As an attachment the browser downloads rather than renders the bytes, so
-        # even a script-capable type is inert here; nosniff (below) blocks sniffing.
+        # Plain download: as an attachment the browser downloads rather than
+        # renders the bytes, so even a script-capable type is inert here and
+        # nosniff (below) blocks sniffing. Preserve the declared type.
         response["Content-Type"] = normalized or _ATTACHMENT_CONTENT_TYPE
         disposition = "attachment"
 

--- a/sbomify/apps/documents/tests/test_views.py
+++ b/sbomify/apps/documents/tests/test_views.py
@@ -23,11 +23,7 @@ from ..models import Document
 def sample_document_component(sample_team, sample_user):
     """Create a sample document component for testing."""
     # Add sample_user as owner to the team for proper permissions
-    Member.objects.get_or_create(
-        user=sample_user,
-        team=sample_team,
-        defaults={"role": "owner"}
-    )
+    Member.objects.get_or_create(user=sample_user, team=sample_team, defaults={"role": "owner"})
 
     return Component.objects.create(
         name="Test Document Component",
@@ -88,9 +84,7 @@ def test_document_download_success(
 
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": sample_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": sample_document.id}))
 
     assert response.status_code == 200
     assert response.content == b"test document content"
@@ -107,9 +101,7 @@ def test_document_download_public_success(
     """Test successful public document download without authentication."""
     create_documents_views_mock(mocker, scenario="success")
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": public_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": public_document.id}))
 
     assert response.status_code == 200
     assert response.content == b"test document content"
@@ -125,9 +117,7 @@ def test_document_download_not_found(
     """Test downloading non-existent document."""
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": "non-existent"})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": "non-existent"}))
 
     assert response.status_code == 404
 
@@ -141,9 +131,7 @@ def test_document_download_forbidden(
     """Test that users without permission cannot download documents."""
     client.force_login(guest_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": sample_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": sample_document.id}))
 
     assert response.status_code == 403
 
@@ -154,9 +142,7 @@ def test_document_download_private_document_public_access_denied(
     sample_document,
 ):
     """Test that private documents cannot be downloaded without authentication."""
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": sample_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": sample_document.id}))
 
     assert response.status_code == 403
 
@@ -173,9 +159,7 @@ def test_document_download_s3_file_not_found(
 
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": sample_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": sample_document.id}))
 
     assert response.status_code == 404
 
@@ -192,9 +176,7 @@ def test_document_download_s3_error(
 
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": sample_document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": sample_document.id}))
 
     assert response.status_code == 500
 
@@ -222,9 +204,7 @@ def test_document_download_with_filename_fallback(
 
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": document.id}))
 
     assert response.status_code == 200
     assert response.content == b"test document content"
@@ -254,13 +234,12 @@ def test_document_download_default_content_type(
 
     client.force_login(sample_user)
 
-    response = client.get(
-        reverse("documents:document_download", kwargs={"document_id": document.id})
-    )
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": document.id}))
 
     assert response.status_code == 200
     assert response.content == b"test document content"
     assert response["Content-Type"] == "application/octet-stream"
+
 
 @pytest.mark.django_db
 def test_document_download_inline(
@@ -283,6 +262,38 @@ def test_document_download_inline(
     assert response["Content-Type"] == "application/pdf"
     assert f'inline; filename="{sample_document.name}"' in response["Content-Disposition"]
     assert response["X-Frame-Options"] == "SAMEORIGIN"
+    assert response["X-Content-Type-Options"] == "nosniff"
+
+
+@pytest.mark.django_db
+def test_document_download_html_never_served_inline(
+    mocker: MockerFixture,
+    client: Client,
+    sample_user: AbstractBaseUser,  # noqa: F811
+    sample_document_component,
+):
+    """A script-capable content type must be forced to attachment even when
+    inline is requested, to prevent stored XSS on the sbomify origin."""
+    create_documents_views_mock(mocker, scenario="success")
+
+    document = Document.objects.create(
+        name="evil",
+        version="1.0",
+        document_filename="evil.html",
+        component=sample_document_component,
+        source="manual_upload",
+        content_type="text/html",
+        file_size=64,
+    )
+
+    client.force_login(sample_user)
+
+    response = client.get(reverse("documents:document_download", kwargs={"document_id": document.id}) + "?view=inline")
+
+    assert response.status_code == 200
+    assert response["Content-Disposition"].startswith("attachment;")
+    assert "inline" not in response["Content-Disposition"]
+    assert response["X-Content-Type-Options"] == "nosniff"
 
 
 @pytest.mark.django_db
@@ -312,7 +323,7 @@ class TestDocumentsTableView:
     ):
         """Test that private view is accessible with auth."""
         setup_authenticated_client_session(authenticated_web_client, sample_document_component.team, sample_user)
-        
+
         url = reverse(
             "documents:documents_table",
             kwargs={"component_id": sample_document_component.id},
@@ -320,14 +331,12 @@ class TestDocumentsTableView:
         response = authenticated_web_client.get(url)
         assert response.status_code == 200
 
-    def test_documents_table_guest_restriction(
-        self, authenticated_web_client, sample_document_component, guest_user
-    ):
+    def test_documents_table_guest_restriction(self, authenticated_web_client, sample_document_component, guest_user):
         """Test that guest members are redirected from private view."""
         # Add guest member
         Member.objects.create(team=sample_document_component.team, user=guest_user, role="guest")
         setup_authenticated_client_session(authenticated_web_client, sample_document_component.team, guest_user)
-        
+
         url = reverse(
             "documents:documents_table",
             kwargs={"component_id": sample_document_component.id},
@@ -353,7 +362,7 @@ class TestDocumentsTableView:
         # Add guest member
         Member.objects.create(team=public_document_component.team, user=guest_user, role="guest")
         setup_authenticated_client_session(authenticated_web_client, public_document_component.team, guest_user)
-        
+
         url = reverse(
             "documents:documents_table_public",
             kwargs={"component_id": public_document_component.id},
@@ -369,15 +378,15 @@ class TestDocumentsTableView:
         """Test successful document deletion."""
         # Mock success result
         mock_delete.return_value = MagicMock(ok=True)
-        
+
         setup_authenticated_client_session(authenticated_web_client, sample_document_component.team, sample_user)
-        
+
         url = reverse(
             "documents:documents_table",
             kwargs={"component_id": sample_document_component.id},
         )
         response = authenticated_web_client.post(url, {"_method": "DELETE"})
-        
+
         assert response.status_code == 200
         # HTMX success response has message in HX-Trigger header
         hx_trigger = response.get("HX-Trigger", "")

--- a/sbomify/apps/documents/tests/test_views.py
+++ b/sbomify/apps/documents/tests/test_views.py
@@ -293,6 +293,8 @@ def test_document_download_html_never_served_inline(
     assert response.status_code == 200
     assert response["Content-Disposition"].startswith("attachment;")
     assert "inline" not in response["Content-Disposition"]
+    # Inline was denied, so the attacker-controlled type must not be echoed back.
+    assert response["Content-Type"] == "application/octet-stream"
     assert response["X-Content-Type-Options"] == "nosniff"
 
 

--- a/sbomify/apps/documents/views/document_download.py
+++ b/sbomify/apps/documents/views/document_download.py
@@ -6,6 +6,7 @@ from django.views import View
 from sbomify.apps.core.errors import error_response
 from sbomify.apps.core.object_store import S3Client
 from sbomify.apps.core.services.access_control import check_component_access
+from sbomify.apps.documents.content_safety import apply_safe_download_headers
 from sbomify.apps.documents.models import Document
 
 logger = logging.getLogger(__name__)
@@ -28,20 +29,16 @@ class DocumentDownloadView(View):
                 document_data = s3.get_document_data(document.document_filename)
 
                 if document_data:
-                    response = HttpResponse(
-                        document_data, content_type=document.content_type or "application/octet-stream"
-                    )
                     # Use original filename if available, otherwise use document name
                     filename = document.name if document.name else f"document_{document.id}"
 
-                    # Check if inline view is requested
-                    disposition_type = "inline" if request.GET.get("view") == "inline" else "attachment"
-                    response["Content-Disposition"] = f'{disposition_type}; filename="{filename}"'
-
-                    # Allow embedding in iframe if inline view
-                    if disposition_type == "inline":
-                        response["X-Frame-Options"] = "SAMEORIGIN"
-
+                    response = HttpResponse(document_data)
+                    apply_safe_download_headers(
+                        response,
+                        content_type=document.content_type,
+                        filename=filename,
+                        inline=request.GET.get("view") == "inline",
+                    )
                     return response
                 else:
                     return error_response(request, HttpResponseNotFound("Document file not found"))


### PR DESCRIPTION
## Summary

Fixes a stored XSS vulnerability in document serving.

Uploaded document bytes **and** their `content_type` are attacker-controlled — the browser-supplied MIME type is stored verbatim at upload time (`documents/apis.py`), with no allowlist or magic-byte check. The download view (`documents/views/document_download.py`) honoured `?view=inline` by serving those bytes with `Content-Disposition: inline` and the stored `content_type`.

### Exploit
1. Attacker creates a **DOCUMENT** component in their own workspace and marks it **public**.
2. Uploads a file whose `content_type` is `text/html` containing `<script>`.
3. Shares `…/document/download/<id>?view=inline`. `check_component_access` grants access for public components, so any visitor renders the HTML on the sbomify origin and executes attacker JS (session riding, CSRF-token theft, exfiltration). `X-Frame-Options: SAMEORIGIN` does not help against direct navigation.

The company-NDA serving path (`documents/access_apis.py`) had the same inline pattern (rendered inside an iframe during the access-request flow).

## Fix
- New shared helper `documents/content_safety.apply_safe_download_headers`:
  - Renders **inline only** for an allowlist of inert content types (`application/pdf`, common images, `text/plain`) — `text/html`, `image/svg+xml`, etc. are never inline.
  - Forces `Content-Disposition: attachment` for everything else (attachment + nosniff makes even a script-capable type inert).
  - Always sets `X-Content-Type-Options: nosniff`.
  - Sanitizes the filename in the header.
- Wired into the document download view and the NDA serving path.

Legitimate inline previews (PDFs, images, the PDF NDA) are unchanged.

## Testing
- Added `test_document_download_html_never_served_inline` (an HTML doc requested inline is forced to attachment + nosniff).
- Existing document download/inline/NDA tests pass. The 5 pre-existing failures in `test_views.py` are an unrelated environment issue (missing Vite manifest in the test container) and fail identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)