### PR TITLE
feat(security): add CSP and X-Content-Type-Options headers

### DIFF
--- a/sbomify/apps/core/middleware.py
+++ b/sbomify/apps/core/middleware.py
@@ -505,8 +505,10 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
 
     Ships in Report-Only mode by default (``settings.CSP_ENFORCE`` is False) so
     violations can be collected before the policy is enforced. The policy string
-    itself comes from ``settings.CONTENT_SECURITY_POLICY``. Responses that already
-    carry a CSP header are left untouched.
+    itself comes from ``settings.CONTENT_SECURITY_POLICY``, with a ``report-uri``
+    directive appended when ``settings.CSP_REPORT_URI`` is set (otherwise
+    Report-Only violations only surface in the browser console). Responses that
+    already carry a CSP header are left untouched.
     """
 
     def process_response(self, request: Any, response: HttpResponse) -> HttpResponse:
@@ -514,13 +516,20 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
         if not policy:
             return response
 
+        already_present = "Content-Security-Policy" in response or "Content-Security-Policy-Report-Only" in response
+        if already_present:
+            return response
+
+        report_uri = getattr(settings, "CSP_REPORT_URI", "")
+        if report_uri:
+            policy = f"{policy}; report-uri {report_uri}"
+
         header = (
             "Content-Security-Policy"
             if getattr(settings, "CSP_ENFORCE", False)
             else "Content-Security-Policy-Report-Only"
         )
-        if "Content-Security-Policy" not in response and "Content-Security-Policy-Report-Only" not in response:
-            response[header] = policy
+        response[header] = policy
         return response
 
 

--- a/sbomify/apps/core/middleware.py
+++ b/sbomify/apps/core/middleware.py
@@ -500,6 +500,30 @@ class RealIPMiddleware(MiddlewareMixin):
             request.META["REMOTE_ADDR"] = client_ip
 
 
+class ContentSecurityPolicyMiddleware(MiddlewareMixin):
+    """Attach a Content-Security-Policy header to responses.
+
+    Ships in Report-Only mode by default (``settings.CSP_ENFORCE`` is False) so
+    violations can be collected before the policy is enforced. The policy string
+    itself comes from ``settings.CONTENT_SECURITY_POLICY``. Responses that already
+    carry a CSP header are left untouched.
+    """
+
+    def process_response(self, request: Any, response: HttpResponse) -> HttpResponse:
+        policy = getattr(settings, "CONTENT_SECURITY_POLICY", "")
+        if not policy:
+            return response
+
+        header = (
+            "Content-Security-Policy"
+            if getattr(settings, "CSP_ENFORCE", False)
+            else "Content-Security-Policy-Report-Only"
+        )
+        if "Content-Security-Policy" not in response and "Content-Security-Policy-Report-Only" not in response:
+            response[header] = policy
+        return response
+
+
 class HtmxMessagesMiddleware:
     """Convert Django session messages to HX-Trigger for HTMX requests.
 

--- a/sbomify/apps/core/middleware.py
+++ b/sbomify/apps/core/middleware.py
@@ -500,6 +500,16 @@ class RealIPMiddleware(MiddlewareMixin):
             request.META["REMOTE_ADDR"] = client_ip
 
 
+def _policy_has_report_uri(policy: str) -> bool:
+    """True if any ``;``-separated directive in ``policy`` is a report-uri.
+
+    Directive names are case-insensitive per the CSP spec; matching the directive
+    at the start of each segment avoids false positives from a URL value in
+    another directive that happens to contain the substring "report-uri".
+    """
+    return any(directive.strip().lower().startswith("report-uri") for directive in policy.split(";"))
+
+
 class ContentSecurityPolicyMiddleware(MiddlewareMixin):
     """Attach a Content-Security-Policy header to responses.
 
@@ -521,10 +531,12 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
             return response
 
         report_uri = getattr(settings, "CSP_REPORT_URI", "")
-        # Only append when the policy doesn't already carry a report-uri (it may
-        # come from the CONTENT_SECURITY_POLICY env var), and normalize any
-        # trailing separator so we don't emit "…; ; report-uri …".
-        if report_uri and "report-uri" not in policy:
+        # Only append when the policy doesn't already carry a report-uri directive
+        # (it may come from the CONTENT_SECURITY_POLICY env var), and normalize any
+        # trailing separator so we don't emit "…; ; report-uri …". The check is
+        # directive-bound and case-insensitive so it won't false-match a URL that
+        # happens to contain "report-uri" inside another directive's value.
+        if report_uri and not _policy_has_report_uri(policy):
             policy = f"{policy.rstrip(' ;')}; report-uri {report_uri}"
 
         header = (

--- a/sbomify/apps/core/middleware.py
+++ b/sbomify/apps/core/middleware.py
@@ -521,8 +521,11 @@ class ContentSecurityPolicyMiddleware(MiddlewareMixin):
             return response
 
         report_uri = getattr(settings, "CSP_REPORT_URI", "")
-        if report_uri:
-            policy = f"{policy}; report-uri {report_uri}"
+        # Only append when the policy doesn't already carry a report-uri (it may
+        # come from the CONTENT_SECURITY_POLICY env var), and normalize any
+        # trailing separator so we don't emit "…; ; report-uri …".
+        if report_uri and "report-uri" not in policy:
+            policy = f"{policy.rstrip(' ;')}; report-uri {report_uri}"
 
         header = (
             "Content-Security-Policy"

--- a/sbomify/apps/core/tests/test_middleware.py
+++ b/sbomify/apps/core/tests/test_middleware.py
@@ -77,6 +77,21 @@ def test_csp_middleware_appends_report_uri_when_configured():
     )
 
 
+@override_settings(
+    CONTENT_SECURITY_POLICY="default-src 'self'; report-uri https://policy.test/r;",
+    CSP_ENFORCE=False,
+    CSP_REPORT_URI="https://example.test/csp-report",
+)
+def test_csp_middleware_does_not_duplicate_existing_report_uri():
+    """A report-uri already in the policy is not duplicated by CSP_REPORT_URI."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    result = middleware.process_response(HttpRequest(), HttpResponse())
+
+    policy = result["Content-Security-Policy-Report-Only"]
+    assert policy.count("report-uri") == 1
+    assert "https://policy.test/r" in policy
+
+
 def test_real_ip_middleware():
     """Test that RealIPMiddleware updates REMOTE_ADDR correctly."""
     middleware = RealIPMiddleware(get_response=lambda r: None)

--- a/sbomify/apps/core/tests/test_middleware.py
+++ b/sbomify/apps/core/tests/test_middleware.py
@@ -92,6 +92,21 @@ def test_csp_middleware_does_not_duplicate_existing_report_uri():
     assert "https://policy.test/r" in policy
 
 
+@override_settings(
+    CONTENT_SECURITY_POLICY="default-src 'self'; Report-URI https://policy.test/r",
+    CSP_ENFORCE=False,
+    CSP_REPORT_URI="https://example.test/csp-report",
+)
+def test_csp_middleware_report_uri_check_is_case_insensitive():
+    """An existing report-uri directive with different casing is still detected."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    result = middleware.process_response(HttpRequest(), HttpResponse())
+
+    policy = result["Content-Security-Policy-Report-Only"].lower()
+    assert policy.count("report-uri") == 1
+    assert "https://example.test/csp-report" not in policy
+
+
 def test_real_ip_middleware():
     """Test that RealIPMiddleware updates REMOTE_ADDR correctly."""
     middleware = RealIPMiddleware(get_response=lambda r: None)

--- a/sbomify/apps/core/tests/test_middleware.py
+++ b/sbomify/apps/core/tests/test_middleware.py
@@ -4,9 +4,49 @@ from django.http import HttpRequest, HttpResponse
 from django.test import override_settings
 
 from sbomify.apps.core.middleware import (
+    ContentSecurityPolicyMiddleware,
     GzipRequestDecompressionMiddleware,
     RealIPMiddleware,
 )
+
+
+@override_settings(
+    CONTENT_SECURITY_POLICY="default-src 'self'; object-src 'none'",
+    CSP_ENFORCE=False,
+)
+def test_csp_middleware_report_only_by_default():
+    """The CSP is attached in Report-Only mode unless enforcement is enabled."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    response = middleware.process_response(HttpRequest(), HttpResponse())
+
+    assert response["Content-Security-Policy-Report-Only"] == "default-src 'self'; object-src 'none'"
+    assert "Content-Security-Policy" not in response
+
+
+@override_settings(
+    CONTENT_SECURITY_POLICY="default-src 'self'; object-src 'none'",
+    CSP_ENFORCE=True,
+)
+def test_csp_middleware_enforced_when_enabled():
+    """CSP_ENFORCE=True emits the enforcing header instead of Report-Only."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    response = middleware.process_response(HttpRequest(), HttpResponse())
+
+    assert response["Content-Security-Policy"] == "default-src 'self'; object-src 'none'"
+    assert "Content-Security-Policy-Report-Only" not in response
+
+
+@override_settings(CONTENT_SECURITY_POLICY="default-src 'self'")
+def test_csp_middleware_preserves_existing_header():
+    """A CSP already set by a view is not overwritten."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    response = HttpResponse()
+    response["Content-Security-Policy"] = "default-src 'none'"
+
+    result = middleware.process_response(HttpRequest(), response)
+
+    assert result["Content-Security-Policy"] == "default-src 'none'"
+    assert "Content-Security-Policy-Report-Only" not in result
 
 
 def test_real_ip_middleware():

--- a/sbomify/apps/core/tests/test_middleware.py
+++ b/sbomify/apps/core/tests/test_middleware.py
@@ -49,6 +49,34 @@ def test_csp_middleware_preserves_existing_header():
     assert "Content-Security-Policy-Report-Only" not in result
 
 
+@override_settings(CONTENT_SECURITY_POLICY="default-src 'self'", CSP_ENFORCE=False)
+def test_csp_middleware_preserves_existing_report_only_header():
+    """An existing Report-Only header set by a view is not overwritten."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    response = HttpResponse()
+    response["Content-Security-Policy-Report-Only"] = "default-src 'none'"
+
+    result = middleware.process_response(HttpRequest(), response)
+
+    assert result["Content-Security-Policy-Report-Only"] == "default-src 'none'"
+    assert "Content-Security-Policy" not in result
+
+
+@override_settings(
+    CONTENT_SECURITY_POLICY="default-src 'self'",
+    CSP_ENFORCE=False,
+    CSP_REPORT_URI="https://example.test/csp-report",
+)
+def test_csp_middleware_appends_report_uri_when_configured():
+    """A configured report endpoint is appended so violations are delivered."""
+    middleware = ContentSecurityPolicyMiddleware(get_response=lambda r: HttpResponse())
+    result = middleware.process_response(HttpRequest(), HttpResponse())
+
+    assert result["Content-Security-Policy-Report-Only"] == (
+        "default-src 'self'; report-uri https://example.test/csp-report"
+    )
+
+
 def test_real_ip_middleware():
     """Test that RealIPMiddleware updates REMOTE_ADDR correctly."""
     middleware = RealIPMiddleware(get_response=lambda r: None)

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -117,7 +117,12 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # Alpine.js expressions (needs 'unsafe-inline'/'unsafe-eval'), Stripe.js and
 # websockets, so the policy stays permissive on scripts while locking down
 # object-src, base-uri and plugin embedding.
+#
+# Report-Only violations are only delivered somewhere if CSP_REPORT_URI points
+# at a collector endpoint (e.g. Sentry's CSP ingest URL); without it, browsers
+# just log violations to their console. Set it to make the rollout actionable.
 CSP_ENFORCE = _env_bool(os.environ.get("CSP_ENFORCE"), default=False)
+CSP_REPORT_URI = os.environ.get("CSP_REPORT_URI", "")
 CONTENT_SECURITY_POLICY = os.environ.get(
     "CONTENT_SECURITY_POLICY",
     "; ".join(

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -106,6 +106,37 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # Allow larger request bodies for OSCAL catalog imports (default is 2.5 MB)
 DATA_UPLOAD_MAX_MEMORY_SIZE = 20 * 1024 * 1024  # 20 MB
 
+# Prevent browsers from MIME-sniffing responses away from their declared
+# Content-Type — defense-in-depth for user-uploaded artifact downloads.
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
+# Content-Security-Policy (see ContentSecurityPolicyMiddleware). Shipped in
+# Report-Only mode by default so violations can be observed before enforcement;
+# set CSP_ENFORCE=True once the reports are clean. The app relies on inline
+# Alpine.js expressions (needs 'unsafe-inline'/'unsafe-eval'), Stripe.js and
+# websockets, so the policy stays permissive on scripts while locking down
+# object-src, base-uri and plugin embedding.
+CSP_ENFORCE = _env_bool(os.environ.get("CSP_ENFORCE"), default=False)
+CONTENT_SECURITY_POLICY = os.environ.get(
+    "CONTENT_SECURITY_POLICY",
+    "; ".join(
+        [
+            "default-src 'self'",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data: blob: https:",
+            "font-src 'self' data:",
+            "connect-src 'self' https: wss: ws:",
+            "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+            "frame-ancestors 'self'",
+            "base-uri 'self'",
+            "object-src 'none'",
+            "worker-src 'self' blob:",
+        ]
+    ),
+)
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -171,6 +202,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "sbomify.apps.core.middleware.HtmxMessagesMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "sbomify.apps.core.middleware.ContentSecurityPolicyMiddleware",
     "allauth.account.middleware.AccountMiddleware",
 ]
 


### PR DESCRIPTION
## Summary

The app set HSTS, `SECURE_SSL_REDIRECT` and `X-Frame-Options`, but shipped **no Content-Security-Policy** and **no `X-Content-Type-Options`**. There was no defense-in-depth backstop for an XSS regression, and no protection against MIME-sniffing of user-uploaded artifact downloads.

## Changes
- `SECURE_CONTENT_TYPE_NOSNIFF = True` and `SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"`.
- New `ContentSecurityPolicyMiddleware` emitting a baseline policy.

### Why Report-Only by default
The app relies on inline **Alpine.js** expressions (which require `script-src 'unsafe-inline' 'unsafe-eval'`), **Stripe.js**, cross-origin **Keycloak** form POSTs, and websockets. A strict enforced policy would break these without a tuning pass. So the middleware ships the policy as `Content-Security-Policy-Report-Only` by default, letting the team collect violation reports before flipping `CSP_ENFORCE=True`. The cheap, low-risk directives (`object-src 'none'`, `base-uri 'self'`) are already in the baseline.

Both the policy string (`CONTENT_SECURITY_POLICY`) and enforcement (`CSP_ENFORCE`) are env-overridable.

## Testing
- Added `test_csp_middleware_*`: report-only by default, enforcing when `CSP_ENFORCE=True`, and existing CSP headers are preserved.
- Full `test_middleware.py` suite (15 tests) passes; `manage.py check` clean.

## Follow-up
Once Report-Only reports are clean (enumerate any remaining external origins), set `CSP_ENFORCE=True`. Longer term, migrate inline Alpine to a nonce-based policy to drop `unsafe-inline`/`unsafe-eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)