### PR TITLE
feat(trust-center): release VEX download, vulnerability posture, and CBOM download

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -2533,11 +2534,11 @@ def download_product_sbom(
 
             # Determine file extension based on format
             extension = ".spdx.json" if format_lower == "spdx" else ".cdx.json"
-            filename = f"{product.name}{extension}"
+            filename = _download_filename(product.name, "", extension)
 
             with open(sbom_path, "rb") as f:
                 response = HttpResponse(f.read(), content_type="application/json")
-            response["Content-Disposition"] = f"attachment; filename={filename}"
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
             return response
     except ValueError as e:
@@ -3112,6 +3113,18 @@ def delete_release(request: HttpRequest, release_id: str) -> Any:
 # =============================================================================
 
 
+def _download_filename(product_name: str, release_name: str, extension: str) -> str:
+    """Build a safe download filename from user-controlled product/release names.
+
+    Product and release names are user-controlled, so they must not reach the
+    ``Content-Disposition`` header raw (header injection / broken headers via
+    newlines, quotes, or non-ASCII). Reduce each to a filesystem-safe slug.
+    """
+    base = f"{product_name}-{release_name}"
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip("-.")
+    return f"{slug or 'release'}{extension}"
+
+
 @router.get(
     "/releases/{release_id}/download",
     response={200: None, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse, 500: ErrorResponse},
@@ -3180,10 +3193,10 @@ def download_release(
 
             # Determine file extension based on format
             extension = ".spdx.json" if format_lower == "spdx" else ".cdx.json"
-            filename = f"{release.product.name}-{release.name}{extension}"
+            filename = _download_filename(release.product.name, release.name, extension)
 
             response = HttpResponse(sbom_content, content_type="application/json")
-            response["Content-Disposition"] = f"attachment; filename={filename}"
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
             return response
 
@@ -3245,9 +3258,9 @@ def download_release_vex(request: HttpRequest, release_id: str) -> Any:
         return 404, {"detail": "No VEX available for this release", "error_code": ErrorCode.NOT_FOUND}
 
     content = json.dumps(document, indent=2)
-    filename = f"{release.product.name}-{release.name}.vex.cdx.json"
+    filename = _download_filename(release.product.name, release.name, ".vex.cdx.json")
     response = HttpResponse(content, content_type="application/json")
-    response["Content-Disposition"] = f"attachment; filename={filename}"
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
     return response
 
 
@@ -3296,9 +3309,9 @@ def download_release_cbom(request: HttpRequest, release_id: str) -> Any:
         return 404, {"detail": "No CBOM available for this release", "error_code": ErrorCode.NOT_FOUND}
 
     content = json.dumps(document, indent=2)
-    filename = f"{release.product.name}-{release.name}.cbom.cdx.json"
+    filename = _download_filename(release.product.name, release.name, ".cbom.cdx.json")
     response = HttpResponse(content, content_type="application/json")
-    response["Content-Disposition"] = f"attachment; filename={filename}"
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
     return response
 
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2705,6 +2705,8 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
     has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
     # Check if release has a VEX to offer the latest-VEX download (Trust Center).
     has_vex = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.VEX).exists()
+    # Check if release has a CBOM to offer the crypto BOM download (Trust Center).
+    has_cbom = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.CBOM).exists()
     has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
@@ -2724,6 +2726,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
         "artifacts_count": artifact_count,
         "has_sboms": has_sboms,
         "has_vex": has_vex,
+        "has_cbom": has_cbom,
         "product": {
             "id": str(release.product.id),
             "name": release.product.name,
@@ -3241,6 +3244,57 @@ def download_release_vex(request: HttpRequest, release_id: str) -> Any:
 
     content = json.dumps(document, indent=2)
     filename = f"{release.product.name}-{release.name}.vex.cdx.json"
+    response = HttpResponse(content, content_type="application/json")
+    response["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
+
+
+@router.get(
+    "/releases/{release_id}/cbom/download",
+    response={200: None, 403: ErrorResponse, 404: ErrorResponse, 500: ErrorResponse},
+    auth=None,
+    tags=["Releases"],
+)
+@decorate_view(optional_token_auth)
+def download_release_cbom(request: HttpRequest, release_id: str) -> Any:
+    """Download the merged CBOM (Cryptography BOM) for a release.
+
+    Combines the newest CBOM of each component in the release into a single CycloneDX document, so a
+    consumer pulls one crypto BOM per release. Gated exactly like the SBOM and VEX downloads: open
+    for a public product, otherwise authenticated with release read access.
+    """
+    try:
+        release = Release.objects.select_related("product").get(pk=release_id)
+    except Release.DoesNotExist:
+        return 404, {"detail": "Release not found", "error_code": ErrorCode.RELEASE_NOT_FOUND}
+
+    if not release.product.is_public:
+        if not request.user or not request.user.is_authenticated:
+            return 403, {"detail": "Authentication required", "error_code": ErrorCode.UNAUTHORIZED}
+        if not can(request, "release:read", release.product):
+            return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
+
+    from django.core.cache import cache
+    from django.db.models import Count, Max
+
+    from sbomify.apps.sboms.cbom import build_release_cbom
+    from sbomify.apps.sboms.models import SBOM
+
+    # Same cache-by-slot-state approach as the VEX download: the merge fans out one
+    # S3 fetch per pinned CBOM and the endpoint is open for public products.
+    slot_state = ReleaseArtifact.objects.filter(release=release, sbom__bom_type=SBOM.BomType.CBOM).aggregate(
+        n=Count("id"), newest=Max("sbom__created_at")
+    )
+    cache_key = f"release-cbom:{release.id}:{slot_state['n']}:{slot_state['newest']}"
+    document = cache.get(cache_key)
+    if document is None:
+        document = build_release_cbom(release) or {"__absent__": True}
+        cache.set(cache_key, document, 900)
+    if document.get("__absent__"):
+        return 404, {"detail": "No CBOM available for this release", "error_code": ErrorCode.NOT_FOUND}
+
+    content = json.dumps(document, indent=2)
+    filename = f"{release.product.name}-{release.name}.cbom.cdx.json"
     response = HttpResponse(content, content_type="application/json")
     response["Content-Disposition"] = f"attachment; filename={filename}"
     return response

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2703,6 +2703,8 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
 
     # Check if release has SBOMs for download capability
     has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
+    # Check if release has a VEX to offer the latest-VEX download (Trust Center).
+    has_vex = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.VEX).exists()
     has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
@@ -2721,6 +2723,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
         "released_at": release.released_at,
         "artifacts_count": artifact_count,
         "has_sboms": has_sboms,
+        "has_vex": has_vex,
         "product": {
             "id": str(release.product.id),
             "name": release.product.name,

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2701,12 +2701,14 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
     # Count artifacts for this release
     artifact_count = release.artifacts.count()
 
-    # Check if release has SBOMs for download capability
-    has_sboms = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).exists()
-    # Check if release has a VEX to offer the latest-VEX download (Trust Center).
-    has_vex = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.VEX).exists()
-    # Check if release has a CBOM to offer the crypto BOM download (Trust Center).
-    has_cbom = release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.CBOM).exists()
+    # Which bom_types the release carries — one query drives all the download
+    # capability flags (SBOM download, and the Trust Center VEX/CBOM downloads).
+    bom_types_present = set(
+        release.artifacts.filter(sbom__isnull=False).values_list("sbom__bom_type", flat=True).distinct()
+    )
+    has_sboms = SBOM.BomType.SBOM.value in bom_types_present
+    has_vex = SBOM.BomType.VEX.value in bom_types_present
+    has_cbom = SBOM.BomType.CBOM.value in bom_types_present
     has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -78,8 +78,7 @@
                         <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                            href="{% url 'api-1:download_release_vex' release.id %}"
                            title="Download latest VEX (CycloneDX)">
-                            <i class="fas fa-shield-halved text-sm" aria-hidden="true"></i>
-                            <span class="text-sm font-medium">VEX</span>
+                            <span class="text-sm font-semibold tracking-wide">VEX</span>
                             <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                     {% endif %}
@@ -147,8 +146,7 @@
                             <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
                                href="{% url 'api-1:download_release_vex' release.id %}"
                                title="Download latest VEX (CycloneDX)">
-                                <i class="fas fa-shield-halved text-base" aria-hidden="true"></i>
-                                <span class="text-sm font-medium">VEX</span>
+                                <span class="text-sm font-semibold tracking-wide">VEX</span>
                                 <i class="fas fa-download text-xs" aria-hidden="true"></i>
                             </a>
                         {% endif %}

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -253,8 +253,7 @@
                     </p>
                     {# Findings list #}
                     <div class="divide-y divide-border" x-show="data.findings.length" x-cloak>
-                        <template x-for="f in data.findings"
-                                  :key="f.id + f.component + f.component_version">
+                        <template x-for="f in data.findings" :key="f.idx">
                             <div class="py-2.5 flex items-start gap-3"
                                  :class="(applied &amp;&amp; f.suppressed) ? 'opacity-50' : ''">
                                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase flex-shrink-0"

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -154,6 +154,108 @@
                 </div>
             </div>
         {% endif %}
+        {# Vulnerability Posture — with and without the release's VEX applied #}
+        {% if vuln_posture.has_data %}
+            {{ vuln_posture|json_script:"vuln-posture-data" }}
+            <div class="tw-card"
+                 x-data="{ data: { raw: {}, applied: {}, findings: [], suppressed_count: 0 }, applied: true, init() { this.data = window.parseJsonScript ? window.parseJsonScript('vuln-posture-data') : JSON.parse(document.getElementById('vuln-posture-data').textContent); }, current() { return this.applied ? this.data.applied : this.data.raw; }, sevPill(sev) { return { critical: 'bg-red-500/10 text-red-600', high: 'bg-orange-500/10 text-orange-600', medium: 'bg-yellow-500/10 text-yellow-700', low: 'bg-cyan-500/10 text-cyan-600' }[sev] || 'bg-border/40 text-text-muted'; } }"
+                 x-init="init()">
+                <div class="px-6 py-4 border-b border-border flex items-center justify-between gap-4 flex-wrap">
+                    <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
+                        <i class="fas fa-shield-halved text-primary" aria-hidden="true"></i>
+                        Vulnerability Posture
+                    </h4>
+                    {# With/Without VEX toggle — only meaningful when the VEX suppresses something #}
+                    <div class="inline-flex rounded-lg border border-border overflow-hidden"
+                         x-show="data.suppressed_count > 0"
+                         x-cloak>
+                        <button type="button"
+                                class="px-3 py-1.5 text-sm font-medium transition-colors"
+                                :class="applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
+                                @click="applied = true">With VEX</button>
+                        <button type="button"
+                                class="px-3 py-1.5 text-sm font-medium border-l border-border transition-colors"
+                                :class="!applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
+                                @click="applied = false">Without VEX</button>
+                    </div>
+                </div>
+                <div class="p-6 space-y-5">
+                    {# Severity breakdown — reflects the active toggle #}
+                    <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-background border border-border">
+                            <div>
+                                <span class="text-xl font-bold text-text" x-text="current().total"></span>
+                                <span class="block text-xs text-text-muted">Total</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-red-500/5 border border-red-500/10">
+                            <div>
+                                <span class="text-xl font-bold text-red-600" x-text="current().critical"></span>
+                                <span class="block text-xs text-text-muted">Critical</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-orange-500/5 border border-orange-500/10">
+                            <div>
+                                <span class="text-xl font-bold text-orange-600" x-text="current().high"></span>
+                                <span class="block text-xs text-text-muted">High</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-yellow-500/5 border border-yellow-500/10">
+                            <div>
+                                <span class="text-xl font-bold text-yellow-700" x-text="current().medium"></span>
+                                <span class="block text-xs text-text-muted">Medium</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-cyan-500/5 border border-cyan-500/10">
+                            <div>
+                                <span class="text-xl font-bold text-cyan-600" x-text="current().low"></span>
+                                <span class="block text-xs text-text-muted">Low</span>
+                            </div>
+                        </div>
+                    </div>
+                    {# Suppression note #}
+                    <p class="text-sm text-text-muted m-0 flex items-center gap-2 flex-wrap"
+                       x-show="data.suppressed_count > 0"
+                       x-cloak>
+                        <i class="fas fa-circle-check text-success" aria-hidden="true"></i>
+                        <span>
+                            <span class="font-semibold text-text" x-text="data.suppressed_count"></span>
+                            finding<span x-show="data.suppressed_count !== 1">s</span>
+                            suppressed by VEX (not affected / false positive).
+                        </span>
+                        <span class="text-warning" x-show="!applied">Showing raw findings without VEX applied.</span>
+                    </p>
+                    {# Findings list #}
+                    <div class="divide-y divide-border" x-show="data.findings.length" x-cloak>
+                        <template x-for="f in data.findings" :key="f.id + f.component">
+                            <div class="py-2.5 flex items-start gap-3"
+                                 :class="(applied &amp;&amp; f.suppressed) ? 'opacity-50' : ''">
+                                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase flex-shrink-0"
+                                      :class="sevPill(f.severity)"
+                                      x-text="f.severity"></span>
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-2 flex-wrap">
+                                        <code class="text-sm text-text" x-text="f.id"></code>
+                                        <span class="text-text-muted text-xs"
+                                              x-show="f.component"
+                                              x-text="f.component + (f.component_version ? ' ' + f.component_version : '')"></span>
+                                        <span class="tw-badge tw-badge-secondary text-xs"
+                                              x-show="f.suppressed"
+                                              x-text="f.state.replace('_', ' ')"></span>
+                                    </div>
+                                    <p class="text-xs text-text-muted m-0 mt-0.5"
+                                       x-show="f.suppressed &amp;&amp; f.justification"
+                                       x-text="'VEX: ' + f.justification.replace(/_/g, ' ')"></p>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                    <p class="text-sm text-text-muted m-0"
+                       x-show="!data.findings.length"
+                       x-cloak>No vulnerabilities found in this release.</p>
+                </div>
+            </div>
+        {% endif %}
         {# Release Artifacts #}
         {% include 'core/components/public_release_artifacts.html.j2' %}
     </div>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -50,28 +50,39 @@
                 </div>
             </div>
             {# Download Buttons - Desktop #}
-            {% if release.has_sboms %}
+            {% if release.has_sboms or release.has_vex %}
                 <div class="hidden lg:flex gap-2 flex-shrink-0">
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}"
-                       title="Download release as CycloneDX">
-                        <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                             alt="CycloneDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                    </a>
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                       title="Download release as SPDX">
-                        <img src="{% static 'img/spdx-logo.svg' %}"
-                             alt="SPDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                    </a>
+                    {% if release.has_sboms %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}"
+                           title="Download release as CycloneDX">
+                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                 alt="CycloneDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                           title="Download release as SPDX">
+                            <img src="{% static 'img/spdx-logo.svg' %}"
+                                 alt="SPDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
+                    {% if release.has_vex %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release_vex' release.id %}"
+                           title="Download latest VEX (CycloneDX)">
+                            <i class="fas fa-shield-halved text-sm" aria-hidden="true"></i>
+                            <span class="text-sm font-medium">VEX</span>
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>
@@ -97,7 +108,7 @@
             {% endif %}
         </div>
         {# Download Card - Mobile Only #}
-        {% if release.has_sboms %}
+        {% if release.has_sboms or release.has_vex %}
             <div class="tw-card lg:hidden">
                 <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
@@ -106,28 +117,41 @@
                     </h4>
                 </div>
                 <div class="p-6">
-                    <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release.</p>
+                    {% if release.has_sboms %}
+                        <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release.</p>
+                    {% endif %}
                     <div class="flex gap-3 flex-wrap">
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}"
-                           title="Download release as CycloneDX">
-                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt="CycloneDX"
-                                 class="h-5 w-auto dark:brightness-0 dark:invert"
-                                 width="20"
-                                 height="20">
-                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                        </a>
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                           title="Download release as SPDX">
-                            <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt="SPDX"
-                                 class="h-5 w-auto dark:brightness-0 dark:invert"
-                                 width="20"
-                                 height="20">
-                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
-                        </a>
+                        {% if release.has_sboms %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}"
+                               title="Download release as CycloneDX">
+                                <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                     alt="CycloneDX"
+                                     class="h-5 w-auto dark:brightness-0 dark:invert"
+                                     width="20"
+                                     height="20">
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                               title="Download release as SPDX">
+                                <img src="{% static 'img/spdx-logo.svg' %}"
+                                     alt="SPDX"
+                                     class="h-5 w-auto dark:brightness-0 dark:invert"
+                                     width="20"
+                                     height="20">
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if release.has_vex %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release_vex' release.id %}"
+                               title="Download latest VEX (CycloneDX)">
+                                <i class="fas fa-shield-halved text-base" aria-hidden="true"></i>
+                                <span class="text-sm font-medium">VEX</span>
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -50,7 +50,7 @@
                 </div>
             </div>
             {# Download Buttons - Desktop #}
-            {% if release.has_sboms or release.has_vex %}
+            {% if release.has_sboms or release.has_vex or release.has_cbom %}
                 <div class="hidden lg:flex gap-2 flex-shrink-0">
                     {% if release.has_sboms %}
                         <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
@@ -82,6 +82,14 @@
                             <i class="fas fa-download text-xs" aria-hidden="true"></i>
                         </a>
                     {% endif %}
+                    {% if release.has_cbom %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                           href="{% url 'api-1:download_release_cbom' release.id %}"
+                           title="Download CBOM (Cryptography BOM, CycloneDX)">
+                            <span class="text-sm font-semibold tracking-wide">CBOM</span>
+                            <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>
@@ -107,7 +115,7 @@
             {% endif %}
         </div>
         {# Download Card - Mobile Only #}
-        {% if release.has_sboms or release.has_vex %}
+        {% if release.has_sboms or release.has_vex or release.has_cbom %}
             <div class="tw-card lg:hidden">
                 <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
@@ -147,6 +155,14 @@
                                href="{% url 'api-1:download_release_vex' release.id %}"
                                title="Download latest VEX (CycloneDX)">
                                 <span class="text-sm font-semibold tracking-wide">VEX</span>
+                                <i class="fas fa-download text-xs" aria-hidden="true"></i>
+                            </a>
+                        {% endif %}
+                        {% if release.has_cbom %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 min-h-10 no-underline"
+                               href="{% url 'api-1:download_release_cbom' release.id %}"
+                               title="Download CBOM (Cryptography BOM, CycloneDX)">
+                                <span class="text-sm font-semibold tracking-wide">CBOM</span>
                                 <i class="fas fa-download text-xs" aria-hidden="true"></i>
                             </a>
                         {% endif %}

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -184,14 +184,18 @@
                     {# With/Without VEX toggle — only meaningful when the VEX suppresses something #}
                     <div class="inline-flex rounded-lg border border-border overflow-hidden"
                          x-show="data.suppressed_count > 0"
-                         x-cloak>
+                         x-cloak
+                         role="group"
+                         aria-label="Apply VEX to the posture">
                         <button type="button"
                                 class="px-3 py-1.5 text-sm font-medium transition-colors"
                                 :class="applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
+                                :aria-pressed="applied"
                                 @click="applied = true">With VEX</button>
                         <button type="button"
                                 class="px-3 py-1.5 text-sm font-medium border-l border-border transition-colors"
                                 :class="!applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
+                                :aria-pressed="!applied"
                                 @click="applied = false">Without VEX</button>
                     </div>
                 </div>
@@ -264,7 +268,7 @@
                                               x-text="f.component + (f.component_version ? ' ' + f.component_version : '')"></span>
                                         <span class="tw-badge tw-badge-secondary text-xs"
                                               x-show="f.suppressed"
-                                              x-text="f.state.replace('_', ' ')"></span>
+                                              x-text="f.state.replace(/_/g, ' ')"></span>
                                     </div>
                                     <p class="text-xs text-text-muted m-0 mt-0.5"
                                        x-show="f.suppressed &amp;&amp; f.justification"

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -249,7 +249,8 @@
                     </p>
                     {# Findings list #}
                     <div class="divide-y divide-border" x-show="data.findings.length" x-cloak>
-                        <template x-for="f in data.findings" :key="f.id + f.component">
+                        <template x-for="f in data.findings"
+                                  :key="f.id + f.component + f.component_version">
                             <div class="py-2.5 flex items-start gap-3"
                                  :class="(applied &amp;&amp; f.suppressed) ? 'opacity-50' : ''">
                                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase flex-shrink-0"

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -197,7 +197,7 @@
                 </div>
                 <div class="p-6 space-y-5">
                     {# Severity breakdown — reflects the active toggle #}
-                    <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+                    <div class="grid grid-cols-2 sm:grid-cols-6 gap-3">
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-background border border-border">
                             <div>
                                 <span class="text-xl font-bold text-text" x-text="current().total"></span>
@@ -226,6 +226,12 @@
                             <div>
                                 <span class="text-xl font-bold text-cyan-600" x-text="current().low"></span>
                                 <span class="block text-xs text-text-muted">Low</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-3 p-3 rounded-lg bg-background border border-border">
+                            <div>
+                                <span class="text-xl font-bold text-text-muted" x-text="current().unknown"></span>
+                                <span class="block text-xs text-text-muted">Unknown</span>
                             </div>
                         </div>
                     </div>

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -262,7 +262,8 @@
                                       x-text="f.severity"></span>
                                 <div class="min-w-0 flex-1">
                                     <div class="flex items-center gap-2 flex-wrap">
-                                        <code class="text-sm text-text" x-text="f.id"></code>
+                                        <span class="font-mono text-sm text-text px-1.5 py-0.5 rounded bg-border/30"
+                                              x-text="f.id"></span>
                                         <span class="text-text-muted text-xs"
                                               x-show="f.component"
                                               x-text="f.component + (f.component_version ? ' ' + f.component_version : '')"></span>

--- a/sbomify/apps/core/tests/test_apis.py
+++ b/sbomify/apps/core/tests/test_apis.py
@@ -385,7 +385,8 @@ def test_download_private_product_sbom_success(
 
     assert response.status_code == 200
     assert response["Content-Type"] == "application/json"
-    assert f"attachment; filename={sample_product.name}.cdx.json" in response["Content-Disposition"]
+    # Name is sanitized (space -> '-') and quoted so it can't break the header.
+    assert response["Content-Disposition"] == 'attachment; filename="test-product.cdx.json"'
 
     # Verify the mock was called with correct parameters
     mock_get_product_sbom_package.assert_called_once()

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -899,7 +899,8 @@ def test_download_release_sbom_success(
 
     assert response.status_code == 200
     assert response["Content-Type"] == "application/json"
-    assert f"attachment; filename={sample_product.name}-v1.0.0.cdx.json" in response["Content-Disposition"]
+    # Name is sanitized (space -> '-') and quoted so it can't break the header.
+    assert response["Content-Disposition"] == 'attachment; filename="test-product-v1.0.0.cdx.json"'
 
     # Verify the mock was called with correct parameters (release and temp_dir)
     mock_get_release_sbom_package.assert_called_once()
@@ -1879,3 +1880,14 @@ def test_delete_release_admin_forbidden(sample_team_with_owner_member: Member): 
 
     assert response.status_code == 403
     assert Release.objects.filter(id=release.id).exists()
+
+
+def test_download_filename_sanitizes_user_names():
+    """Product/release names can't inject the Content-Disposition header."""
+    from sbomify.apps.core.apis import _download_filename
+
+    assert _download_filename("Acme Corp", "v1.0", ".vex.cdx.json") == "Acme-Corp-v1.0.vex.cdx.json"
+    dirty = _download_filename('bad"\r\nX-Evil: 1', "v2", ".cdx.json")
+    assert "\r" not in dirty and "\n" not in dirty and '"' not in dirty
+    assert dirty.endswith(".cdx.json")
+    assert _download_filename("", "", ".cdx.json") == "release.cdx.json"

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -379,10 +379,11 @@ def test_build_release_response_has_vex_flag(
     )
     ReleaseArtifact.objects.create(release=release, sbom=sbom)
 
-    # SBOM only: has_sboms true, has_vex false.
+    # SBOM only: has_sboms true, has_vex/has_cbom false.
     before = _build_release_response(request, release)
     assert before["has_sboms"] is True
     assert before["has_vex"] is False
+    assert before["has_cbom"] is False
 
     # Add a VEX slot: has_vex flips true, has_sboms unchanged.
     vex = SBOM.objects.create(
@@ -397,6 +398,18 @@ def test_build_release_response_has_vex_flag(
     after = _build_release_response(request, release)
     assert after["has_sboms"] is True
     assert after["has_vex"] is True
+
+    # Add a CBOM slot: has_cbom flips true.
+    cbom = SBOM.objects.create(
+        name="cb",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="cb.json",
+        component=sample_component,
+        bom_type=SBOM.BomType.CBOM,
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=cbom)
+    assert _build_release_response(request, release)["has_cbom"] is True
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -359,6 +359,47 @@ def test_get_release_success(
 
 
 @pytest.mark.django_db
+def test_build_release_response_has_vex_flag(
+    sample_product: Product,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+):
+    """The release response dict (consumed by the public Trust Center page)
+    exposes has_vex so the latest-VEX download button gates independently of the
+    SBOM download."""
+    from django.test import RequestFactory
+
+    from sbomify.apps.core.apis import _build_release_response
+
+    request = RequestFactory().get("/")
+    request.user = sample_product.team.members.first()
+
+    release = Release.objects.create(product=sample_product, name="v1.0.0")
+    sbom = SBOM.objects.create(
+        name="s", format="cyclonedx", format_version="1.6", sbom_filename="s.json", component=sample_component
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=sbom)
+
+    # SBOM only: has_sboms true, has_vex false.
+    before = _build_release_response(request, release)
+    assert before["has_sboms"] is True
+    assert before["has_vex"] is False
+
+    # Add a VEX slot: has_vex flips true, has_sboms unchanged.
+    vex = SBOM.objects.create(
+        name="v",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="v.json",
+        component=sample_component,
+        bom_type=SBOM.BomType.VEX,
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=vex)
+    after = _build_release_response(request, release)
+    assert after["has_sboms"] is True
+    assert after["has_vex"] is True
+
+
+@pytest.mark.django_db
 def test_update_release_success(
     sample_product: Product,  # noqa: F811
     sample_access_token: AccessToken,  # noqa: F811

--- a/sbomify/apps/core/tests/test_release_public_posture.py
+++ b/sbomify/apps/core/tests/test_release_public_posture.py
@@ -24,7 +24,9 @@ def _public_release_with_scan(team):
         sbom=sbom,
         plugin_name="osv",
         plugin_version="1.0.0",
+        plugin_config_hash="",
         category="security",
+        run_reason="on_upload",
         status="completed",
         result={
             "findings": [

--- a/sbomify/apps/core/tests/test_release_public_posture.py
+++ b/sbomify/apps/core/tests/test_release_public_posture.py
@@ -1,0 +1,74 @@
+"""The public (Trust Center) release page renders the vulnerability posture card
+when the release has scanned SBOMs."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+
+
+def _public_release_with_scan(team):
+    product = Product.objects.create(name="Public P", team=team, is_public=True)
+    release = Release.objects.create(product=product, name="v1.0.0")
+    component = Component.objects.create(name="c", team=team)
+    sbom = SBOM.objects.create(
+        name="app", format="cyclonedx", format_version="1.6", sbom_filename="app.json", component=component
+    )
+    ReleaseArtifact.objects.create(release=release, sbom=sbom)
+    AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name="osv",
+        plugin_version="1.0.0",
+        category="security",
+        status="completed",
+        result={
+            "findings": [
+                {"id": "CVE-2026-1", "severity": "high", "component": {"name": "foo"}},
+                {
+                    "id": "CVE-2026-2",
+                    "severity": "critical",
+                    "component": {"name": "bar"},
+                    "analysis_state": "not_affected",
+                    "analysis_justification": "code_not_reachable",
+                },
+            ],
+            "summary": {"by_severity": {"high": 1}, "total_findings": 1, "suppressed_count": 1},
+        },
+    )
+    return product, release
+
+
+@pytest.mark.django_db
+def test_public_release_page_shows_vuln_posture(sample_team_with_owner_member):
+    product, release = _public_release_with_scan(sample_team_with_owner_member.team)
+    url = reverse("core:release_details_public", kwargs={"product_id": product.id, "release_id": release.id})
+
+    resp = Client().get(url)
+
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    # The posture card and its embedded data are present.
+    assert "Vulnerability Posture" in html
+    assert 'id="vuln-posture-data"' in html
+    # Data carries both raw and VEX-applied counts plus the suppressed finding.
+    assert "CVE-2026-1" in html
+    assert "not_affected" in html
+    assert '"suppressed_count": 1' in html
+
+
+@pytest.mark.django_db
+def test_public_release_page_no_posture_without_scans(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    product = Product.objects.create(name="Empty P", team=team, is_public=True)
+    release = Release.objects.create(product=product, name="v1.0.0")
+    url = reverse("core:release_details_public", kwargs={"product_id": product.id, "release_id": release.id})
+
+    resp = Client().get(url)
+
+    assert resp.status_code == 200
+    assert "Vulnerability Posture" not in resp.content.decode()

--- a/sbomify/apps/core/views/release_details_public.py
+++ b/sbomify/apps/core/views/release_details_public.py
@@ -63,9 +63,16 @@ class ReleaseDetailsPublicView(View):
         # Get workspace public URL for breadcrumbs
         workspace_public_url = get_workspace_public_url(request, team)
 
+        # Vulnerability posture for the release, with and without its VEX applied,
+        # so the Trust Center can show the effect of the VEX as a toggle.
+        from sbomify.apps.vulnerability_scanning.posture import build_release_vuln_posture
+
+        vuln_posture = build_release_vuln_posture(release_obj)
+
         context = {
             "brand": brand,
             "release": release,
+            "vuln_posture": vuln_posture,
             # `product` is consumed by the breadcrumb tag so the release page
             # gets a `Trust Center > Product` breadcrumb consistent with the
             # releases list and component pages. The current release isn't

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -63,7 +63,9 @@ def build_release_cbom(release: Any) -> dict[str, Any] | None:
             continue
         found = True
         for comp in document.get("components") or []:
-            ref = comp.get("bom-ref") if isinstance(comp, dict) else None
+            if not isinstance(comp, dict):
+                continue
+            ref = comp.get("bom-ref")
             if ref and ref in seen_refs:
                 continue
             if ref:

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -45,7 +45,7 @@ def build_release_cbom(release: Any) -> dict[str, Any] | None:
     components: list[dict[str, Any]] = []
     dependencies: list[dict[str, Any]] = []
     seen_refs: set[str] = set()
-    seen_dep_refs: set[str] = set()
+    dep_by_ref: dict[str, dict[str, Any]] = {}  # merge dependsOn for a shared source ref
     seen_components: set[Any] = set()
     found = False
     artifacts = (
@@ -70,10 +70,25 @@ def build_release_cbom(release: Any) -> dict[str, Any] | None:
                 seen_refs.add(ref)
             components.append(comp)
         for dep in document.get("dependencies") or []:
-            ref = dep.get("ref") if isinstance(dep, dict) else None
-            if ref and ref not in seen_dep_refs:
-                seen_dep_refs.add(ref)
-                dependencies.append(dep)
+            if not isinstance(dep, dict):
+                continue
+            ref = dep.get("ref")
+            if not ref:
+                continue
+            existing = dep_by_ref.get(ref)
+            if existing is None:
+                # Copy so merging into it never mutates the source document.
+                new_dep = {**dep, "dependsOn": list(dep.get("dependsOn") or [])}
+                dep_by_ref[ref] = new_dep
+                dependencies.append(new_dep)
+            else:
+                # Same source node in two CBOMs: union the targets rather than
+                # dropping the second edge (which would hide crypto usage).
+                have = set(existing["dependsOn"])
+                for target in dep.get("dependsOn") or []:
+                    if target not in have:
+                        have.add(target)
+                        existing["dependsOn"].append(target)
 
     if not found:
         return None

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -77,9 +77,11 @@ def build_release_cbom(release: Any) -> dict[str, Any] | None:
             if not isinstance(comp, dict):
                 continue
             ref = comp.get("bom-ref")
-            if ref and ref in seen_refs:
-                continue
-            if ref:
+            # Only dedupe on a real string bom-ref; a malformed non-string ref is
+            # unhashable and can't be a dedup key, so keep the component as-is.
+            if isinstance(ref, str) and ref:
+                if ref in seen_refs:
+                    continue
                 seen_refs.add(ref)
             components.append(comp)
         for dep in document.get("dependencies") or []:

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -16,11 +16,17 @@ from typing import Any
 
 def _document_from_cbom_sbom(cbom: Any) -> dict[str, Any] | None:
     """Load a CBOM SBOM row's document from S3. ``None`` when absent or unreadable."""
+    from botocore.exceptions import BotoCoreError, ClientError
+
     from sbomify.apps.core.object_store import S3Client
 
     if cbom is None or not cbom.sbom_filename:
         return None
-    raw = S3Client("SBOMS").get_sbom_data(cbom.sbom_filename)
+    try:
+        raw = S3Client("SBOMS").get_sbom_data(cbom.sbom_filename)
+    except (ClientError, BotoCoreError):
+        # A missing/unreadable object must not 500 the merge — skip this CBOM.
+        return None
     if not raw:
         return None
     try:

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -81,19 +81,24 @@ def build_release_cbom(release: Any) -> dict[str, Any] | None:
             if not isinstance(dep, dict):
                 continue
             ref = dep.get("ref")
-            if not ref:
+            if not isinstance(ref, str) or not ref:
                 continue
+            # A dependsOn entry is normatively a list of bom-ref strings; tolerate a
+            # malformed CBOM by keeping only the string targets rather than raising
+            # (a non-list dependsOn contributes nothing).
+            raw_targets = dep.get("dependsOn")
+            targets = [t for t in raw_targets if isinstance(t, str)] if isinstance(raw_targets, list) else []
             existing = dep_by_ref.get(ref)
             if existing is None:
                 # Copy so merging into it never mutates the source document.
-                new_dep = {**dep, "dependsOn": list(dep.get("dependsOn") or [])}
+                new_dep = {**dep, "dependsOn": list(targets)}
                 dep_by_ref[ref] = new_dep
                 dependencies.append(new_dep)
             else:
                 # Same source node in two CBOMs: union the targets rather than
                 # dropping the second edge (which would hide crypto usage).
                 have = set(existing["dependsOn"])
-                for target in dep.get("dependsOn") or []:
+                for target in targets:
                     if target not in have:
                         have.add(target)
                         existing["dependsOn"].append(target)

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -10,8 +10,11 @@ download.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _document_from_cbom_sbom(cbom: Any) -> dict[str, Any] | None:
@@ -24,8 +27,10 @@ def _document_from_cbom_sbom(cbom: Any) -> dict[str, Any] | None:
         return None
     try:
         raw = S3Client("SBOMS").get_sbom_data(cbom.sbom_filename)
-    except (ClientError, BotoCoreError):
-        # A missing/unreadable object must not 500 the merge — skip this CBOM.
+    except (ClientError, BotoCoreError) as exc:
+        # A missing/unreadable object must not 500 the merge — skip this CBOM, but
+        # log so a genuinely misconfigured/unreachable bucket stays diagnosable.
+        logger.warning("Could not load CBOM artifact %s from S3: %s", cbom.sbom_filename, exc)
         return None
     if not raw:
         return None

--- a/sbomify/apps/sboms/cbom.py
+++ b/sbomify/apps/sboms/cbom.py
@@ -1,0 +1,96 @@
+"""Merge a release's CBOM (Cryptography BOM) artifacts into one document.
+
+A release can pin a CBOM per component. Consumers of the Trust Center want a
+single crypto BOM for the release, so this unions the cryptographic-asset
+components (and their dependency edges) of the newest CBOM in each component's
+release slot into one CycloneDX 1.6 document — the same shape as the merged VEX
+download.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+
+def _document_from_cbom_sbom(cbom: Any) -> dict[str, Any] | None:
+    """Load a CBOM SBOM row's document from S3. ``None`` when absent or unreadable."""
+    from sbomify.apps.core.object_store import S3Client
+
+    if cbom is None or not cbom.sbom_filename:
+        return None
+    raw = S3Client("SBOMS").get_sbom_data(cbom.sbom_filename)
+    if not raw:
+        return None
+    try:
+        document = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return document if isinstance(document, dict) else None
+
+
+def build_release_cbom(release: Any) -> dict[str, Any] | None:
+    """Merge the CBOM pinned in each component's release slot into one CycloneDX document.
+
+    Only CBOM artifacts actually in the release (newest per component) are merged, so a component
+    added to the product later never bleeds into an old release. Returns ``None`` when the release
+    holds no CBOM.
+    """
+    from django.utils import timezone
+
+    from sbomify.apps.core.models import ReleaseArtifact
+    from sbomify.apps.sboms.models import SBOM
+
+    components: list[dict[str, Any]] = []
+    dependencies: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+    seen_dep_refs: set[str] = set()
+    seen_components: set[Any] = set()
+    found = False
+    artifacts = (
+        ReleaseArtifact.objects.filter(release=release, sbom__bom_type=SBOM.BomType.CBOM)
+        .select_related("sbom")
+        .order_by("sbom__component_id", "-sbom__created_at")
+    )
+    for artifact in artifacts:
+        cbom_sbom = artifact.sbom
+        if cbom_sbom is None or cbom_sbom.component_id in seen_components:
+            continue
+        seen_components.add(cbom_sbom.component_id)
+        document = _document_from_cbom_sbom(cbom_sbom)
+        if document is None:
+            continue
+        found = True
+        for comp in document.get("components") or []:
+            ref = comp.get("bom-ref") if isinstance(comp, dict) else None
+            if ref and ref in seen_refs:
+                continue
+            if ref:
+                seen_refs.add(ref)
+            components.append(comp)
+        for dep in document.get("dependencies") or []:
+            ref = dep.get("ref") if isinstance(dep, dict) else None
+            if ref and ref not in seen_dep_refs:
+                seen_dep_refs.add(ref)
+                dependencies.append(dep)
+
+    if not found:
+        return None
+
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "serialNumber": "urn:uuid:" + str(uuid.uuid4()),
+        "version": 1,
+        "metadata": {
+            "timestamp": timezone.now().isoformat(),
+            "component": {
+                "type": "application",
+                "name": f"{release.product.name} {release.name}",
+                "bom-ref": f"release-{release.id}",
+            },
+        },
+        "components": components,
+        "dependencies": dependencies,
+    }

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -100,6 +100,29 @@ def test_build_release_cbom_unions_shared_dependency_edges(sample_team_with_owne
 
 
 @pytest.mark.django_db
+def test_build_release_cbom_skips_non_dict_components(sample_team_with_owner_member, mocker):
+    """A malformed CBOM with a non-dict component entry is skipped, not appended
+    (which would produce an invalid merged CycloneDX document)."""
+    import json as _json
+
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "a.cbom.json"))
+    doc = _json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"bom-ref": "good"}, "junk", None, 42],
+        }
+    ).encode()
+    _mock_s3(mocker, {"a.cbom.json": doc})
+
+    merged = build_release_cbom(release)
+    assert all(isinstance(c, dict) for c in merged["components"])
+    assert {c["bom-ref"] for c in merged["components"]} == {"good"}
+
+
+@pytest.mark.django_db
 def test_build_release_cbom_none_without_slot(sample_team_with_owner_member):
     team = sample_team_with_owner_member.team
     _product, release, _c1, _c2 = _release_with_components(team, is_public=True)

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -138,6 +138,34 @@ def test_build_release_cbom_skips_missing_s3_object(sample_team_with_owner_membe
 
 
 @pytest.mark.django_db
+def test_build_release_cbom_tolerates_malformed_dependsOn(sample_team_with_owner_member, mocker):
+    """A malformed dependsOn (non-list, or containing non-string entries) is
+    coerced to its string targets instead of raising."""
+    import json as _json
+
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "a.cbom.json"))
+    doc = _json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"bom-ref": "x"}],
+            "dependencies": [
+                {"ref": "x", "dependsOn": ["ok", {"nested": 1}, 42, None]},
+                {"ref": "y", "dependsOn": "not-a-list"},
+                {"ref": 99, "dependsOn": ["ignored"]},
+            ],
+        }
+    ).encode()
+    _mock_s3(mocker, {"a.cbom.json": doc})
+
+    merged = build_release_cbom(release)
+    edges = {d["ref"]: d["dependsOn"] for d in merged["dependencies"]}
+    assert edges == {"x": ["ok"], "y": []}
+
+
+@pytest.mark.django_db
 def test_build_release_cbom_none_without_slot(sample_team_with_owner_member):
     team = sample_team_with_owner_member.team
     _product, release, _c1, _c2 = _release_with_components(team, is_public=True)

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -1,0 +1,103 @@
+"""Merged release-level CBOM: one crypto BOM per release, built from the CBOM
+artifacts pinned in the release's slots, gated like the SBOM/VEX downloads."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.core.cache import cache
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+from sbomify.apps.sboms.cbom import build_release_cbom
+from sbomify.apps.sboms.models import SBOM
+
+
+def _release_with_components(team, *, is_public: bool):
+    product = Product.objects.create(name="P", team=team, is_public=is_public)
+    release = Release.objects.create(product=product, name="v1")
+    c1 = Component.objects.create(name="c1", team=team)
+    c2 = Component.objects.create(name="c2", team=team)
+    return product, release, c1, c2
+
+
+def _cbom_sbom(component, filename: str) -> SBOM:
+    return SBOM.objects.create(
+        name=f"cbom-{filename}",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename=filename,
+        component=component,
+        bom_type=SBOM.BomType.CBOM,
+    )
+
+
+def _doc(ref: str) -> bytes:
+    return json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"type": "cryptographic-asset", "bom-ref": ref, "name": ref.split("/")[-1]}],
+        }
+    ).encode()
+
+
+def _mock_s3(mocker, docs_by_filename: dict[str, bytes]):
+    s3 = mocker.patch("sbomify.apps.core.object_store.S3Client")
+    s3.return_value.get_sbom_data.side_effect = lambda filename: docs_by_filename[filename]
+    return s3
+
+
+@pytest.mark.django_db
+def test_build_release_cbom_merges_slot_documents(sample_team_with_owner_member, mocker):
+    team = sample_team_with_owner_member.team
+    _product, release, c1, c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "c1.cbom.json"))
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c2, "c2.cbom.json"))
+    _mock_s3(mocker, {"c1.cbom.json": _doc("crypto/a"), "c2.cbom.json": _doc("crypto/b")})
+
+    merged = build_release_cbom(release)
+
+    assert merged is not None
+    assert {c["bom-ref"] for c in merged["components"]} == {"crypto/a", "crypto/b"}
+
+
+@pytest.mark.django_db
+def test_build_release_cbom_none_without_slot(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    _product, release, _c1, _c2 = _release_with_components(team, is_public=True)
+    assert build_release_cbom(release) is None
+
+
+@pytest.mark.django_db
+def test_download_release_cbom_public_returns_attachment(sample_team_with_owner_member, mocker):
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "c1.cbom.json"))
+    _mock_s3(mocker, {"c1.cbom.json": _doc("crypto/a")})
+    cache.clear()
+
+    resp = Client().get(reverse("api-1:download_release_cbom", kwargs={"release_id": release.id}))
+
+    assert resp.status_code == 200
+    assert "attachment" in resp["Content-Disposition"]
+    assert resp["Content-Disposition"].endswith(".cbom.cdx.json")
+
+
+@pytest.mark.django_db
+def test_download_release_cbom_404_when_absent(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    _product, release, _c1, _c2 = _release_with_components(team, is_public=True)
+    cache.clear()
+    resp = Client().get(reverse("api-1:download_release_cbom", kwargs={"release_id": release.id}))
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_download_release_cbom_private_requires_auth(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    _product, release, _c1, _c2 = _release_with_components(team, is_public=False)
+    resp = Client().get(reverse("api-1:download_release_cbom", kwargs={"release_id": release.id}))
+    assert resp.status_code == 403

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -123,6 +123,21 @@ def test_build_release_cbom_skips_non_dict_components(sample_team_with_owner_mem
 
 
 @pytest.mark.django_db
+def test_build_release_cbom_skips_missing_s3_object(sample_team_with_owner_member, mocker):
+    """A missing/unreadable CBOM object is skipped, not 500 — the S3 ClientError
+    must be swallowed by the loader."""
+    from botocore.exceptions import ClientError
+
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "gone.cbom.json"))
+    s3 = mocker.patch("sbomify.apps.core.object_store.S3Client")
+    s3.return_value.get_sbom_data.side_effect = ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+
+    assert build_release_cbom(release) is None
+
+
+@pytest.mark.django_db
 def test_build_release_cbom_none_without_slot(sample_team_with_owner_member):
     team = sample_team_with_owner_member.team
     _product, release, _c1, _c2 = _release_with_components(team, is_public=True)
@@ -141,7 +156,7 @@ def test_download_release_cbom_public_returns_attachment(sample_team_with_owner_
 
     assert resp.status_code == 200
     assert "attachment" in resp["Content-Disposition"]
-    assert resp["Content-Disposition"].endswith(".cbom.cdx.json")
+    assert resp["Content-Disposition"].rstrip('"').endswith(".cbom.cdx.json")
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -65,6 +65,41 @@ def test_build_release_cbom_merges_slot_documents(sample_team_with_owner_member,
 
 
 @pytest.mark.django_db
+def test_build_release_cbom_unions_shared_dependency_edges(sample_team_with_owner_member, mocker):
+    """Two components' CBOMs sharing a source node union their dependsOn targets
+    rather than dropping the second edge (which would hide crypto usage)."""
+    team = sample_team_with_owner_member.team
+    _product, release, c1, c2 = _release_with_components(team, is_public=True)
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c1, "a.cbom.json"))
+    ReleaseArtifact.objects.create(release=release, sbom=_cbom_sbom(c2, "b.cbom.json"))
+    import json as _json
+
+    doc_a = _json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"bom-ref": "tls-ctx"}, {"bom-ref": "rsa2048"}],
+            "dependencies": [{"ref": "tls-ctx", "dependsOn": ["rsa2048"]}],
+        }
+    ).encode()
+    doc_b = _json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"bom-ref": "tls-ctx"}, {"bom-ref": "ecdsaP256"}],
+            "dependencies": [{"ref": "tls-ctx", "dependsOn": ["ecdsaP256"]}],
+        }
+    ).encode()
+    _mock_s3(mocker, {"a.cbom.json": doc_a, "b.cbom.json": doc_b})
+
+    merged = build_release_cbom(release)
+
+    edges = {d["ref"]: sorted(d["dependsOn"]) for d in merged["dependencies"]}
+    assert edges == {"tls-ctx": ["ecdsaP256", "rsa2048"]}
+    assert {c["bom-ref"] for c in merged["components"]} == {"tls-ctx", "rsa2048", "ecdsaP256"}
+
+
+@pytest.mark.django_db
 def test_build_release_cbom_none_without_slot(sample_team_with_owner_member):
     team = sample_team_with_owner_member.team
     _product, release, _c1, _c2 = _release_with_components(team, is_public=True)

--- a/sbomify/apps/sboms/tests/test_release_cbom.py
+++ b/sbomify/apps/sboms/tests/test_release_cbom.py
@@ -150,7 +150,7 @@ def test_build_release_cbom_tolerates_malformed_dependsOn(sample_team_with_owner
         {
             "bomFormat": "CycloneDX",
             "specVersion": "1.6",
-            "components": [{"bom-ref": "x"}],
+            "components": [{"bom-ref": "x"}, {"bom-ref": {"weird": 1}}, {"name": "no-ref"}],
             "dependencies": [
                 {"ref": "x", "dependsOn": ["ok", {"nested": 1}, 42, None]},
                 {"ref": "y", "dependsOn": "not-a-list"},
@@ -163,6 +163,9 @@ def test_build_release_cbom_tolerates_malformed_dependsOn(sample_team_with_owner
     merged = build_release_cbom(release)
     edges = {d["ref"]: d["dependsOn"] for d in merged["dependencies"]}
     assert edges == {"x": ["ok"], "y": []}
+    # Non-string / missing bom-ref components are kept without raising on the set key.
+    assert len(merged["components"]) == 3
+    assert all(isinstance(c, dict) for c in merged["components"])
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -106,10 +106,21 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             purl = (component.get("purl") or "").lower()
             name = (component.get("name") or "").lower()
             version = (component.get("version") or "").lower()
-            # Dedupe only when a package identity is actually known. Without one we
-            # cannot confirm two same-id findings are the same package, so keep them
-            # distinct (fail open) rather than collapse possibly-unrelated findings.
-            identity = purl or (f"{name}@{version}" if name else None)
+            # Dedupe only when a package identity is actually known, and fail open
+            # otherwise so instances aren't wrongly collapsed:
+            #  - purl, or name+version -> a stable identity, deduped release-wide;
+            #  - name only -> scoped to this SBOM, so two providers of one SBOM
+            #    collapse but the same name in another component (maybe a different
+            #    version) stays distinct;
+            #  - no name -> never deduped.
+            if purl:
+                identity: str | None = purl
+            elif name and version:
+                identity = f"{name}@{version}"
+            elif name:
+                identity = f"sbom:{run.sbom_id}:{name}"
+            else:
+                identity = None
             if identity is not None:
                 dedupe_key = ((finding.get("id") or "").lower(), identity)
                 if dedupe_key in seen:

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -1,0 +1,131 @@
+"""Aggregate a release's vulnerability posture for the public Trust Center page.
+
+A release ships specific SBOM versions (pinned in its artifact slots). This walks
+those SBOMs' latest completed security scans and rolls their findings up into two
+severity breakdowns — with the release's VEX applied (suppressed findings dropped)
+and without it (every finding active) — so the Trust Center can show the effect of
+the VEX as a toggle. The stored scan results already carry the VEX overlay
+(``analysis_state`` on suppressed findings), so the two views derive from one read.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# CycloneDX analysis states that suppress a finding (mirrors vex._SUPPRESSING_STATES).
+_SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
+_SEVERITIES = ("critical", "high", "medium", "low", "unknown")
+
+# Provider bookkeeping findings (scan errors, "no product") are not vulnerabilities
+# and must not inflate a customer-facing posture.
+_OPERATIONAL_ID_PREFIXES = ("dependency-track:", "osv:error")
+
+
+def _is_vulnerability(finding: dict[str, Any]) -> bool:
+    fid = (finding.get("id") or "").lower()
+    if any(fid.startswith(p) for p in _OPERATIONAL_ID_PREFIXES):
+        return False
+    return (finding.get("status") or "").lower() not in ("error", "pass", "info") or bool(fid)
+
+
+def _severity_bucket(finding: dict[str, Any]) -> str:
+    sev = (finding.get("severity") or "unknown").lower()
+    return sev if sev in _SEVERITIES else "unknown"
+
+
+def _is_suppressed(finding: dict[str, Any]) -> bool:
+    return (finding.get("analysis_state") or "") in _SUPPRESSING_STATES
+
+
+def _empty_counts() -> dict[str, int]:
+    return {sev: 0 for sev in _SEVERITIES} | {"total": 0}
+
+
+def build_release_vuln_posture(release: Any) -> dict[str, Any]:
+    """Return the release's vulnerability posture, or ``{"has_data": False}`` when
+    the release has no scanned SBOMs.
+
+    Shape::
+
+        {
+          "has_data": True,
+          "raw": {critical, high, medium, low, unknown, total},      # without VEX
+          "applied": {critical, high, medium, low, unknown, total},  # with VEX
+          "suppressed_count": int,
+          "findings": [ {id, severity, component, suppressed, state, justification, title}, ... ],
+        }
+    """
+    from sbomify.apps.plugins.models import AssessmentRun
+    from sbomify.apps.plugins.sdk.enums import AssessmentCategory, RunStatus
+    from sbomify.apps.sboms.models import SBOM
+
+    sbom_ids = list(
+        release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).values_list("sbom_id", flat=True)
+    )
+    if not sbom_ids:
+        return {"has_data": False}
+
+    # Latest completed security run per (sbom, provider), so a workspace running more
+    # than one scanner keeps both providers' findings for the shipped SBOMs.
+    runs = AssessmentRun.objects.filter(
+        sbom_id__in=sbom_ids,
+        category=AssessmentCategory.SECURITY.value,
+        status=RunStatus.COMPLETED.value,
+    ).order_by("sbom_id", "plugin_name", "-created_at")
+    latest_per_provider: dict[tuple[Any, str], AssessmentRun] = {}
+    for run in runs:
+        key = (run.sbom_id, run.plugin_name)
+        if key not in latest_per_provider:
+            latest_per_provider[key] = run
+    if not latest_per_provider:
+        return {"has_data": False}
+
+    raw = _empty_counts()
+    applied = _empty_counts()
+    findings: list[dict[str, Any]] = []
+    suppressed_count = 0
+    seen: set[tuple[str, str]] = set()  # dedupe the same vuln id+package across providers
+
+    for run in latest_per_provider.values():
+        for finding in (run.result or {}).get("findings", []) or []:
+            if not isinstance(finding, dict) or not _is_vulnerability(finding):
+                continue
+            component = finding.get("component") or {}
+            dedupe_key = ((finding.get("id") or "").lower(), (component.get("name") or "").lower())
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+
+            sev = _severity_bucket(finding)
+            suppressed = _is_suppressed(finding)
+            raw[sev] += 1
+            raw["total"] += 1
+            if suppressed:
+                suppressed_count += 1
+            else:
+                applied[sev] += 1
+                applied["total"] += 1
+            findings.append(
+                {
+                    "id": finding.get("id"),
+                    "severity": sev,
+                    "component": component.get("name") or "",
+                    "component_version": component.get("version") or "",
+                    "suppressed": suppressed,
+                    "state": finding.get("analysis_state") or "",
+                    "justification": finding.get("analysis_justification") or "",
+                    "title": finding.get("title") or finding.get("description") or "",
+                }
+            )
+
+    # Most severe first, suppressed sink to the bottom within each severity.
+    order = {sev: i for i, sev in enumerate(_SEVERITIES)}
+    findings.sort(key=lambda f: (order.get(f["severity"], 99), f["suppressed"], f["id"] or ""))
+
+    return {
+        "has_data": True,
+        "raw": raw,
+        "applied": applied,
+        "suppressed_count": suppressed_count,
+        "findings": findings,
+    }

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -103,13 +103,18 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             meaningful_runs += 1
         for finding in real_findings:
             component = finding.get("component") or {}
-            identity = (component.get("purl") or "").lower() or (
-                f"{(component.get('name') or '').lower()}@{(component.get('version') or '').lower()}"
-            )
-            dedupe_key = ((finding.get("id") or "").lower(), identity)
-            if dedupe_key in seen:
-                continue
-            seen.add(dedupe_key)
+            purl = (component.get("purl") or "").lower()
+            name = (component.get("name") or "").lower()
+            version = (component.get("version") or "").lower()
+            # Dedupe only when a package identity is actually known. Without one we
+            # cannot confirm two same-id findings are the same package, so keep them
+            # distinct (fail open) rather than collapse possibly-unrelated findings.
+            identity = purl or (f"{name}@{version}" if name else None)
+            if identity is not None:
+                dedupe_key = ((finding.get("id") or "").lower(), identity)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
 
             sev = _severity_bucket(finding)
             suppressed = _is_suppressed(finding)

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -102,7 +102,10 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
         if not run_findings or real_findings:
             meaningful_runs += 1
         for finding in real_findings:
-            component = finding.get("component") or {}
+            raw_component = finding.get("component")
+            # Stored scan results are provider-controlled JSON; a non-dict component
+            # must not raise (and 500 the Trust Center) when we read its fields.
+            component = raw_component if isinstance(raw_component, dict) else {}
             purl = (component.get("purl") or "").lower()
             name = (component.get("name") or "").lower()
             version = (component.get("version") or "").lower()

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -160,6 +160,11 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     # Most severe first, suppressed sink to the bottom within each severity.
     order = {sev: i for i, sev in enumerate(_SEVERITIES)}
     findings.sort(key=lambda f: (order.get(f["severity"], 99), f["suppressed"], f["id"] or ""))
+    # Stable unique key for the client list: distinct findings can share
+    # id+package (same id with no package, or a name-only package across SBOMs),
+    # so id+component is not unique — index the sorted list instead.
+    for i, f in enumerate(findings):
+        f["idx"] = i
 
     return {
         "has_data": True,

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -23,9 +23,11 @@ _OPERATIONAL_ID_PREFIXES = ("dependency-track:", "osv:error")
 
 def _is_vulnerability(finding: dict[str, Any]) -> bool:
     fid = (finding.get("id") or "").lower()
-    if any(fid.startswith(p) for p in _OPERATIONAL_ID_PREFIXES):
+    if not fid or any(fid.startswith(p) for p in _OPERATIONAL_ID_PREFIXES):
         return False
-    return (finding.get("status") or "").lower() not in ("error", "pass", "info") or bool(fid)
+    # Security findings carry no status; a compliance/operational status (pass,
+    # info, warning, error) marks a non-vulnerability, so it must not count.
+    return (finding.get("status") or "").lower() not in ("error", "pass", "info", "warning")
 
 
 def _severity_bucket(finding: dict[str, Any]) -> str:
@@ -65,32 +67,32 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     if not sbom_ids:
         return {"has_data": False}
 
-    # Latest completed security run per (sbom, provider), so a workspace running more
-    # than one scanner keeps both providers' findings for the shipped SBOMs.
-    runs = AssessmentRun.objects.filter(
-        sbom_id__in=sbom_ids,
-        category=AssessmentCategory.SECURITY.value,
-        status=RunStatus.COMPLETED.value,
-    ).order_by("sbom_id", "plugin_name", "-created_at")
-    latest_per_provider: dict[tuple[Any, str], AssessmentRun] = {}
-    for run in runs:
-        key = (run.sbom_id, run.plugin_name)
-        if key not in latest_per_provider:
-            latest_per_provider[key] = run
-    if not latest_per_provider:
+    # Latest completed security run per (sbom, provider), resolved in the database
+    # (DISTINCT ON) rather than materializing every historical run — a workspace
+    # running more than one scanner keeps both providers' findings.
+    runs = list(
+        AssessmentRun.objects.filter(
+            sbom_id__in=sbom_ids,
+            category=AssessmentCategory.SECURITY.value,
+            status=RunStatus.COMPLETED.value,
+        )
+        .order_by("sbom_id", "plugin_name", "-created_at")
+        .distinct("sbom_id", "plugin_name")
+    )
+    if not runs:
         return {"has_data": False}
 
     raw = _empty_counts()
     applied = _empty_counts()
     findings: list[dict[str, Any]] = []
     suppressed_count = 0
-    # Dedupe the same vuln on the same package VERSION across providers; a shared
-    # package name at different versions stays distinct so a release shipping two
-    # versions of a vulnerable dep isn't undercounted.
-    seen: set[tuple[str, str, str]] = set()
+    # Dedupe the same vuln on the same package identity (purl, or name+version) across
+    # providers; a shared package name at different versions stays distinct so a release
+    # shipping two versions of a vulnerable dep isn't undercounted.
+    seen: set[tuple[str, str]] = set()
     meaningful_runs = 0
 
-    for run in latest_per_provider.values():
+    for run in runs:
         run_findings = (run.result or {}).get("findings", []) or []
         real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
         # A run that produced findings but none are real vulnerabilities (only
@@ -101,11 +103,10 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             meaningful_runs += 1
         for finding in real_findings:
             component = finding.get("component") or {}
-            dedupe_key = (
-                (finding.get("id") or "").lower(),
-                (component.get("name") or "").lower(),
-                (component.get("version") or "").lower(),
+            identity = (component.get("purl") or "").lower() or (
+                f"{(component.get('name') or '').lower()}@{(component.get('version') or '').lower()}"
             )
+            dedupe_key = ((finding.get("id") or "").lower(), identity)
             if dedupe_key in seen:
                 continue
             seen.add(dedupe_key)

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -84,14 +84,28 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     applied = _empty_counts()
     findings: list[dict[str, Any]] = []
     suppressed_count = 0
-    seen: set[tuple[str, str]] = set()  # dedupe the same vuln id+package across providers
+    # Dedupe the same vuln on the same package VERSION across providers; a shared
+    # package name at different versions stays distinct so a release shipping two
+    # versions of a vulnerable dep isn't undercounted.
+    seen: set[tuple[str, str, str]] = set()
+    meaningful_runs = 0
 
     for run in latest_per_provider.values():
-        for finding in (run.result or {}).get("findings", []) or []:
-            if not isinstance(finding, dict) or not _is_vulnerability(finding):
-                continue
+        run_findings = (run.result or {}).get("findings", []) or []
+        real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
+        # A run that produced findings but none are real vulnerabilities (only
+        # operational error / no-product markers) did not actually analyze the SBOM,
+        # so it must not let the release advertise a clean posture. A run with no
+        # findings at all is a genuine clean scan and does count.
+        if not run_findings or real_findings:
+            meaningful_runs += 1
+        for finding in real_findings:
             component = finding.get("component") or {}
-            dedupe_key = ((finding.get("id") or "").lower(), (component.get("name") or "").lower())
+            dedupe_key = (
+                (finding.get("id") or "").lower(),
+                (component.get("name") or "").lower(),
+                (component.get("version") or "").lower(),
+            )
             if dedupe_key in seen:
                 continue
             seen.add(dedupe_key)
@@ -117,6 +131,11 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
                     "title": finding.get("title") or finding.get("description") or "",
                 }
             )
+
+    # Every run that ran only produced operational error markers — the release was
+    # not actually analyzed, so don't let the Trust Center claim it is clean.
+    if meaningful_runs == 0:
+        return {"has_data": False}
 
     # Most severe first, suppressed sink to the bottom within each severity.
     order = {sev: i for i, sev in enumerate(_SEVERITIES)}

--- a/sbomify/apps/vulnerability_scanning/tests/test_apis.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_apis.py
@@ -116,7 +116,9 @@ def test_drill_down_excludes_vex_suppressed_findings(
         sbom=sbom,
         plugin_name="osv",
         plugin_version="1.0.0",
+        plugin_config_hash="",
         category="security",
+        run_reason="on_upload",
         status="completed",
         result={
             "findings": [

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -215,3 +215,21 @@ def test_posture_no_package_identity_findings_not_collapsed(release):
     )
     p = build_release_vuln_posture(rel)
     assert p["raw"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_name_only_dedup_scoped_to_sbom(release):
+    """A name-only finding (no version) dedupes across providers within one SBOM,
+    but the same name in a different component stays distinct (could be a diff version)."""
+    rel, component = release
+    a = _sbom(component, "compA")
+    b = _sbom(Component.objects.create(name="c2", team=component.team), "compB")
+    ReleaseArtifact.objects.create(release=rel, sbom=a)
+    ReleaseArtifact.objects.create(release=rel, sbom=b)
+    # Same SBOM, two providers, name-only -> collapses to 1.
+    _run(a, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="osv")
+    _run(a, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="dependency-track")
+    # Different SBOM, same name-only -> stays distinct.
+    _run(b, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="osv")
+
+    assert build_release_vuln_posture(rel)["raw"]["total"] == 2

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -153,3 +153,47 @@ def test_posture_genuinely_clean_scan_has_data(release):
     p = build_release_vuln_posture(rel)
     assert p["has_data"] is True
     assert p["raw"]["total"] == 0
+
+
+@pytest.mark.django_db
+def test_posture_excludes_findings_with_compliance_status(release):
+    """A finding carrying a compliance/operational status (pass/info/warning) is not
+    a vulnerability even with a real-looking id."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [
+            {"id": "CVE-REAL", "severity": "high", "component": {"name": "foo"}},
+            {"id": "SOME-CHECK", "severity": "high", "status": "pass", "component": {"name": "foo"}},
+        ],
+    )
+    p = build_release_vuln_posture(rel)
+    assert [f["id"] for f in p["findings"]] == ["CVE-REAL"]
+    assert p["raw"]["total"] == 1
+
+
+@pytest.mark.django_db
+def test_posture_same_name_version_different_ecosystem_kept(release):
+    """Same CVE id and name+version but different purl (ecosystem) stays distinct."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [
+            {
+                "id": "CVE-X",
+                "severity": "high",
+                "component": {"name": "foo", "version": "1.0", "purl": "pkg:npm/foo@1.0"},
+            },
+            {
+                "id": "CVE-X",
+                "severity": "high",
+                "component": {"name": "foo", "version": "1.0", "purl": "pkg:pypi/foo@1.0"},
+            },
+        ],
+    )
+    p = build_release_vuln_posture(rel)
+    assert p["raw"]["total"] == 2

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -253,3 +253,27 @@ def test_posture_tolerates_non_dict_component(release):
     p = build_release_vuln_posture(rel)
     assert p["raw"]["total"] == 2
     assert {f["id"] for f in p["findings"]} == {"CVE-1", "CVE-2"}
+
+
+@pytest.mark.django_db
+def test_posture_findings_have_unique_idx_keys(release):
+    """Distinct findings that share id+package (no package, or name-only across
+    SBOMs) still get a unique idx so the client list key can't collide."""
+    rel, component = release
+    a = _sbom(component, "compA")
+    b = _sbom(Component.objects.create(name="c2", team=component.team), "compB")
+    ReleaseArtifact.objects.create(release=rel, sbom=a)
+    ReleaseArtifact.objects.create(release=rel, sbom=b)
+    # One run per SBOM (DISTINCT ON keeps the latest per sbom+plugin), each with a
+    # no-package finding and a name-only finding that share ids across the two SBOMs.
+    findings_data = [
+        {"id": "CVE-1", "severity": "high", "component": {}},  # no package identity
+        {"id": "CVE-2", "severity": "low", "component": {"name": "foo"}},  # name only
+    ]
+    _run(a, findings_data)
+    _run(b, findings_data)
+
+    findings = build_release_vuln_posture(rel)["findings"]
+    idxs = [f["idx"] for f in findings]
+    # CVE-1 kept for both SBOMs (no identity), CVE-2 kept for both (name scoped per SBOM).
+    assert len(idxs) == len(set(idxs)) == 4

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -1,0 +1,112 @@
+"""Release vulnerability posture aggregation for the Trust Center."""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.core.models import Component, Product, Release, ReleaseArtifact
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.vulnerability_scanning.posture import build_release_vuln_posture
+
+
+def _sbom(component: Component, name: str, bom_type=SBOM.BomType.SBOM) -> SBOM:
+    return SBOM.objects.create(
+        name=name,
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename=f"{name}.json",
+        component=component,
+        bom_type=bom_type,
+    )
+
+
+def _run(sbom: SBOM, findings: list[dict], plugin="osv") -> AssessmentRun:
+    return AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name=plugin,
+        plugin_version="1.0.0",
+        category="security",
+        status="completed",
+        result={"findings": findings, "summary": {}},
+    )
+
+
+@pytest.fixture
+def release(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    product = Product.objects.create(name="P", team=team)
+    return Release.objects.create(product=product, name="v1"), Component.objects.create(name="c", team=team)
+
+
+@pytest.mark.django_db
+def test_posture_no_scanned_sboms(release):
+    rel, _component = release
+    assert build_release_vuln_posture(rel) == {"has_data": False}
+
+
+@pytest.mark.django_db
+def test_posture_splits_raw_vs_vex_applied(release):
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [
+            {"id": "CVE-1", "severity": "critical", "component": {"name": "foo"}},
+            {
+                "id": "CVE-2",
+                "severity": "high",
+                "component": {"name": "bar"},
+                "analysis_state": "not_affected",
+                "analysis_justification": "code_not_reachable",
+            },
+            {
+                "id": "CVE-3",
+                "severity": "medium",
+                "component": {"name": "baz"},
+                "analysis_state": "false_positive",
+            },
+            # operational finding must be ignored entirely
+            {"id": "dependency-track:error", "severity": "high", "status": "error", "component": {}},
+        ],
+    )
+
+    p = build_release_vuln_posture(rel)
+    assert p["has_data"] is True
+    # Without VEX: CVE-1/2/3 count (operational excluded).
+    assert p["raw"] == {"critical": 1, "high": 1, "medium": 1, "low": 0, "unknown": 0, "total": 3}
+    # With VEX: only CVE-1 survives (CVE-2 not_affected, CVE-3 false_positive dropped).
+    assert p["applied"] == {"critical": 1, "high": 0, "medium": 0, "low": 0, "unknown": 0, "total": 1}
+    assert p["suppressed_count"] == 2
+    supp = {f["id"]: f for f in p["findings"]}
+    assert supp["CVE-2"]["suppressed"] is True
+    assert supp["CVE-2"]["justification"] == "code_not_reachable"
+    assert supp["CVE-1"]["suppressed"] is False
+    assert "dependency-track:error" not in supp
+
+
+@pytest.mark.django_db
+def test_posture_uses_latest_run_per_sbom(release):
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [{"id": "CVE-OLD", "severity": "high", "component": {"name": "foo"}}])
+    _run(sbom, [{"id": "CVE-NEW", "severity": "critical", "component": {"name": "foo"}}])
+
+    p = build_release_vuln_posture(rel)
+    ids = {f["id"] for f in p["findings"]}
+    assert ids == {"CVE-NEW"}
+    assert p["raw"]["total"] == 1
+
+
+@pytest.mark.django_db
+def test_posture_dedupes_same_vuln_across_providers(release):
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="osv")
+    _run(sbom, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="dependency-track")
+
+    p = build_release_vuln_posture(rel)
+    assert p["raw"]["total"] == 1

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -110,3 +110,46 @@ def test_posture_dedupes_same_vuln_across_providers(release):
 
     p = build_release_vuln_posture(rel)
     assert p["raw"]["total"] == 1
+
+
+@pytest.mark.django_db
+def test_posture_keeps_same_cve_different_versions(release):
+    """Two components shipping the same package at different versions, both hit by
+    one CVE, are counted separately — not collapsed by the cross-provider dedup."""
+    rel, component = release
+    a = _sbom(component, "compA")
+    b = _sbom(Component.objects.create(name="c2", team=component.team), "compB")
+    ReleaseArtifact.objects.create(release=rel, sbom=a)
+    ReleaseArtifact.objects.create(release=rel, sbom=b)
+    _run(a, [{"id": "CVE-9", "severity": "high", "component": {"name": "openssl", "version": "1.1.1w"}}])
+    _run(b, [{"id": "CVE-9", "severity": "high", "component": {"name": "openssl", "version": "3.0.0"}}])
+
+    p = build_release_vuln_posture(rel)
+    assert p["raw"]["total"] == 2
+    assert {f["component_version"] for f in p["findings"]} == {"1.1.1w", "3.0.0"}
+
+
+@pytest.mark.django_db
+def test_posture_operational_only_run_is_not_clean(release):
+    """A run whose only finding is an operational error marker did not analyze the
+    SBOM, so the release must not be advertised as vulnerability-free."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [{"id": "dependency-track:no-product", "severity": "info", "status": "info", "component": {}}])
+
+    assert build_release_vuln_posture(rel) == {"has_data": False}
+
+
+@pytest.mark.django_db
+def test_posture_genuinely_clean_scan_has_data(release):
+    """A real scan that found nothing (empty findings, no error markers) still shows
+    a posture — a clean release is a valuable Trust Center signal."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [])
+
+    p = build_release_vuln_posture(rel)
+    assert p["has_data"] is True
+    assert p["raw"]["total"] == 0

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -197,3 +197,21 @@ def test_posture_same_name_version_different_ecosystem_kept(release):
     )
     p = build_release_vuln_posture(rel)
     assert p["raw"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_no_package_identity_findings_not_collapsed(release):
+    """Findings that carry no package identity (no purl/name/version) with the same
+    id are kept distinct — we can't confirm they are the same package, so fail open."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [
+            {"id": "CVE-N", "severity": "high", "component": {}},
+            {"id": "CVE-N", "severity": "high", "component": {}},
+        ],
+    )
+    p = build_release_vuln_posture(rel)
+    assert p["raw"]["total"] == 2

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -26,7 +26,9 @@ def _run(sbom: SBOM, findings: list[dict], plugin="osv") -> AssessmentRun:
         sbom=sbom,
         plugin_name=plugin,
         plugin_version="1.0.0",
+        plugin_config_hash="",
         category="security",
+        run_reason="on_upload",
         status="completed",
         result={"findings": findings, "summary": {}},
     )

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -235,3 +235,21 @@ def test_posture_name_only_dedup_scoped_to_sbom(release):
     _run(b, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="osv")
 
     assert build_release_vuln_posture(rel)["raw"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_tolerates_non_dict_component(release):
+    """A provider-controlled finding with a non-dict component must not 500 the page."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [
+            {"id": "CVE-1", "severity": "high", "component": "not-a-dict"},
+            {"id": "CVE-2", "severity": "low", "component": None},
+        ],
+    )
+    p = build_release_vuln_posture(rel)
+    assert p["raw"]["total"] == 2
+    assert {f["id"] for f in p["findings"]} == {"CVE-1", "CVE-2"}

--- a/sbomify/apps/vulnerability_scanning/tests/test_release_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_release_vex.py
@@ -117,7 +117,7 @@ def test_download_release_vex_public_returns_attachment(sample_team_with_owner_m
 
     assert resp.status_code == 200
     assert "attachment" in resp["Content-Disposition"]
-    assert resp["Content-Disposition"].endswith(".vex.cdx.json")
+    assert resp["Content-Disposition"].rstrip('"').endswith(".vex.cdx.json")
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -463,8 +463,10 @@ def _document_from_vex_sbom(vex: Any) -> dict[str, Any] | None:
         return None
     try:
         raw = S3Client("SBOMS").get_sbom_data(vex.sbom_filename)
-    except (ClientError, BotoCoreError):
-        # A missing/unreadable object must not 500 the merge — skip this VEX.
+    except (ClientError, BotoCoreError) as exc:
+        # A missing/unreadable object must not 500 the merge — skip this VEX, but
+        # log so a genuinely misconfigured/unreachable bucket stays diagnosable.
+        logger.warning("Could not load VEX artifact %s from S3: %s", vex.sbom_filename, exc)
         return None
     if not raw:
         return None

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -455,11 +455,17 @@ def load_vex_suppressions(
 
 def _document_from_vex_sbom(vex: Any) -> dict[str, Any] | None:
     """Load a VEX SBOM row's document from S3. ``None`` when the row is absent or unreadable."""
+    from botocore.exceptions import BotoCoreError, ClientError
+
     from sbomify.apps.core.object_store import S3Client
 
     if vex is None or not vex.sbom_filename:
         return None
-    raw = S3Client("SBOMS").get_sbom_data(vex.sbom_filename)
+    try:
+        raw = S3Client("SBOMS").get_sbom_data(vex.sbom_filename)
+    except (ClientError, BotoCoreError):
+        # A missing/unreadable object must not 500 the merge — skip this VEX.
+        return None
     if not raw:
         return None
     try:


### PR DESCRIPTION
## What

Completes the Trust Center UI for the VEX lifecycle (#1094): the public release page now surfaces the release's security artifacts and the effect of its VEX. Supersedes #1112 (which was the VEX download button alone — its commits are included here).

Three cohesive additions to the public release page:

### 1. Latest-VEX download button
`_build_release_response` gains `has_vex`; the page shows a VEX download button (desktop + mobile) pointing at the existing `GET /releases/{id}/vex/download` (release-slot-scoped, cached, from #1048).

### 2. Vulnerability posture card (the customer's named ask)
`build_release_vuln_posture` rolls the release's pinned SBOMs' latest security scans into two severity breakdowns — **with** the VEX applied (suppressed findings dropped) and **without** it — derived from the stored scan results (the VEX overlay already lives on each finding, so no re-derivation). The card renders:
- a severity grid bound to a **With VEX / Without VEX** toggle,
- a suppression note ("N findings suppressed by VEX"),
- a findings list showing which findings the VEX cleared and the justification.

Operational scanner findings (`dependency-track:error` etc.) are excluded so the customer-facing posture only counts real vulnerabilities. Aggregation is DB-only (findings live in `AssessmentRun.result`, not S3), so it renders synchronously via `json_script` + Alpine.

### 3. CBOM download button
Mirrors the VEX download for the crypto BOM: `has_cbom` flag, `build_release_cbom` (merges the newest CBOM per component slot), and `GET /releases/{id}/cbom/download` (slot-state cached, same gating).

## Theme

All three buttons mirror the existing SBOM/SPDX download buttons exactly (`tw-btn-secondary`, identity token + download icon). The posture card reuses the dashboard's severity color language and the existing toggle pattern. No new JS bundle — inline Alpine + existing `main.ts`.

## Tests

- `test_posture.py`: raw-vs-VEX split, latest-run-per-SBOM, cross-provider dedupe, operational-finding exclusion.
- `test_release_public_posture.py`: the public page renders the posture card with embedded data, and omits it without scans.
- `test_release_cbom.py`: CBOM merge, 200 attachment, 404 when absent, private-auth gate.
- `test_release_apis.py`: `has_vex`/`has_cbom` flags flip correctly.
- Template render + URL resolution verified for both buttons.

Validated live on staging this week: the VEX download endpoint (200 + filename, 404 when absent) and the full suppression domino that feeds the posture card.

Closes the Trust Center download + posture items in #1094.