### PR TITLE
perf(vuln): stop projecting AssessmentRun.result on the component page (fixes vuln-graph 504 + slow SBOM list)

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4137,6 +4137,10 @@ def list_component_sboms(
         from sbomify.apps.plugins.models import AssessmentRun, RegisteredPlugin, TeamPluginSettings
         from sbomify.apps.plugins.schemas import AssessmentStatusSummary
         from sbomify.apps.plugins.sdk.enums import RunStatus
+        from sbomify.apps.vulnerability_scanning.utils import (
+            RESULT_SUMMARY_ANNOTATIONS,
+            reconstruct_result_summary,
+        )
 
         # Build response items with vulnerability status, releases, and assessments.
         # Everything below is batched by sbom-id so the cost is constant in
@@ -4204,10 +4208,17 @@ def list_component_sboms(
         try:
             latest_runs = list(
                 AssessmentRun.objects.filter(sbom_id__in=sbom_ids)
+                .defer("result")
+                .annotate(**RESULT_SUMMARY_ANNOTATIONS)
                 .order_by("sbom_id", "plugin_name", "-created_at")
                 .distinct("sbom_id", "plugin_name")
             )
             for run in latest_runs:
+                # Rebuild the small summary slice from the SQL annotations so the
+                # status helpers below never lazy-load the deferred multi-MB
+                # ``result`` blob — one fat de-TOAST per row was part of what made
+                # this endpoint take tens of seconds.
+                run.result = reconstruct_result_summary(run)
                 runs_by_sbom[str(run.sbom_id)].append(run)
                 plugin_names_seen.add(run.plugin_name)
         except (DatabaseError, OperationalError) as db_err:

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4210,7 +4210,10 @@ def list_component_sboms(
                 AssessmentRun.objects.filter(sbom_id__in=sbom_ids)
                 .defer("result")
                 .annotate(**RESULT_SUMMARY_ANNOTATIONS)
-                .order_by("sbom_id", "plugin_name", "-created_at")
+                # -id breaks created_at ties deterministically (newest row wins),
+                # matching vulnerability_trends so both surfaces agree on which
+                # run is "latest" when two share a timestamp.
+                .order_by("sbom_id", "plugin_name", "-created_at", "-id")
                 .distinct("sbom_id", "plugin_name")
             )
             for run in latest_runs:

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -74,9 +74,9 @@ def test_reconstructed_counts_match_reading_the_blob(sample_team_with_owner_memb
 
     annotated = {
         row["id"]: row
-        for row in AssessmentRun.objects.annotate(**RESULT_SUMMARY_ANNOTATIONS).values(
-            "id", *RESULT_SUMMARY_ANNOTATIONS
-        )
+        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
+        .annotate(**RESULT_SUMMARY_ANNOTATIONS)
+        .values("id", *RESULT_SUMMARY_ANNOTATIONS)
     }
 
     for label, result in RESULT_SHAPES:
@@ -94,9 +94,9 @@ def test_reconstruction_preserves_status_helper_verdicts(sample_team_with_owner_
 
     annotated = {
         row["id"]: row
-        for row in AssessmentRun.objects.annotate(**RESULT_SUMMARY_ANNOTATIONS).values(
-            "id", "category", "status", *RESULT_SUMMARY_ANNOTATIONS
-        )
+        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
+        .annotate(**RESULT_SUMMARY_ANNOTATIONS)
+        .values("id", "category", "status", *RESULT_SUMMARY_ANNOTATIONS)
     }
 
     for label in dict(RESULT_SHAPES):

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -13,6 +13,7 @@ from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.vulnerability_scanning.utils import (
     RESULT_SUMMARY_ANNOTATIONS,
+    RESULT_SUMMARY_FIELDS,
     extract_severity_counts,
     reconstruct_result_summary,
 )
@@ -76,7 +77,7 @@ def test_reconstructed_counts_match_reading_the_blob(sample_team_with_owner_memb
         row["id"]: row
         for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
         .annotate(**RESULT_SUMMARY_ANNOTATIONS)
-        .values("id", *RESULT_SUMMARY_ANNOTATIONS)
+        .values("id", *RESULT_SUMMARY_FIELDS)
     }
 
     for label, result in RESULT_SHAPES:
@@ -96,7 +97,7 @@ def test_reconstruction_preserves_status_helper_verdicts(sample_team_with_owner_
         row["id"]: row
         for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
         .annotate(**RESULT_SUMMARY_ANNOTATIONS)
-        .values("id", "category", "status", *RESULT_SUMMARY_ANNOTATIONS)
+        .values("id", "category", "status", *RESULT_SUMMARY_FIELDS)
     }
 
     for label, original in RESULT_SHAPES:

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -99,10 +99,13 @@ def test_reconstruction_preserves_status_helper_verdicts(sample_team_with_owner_
         .values("id", "category", "status", *RESULT_SUMMARY_ANNOTATIONS)
     }
 
-    for label in dict(RESULT_SHAPES):
+    for label, original in RESULT_SHAPES:
         run = runs[label]
-        rebuilt_run = AssessmentRun(
-            category=run.category, status=run.status, result=reconstruct_result_summary(annotated[run.id])
-        )
+        rebuilt = reconstruct_result_summary(annotated[run.id])
+        # A run with no summary must reconstruct WITHOUT a summary key, so
+        # consumers gating on isinstance(result["summary"], dict) branch the
+        # same way for the real blob and the reconstruction.
+        assert isinstance(rebuilt.get("summary"), dict) == isinstance(original.get("summary"), dict), f"summary/{label}"
+        rebuilt_run = AssessmentRun(category=run.category, status=run.status, result=rebuilt)
         assert _is_run_skipped(rebuilt_run) == _is_run_skipped(run), f"skipped/{label}"
         assert _is_run_failing(rebuilt_run) == _is_run_failing(run), f"failing/{label}"

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -1,0 +1,108 @@
+"""The SQL summary annotations must reproduce, per row, exactly what reading the
+full ``AssessmentRun.result`` blob in Python would — so the vuln-trends and
+sbom-list endpoints can stop projecting the multi-MB JSONB column.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.plugins.apis import _is_run_failing, _is_run_skipped
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.vulnerability_scanning.utils import (
+    RESULT_SUMMARY_ANNOTATIONS,
+    extract_severity_counts,
+    reconstruct_result_summary,
+)
+
+# (label, stored result JSON) — deliberately includes the shapes a Dependency
+# Track scan error can produce, which used to crash extract_severity_counts.
+RESULT_SHAPES = [
+    (
+        "normal",
+        {"summary": {"total_findings": 4, "by_severity": {"critical": 1, "high": 2, "medium": 1, "low": 0, "info": 0}}},
+    ),
+    ("skipped", {"metadata": {"skipped": True}, "summary": {"total_findings": 5, "by_severity": {"critical": 3}}}),
+    ("null_summary", {"findings": [], "summary": None}),
+    ("no_summary_error", {"status": "error", "error": "DT unavailable"}),
+    ("null_by_severity", {"summary": {"total_findings": 2, "by_severity": None}}),
+    (
+        "compliance_counts",
+        {
+            "summary": {
+                "total_findings": 3,
+                "fail_count": 2,
+                "pass_count": 0,
+                "error_count": 1,
+                "by_severity": {"high": 3},
+            }
+        },
+    ),
+    ("empty", {}),
+]
+
+
+def _make_run(component: Component, result: dict, plugin: str) -> AssessmentRun:
+    sbom = SBOM.objects.create(
+        name=f"app-{plugin}",
+        version=f"1.0.{plugin}",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="a.json",
+        component=component,
+    )
+    return AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name=plugin,
+        plugin_version="1.0.0",
+        plugin_config_hash="",
+        category="security",
+        run_reason="on_upload",
+        status="completed",
+        result=result,
+    )
+
+
+@pytest.mark.django_db
+def test_reconstructed_counts_match_reading_the_blob(sample_team_with_owner_member):
+    """extract_severity_counts on the reconstruction equals extracting from the
+    real result — for every shape, and without crashing on null summaries."""
+    component = Component.objects.create(name="c", team=sample_team_with_owner_member.team)
+    runs = {label: _make_run(component, result, f"osv-{i}") for i, (label, result) in enumerate(RESULT_SHAPES)}
+
+    annotated = {
+        row["id"]: row
+        for row in AssessmentRun.objects.annotate(**RESULT_SUMMARY_ANNOTATIONS).values(
+            "id", *RESULT_SUMMARY_ANNOTATIONS
+        )
+    }
+
+    for label, result in RESULT_SHAPES:
+        row = annotated[runs[label].id]
+        rebuilt = reconstruct_result_summary(row)
+        assert extract_severity_counts(rebuilt) == extract_severity_counts(result), label
+
+
+@pytest.mark.django_db
+def test_reconstruction_preserves_status_helper_verdicts(sample_team_with_owner_member):
+    """_is_run_failing / _is_run_skipped give the same verdict whether they read
+    the real blob or the reconstructed one (they distinguish missing pass_count)."""
+    component = Component.objects.create(name="c2", team=sample_team_with_owner_member.team)
+    runs = {label: _make_run(component, result, f"dt-{i}") for i, (label, result) in enumerate(RESULT_SHAPES)}
+
+    annotated = {
+        row["id"]: row
+        for row in AssessmentRun.objects.annotate(**RESULT_SUMMARY_ANNOTATIONS).values(
+            "id", "category", "status", *RESULT_SUMMARY_ANNOTATIONS
+        )
+    }
+
+    for label in dict(RESULT_SHAPES):
+        run = runs[label]
+        rebuilt_run = AssessmentRun(
+            category=run.category, status=run.status, result=reconstruct_result_summary(annotated[run.id])
+        )
+        assert _is_run_skipped(rebuilt_run) == _is_run_skipped(run), f"skipped/{label}"
+        assert _is_run_failing(rebuilt_run) == _is_run_failing(run), f"failing/{label}"

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -29,6 +29,9 @@ RESULT_SHAPES = [
     ("null_summary", {"findings": [], "summary": None}),
     ("no_summary_error", {"status": "error", "error": "DT unavailable"}),
     ("null_by_severity", {"summary": {"total_findings": 2, "by_severity": None}}),
+    # unknown-severity findings count toward _is_run_failing, so the
+    # reconstruction must round-trip the `unknown` key too.
+    ("unknown_only", {"summary": {"total_findings": 2, "by_severity": {"unknown": 2}}}),
     (
         "compliance_counts",
         {

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from django.db.models.fields.json import KeyTextTransform
+
 _ZERO_COUNTS = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 
 
@@ -34,13 +36,102 @@ def extract_severity_counts(result_json: dict[str, Any] | None) -> dict[str, int
     if isinstance(metadata, dict) and metadata.get("skipped"):
         return dict(_ZERO_COUNTS)
 
-    summary = result_json.get("summary", {})
-    by_severity = summary.get("by_severity", {})
+    # A provider may store a scan-error result with a null or non-dict summary
+    # (or a null by_severity). ``.get("summary", {})`` only defaults on an
+    # ABSENT key, not a present-but-null one, so guard both explicitly rather
+    # than dereferencing ``None``.
+    summary = result_json.get("summary")
+    if not isinstance(summary, dict):
+        return dict(_ZERO_COUNTS)
+    by_severity = summary.get("by_severity")
+    if not isinstance(by_severity, dict):
+        by_severity = {}
     return {
-        "total": summary.get("total_findings", 0),
-        "critical": by_severity.get("critical", 0),
-        "high": by_severity.get("high", 0),
-        "medium": by_severity.get("medium", 0),
-        "low": by_severity.get("low", 0),
-        "info": by_severity.get("info", 0),
+        "total": summary.get("total_findings", 0) or 0,
+        "critical": by_severity.get("critical", 0) or 0,
+        "high": by_severity.get("high", 0) or 0,
+        "medium": by_severity.get("medium", 0) or 0,
+        "low": by_severity.get("low", 0) or 0,
+        "info": by_severity.get("info", 0) or 0,
     }
+
+
+def _nested_key(first: str, *rest: str) -> KeyTextTransform:
+    """Build a nested ``result -> a -> b -> ... ->> last`` JSON text extraction.
+
+    Used to pull scalar fields out of ``AssessmentRun.result`` in SQL so callers
+    never SELECT (and Python never parses) the multi-MB ``findings`` blob.
+    """
+    expr = KeyTextTransform(first, "result")
+    for key in rest:
+        expr = KeyTextTransform(key, expr)
+    return expr
+
+
+# Annotations that surface the small summary slice of ``AssessmentRun.result``
+# as scalar columns. Apply with ``.annotate(**RESULT_SUMMARY_ANNOTATIONS)`` and
+# then ``.values("created_at", *RESULT_SUMMARY_ANNOTATIONS)`` (or ``.defer("result")``
+# on a model queryset) so the fat JSONB column stays out of the SELECT list.
+RESULT_SUMMARY_ANNOTATIONS: dict[str, KeyTextTransform] = {
+    "ann_skipped": _nested_key("metadata", "skipped"),
+    "ann_total": _nested_key("summary", "total_findings"),
+    "ann_suppressed": _nested_key("summary", "suppressed_count"),
+    "ann_fail": _nested_key("summary", "fail_count"),
+    "ann_pass": _nested_key("summary", "pass_count"),
+    "ann_error": _nested_key("summary", "error_count"),
+    "ann_critical": _nested_key("summary", "by_severity", "critical"),
+    "ann_high": _nested_key("summary", "by_severity", "high"),
+    "ann_medium": _nested_key("summary", "by_severity", "medium"),
+    "ann_low": _nested_key("summary", "by_severity", "low"),
+    "ann_info": _nested_key("summary", "by_severity", "info"),
+}
+
+
+def _ann(row: Any, key: str) -> Any:
+    return row.get(key) if isinstance(row, dict) else getattr(row, key, None)
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def reconstruct_result_summary(row: Any) -> dict[str, Any]:
+    """Rebuild the small ``result`` slice the severity/status readers use from
+    the ``ann_*`` annotations produced by :data:`RESULT_SUMMARY_ANNOTATIONS`.
+
+    ``row`` is either a ``.values()`` dict or a model instance carrying the
+    annotations. Absent JSON keys stay absent (not zero) so callers that
+    distinguish missing-vs-0 — e.g. ``_is_run_failing`` reading ``pass_count`` —
+    keep their behaviour. The returned dict is a drop-in for
+    :func:`extract_severity_counts` and the plugin status helpers, letting the
+    caller ``.defer("result")``.
+    """
+    summary: dict[str, Any] = {}
+    by_severity: dict[str, int] = {}
+    for sev in ("critical", "high", "medium", "low", "info"):
+        value = _int_or_none(_ann(row, f"ann_{sev}"))
+        if value is not None:
+            by_severity[sev] = value
+    if by_severity:
+        summary["by_severity"] = by_severity
+    for key, ann in (
+        ("total_findings", "ann_total"),
+        ("suppressed_count", "ann_suppressed"),
+        ("fail_count", "ann_fail"),
+        ("pass_count", "ann_pass"),
+        ("error_count", "ann_error"),
+    ):
+        value = _int_or_none(_ann(row, ann))
+        if value is not None:
+            summary[key] = value
+
+    result: dict[str, Any] = {"summary": summary}
+    skipped = _ann(row, "ann_skipped")
+    if skipped is not None:
+        result["metadata"] = {"skipped": str(skipped).lower() == "true"}
+    return result

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -141,7 +141,13 @@ def reconstruct_result_summary(row: Any) -> dict[str, Any]:
         if value is not None:
             summary[key] = value
 
-    result: dict[str, Any] = {"summary": summary}
+    # Omit an empty summary (rather than emitting {"summary": {}}) so a run with
+    # no reconstructed data faithfully mirrors a real blob that has no summary
+    # key — consumers that gate on isinstance(result["summary"], dict) then
+    # branch the same way for both.
+    result: dict[str, Any] = {}
+    if summary:
+        result["summary"] = summary
     skipped = _ann(row, "ann_skipped")
     if skipped is not None:
         result["metadata"] = {"skipped": _is_truthy(skipped)}

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from django.db.models.fields.json import KeyTextTransform
+from django.db.models.fields.json import KeyTextTransform, KeyTransform
 
 _ZERO_COUNTS = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 
@@ -59,18 +59,22 @@ def extract_severity_counts(result_json: dict[str, Any] | None) -> dict[str, int
 def _nested_key(first: str, *rest: str) -> KeyTextTransform:
     """Build a nested ``result -> a -> b -> ... ->> last`` JSON text extraction.
 
-    Used to pull scalar fields out of ``AssessmentRun.result`` in SQL so callers
-    never SELECT (and Python never parses) the multi-MB ``findings`` blob.
+    Intermediate keys use ``KeyTransform`` (JSON ``->``) and only the leaf uses
+    ``KeyTextTransform`` (text ``->>``); Postgres renders the whole chain as a
+    single ``#>>`` path extraction. Used to pull scalar fields out of
+    ``AssessmentRun.result`` in SQL so callers never SELECT (and Python never
+    parses) the multi-MB ``findings`` blob.
     """
-    expr = KeyTextTransform(first, "result")
-    for key in rest:
-        expr = KeyTextTransform(key, expr)
-    return expr
+    *intermediate, leaf = (first, *rest)
+    expr: Any = "result"
+    for key in intermediate:
+        expr = KeyTransform(key, expr)
+    return KeyTextTransform(leaf, expr)
 
 
 # Annotations that surface the small summary slice of ``AssessmentRun.result``
 # as scalar columns. Apply with ``.annotate(**RESULT_SUMMARY_ANNOTATIONS)`` and
-# then ``.values("created_at", *RESULT_SUMMARY_ANNOTATIONS)`` (or ``.defer("result")``
+# then ``.values("created_at", *RESULT_SUMMARY_FIELDS)`` (or ``.defer("result")``
 # on a model queryset) so the fat JSONB column stays out of the SELECT list.
 RESULT_SUMMARY_ANNOTATIONS: dict[str, KeyTextTransform] = {
     "ann_skipped": _nested_key("metadata", "skipped"),
@@ -85,6 +89,10 @@ RESULT_SUMMARY_ANNOTATIONS: dict[str, KeyTextTransform] = {
     "ann_low": _nested_key("summary", "by_severity", "low"),
     "ann_info": _nested_key("summary", "by_severity", "info"),
 }
+
+# Explicit annotation-field names for ``.values(*RESULT_SUMMARY_FIELDS)`` so the
+# select list doesn't rely on implicit dict-key iteration to name the columns.
+RESULT_SUMMARY_FIELDS: tuple[str, ...] = tuple(RESULT_SUMMARY_ANNOTATIONS)
 
 
 def _ann(row: Any, key: str) -> Any:

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -100,6 +100,17 @@ def _int_or_none(value: Any) -> int | None:
         return None
 
 
+def _is_truthy(value: Any) -> bool:
+    """Coerce a JSON-extracted flag to bool across DB backends.
+
+    Postgres returns the text ``"true"``/``"false"`` for a JSON boolean; SQLite's
+    JSON1 returns ``1``/``0``. Accept the truthy spellings from either.
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "1", "t")
+
+
 def reconstruct_result_summary(row: Any) -> dict[str, Any]:
     """Rebuild the small ``result`` slice the severity/status readers use from
     the ``ann_*`` annotations produced by :data:`RESULT_SUMMARY_ANNOTATIONS`.
@@ -133,5 +144,5 @@ def reconstruct_result_summary(row: Any) -> dict[str, Any]:
     result: dict[str, Any] = {"summary": summary}
     skipped = _ann(row, "ann_skipped")
     if skipped is not None:
-        result["metadata"] = {"skipped": str(skipped).lower() == "true"}
+        result["metadata"] = {"skipped": _is_truthy(skipped)}
     return result

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -88,6 +88,9 @@ RESULT_SUMMARY_ANNOTATIONS: dict[str, KeyTextTransform] = {
     "ann_medium": _nested_key("summary", "by_severity", "medium"),
     "ann_low": _nested_key("summary", "by_severity", "low"),
     "ann_info": _nested_key("summary", "by_severity", "info"),
+    # `unknown` is summed by _is_run_failing, so it must round-trip too or an
+    # unknown-only run would reconstruct as passing.
+    "ann_unknown": _nested_key("summary", "by_severity", "unknown"),
 }
 
 # Explicit annotation-field names for ``.values(*RESULT_SUMMARY_FIELDS)`` so the
@@ -132,7 +135,7 @@ def reconstruct_result_summary(row: Any) -> dict[str, Any]:
     """
     summary: dict[str, Any] = {}
     by_severity: dict[str, int] = {}
-    for sev in ("critical", "high", "medium", "low", "info"):
+    for sev in ("critical", "high", "medium", "low", "info", "unknown"):
         value = _int_or_none(_ann(row, f"ann_{sev}"))
         if value is not None:
             by_severity[sev] = value

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -15,7 +15,11 @@ from sbomify.apps.core.utils import token_to_number
 from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
-from sbomify.apps.vulnerability_scanning.utils import extract_severity_counts
+from sbomify.apps.vulnerability_scanning.utils import (
+    RESULT_SUMMARY_ANNOTATIONS,
+    extract_severity_counts,
+    reconstruct_result_summary,
+)
 
 # Sentinel release_id meaning "the latest release" rather than a specific one.
 # Works in both scopes: under a specific product it's that product's is_latest
@@ -255,10 +259,20 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # VEX-suppressed findings are already excluded from each run's stored
         # summary (applied server-side at scan time / on VEX upload), so counts read
         # straight from the result.
+        #
+        # The severity summary is pulled out of ``result`` in SQL (via
+        # RESULT_SUMMARY_ANNOTATIONS) rather than projecting the whole JSONB
+        # column: the multi-MB ``findings`` array is never transferred to Python
+        # or parsed, which is what let a component with many historical runs push
+        # this endpoint into a 60-90s timeout.
         with transaction.atomic():
-            for run in timeline_query.values("created_at", "result").iterator():
+            for run in (
+                timeline_query.annotate(**RESULT_SUMMARY_ANNOTATIONS)
+                .values("created_at", *RESULT_SUMMARY_ANNOTATIONS)
+                .iterator()
+            ):
                 day_key = run["created_at"].date().isoformat()
-                counts = extract_severity_counts(run["result"])
+                counts = extract_severity_counts(reconstruct_result_summary(run))
 
                 # Timeline chart: per-day scan activity (a trend, not a snapshot).
                 if day_key not in daily_data:
@@ -274,13 +288,14 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # via DISTINCT ON — no client-side scan of the whole history. The
                 # -id secondary sort breaks created_at ties deterministically.
                 for snap in (
-                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
+                    snapshot_scope.annotate(**RESULT_SUMMARY_ANNOTATIONS)
+                    .order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")
-                    .values("result", "plugin_name", "sbom_id")
+                    .values("plugin_name", "sbom_id", *RESULT_SUMMARY_ANNOTATIONS)
                     .iterator()
                 ):
                     key = (snap["sbom_id"], snap["plugin_name"] or "unknown")
-                    latest_run_counts[key] = extract_severity_counts(snap["result"])
+                    latest_run_counts[key] = extract_severity_counts(reconstruct_result_summary(snap))
             else:
                 # Portable fallback (the SQLite test backend has no DISTINCT ON):
                 # pick the latest run per pair over lightweight columns, then load
@@ -296,13 +311,17 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     if key not in latest_run_key or (created, run_id) > latest_run_key[key]:
                         latest_run_key[key] = (created, run_id)
                         latest_run_id[key] = run_id
-                results_by_id = {
-                    row["id"]: row["result"]
-                    for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values())).values("id", "result")
+                annotated_by_id = {
+                    row["id"]: row
+                    for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values()))
+                    .annotate(**RESULT_SUMMARY_ANNOTATIONS)
+                    .values("id", *RESULT_SUMMARY_ANNOTATIONS)
                 }
                 latest_run_counts = {}
                 for key, run_id in latest_run_id.items():
-                    latest_run_counts[key] = extract_severity_counts(results_by_id.get(run_id))
+                    latest_run_counts[key] = extract_severity_counts(
+                        reconstruct_result_summary(annotated_by_id.get(run_id))
+                    )
 
         # Build time series with all days (including zeros)
         time_series = []
@@ -357,7 +376,9 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
 
         # Build recent scans (within the selected window, matching the timeline).
         recent_runs = list(
-            timeline_query.order_by("-created_at")[:5].values(
+            timeline_query.annotate(**RESULT_SUMMARY_ANNOTATIONS)
+            .order_by("-created_at")[:5]
+            .values(
                 "id",
                 "sbom__id",
                 "sbom__name",
@@ -365,8 +386,8 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 "sbom__component__id",
                 "sbom__component__name",
                 "plugin_name",
-                "result",
                 "created_at",
+                *RESULT_SUMMARY_ANNOTATIONS,
             )
         )
 
@@ -374,7 +395,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         for scan in recent_runs:
             version = scan["sbom__version"] or ""
             version_display = version[:17] + "..." if len(version) > 17 else version
-            counts = extract_severity_counts(scan["result"])
+            counts = extract_severity_counts(reconstruct_result_summary(scan))
             formatted_scans.append(
                 {
                     "id": str(scan["id"]),

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -17,6 +17,7 @@ from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
 from sbomify.apps.vulnerability_scanning.utils import (
     RESULT_SUMMARY_ANNOTATIONS,
+    RESULT_SUMMARY_FIELDS,
     extract_severity_counts,
     reconstruct_result_summary,
 )
@@ -268,7 +269,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         with transaction.atomic():
             for run in (
                 timeline_query.annotate(**RESULT_SUMMARY_ANNOTATIONS)
-                .values("created_at", *RESULT_SUMMARY_ANNOTATIONS)
+                .values("created_at", *RESULT_SUMMARY_FIELDS)
                 .iterator()
             ):
                 day_key = run["created_at"].date().isoformat()
@@ -291,7 +292,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     snapshot_scope.annotate(**RESULT_SUMMARY_ANNOTATIONS)
                     .order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")
-                    .values("plugin_name", "sbom_id", *RESULT_SUMMARY_ANNOTATIONS)
+                    .values("plugin_name", "sbom_id", *RESULT_SUMMARY_FIELDS)
                     .iterator()
                 ):
                     key = (snap["sbom_id"], snap["plugin_name"] or "unknown")
@@ -315,7 +316,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     row["id"]: row
                     for row in AssessmentRun.objects.filter(id__in=list(latest_run_id.values()))
                     .annotate(**RESULT_SUMMARY_ANNOTATIONS)
-                    .values("id", *RESULT_SUMMARY_ANNOTATIONS)
+                    .values("id", *RESULT_SUMMARY_FIELDS)
                 }
                 latest_run_counts = {}
                 for key, run_id in latest_run_id.items():
@@ -387,7 +388,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 "sbom__component__name",
                 "plugin_name",
                 "created_at",
-                *RESULT_SUMMARY_ANNOTATIONS,
+                *RESULT_SUMMARY_FIELDS,
             )
         )
 


### PR DESCRIPTION
## What

The component detail page's two heaviest HTMX endpoints — `/vulnerability-trends/?component_id=...` (the vuln graph) and `/component/<id>/sboms/` (the SBOM list) — read and JSON-parsed the entire `AssessmentRun.result` JSONB (the multi-MB `findings` array) once per row, only to extract ~6 severity integers per run.

On a component with many historical scans (an hourly DT cron plus scan-error retries piling up rows), that made the vuln graph time out at 60–90s → `504` (htmx doesn't swap on 5xx, so the card spins forever) and the SBOM list take 22–48s. Other endpoints on the same page stayed sub-second because they never project that column — that's the whole difference.

## Change

- `RESULT_SUMMARY_ANNOTATIONS` (`vulnerability_scanning/utils.py`): JSON-path text annotations that surface `summary.total_findings`, `summary.by_severity.*`, the fail/pass/error counts and `metadata.skipped` as scalar columns, so the fat `findings` blob stays out of the SELECT list.
- `reconstruct_result_summary`: rebuilds the small `result` slice the readers use from those annotations. Absent JSON keys stay absent, so callers that distinguish missing-vs-0 (e.g. `_is_run_failing` reading `pass_count`) keep their behaviour.
- `_get_trends_data` (`vulnerability_trends.py`): the timeline loop, both snapshot paths, and recent-scans annotate instead of projecting `result`.
- `list_component_sboms` (`core/apis.py`): `.defer("result").annotate(...)`, then reconstruct `run.result` from the annotations before the status helpers read it — so `_is_run_failing` / `_is_run_skipped` / `_compute_status_summary` are untouched and never lazy-load the blob.
- `extract_severity_counts` is hardened against a present-but-null `summary`/`by_severity` — a Dependency-Track scan-error result shape that raised `AttributeError` before.

Net: the `findings` blob is neither transferred to the app nor parsed; each row goes from multi-MB to a few hundred bytes.

## Tests

`test_result_annotations.py` proves, on real Postgres JSON extraction, that the annotation → reconstruct → `extract_severity_counts` roundtrip is per-row equal to reading the real blob, and that `_is_run_failing` / `_is_run_skipped` give identical verdicts — across normal / skipped / null-summary / no-summary-error / null-by_severity / compliance-counts / empty shapes. The existing trends, posture, sbom-table, and plugins suites pass unchanged. Query-only change, no migration.

## Follow-ups (not in this PR)

- Denormalize the severity counts into small int columns at write time — removes the remaining Postgres-side de-TOAST entirely (this PR removes the transfer + parse, not the DB de-TOAST).
- A retention/prune cron so `plugins_assessment_runs` stops growing unbounded (the row growth is the upstream cause; a manual prune + `VACUUM` is the immediate mitigation on the affected env).
