### PR TITLE
feat(trust-center): latest-VEX download button on the public release page

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2703,6 +2703,8 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
 
     # Check if release has SBOMs for download capability
     has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
+    # Check if release has a VEX to offer the latest-VEX download (Trust Center).
+    has_vex = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.VEX).exists()
     has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
@@ -2721,6 +2723,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
         "released_at": release.released_at,
         "artifacts_count": artifact_count,
         "has_sboms": has_sboms,
+        "has_vex": has_vex,
         "product": {
             "id": str(release.product.id),
             "name": release.product.name,

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -78,8 +78,7 @@
                         <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                            href="{% url 'api-1:download_release_vex' release.id %}"
                            title="Download latest VEX (CycloneDX)">
-                            <i class="fas fa-shield-halved text-sm" aria-hidden="true"></i>
-                            <span class="text-sm font-medium">VEX</span>
+                            <span class="text-sm font-semibold tracking-wide">VEX</span>
                             <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                     {% endif %}
@@ -147,8 +146,7 @@
                             <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                                href="{% url 'api-1:download_release_vex' release.id %}"
                                title="Download latest VEX (CycloneDX)">
-                                <i class="fas fa-shield-halved text-base" aria-hidden="true"></i>
-                                <span class="text-sm font-medium">VEX</span>
+                                <span class="text-sm font-semibold tracking-wide">VEX</span>
                                 <i class="fas fa-download text-xs" aria-hidden="true"></i>
                             </a>
                         {% endif %}

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -50,28 +50,39 @@
                 </div>
             </div>
             {# Download Buttons - Desktop #}
-            {% if release.has_sboms %}
+            {% if release.has_sboms or release.has_vex %}
                 <div class="hidden lg:flex gap-2 flex-shrink-0">
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}"
-                       title="Download release as CycloneDX">
-                        <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                             alt="CycloneDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                    </a>
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                       title="Download release as SPDX">
-                        <img src="{% static 'img/spdx-logo.svg' %}"
-                             alt="SPDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                    </a>
+                    {% if release.has_sboms %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}"
+                           title="Download release as CycloneDX">
+                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                 alt="CycloneDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                           title="Download release as SPDX">
+                            <img src="{% static 'img/spdx-logo.svg' %}"
+                                 alt="SPDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                    {% if release.has_vex %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release_vex' release.id %}"
+                           title="Download latest VEX (CycloneDX)">
+                            <i class="fas fa-shield-halved text-sm" aria-hidden="true"></i>
+                            <span class="text-sm font-medium">VEX</span>
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>
@@ -97,7 +108,7 @@
             {% endif %}
         </div>
         {# Download Card - Mobile Only #}
-        {% if release.has_sboms %}
+        {% if release.has_sboms or release.has_vex %}
             <div class="tw-card lg:hidden">
                 <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
@@ -106,28 +117,41 @@
                     </h4>
                 </div>
                 <div class="p-6">
-                    <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release.</p>
+                    {% if release.has_sboms %}
+                        <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release.</p>
+                    {% endif %}
                     <div class="flex gap-3 flex-wrap">
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}"
-                           title="Download release as CycloneDX">
-                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt="CycloneDX"
-                                 class="h-5 w-auto dark:brightness-0 dark:invert"
-                                 width="20"
-                                 height="20">
-                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                        </a>
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                           title="Download release as SPDX">
-                            <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt="SPDX"
-                                 class="h-5 w-auto dark:brightness-0 dark:invert"
-                                 width="20"
-                                 height="20">
-                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                        </a>
+                        {% if release.has_sboms %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}"
+                               title="Download release as CycloneDX">
+                                <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                     alt="CycloneDX"
+                                     class="h-5 w-auto dark:brightness-0 dark:invert"
+                                     width="20"
+                                     height="20">
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                               title="Download release as SPDX">
+                                <img src="{% static 'img/spdx-logo.svg' %}"
+                                     alt="SPDX"
+                                     class="h-5 w-auto dark:brightness-0 dark:invert"
+                                     width="20"
+                                     height="20">
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if release.has_vex %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release_vex' release.id %}"
+                               title="Download latest VEX (CycloneDX)">
+                                <i class="fas fa-shield-halved text-base" aria-hidden="true"></i>
+                                <span class="text-sm font-medium">VEX</span>
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -359,6 +359,47 @@ def test_get_release_success(
 
 
 @pytest.mark.django_db
+def test_build_release_response_has_vex_flag(
+    sample_product: Product,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+):
+    """The release response dict (consumed by the public Trust Center page)
+    exposes has_vex so the latest-VEX download button gates independently of the
+    SBOM download."""
+    from django.test import RequestFactory
+
+    from sbomify.apps.core.apis import _build_release_response
+
+    request = RequestFactory().get("/")
+    request.user = sample_product.team.members.first()
+
+    release = Release.objects.create(product=sample_product, name="v1.0.0")
+    sbom = SBOM.objects.create(
+        name="s", format="cyclonedx", format_version="1.6", sbom_filename="s.json", component=sample_component
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=sbom)
+
+    # SBOM only: has_sboms true, has_vex false.
+    before = _build_release_response(request, release)
+    assert before["has_sboms"] is True
+    assert before["has_vex"] is False
+
+    # Add a VEX slot: has_vex flips true, has_sboms unchanged.
+    vex = SBOM.objects.create(
+        name="v",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="v.json",
+        component=sample_component,
+        bom_type=SBOM.BomType.VEX,
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=vex)
+    after = _build_release_response(request, release)
+    assert after["has_sboms"] is True
+    assert after["has_vex"] is True
+
+
+@pytest.mark.django_db
 def test_update_release_success(
     sample_product: Product,  # noqa: F811
     sample_access_token: AccessToken,  # noqa: F811


### PR DESCRIPTION
## What

Adds the latest-VEX download button to the public (Trust Center) release page, completing the frontend half of the release VEX download from #1094.

- `_build_release_response` gains a `has_vex` flag — true when the release holds a `bom_type=vex` artifact slot, mirroring the existing `has_sboms`.
- The public release page (`release_details_public.html.j2`) shows a VEX download button in both the desktop button group and the mobile download card, gated on `has_vex`, pointing at the existing `GET /releases/{id}/vex/download` endpoint (release-slot-scoped and cached, from #1048).
- The button appears whenever the release has a VEX, independently of the SBOM download (a release can offer a VEX without an SBOM slot).

## Backend context

The download endpoint already merges the VEX pinned in the release's artifact slots into one gated CycloneDX document. This PR is purely the pointer/button that surfaces it — validated live on staging this week (200 + correct attachment filename, 404 when no VEX).

## Tests

- `test_build_release_response_has_vex_flag`: the response dict exposes `has_vex`, flips true only when a VEX slot is added, and leaves `has_sboms` unchanged.
- Template render verified: `has_vex=True` emits the button with the resolved download URL; `has_vex=False` emits nothing.

Part of #1094 (Trust Center: latest-VEX download).