### PR TITLE
feat(trust-center): drop the with/without-VEX toggle from the release posture

### DIFF
--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -170,71 +170,55 @@
                 </div>
             </div>
         {% endif %}
-        {# Vulnerability Posture — with and without the release's VEX applied #}
+        {# Vulnerability Posture — the release's VEX-applied posture #}
         {% if vuln_posture.has_data %}
             {{ vuln_posture|json_script:"vuln-posture-data" }}
             <div class="tw-card"
-                 x-data="{ data: { raw: {}, applied: {}, findings: [], suppressed_count: 0 }, applied: true, init() { this.data = window.parseJsonScript ? window.parseJsonScript('vuln-posture-data') : JSON.parse(document.getElementById('vuln-posture-data').textContent); }, current() { return this.applied ? this.data.applied : this.data.raw; }, sevPill(sev) { return { critical: 'bg-red-500/10 text-red-600', high: 'bg-orange-500/10 text-orange-600', medium: 'bg-yellow-500/10 text-yellow-700', low: 'bg-cyan-500/10 text-cyan-600' }[sev] || 'bg-border/40 text-text-muted'; } }"
+                 x-data="{ data: { counts: {}, findings: [], suppressed_count: 0 }, init() { this.data = window.parseJsonScript ? window.parseJsonScript('vuln-posture-data') : JSON.parse(document.getElementById('vuln-posture-data').textContent); }, sevPill(sev) { return { critical: 'bg-red-500/10 text-red-600', high: 'bg-orange-500/10 text-orange-600', medium: 'bg-yellow-500/10 text-yellow-700', low: 'bg-cyan-500/10 text-cyan-600' }[sev] || 'bg-border/40 text-text-muted'; } }"
                  x-init="init()">
-                <div class="px-6 py-4 border-b border-border flex items-center justify-between gap-4 flex-wrap">
+                <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
                         <i class="fas fa-shield-halved text-primary" aria-hidden="true"></i>
                         Vulnerability Posture
                     </h4>
-                    {# With/Without VEX toggle — only meaningful when the VEX suppresses something #}
-                    <div class="inline-flex rounded-lg border border-border overflow-hidden"
-                         x-show="data.suppressed_count > 0"
-                         x-cloak
-                         role="group"
-                         aria-label="Apply VEX to the posture">
-                        <button type="button"
-                                class="px-3 py-1.5 text-sm font-medium transition-colors"
-                                :class="applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
-                                :aria-pressed="applied"
-                                @click="applied = true">With VEX</button>
-                        <button type="button"
-                                class="px-3 py-1.5 text-sm font-medium border-l border-border transition-colors"
-                                :class="!applied ? 'bg-primary text-white' : 'bg-surface text-text hover:bg-background'"
-                                :aria-pressed="!applied"
-                                @click="applied = false">Without VEX</button>
-                    </div>
                 </div>
                 <div class="p-6 space-y-5">
-                    {# Severity breakdown — reflects the active toggle #}
+                    {# Severity breakdown (VEX applied) #}
                     <div class="grid grid-cols-2 sm:grid-cols-6 gap-3">
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-background border border-border">
                             <div>
-                                <span class="text-xl font-bold text-text" x-text="current().total"></span>
+                                <span class="text-xl font-bold text-text" x-text="data.counts.total"></span>
                                 <span class="block text-xs text-text-muted">Total</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-red-500/5 border border-red-500/10">
                             <div>
-                                <span class="text-xl font-bold text-red-600" x-text="current().critical"></span>
+                                <span class="text-xl font-bold text-red-600" x-text="data.counts.critical"></span>
                                 <span class="block text-xs text-text-muted">Critical</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-orange-500/5 border border-orange-500/10">
                             <div>
-                                <span class="text-xl font-bold text-orange-600" x-text="current().high"></span>
+                                <span class="text-xl font-bold text-orange-600" x-text="data.counts.high"></span>
                                 <span class="block text-xs text-text-muted">High</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-yellow-500/5 border border-yellow-500/10">
                             <div>
-                                <span class="text-xl font-bold text-yellow-700" x-text="current().medium"></span>
+                                <span class="text-xl font-bold text-yellow-700" x-text="data.counts.medium"></span>
                                 <span class="block text-xs text-text-muted">Medium</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-cyan-500/5 border border-cyan-500/10">
                             <div>
-                                <span class="text-xl font-bold text-cyan-600" x-text="current().low"></span>
+                                <span class="text-xl font-bold text-cyan-600" x-text="data.counts.low"></span>
                                 <span class="block text-xs text-text-muted">Low</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-3 p-3 rounded-lg bg-background border border-border">
                             <div>
-                                <span class="text-xl font-bold text-text-muted" x-text="current().unknown"></span>
+                                <span class="text-xl font-bold text-text-muted"
+                                      x-text="data.counts.unknown"></span>
                                 <span class="block text-xs text-text-muted">Unknown</span>
                             </div>
                         </div>
@@ -249,13 +233,12 @@
                             finding<span x-show="data.suppressed_count !== 1">s</span>
                             suppressed by VEX (not affected / false positive).
                         </span>
-                        <span class="text-warning" x-show="!applied">Showing raw findings without VEX applied.</span>
                     </p>
                     {# Findings list #}
                     <div class="divide-y divide-border" x-show="data.findings.length" x-cloak>
                         <template x-for="f in data.findings" :key="f.idx">
                             <div class="py-2.5 flex items-start gap-3"
-                                 :class="(applied &amp;&amp; f.suppressed) ? 'opacity-50' : ''">
+                                 :class="f.suppressed ? 'opacity-50' : ''">
                                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase flex-shrink-0"
                                       :class="sevPill(f.severity)"
                                       x-text="f.severity"></span>

--- a/sbomify/apps/core/tests/test_release_public_posture.py
+++ b/sbomify/apps/core/tests/test_release_public_posture.py
@@ -54,13 +54,24 @@ def test_public_release_page_shows_vuln_posture(sample_team_with_owner_member):
 
     assert resp.status_code == 200
     html = resp.content.decode()
-    # The posture card and its embedded data are present.
     assert "Vulnerability Posture" in html
     assert 'id="vuln-posture-data"' in html
-    # Data carries the VEX-applied counts plus the suppressed finding.
-    assert "CVE-2026-1" in html
-    assert "not_affected" in html
-    assert '"suppressed_count": 1' in html
+
+    # Parse the embedded posture data and verify the VEX-applied breakdown: the
+    # active high finding counts, the not_affected critical is suppressed (dropped
+    # from counts) but still listed with its state.
+    import json
+    import re
+
+    match = re.search(r'<script id="vuln-posture-data"[^>]*>(.*?)</script>', html, re.DOTALL)
+    assert match is not None
+    posture = json.loads(match.group(1))
+    assert posture["counts"] == {"critical": 0, "high": 1, "medium": 0, "low": 0, "unknown": 0, "total": 1}
+    assert posture["suppressed_count"] == 1
+    by_id = {f["id"]: f for f in posture["findings"]}
+    assert by_id["CVE-2026-1"]["suppressed"] is False
+    assert by_id["CVE-2026-2"]["suppressed"] is True
+    assert by_id["CVE-2026-2"]["state"] == "not_affected"
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_release_public_posture.py
+++ b/sbomify/apps/core/tests/test_release_public_posture.py
@@ -57,7 +57,7 @@ def test_public_release_page_shows_vuln_posture(sample_team_with_owner_member):
     # The posture card and its embedded data are present.
     assert "Vulnerability Posture" in html
     assert 'id="vuln-posture-data"' in html
-    # Data carries both raw and VEX-applied counts plus the suppressed finding.
+    # Data carries the VEX-applied counts plus the suppressed finding.
     assert "CVE-2026-1" in html
     assert "not_affected" in html
     assert '"suppressed_count": 1' in html

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -53,7 +53,10 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
           "has_data": True,
           "counts": {critical, high, medium, low, unknown, total},  # VEX-applied
           "suppressed_count": int,
-          "findings": [ {id, severity, component, suppressed, state, justification, title}, ... ],
+          "findings": [
+            {id, severity, component, component_version, suppressed, state, justification, title, idx},
+            ...
+          ],  # idx is a stable per-item key for the client list
         }
     """
     from sbomify.apps.plugins.models import AssessmentRun

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -1,11 +1,11 @@
 """Aggregate a release's vulnerability posture for the public Trust Center page.
 
 A release ships specific SBOM versions (pinned in its artifact slots). This walks
-those SBOMs' latest completed security scans and rolls their findings up into two
-severity breakdowns — with the release's VEX applied (suppressed findings dropped)
-and without it (every finding active) — so the Trust Center can show the effect of
-the VEX as a toggle. The stored scan results already carry the VEX overlay
-(``analysis_state`` on suppressed findings), so the two views derive from one read.
+those SBOMs' latest completed security scans and rolls their findings up into a
+severity breakdown with the release's VEX applied — suppressed findings drop out
+of the counts (they still appear in the list, marked with their justification).
+The stored scan results already carry the VEX overlay (``analysis_state`` on
+suppressed findings), so the counts derive from one read.
 """
 
 from __future__ import annotations
@@ -51,8 +51,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
 
         {
           "has_data": True,
-          "raw": {critical, high, medium, low, unknown, total},      # without VEX
-          "applied": {critical, high, medium, low, unknown, total},  # with VEX
+          "counts": {critical, high, medium, low, unknown, total},  # VEX-applied
           "suppressed_count": int,
           "findings": [ {id, severity, component, suppressed, state, justification, title}, ... ],
         }
@@ -82,8 +81,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     if not runs:
         return {"has_data": False}
 
-    raw = _empty_counts()
-    applied = _empty_counts()
+    counts = _empty_counts()
     findings: list[dict[str, Any]] = []
     suppressed_count = 0
     # Dedupe the same vuln on the same package identity (purl, or name+version) across
@@ -132,13 +130,13 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
 
             sev = _severity_bucket(finding)
             suppressed = _is_suppressed(finding)
-            raw[sev] += 1
-            raw["total"] += 1
+            # The Trust Center shows the VEX-applied posture: suppressed findings
+            # drop out of the counts (they still appear in the list, marked).
             if suppressed:
                 suppressed_count += 1
             else:
-                applied[sev] += 1
-                applied["total"] += 1
+                counts[sev] += 1
+                counts["total"] += 1
             findings.append(
                 {
                     "id": finding.get("id"),
@@ -168,8 +166,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
 
     return {
         "has_data": True,
-        "raw": raw,
-        "applied": applied,
+        "counts": counts,
         "suppressed_count": suppressed_count,
         "findings": findings,
     }

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -76,10 +76,9 @@ def test_posture_splits_raw_vs_vex_applied(release):
 
     p = build_release_vuln_posture(rel)
     assert p["has_data"] is True
-    # Without VEX: CVE-1/2/3 count (operational excluded).
-    assert p["raw"] == {"critical": 1, "high": 1, "medium": 1, "low": 0, "unknown": 0, "total": 3}
-    # With VEX: only CVE-1 survives (CVE-2 not_affected, CVE-3 false_positive dropped).
-    assert p["applied"] == {"critical": 1, "high": 0, "medium": 0, "low": 0, "unknown": 0, "total": 1}
+    # VEX applied: only CVE-1 survives (CVE-2 not_affected, CVE-3 false_positive dropped);
+    # the operational finding is excluded entirely.
+    assert p["counts"] == {"critical": 1, "high": 0, "medium": 0, "low": 0, "unknown": 0, "total": 1}
     assert p["suppressed_count"] == 2
     supp = {f["id"]: f for f in p["findings"]}
     assert supp["CVE-2"]["suppressed"] is True
@@ -99,7 +98,7 @@ def test_posture_uses_latest_run_per_sbom(release):
     p = build_release_vuln_posture(rel)
     ids = {f["id"] for f in p["findings"]}
     assert ids == {"CVE-NEW"}
-    assert p["raw"]["total"] == 1
+    assert p["counts"]["total"] == 1
 
 
 @pytest.mark.django_db
@@ -111,7 +110,7 @@ def test_posture_dedupes_same_vuln_across_providers(release):
     _run(sbom, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="dependency-track")
 
     p = build_release_vuln_posture(rel)
-    assert p["raw"]["total"] == 1
+    assert p["counts"]["total"] == 1
 
 
 @pytest.mark.django_db
@@ -127,7 +126,7 @@ def test_posture_keeps_same_cve_different_versions(release):
     _run(b, [{"id": "CVE-9", "severity": "high", "component": {"name": "openssl", "version": "3.0.0"}}])
 
     p = build_release_vuln_posture(rel)
-    assert p["raw"]["total"] == 2
+    assert p["counts"]["total"] == 2
     assert {f["component_version"] for f in p["findings"]} == {"1.1.1w", "3.0.0"}
 
 
@@ -154,7 +153,7 @@ def test_posture_genuinely_clean_scan_has_data(release):
 
     p = build_release_vuln_posture(rel)
     assert p["has_data"] is True
-    assert p["raw"]["total"] == 0
+    assert p["counts"]["total"] == 0
 
 
 @pytest.mark.django_db
@@ -173,7 +172,7 @@ def test_posture_excludes_findings_with_compliance_status(release):
     )
     p = build_release_vuln_posture(rel)
     assert [f["id"] for f in p["findings"]] == ["CVE-REAL"]
-    assert p["raw"]["total"] == 1
+    assert p["counts"]["total"] == 1
 
 
 @pytest.mark.django_db
@@ -198,7 +197,7 @@ def test_posture_same_name_version_different_ecosystem_kept(release):
         ],
     )
     p = build_release_vuln_posture(rel)
-    assert p["raw"]["total"] == 2
+    assert p["counts"]["total"] == 2
 
 
 @pytest.mark.django_db
@@ -216,7 +215,7 @@ def test_posture_no_package_identity_findings_not_collapsed(release):
         ],
     )
     p = build_release_vuln_posture(rel)
-    assert p["raw"]["total"] == 2
+    assert p["counts"]["total"] == 2
 
 
 @pytest.mark.django_db
@@ -234,7 +233,7 @@ def test_posture_name_only_dedup_scoped_to_sbom(release):
     # Different SBOM, same name-only -> stays distinct.
     _run(b, [{"id": "CVE-1", "severity": "high", "component": {"name": "foo"}}], plugin="osv")
 
-    assert build_release_vuln_posture(rel)["raw"]["total"] == 2
+    assert build_release_vuln_posture(rel)["counts"]["total"] == 2
 
 
 @pytest.mark.django_db
@@ -251,7 +250,7 @@ def test_posture_tolerates_non_dict_component(release):
         ],
     )
     p = build_release_vuln_posture(rel)
-    assert p["raw"]["total"] == 2
+    assert p["counts"]["total"] == 2
     assert {f["id"] for f in p["findings"]} == {"CVE-1", "CVE-2"}
 
 


### PR DESCRIPTION
## What

Per Viktor's review of #1113: the vulnerability posture card no longer has a With/Without-VEX toggle. If a release has a VEX, there's no reason to show the posture without it — so the card always shows the **VEX-applied** posture.

- Removed the toggle buttons and the raw (without-VEX) severity counts.
- `build_release_vuln_posture` now returns a single `counts` breakdown (VEX-applied) instead of `raw` + `applied`; the Alpine component drops the `applied`/`current()` toggle state.
- Kept the informative bits: the "N findings suppressed by VEX" note and the findings list, where suppressed findings still appear dimmed with their analysis state + justification. That's the "which findings were cleared and why" context, just without the redundant toggle.

## Verified

Rendered live on the local Trust Center: the card shows the applied counts (suppressed findings dropped from the totals), the suppression note, and the findings list with suppressed entries marked. No toggle.

## Tests

Updated the posture tests to assert the single `counts` breakdown; the split test now checks the VEX-applied counts + `suppressed_count`. 151 tests green.

Follow-up to #1113.