### PR TITLE
fix(vex): survive legacy non-dict finding shapes on re-annotate

### DIFF
--- a/sbomify/apps/vulnerability_scanning/tests/test_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex.py
@@ -400,3 +400,23 @@ def test_derive_caps_statement_count() -> None:
     """A pathological VEX cannot register unbounded statements."""
     doc = _vex_doc(*[_stmt(f"CVE-{i}", "pkg:npm/foo@1.0.0") for i in range(vex.MAX_VEX_STATEMENTS + 5)])
     assert len(vex.derive_vex_suppressions(doc)) == vex.MAX_VEX_STATEMENTS
+
+
+def test_reapply_survives_legacy_non_dict_component() -> None:
+    """A legacy stored finding with a non-dict component / non-list aliases must not
+    crash the reapply that runs over every stored run when a VEX is uploaded/deleted."""
+    stored = {
+        "findings": [
+            {"id": "CVE-1", "severity": "high", "component": "legacy-string", "aliases": "not-a-list"},
+        ],
+        "summary": {},
+    }
+    # Package-scoped statement can't match a finding with no usable package -> no crash, not suppressed.
+    pkg_stmts = vex.derive_vex_suppressions(_vex_doc(_stmt("CVE-1", "pkg:npm/foo@1.0.0")))
+    out = vex.reapply_vex_to_stored_result(stored, pkg_stmts)
+    assert out["summary"]["suppressed_count"] == 0
+    assert out["summary"]["by_severity"]["high"] == 1
+    # Product-scoped (DT) statement matches by id alone -> suppresses, still no crash.
+    dt_stmts = vex.derive_vex_suppressions(_dt_vex_doc("root", "CVE-1"))
+    out2 = vex.reapply_vex_to_stored_result(stored, dt_stmts)
+    assert out2["summary"]["suppressed_count"] == 1

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -156,7 +156,12 @@ def derive_vex_suppressions(document: dict[str, Any] | None) -> list[dict[str, A
 
 
 def _finding_package(finding: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
-    component = finding.get("component") or {}
+    # Stored scan results are provider-controlled JSON and legacy runs may carry a
+    # non-dict component; coerce it so re-annotating old runs can't raise (and crash
+    # the whole reapply domino) on ``.get``.
+    component = finding.get("component")
+    if not isinstance(component, dict):
+        return None, None, None
     purl = component.get("purl")
     if purl:
         ptype, name, version = _pkg_from_purl(purl)
@@ -169,8 +174,10 @@ def _finding_ids(finding: dict[str, Any]) -> set[str]:
     primary = _norm_id(finding.get("id"))
     if primary:
         ids.add(primary)
-    for alias in finding.get("aliases") or []:
-        alias_id = _norm_id(alias)
+    aliases = finding.get("aliases")
+    # Tolerate a non-list aliases from legacy/malformed stored results.
+    for alias in aliases if isinstance(aliases, list) else []:
+        alias_id = _norm_id(alias) if isinstance(alias, str) else None
         if alias_id:
             ids.add(alias_id)
     return ids


### PR DESCRIPTION
## What

Hardens the VEX re-apply against legacy / malformed stored scan data so it can't crash the suppression domino.

## Why (backwards compatibility)

When a VEX is uploaded or **deleted**, `reannotate_component_runs` walks **every** completed security `AssessmentRun` of the component — including runs created before the VEX feature. For each it calls `_finding_package` / `_finding_ids`, which assumed:

- `finding["component"]` is a dict (`component.get("purl")`), and
- `finding["aliases"]` is a list of strings.

Stored scan results are provider-controlled JSON, and a legacy run with a non-dict `component` (or non-list `aliases`) would raise `AttributeError` / `TypeError`, crashing `reapply_vex_to_stored_result` and the whole dramatiq re-apply task. The VEX upload/delete itself returns 201/204, but suppression silently never lands (task retries 3× then dies).

## Fix

- `_finding_package`: coerce a non-dict `component` to "no package identity" instead of calling `.get` on it.
- `_finding_ids`: tolerate a non-list `aliases` (and non-string entries).

This matches the guard already applied to the posture aggregation (`posture.py`) during the #1113 review — this PR closes the same gap in the shared `vex.py` readers that the re-annotate path uses.

## Tests

`test_reapply_survives_legacy_non_dict_component`: a stored finding with `component: "legacy-string"` and `aliases: "not-a-list"` no longer crashes — a package-scoped statement correctly doesn't match it, and a product-scoped (DT) statement still suppresses by id alone.

No migration, no API change; purely a robustness fix over existing data.