### PR TITLE
fix(core): only trust X-Real-IP from configured trusted proxies

### DIFF
--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -95,20 +95,26 @@ def test_schema_org_metadata_tag(mocker):
         assert "billingIncrement" in ps
 
 
-def test_get_client_ip_simplified():
-    """
-    Test get_client_ip simply returns X-Real-IP if present, otherwise REMOTE_ADDR.
-    The application trusts the upstream proxy (Caddy) to sanitize these headers.
-    """
+def test_get_client_ip_honours_x_real_ip_from_trusted_proxy():
+    """X-Real-IP is honoured when the direct peer is a trusted proxy."""
     request = HttpRequest()
 
-    # 1. X-Real-IP present (from Caddy)
+    # Direct peer (REMOTE_ADDR) is a private/loopback proxy → header trusted.
     request.META = {"HTTP_X_REAL_IP": "1.2.3.4", "REMOTE_ADDR": "10.0.0.1"}
     assert get_client_ip(request) == "1.2.3.4"
 
-    # 2. X-Real-IP missing, fallback to REMOTE_ADDR
+    # X-Real-IP missing → fall back to REMOTE_ADDR.
     request.META = {"REMOTE_ADDR": "10.0.0.1"}
     assert get_client_ip(request) == "10.0.0.1"
+
+
+def test_get_client_ip_ignores_spoofed_x_real_ip_from_untrusted_peer():
+    """A client reaching Django directly cannot spoof its IP via X-Real-IP."""
+    request = HttpRequest()
+
+    # Direct peer is a public, untrusted address → X-Real-IP is ignored.
+    request.META = {"HTTP_X_REAL_IP": "1.2.3.4", "REMOTE_ADDR": "203.0.113.7"}
+    assert get_client_ip(request) == "203.0.113.7"
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_utils.py
+++ b/sbomify/apps/core/tests/test_utils.py
@@ -117,6 +117,14 @@ def test_get_client_ip_ignores_spoofed_x_real_ip_from_untrusted_peer():
     assert get_client_ip(request) == "203.0.113.7"
 
 
+def test_get_client_ip_rejects_non_ip_x_real_ip_from_trusted_proxy():
+    """A trusted proxy forwarding a non-IP value falls back to REMOTE_ADDR."""
+    request = HttpRequest()
+
+    request.META = {"HTTP_X_REAL_IP": "not-an-ip", "REMOTE_ADDR": "10.0.0.1"}
+    assert get_client_ip(request) == "10.0.0.1"
+
+
 @pytest.mark.django_db
 class TestAddArtifactToReleaseCrossTeamCheck:
     """Regression tests for the defense-in-depth cross-team check in add_artifact_to_release.

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -251,8 +251,8 @@ def get_client_ip(request: HttpRequest) -> str | None:
     otherwise a client reaching Django directly could spoof X-Real-IP and defeat
     per-IP rate limiting.
     """
-    remote_addr = request.META.get("REMOTE_ADDR")
-    real_ip = request.META.get("HTTP_X_REAL_IP")
+    remote_addr: str | None = request.META.get("REMOTE_ADDR")
+    real_ip: str | None = request.META.get("HTTP_X_REAL_IP")
     if real_ip and _is_trusted_proxy(remote_addr):
         candidate = real_ip.split(",")[0].strip()
         # A trusted proxy shouldn't forward garbage, but validate anyway so a

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -5,15 +5,18 @@ Utility code used by multiple apps.
 from __future__ import annotations
 
 import collections.abc
+import ipaddress
 import logging
 import string
 import uuid
 from dataclasses import dataclass
+from functools import lru_cache
 from secrets import token_urlsafe
 from typing import Any
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
+from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models, transaction
 from django.http import HttpRequest
@@ -211,15 +214,47 @@ def get_current_team_id(request: HttpRequest) -> int | None:
     return token_to_number(team_key)
 
 
+@lru_cache(maxsize=1)
+def _trusted_proxy_networks(
+    cidrs: tuple[str, ...],
+) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    """Compile the configured trusted-proxy CIDRs, skipping invalid entries."""
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for cidr in cidrs:
+        try:
+            networks.append(ipaddress.ip_network(cidr, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid TRUSTED_PROXIES entry: %r", cidr)
+    return tuple(networks)
+
+
+def _is_trusted_proxy(ip: str | None) -> bool:
+    """Return True if ``ip`` is within a configured trusted-proxy network."""
+    if not ip:
+        return False
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    cidrs = tuple(getattr(settings, "TRUSTED_PROXIES", ()) or ())
+    return any(addr in net for net in _trusted_proxy_networks(cidrs))
+
+
 def get_client_ip(request: HttpRequest) -> str | None:
     """
     Get the client IP address from the request.
 
-    We assume the application is running behind a trusted reverse proxy (Caddy)
-    which validates the source and sets the X-Real-IP header to the correct
-    client IP (handling Cloudflare, etc.).
+    The application runs behind a trusted reverse proxy (Caddy) that sets the
+    X-Real-IP header to the real client IP. That header is only honoured when the
+    direct peer (REMOTE_ADDR) is a trusted proxy (settings.TRUSTED_PROXIES);
+    otherwise a client reaching Django directly could spoof X-Real-IP and defeat
+    per-IP rate limiting.
     """
-    return request.META.get("HTTP_X_REAL_IP") or request.META.get("REMOTE_ADDR")
+    remote_addr = request.META.get("REMOTE_ADDR")
+    real_ip = request.META.get("HTTP_X_REAL_IP")
+    if real_ip and _is_trusted_proxy(remote_addr):
+        return real_ip.split(",")[0].strip()
+    return remote_addr
 
 
 def get_by_uuid_or_pk(

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -220,11 +220,12 @@ def _trusted_proxy_networks(
 ) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
     """Compile the configured trusted-proxy CIDRs, skipping invalid entries."""
     networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
-    for cidr in cidrs:
+    for index, cidr in enumerate(cidrs):
         try:
             networks.append(ipaddress.ip_network(cidr, strict=False))
         except ValueError:
-            logger.warning("Ignoring invalid TRUSTED_PROXIES entry: %r", cidr)
+            # Log the position, not the raw value, to avoid echoing config data.
+            logger.warning("Ignoring invalid TRUSTED_PROXIES entry at index %d; check the CIDR syntax.", index)
     return tuple(networks)
 
 
@@ -253,7 +254,15 @@ def get_client_ip(request: HttpRequest) -> str | None:
     remote_addr = request.META.get("REMOTE_ADDR")
     real_ip = request.META.get("HTTP_X_REAL_IP")
     if real_ip and _is_trusted_proxy(remote_addr):
-        return real_ip.split(",")[0].strip()
+        candidate = real_ip.split(",")[0].strip()
+        # A trusted proxy shouldn't forward garbage, but validate anyway so a
+        # misconfigured proxy can't propagate non-IP strings into rate limiting
+        # or audit fields; fall back to the (trusted) peer address on failure.
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            return remote_addr
+        return candidate
     return remote_addr
 
 

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -103,6 +103,20 @@ AUTH_USER_MODEL = "core.User"
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# Networks whose requests are allowed to set the client IP via the X-Real-IP
+# header (see core.utils.get_client_ip). Only honour that header when the direct
+# peer (REMOTE_ADDR) is a trusted reverse proxy; otherwise a client reaching
+# Django directly could spoof its IP and defeat per-IP rate limiting. Defaults
+# to loopback + RFC1918 ranges, which cover the Caddy sidecar in Docker.
+TRUSTED_PROXIES = [
+    cidr.strip()
+    for cidr in os.environ.get(
+        "TRUSTED_PROXIES",
+        "127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+    ).split(",")
+    if cidr.strip()
+]
+
 # Allow larger request bodies for OSCAL catalog imports (default is 2.5 MB)
 DATA_UPLOAD_MAX_MEMORY_SIZE = 20 * 1024 * 1024  # 20 MB
 

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -106,8 +106,14 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # Networks whose requests are allowed to set the client IP via the X-Real-IP
 # header (see core.utils.get_client_ip). Only honour that header when the direct
 # peer (REMOTE_ADDR) is a trusted reverse proxy; otherwise a client reaching
-# Django directly could spoof its IP and defeat per-IP rate limiting. Defaults
-# to loopback + RFC1918 ranges, which cover the Caddy sidecar in Docker.
+# Django directly could spoof its IP and defeat per-IP rate limiting.
+#
+# The default trusts loopback + RFC1918 ranges, which cover the Caddy sidecar in
+# the default Docker topology (where the app is NOT directly reachable — the
+# backend port is unpublished). If Django can be reached directly from any other
+# private segment (shared cluster, corp VPN), narrow this to the actual
+# reverse-proxy address(es) via the TRUSTED_PROXIES env var so those clients
+# cannot spoof X-Real-IP.
 TRUSTED_PROXIES = [
     cidr.strip()
     for cidr in os.environ.get(


### PR DESCRIPTION
## Summary

`core.utils.get_client_ip` returned the `X-Real-IP` header unconditionally (`HTTP_X_REAL_IP or REMOTE_ADDR`). Any client able to reach Django directly — bypassing Caddy, or if Caddy ever forwarded a client-supplied value — could set `X-Real-IP` to an arbitrary address.

This value feeds the per-IP rate limiter on the **unauthenticated** OIDC token-exchange endpoint (`oidc/apis.py`) and `RealIPMiddleware`, so header rotation defeats brute-force/enumeration protection. It also drives IP-based audit fields (e.g. NDA signature IPs).

## Fix
- `get_client_ip` now honours `X-Real-IP` **only** when the direct peer (`REMOTE_ADDR`) is within a configured trusted-proxy network.
- New `settings.TRUSTED_PROXIES`, defaulting to loopback + RFC1918 ranges (`127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`) — which cover the Caddy sidecar in Docker — and overridable via the `TRUSTED_PROXIES` env var.
- Invalid CIDR entries are logged and skipped; parsing is cached.

Legitimate proxied traffic is unaffected (Caddy connects from a private address, so its `X-Real-IP` is still trusted). A public client reaching Django directly can no longer spoof its IP.

## Testing
- Existing NDA-signing proxy tests pass unchanged (`REMOTE_ADDR=127.0.0.1` is trusted).
- Updated `test_get_client_ip_*` to cover both the trusted-proxy and spoofed-untrusted-peer cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)