### PR TITLE
fix(releases): make release-artifact plumbing bom_type-aware

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -322,11 +322,17 @@ def _build_component_response(
     has_crud_permissions: bool | None = None,
 ) -> dict[str, Any]:
     """Build the API response for a single Component."""
+    from sbomify.apps.sboms.models import SBOM
+
     response = _build_item_base(request, component, has_crud_permissions)
     response["visibility"] = component.visibility
     response["gating_mode"] = component.gating_mode
     response["nda_document_id"] = str(component.nda_document.id) if component.nda_document_id else None
-    response["sbom_count"] = component.sbom_count if hasattr(component, "sbom_count") else component.sbom_set.count()
+    response["sbom_count"] = (
+        component.sbom_count
+        if hasattr(component, "sbom_count")
+        else component.sbom_set.filter(bom_type=SBOM.BomType.SBOM).count()
+    )
     response["document_count"] = (
         component.document_count if hasattr(component, "document_count") else component.document_set.count()
     )
@@ -2320,7 +2326,7 @@ def list_component_releases(
             artifact_count = release.artifacts.count()
 
             # Check if release has SBOMs for download capability
-            has_sboms = release.artifacts.filter(sbom__isnull=False).exists()
+            has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
 
             response_data.append(
                 {
@@ -2561,6 +2567,7 @@ def list_all_releases(
     page_size: int = Query(15),  # type: ignore[type-arg]
 ) -> Any:
     """List all releases across all products for the current user's team, optionally filtered by product and version."""
+    from sbomify.apps.sboms.models import SBOM
 
     try:
         # Special handling for public product access
@@ -2647,7 +2654,7 @@ def list_all_releases(
                 artifact_count = release.artifacts.count()
 
                 # Check if release has SBOMs for download capability
-                has_sboms = release.artifacts.filter(sbom__isnull=False).exists()
+                has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
 
                 # Ensure the product exists
                 if not release.product:
@@ -2688,11 +2695,13 @@ def list_all_releases(
 
 def _build_release_response(request: HttpRequest, release: Release, include_artifacts: bool = False) -> dict[str, Any]:
     """Build a standardized response for releases."""
+    from sbomify.apps.sboms.models import SBOM
+
     # Count artifacts for this release
     artifact_count = release.artifacts.count()
 
     # Check if release has SBOMs for download capability
-    has_sboms = release.artifacts.filter(sbom__isnull=False).exists()
+    has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
     has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
@@ -3134,7 +3143,11 @@ def download_release(
             return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
 
     # Get all SBOM artifacts in the release
-    sbom_artifacts = release.artifacts.filter(sbom__isnull=False).select_related("sbom")
+    from sbomify.apps.sboms.models import SBOM
+
+    sbom_artifacts = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).select_related(
+        "sbom"
+    )
 
     if not sbom_artifacts.exists():
         return HttpResponse(
@@ -3964,7 +3977,9 @@ def list_component_sboms(
         from sbomify.apps.sboms.models import SBOM
 
         try:
-            sboms_queryset = SBOM.objects.filter(component_id=component_id).order_by("-created_at")
+            sboms_queryset = SBOM.objects.filter(component_id=component_id, bom_type=SBOM.BomType.SBOM).order_by(
+                "-created_at"
+            )
             # Apply pagination
             paginated_sboms, pagination_meta = _paginate_queryset(sboms_queryset, page, page_size)
         except (DatabaseError, OperationalError) as db_err:

--- a/sbomify/apps/core/models.py
+++ b/sbomify/apps/core/models.py
@@ -76,28 +76,34 @@ class Component(SbomComponent):
         proxy = True
         app_label = "core"
 
-    def get_latest_sboms_by_format(self) -> dict[str, Any]:
-        """Get the latest SBOM for each format (CycloneDX, SPDX, etc.).
+    def get_latest_sboms_by_format(self) -> dict[Any, Any]:
+        """Get the latest artifact for each (format, bom_type).
+
+        Keyed on (format, bom_type) rather than format alone so a CBOM or VEX (which share the
+        cyclonedx format) each keep their own latest slot instead of one displacing the other.
 
         Returns:
-            Dict mapping format names to their latest SBOM objects.
-            Example: {'cyclonedx': <SBOM>, 'spdx': <SBOM>}
+            Dict mapping (format, bom_type) tuples to their latest SBOM-table objects.
+            Example: {('cyclonedx', 'sbom'): <SBOM>, ('cyclonedx', 'cbom'): <CBOM>, ('spdx', 'sbom'): <SBOM>}
         """
         from django.db.models import Max
 
-        # Get the latest created_at for each format
-        latest_by_format = self.sbom_set.values("format").annotate(latest_created=Max("created_at"))
+        # Latest artifact per (format, bom_type). Keying on bom_type as well as format keeps a
+        # newer CBOM or VEX (same cyclonedx format, different bom_type) from displacing the latest
+        # real SBOM in the single cyclonedx slot. The key is a (format, bom_type) tuple.
+        latest_by_format = self.sbom_set.values("format", "bom_type").annotate(latest_created=Max("created_at"))
 
         latest_sboms = {}
         for format_info in latest_by_format:
             format_name = format_info["format"]
+            bom_type = format_info["bom_type"]
             latest_created = format_info["latest_created"]
 
-            # Get the actual SBOM object for this format and creation time
-            sbom = self.sbom_set.filter(format=format_name, created_at=latest_created).first()
+            # Get the actual SBOM object for this (format, bom_type) and creation time
+            sbom = self.sbom_set.filter(format=format_name, bom_type=bom_type, created_at=latest_created).first()
 
             if sbom:
-                latest_sboms[format_name] = sbom
+                latest_sboms[(format_name, bom_type)] = sbom
 
         return latest_sboms
 
@@ -406,9 +412,13 @@ class Release(models.Model):
         try:
             # Determine if this is an SBOM or Document
             if hasattr(artifact, "format"):  # SBOM
-                # Remove any existing SBOM of the same format from the same component
+                # Remove any existing artifact of the same format AND bom_type from the same
+                # component. Keying on bom_type keeps a CBOM/VEX (same cyclonedx format) from
+                # evicting the component's real SBOM: each bom_type replaces only its own slot.
                 deleted, _ = self.artifacts.filter(
-                    sbom__component=artifact.component, sbom__format=artifact.format
+                    sbom__component=artifact.component,
+                    sbom__format=artifact.format,
+                    sbom__bom_type=artifact.bom_type,
                 ).delete()
                 replaced = deleted > 0
 

--- a/sbomify/apps/core/services/querysets.py
+++ b/sbomify/apps/core/services/querysets.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from django.db.models import Count, Prefetch, QuerySet
+from django.db.models import Count, Prefetch, Q, QuerySet
 
 from sbomify.apps.core.models import Component, Product
-from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
+from sbomify.apps.sboms.models import SBOM, ProductIdentifier, ProductLink
 
 
 def optimize_product_queryset(queryset: QuerySet[Product]) -> QuerySet[Product]:
@@ -33,6 +33,7 @@ def optimize_product_queryset(queryset: QuerySet[Product]) -> QuerySet[Product]:
 
 def optimize_component_queryset(queryset: QuerySet[Component]) -> QuerySet[Component]:
     return queryset.select_related("team").annotate(
-        sbom_count=Count("sbom", distinct=True),
+        # Count only real SBOMs — CBOM/VEX rows live in the same table and must not inflate the badge.
+        sbom_count=Count("sbom", filter=Q(sbom__bom_type=SBOM.BomType.SBOM), distinct=True),
         document_count=Count("document", distinct=True),
     )

--- a/sbomify/apps/core/tests/test_release_models.py
+++ b/sbomify/apps/core/tests/test_release_models.py
@@ -569,6 +569,44 @@ def test_latest_release_auto_management_integration(
     assert document in documents
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize("other_bom_type", [SBOM.BomType.CBOM, SBOM.BomType.VEX])
+def test_non_sbom_upload_does_not_evict_sbom_from_latest_release(
+    other_bom_type,
+    sample_product: Product,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+):
+    """A CBOM/VEX (same cyclonedx format) uploaded after an SBOM must not evict the SBOM from
+    the latest release — it takes its own slot. Regression for the live bug shipped with CBOM
+    auto-detection."""
+    sample_component.team = sample_product.team
+    sample_component.save()
+    latest_release = Release.objects.get(product=sample_product, is_latest=True)
+
+    sbom = SBOM.objects.create(
+        component=sample_component, format="cyclonedx", format_version="1.6", name="Real SBOM", version="1.0.0"
+    )
+    latest_release.refresh_from_db()
+    assert sbom in latest_release.get_sboms()
+
+    # Upload a same-format non-SBOM artifact (CBOM or VEX).
+    other = SBOM.objects.create(
+        component=sample_component,
+        format="cyclonedx",
+        format_version="1.6",
+        name=f"{other_bom_type} artifact",
+        version="1.0.0",
+        bom_type=other_bom_type,
+    )
+
+    latest_release.refresh_from_db()
+    artifacts = latest_release.get_sboms()
+    assert sbom in artifacts  # the real SBOM survived
+    assert other in artifacts  # the non-SBOM has its own slot
+    # The release keeps exactly one artifact per (component, format, bom_type).
+    assert latest_release.artifacts.filter(sbom__component=sample_component).count() == 2
+
+
 # =============================================================================
 # COMPONENT MODEL ARTIFACT METHODS TESTS
 # =============================================================================
@@ -606,14 +644,42 @@ def test_component_get_latest_sboms_by_format(
 
     latest_sboms = sample_component.get_latest_sboms_by_format()
 
-    # Should return latest SBOM for each format
+    # Keyed on (format, bom_type); should return the latest SBOM for each format
     assert len(latest_sboms) == 2
-    assert "cyclonedx" in latest_sboms
-    assert "spdx" in latest_sboms
+    assert ("cyclonedx", SBOM.BomType.SBOM) in latest_sboms
+    assert ("spdx", SBOM.BomType.SBOM) in latest_sboms
 
     # Check that we got the latest SBOMs for each format
-    assert latest_sboms["cyclonedx"] == sbom_cyclone_new  # Latest by created_at
-    assert latest_sboms["spdx"] == sbom_spdx
+    assert latest_sboms[("cyclonedx", SBOM.BomType.SBOM)] == sbom_cyclone_new  # Latest by created_at
+    assert latest_sboms[("spdx", SBOM.BomType.SBOM)] == sbom_spdx
+
+
+@pytest.mark.django_db
+def test_get_latest_sboms_by_format_separates_bom_type(
+    sample_component: Component,  # noqa: F811
+):
+    """A same-format CBOM must not displace the SBOM slot: each (format, bom_type) is its own key."""
+    sbom = SBOM.objects.create(
+        component=sample_component,
+        format="cyclonedx",
+        format_version="1.6",
+        name="Real SBOM",
+        version="1.0.0",
+        bom_type=SBOM.BomType.SBOM,
+    )
+    cbom = SBOM.objects.create(
+        component=sample_component,
+        format="cyclonedx",
+        format_version="1.6",
+        name="CBOM",
+        version="1.0.0",
+        bom_type=SBOM.BomType.CBOM,
+    )
+
+    latest = sample_component.get_latest_sboms_by_format()
+
+    assert latest[("cyclonedx", SBOM.BomType.SBOM)] == sbom
+    assert latest[("cyclonedx", SBOM.BomType.CBOM)] == cbom
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/utils.py
+++ b/sbomify/apps/core/utils.py
@@ -560,8 +560,13 @@ def add_artifact_to_release(
             }
 
         if sbom:
+            # Match on bom_type as well as format so a CBOM/VEX (same cyclonedx format) only
+            # replaces its own kind and never evicts the component's real SBOM from the release.
             same = ReleaseArtifact.objects.filter(
-                release=release, sbom__component=sbom.component, sbom__format=sbom.format
+                release=release,
+                sbom__component=sbom.component,
+                sbom__format=sbom.format,
+                sbom__bom_type=sbom.bom_type,
             )
             existing_same = same.first()
             if existing_same:

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -89,7 +89,11 @@ def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: 
         .select_related("product")
         .annotate(
             annotated_artifacts_count=Count("artifacts"),
-            annotated_has_sboms=Exists(ReleaseArtifact.objects.filter(release=OuterRef("pk"), sbom__isnull=False)),
+            annotated_has_sboms=Exists(
+                ReleaseArtifact.objects.filter(
+                    release=OuterRef("pk"), sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
+                )
+            ),
         )
         # Reuse the model's default ordering (which sorts NULL released_at LAST,
         # so unreleased rows don't float to the top) and append ``name`` as a

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -215,9 +215,10 @@ class BaseSBOMBuilder(ABC):
         ``(members, {str(sbom.id): (path, id) | None})``.
         """
         from sbomify.apps.core.models import Component
+        from sbomify.apps.sboms.models import SBOM
 
         sbom_artifacts = (
-            release.artifacts.filter(sbom__isnull=False)
+            release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM)
             # select_related joins the whole sbom -> component -> team FK chain in
             # one query; a prefetch_related on the same path would just add a
             # redundant query.

--- a/sbomify/apps/sboms/queries.py
+++ b/sbomify/apps/sboms/queries.py
@@ -6,4 +6,11 @@ from sbomify.apps.sboms.models import SBOM
 
 
 def get_latest_sbom_id_for_component(component_id: str) -> Optional[str]:
-    return SBOM.objects.filter(component_id=component_id).order_by("-created_at").values_list("id", flat=True).first()
+    # Only real SBOMs — a component's newest row may be a CBOM/VEX (same table), which must not
+    # be treated as "the latest SBOM" (that would pin the vuln dashboard to an unscanned artifact).
+    return (
+        SBOM.objects.filter(component_id=component_id, bom_type=SBOM.BomType.SBOM)
+        .order_by("-created_at")
+        .values_list("id", flat=True)
+        .first()
+    )

--- a/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
+++ b/sbomify/apps/sboms/tests/test_aggregate_document_scoping.py
@@ -73,6 +73,34 @@ def test_fingerprint_reacts_to_public_document_changes(team_with_business_plan):
 
 
 @pytest.mark.django_db
+def test_aggregate_members_exclude_cbom_of_same_component(team_with_business_plan):
+    """A CBOM (same cyclonedx format, different bom_type) in the release must not enter the SBOM
+    aggregate: the fingerprint over SBOM members is unchanged when a CBOM is added."""
+    team = team_with_business_plan
+    product = Product.objects.create(name="P-cbom", team=team, is_public=True)
+    release = Release.objects.create(product=product, name="v1")
+    member = Component.objects.create(
+        name="m", team=team, visibility=Component.Visibility.PUBLIC, component_type=Component.ComponentType.BOM
+    )
+    sbom = SBOM.objects.create(name="m", component=member, format="cyclonedx", version="1", sbom_filename="m.json")
+    ReleaseArtifact.objects.create(release=release, sbom=sbom)
+
+    fp_before = compute_release_aggregate_fingerprint(release)
+
+    cbom = SBOM.objects.create(
+        name="m-cbom",
+        component=member,
+        format="cyclonedx",
+        version="1",
+        sbom_filename="m-cbom.json",
+        bom_type=SBOM.BomType.CBOM,
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=cbom)
+
+    assert compute_release_aggregate_fingerprint(release) == fp_before  # CBOM is not an SBOM member
+
+
+@pytest.mark.django_db
 def test_public_product_spdx_aggregate_excludes_nonpublic_documents(team_with_business_plan):
     """The SPDX external-reference builder scopes documents the same way as the CycloneDX one."""
     from sbomify.apps.sboms.utils import create_product_spdx_external_references

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1354,7 +1354,7 @@ class ReleaseSBOMBuilder:
 
             # Get all SBOM artifacts in this release with optimized query
             sbom_artifacts = (
-                release.artifacts.filter(sbom__isnull=False)
+                release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM)
                 .select_related("sbom__component", "sbom__component__team")
                 .prefetch_related("sbom__component__team")
             )
@@ -1801,7 +1801,11 @@ def compute_release_aggregate_fingerprint(release: Any) -> str:
             digest.update(b)
 
     members = (
-        release.artifacts.filter(sbom__isnull=False, sbom__component__visibility=Component.Visibility.PUBLIC)
+        release.artifacts.filter(
+            sbom__isnull=False,
+            sbom__bom_type=SBOM.BomType.SBOM,
+            sbom__component__visibility=Component.Visibility.PUBLIC,
+        )
         .order_by("sbom__id")
         .values_list("sbom__id", "sbom__sbom_filename")
     )

--- a/sbomify/apps/tea/apis.py
+++ b/sbomify/apps/tea/apis.py
@@ -256,7 +256,7 @@ def _build_product_release_response(
         # Map component_id -> ComponentRelease.uuid via junction table (public components only)
         artifact_sboms = [
             artifact.sbom
-            for artifact in release.artifacts.all()
+            for artifact in release.artifacts.filter(sbom__bom_type=SBOM.BomType.SBOM)
             if artifact.sbom
             and artifact.sbom.component_id
             and artifact.sbom.component.visibility == Component.Visibility.PUBLIC

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -21,6 +21,7 @@ from sbomify.apps.core.domain.exceptions import DomainError, NotFoundError, Perm
 from sbomify.apps.core.models import User
 from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.queries import require_team_member
 
@@ -139,9 +140,9 @@ def get_team_vulnerability_stats(
         if release_id:
             from sbomify.apps.core.models import ReleaseArtifact
 
-            sbom_ids_in_release = ReleaseArtifact.objects.filter(release_id=release_id, sbom__isnull=False).values_list(
-                "sbom_id", flat=True
-            )
+            sbom_ids_in_release = ReleaseArtifact.objects.filter(
+                release_id=release_id, sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
+            ).values_list("sbom_id", flat=True)
             recent_results_query = recent_results_query.filter(sbom_id__in=sbom_ids_in_release)
 
         if component_id:
@@ -259,9 +260,9 @@ def get_team_vulnerability_timeseries(
         if release_id:
             from sbomify.apps.core.models import ReleaseArtifact
 
-            sbom_ids_in_release = ReleaseArtifact.objects.filter(release_id=release_id, sbom__isnull=False).values_list(
-                "sbom_id", flat=True
-            )
+            sbom_ids_in_release = ReleaseArtifact.objects.filter(
+                release_id=release_id, sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
+            ).values_list("sbom_id", flat=True)
             results_query = results_query.filter(sbom_id__in=sbom_ids_in_release)
 
         if component_id:
@@ -404,9 +405,9 @@ def get_team_vulnerability_drill_down(
         if release_id:
             from sbomify.apps.core.models import ReleaseArtifact
 
-            sbom_ids_in_release = ReleaseArtifact.objects.filter(release_id=release_id, sbom__isnull=False).values_list(
-                "sbom_id", flat=True
-            )
+            sbom_ids_in_release = ReleaseArtifact.objects.filter(
+                release_id=release_id, sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
+            ).values_list("sbom_id", flat=True)
             results_query = results_query.filter(sbom_id__in=sbom_ids_in_release)
 
         if component_id:

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -209,6 +209,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             # each in-scope product (the chosen product, or every team product
             # under All Products); a concrete id resolves to that one release.
             from sbomify.apps.core.models import ReleaseArtifact
+            from sbomify.apps.sboms.models import SBOM
 
             if release_id == LATEST_RELEASE:
                 latest_releases = Release.objects.filter(product__team=team, is_latest=True)
@@ -219,7 +220,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 release_ids = [release_id]
 
             sbom_ids_in_release = ReleaseArtifact.objects.filter(
-                release_id__in=release_ids, sbom__isnull=False
+                release_id__in=release_ids, sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
             ).values_list("sbom_id", flat=True)
             scoped_query = scoped_query.filter(sbom_id__in=sbom_ids_in_release)
 


### PR DESCRIPTION
## What

Makes release-artifact plumbing `bom_type`-aware so VEX/CBOM artifacts stop evicting a component's real SBOM from its latest release.

VEX and CBOM are stored as rows in the `sboms.SBOM` table (`bom_type=vex/cbom`, `format=cyclonedx`), but release-artifact association and "latest SBOM" selection keyed on `format` alone. So a CBOM or VEX uploaded to a component evicted the component's real SBOM from its latest release and took its slot.

## Why now

1. **It is a live bug today.** CBOM auto-detection (#1064) tags uploads `bom_type=cbom`, so uploading a CBOM after an SBOM already silently evicts the SBOM from the latest release. Two more live leaks ride along: the vuln dashboard's "latest SBOM" pinned to a CBOM so the real findings vanished, and the `sbom_count` badge counted CBOM/VEX rows.
2. **It is the blocking prerequisite for the VEX lifecycle** (#1094). The first VEX upload would corrupt every release without this.

## Change

**Root: one slot per `(component, format, bom_type)`.** An SBOM replaces only an SBOM, a CBOM only a CBOM, a VEX only a VEX. `add_artifact_to_latest_release`, `get_latest_sboms_by_format`, and `add_artifact_to_release` now key on `bom_type`.

**Read guards** so CBOM/VEX rows never leak into an SBOM aggregate, count, download, or scan scope: aggregate builders and cache fingerprint, `get_release_sbom` download, the `has_sboms` affordances including the public Trust Center, vuln-scan release scoping, the TEA collection, `list_component_sboms`, and the `sbom_count` badge.

**Live-bug fixes:** `get_latest_sbom_id_for_component` and the `sbom_count` annotation now count SBOMs only.

## Tests

- CBOM and VEX no longer evict the SBOM from the latest release (parametrized).
- `get_latest_sboms_by_format` keeps a same-format CBOM in its own `(format, bom_type)` slot.
- A CBOM added to a release stays out of the SBOM aggregate member fingerprint.
- Green: release models, aggregate scoping and cache, all `vulnerability_scanning`, TEA, and `sboms` suites.

## Scope

Prerequisite only. The event-stream model, the VEX versioning storage key, and CBOM/VEX Trust Center exposure are separate #1094 workstreams.

Part of #1094.
