### PR TITLE
fix(dt): support Dependency-Track 4 and 5 (version endpoint 404 + findings pagination)

### DIFF
--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -141,18 +141,36 @@ class DependencyTrackClient:
 
         return self._make_request("GET", endpoint, params=paginated_params)
 
+    # Dependency-Track's version endpoint sits at a different path across major
+    # versions: v4 serves it at /api/version, v5 at /api/v1/version. Both lines
+    # are maintained upstream, so probe them in order and use whichever answers.
+    VERSION_ENDPOINTS = ("/version", "/v1/version")
+
+    def _request_version(self) -> dict[str, Any]:
+        """Return DT's version metadata, trying each supported version path.
+
+        Raises the last :class:`DependencyTrackAPIError` when none respond (e.g.
+        the server is unreachable or the API key is rejected on every path).
+        """
+        last_error: DependencyTrackAPIError | None = None
+        for endpoint in self.VERSION_ENDPOINTS:
+            try:
+                return self._make_request("GET", endpoint)
+            except DependencyTrackAPIError as e:
+                last_error = e
+        raise last_error or DependencyTrackAPIError("No Dependency Track version endpoint responded")
+
     def health_check(self) -> dict[str, Any]:
         """Check the health status of the Dependency Track server.
 
-        Uses /api/v1/version as the sole health indicator. This endpoint is
-        authenticated and always available when the API is reachable. The
-        /health/* endpoints are unauthenticated management endpoints that are
-        typically not exposed through reverse proxies in production, so we
-        don't rely on them.
+        Uses the version endpoint as the reachability indicator, probing both
+        the DT 4 (/api/version) and DT 5 (/api/v1/version) paths. The /health/*
+        endpoints are unauthenticated management endpoints that are typically
+        not exposed through reverse proxies in production, so we don't rely on
+        them.
         """
         try:
-            version_response = self._make_request("GET", "/v1/version")
-            return {"status": "healthy", "details": {"version": version_response}}
+            return {"status": "healthy", "details": {"version": self._request_version()}}
         except DependencyTrackAPIError as e:
             result: dict[str, Any] = {"status": "unhealthy", "error": str(e)}
             if e.status_code:
@@ -161,7 +179,7 @@ class DependencyTrackClient:
 
     def get_version(self) -> dict[str, Any]:
         """Get the version information of the Dependency Track server."""
-        return self._make_request("GET", "/v1/version")
+        return self._request_version()
 
     def create_project(
         self, name: str, version: str = "1.0.0", description: Optional[str] = None, tags: Optional[list[str]] = None
@@ -308,19 +326,65 @@ class DependencyTrackClient:
         """Get vulnerability metrics for a project."""
         return self._make_request("GET", f"/v1/metrics/project/{project_uuid}/current")
 
+    # Page size used when fetching the complete finding set. DT 5 caps an
+    # un-paged request at its default page size, so we page explicitly.
+    FINDINGS_PAGE_SIZE = 500
+
+    @staticmethod
+    def _as_finding_page(response: Any) -> dict[str, Any]:
+        """Normalise a finding response into ``{content, totalElements, ...}``."""
+        if isinstance(response, dict) and "content" in response:
+            return response
+        if isinstance(response, list):
+            return {"content": response, "totalElements": len(response), "paginated": False}
+        return {"content": [], "totalElements": 0, "paginated": False}
+
     def get_project_vulnerabilities(
         self, project_uuid: str, suppressed: bool = False, limit: Optional[int] = None, offset: Optional[int] = None
     ) -> dict[str, Any]:
-        """Get vulnerabilities for a project using the optimized finding endpoint."""
-        params = {"suppressed": str(suppressed).lower()}
-        response = self._make_paginated_request(f"/v1/finding/project/{project_uuid}", params, limit, offset)
+        """Get vulnerabilities for a project via the finding endpoint.
 
-        if isinstance(response, dict) and "content" in response:
-            return response
-        elif isinstance(response, list):
-            return {"content": response, "totalElements": len(response), "paginated": False}
-        else:
-            return {"content": [], "totalElements": 0, "paginated": False}
+        With an explicit ``limit``/``offset`` the caller's page is returned as
+        is. Without them (the scan path) the COMPLETE result set is fetched:
+        DT 4's finding endpoint ignored pagination and returned every row in one
+        response, but DT 5 enforces a default page size (100), so an un-paged
+        call there would silently truncate the findings. Page through until the
+        reported total is collected, detecting DT 4's all-in-one response (a page
+        larger than requested, or reaching ``totalElements``) to stop.
+        """
+        params = {"suppressed": str(suppressed).lower()}
+
+        if limit is not None or offset is not None:
+            return self._as_finding_page(
+                self._make_paginated_request(f"/v1/finding/project/{project_uuid}", params, limit, offset)
+            )
+
+        findings: list[Any] = []
+        page_offset = 0
+        while True:
+            page = self._as_finding_page(
+                self._make_paginated_request(
+                    f"/v1/finding/project/{project_uuid}", params, self.FINDINGS_PAGE_SIZE, page_offset
+                )
+            )
+            rows = page["content"]
+            findings.extend(rows)
+            total = page.get("totalElements")
+
+            if not isinstance(total, int):
+                # No pagination metadata to page against — page 1 is the full set.
+                break
+            if len(rows) > self.FINDINGS_PAGE_SIZE:
+                # Server ignored the page size and returned everything (DT 4).
+                break
+            if len(rows) == 0 or len(findings) >= total:
+                break
+            page_offset += self.FINDINGS_PAGE_SIZE
+            if page_offset > 100_000:
+                # ponytail: hard cap so a server that ignores offset can't loop forever.
+                break
+
+        return {"content": findings, "totalElements": len(findings), "paginated": False}
 
     def get_project_components(self, project_uuid: str) -> list[dict[str, Any]]:
         """Get all components for a project."""

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -149,16 +149,21 @@ class DependencyTrackClient:
     def _request_version(self) -> dict[str, Any]:
         """Return DT's version metadata, trying each supported version path.
 
-        Raises the last :class:`DependencyTrackAPIError` when none respond (e.g.
-        the server is unreachable or the API key is rejected on every path).
+        A 404/405 just means this DT version doesn't serve that path, so probing
+        continues. Any other error (401 bad key, 5xx, connection failure) is a
+        real fault and is surfaced ahead of a later "path not found" so the
+        health check reports the true cause rather than a misleading 404.
         """
+        real_fault: DependencyTrackAPIError | None = None
         last_error: DependencyTrackAPIError | None = None
         for endpoint in self.VERSION_ENDPOINTS:
             try:
                 return self._make_request("GET", endpoint)
             except DependencyTrackAPIError as e:
                 last_error = e
-        raise last_error or DependencyTrackAPIError("No Dependency Track version endpoint responded")
+                if real_fault is None and e.status_code not in (404, 405):
+                    real_fault = e
+        raise real_fault or last_error or DependencyTrackAPIError("No Dependency Track version endpoint responded")
 
     def health_check(self) -> dict[str, Any]:
         """Check the health status of the Dependency Track server.
@@ -329,6 +334,9 @@ class DependencyTrackClient:
     # Page size used when fetching the complete finding set. DT 5 caps an
     # un-paged request at its default page size, so we page explicitly.
     FINDINGS_PAGE_SIZE = 500
+    # Safety cap so a misbehaving server can't drive an unbounded loop; 2000
+    # pages of 500 is a million findings, far beyond any real project.
+    MAX_FINDING_PAGES = 2000
 
     @staticmethod
     def _as_finding_page(response: Any) -> dict[str, Any]:
@@ -361,7 +369,11 @@ class DependencyTrackClient:
 
         findings: list[Any] = []
         page_offset = 0
-        while True:
+        # ponytail: bounded loop so a server that never reports completion can't
+        # spin forever; MAX_FINDING_PAGES pages of FINDINGS_PAGE_SIZE covers any
+        # realistic project. Advance by rows *returned*, not the requested size,
+        # so a server that caps the page below FINDINGS_PAGE_SIZE isn't skipped.
+        for _ in range(self.MAX_FINDING_PAGES):
             page = self._as_finding_page(
                 self._make_paginated_request(
                     f"/v1/finding/project/{project_uuid}", params, self.FINDINGS_PAGE_SIZE, page_offset
@@ -379,10 +391,16 @@ class DependencyTrackClient:
                 break
             if len(rows) == 0 or len(findings) >= total:
                 break
-            page_offset += self.FINDINGS_PAGE_SIZE
-            if page_offset > 100_000:
-                # ponytail: hard cap so a server that ignores offset can't loop forever.
-                break
+            page_offset += len(rows)
+        else:
+            # Loop exhausted without a natural stop — surface it instead of
+            # silently returning a partial set.
+            logger.warning(
+                "DT finding pagination hit the %d-page cap for project %s (collected %d)",
+                self.MAX_FINDING_PAGES,
+                project_uuid,
+                len(findings),
+            )
 
         return {"content": findings, "totalElements": len(findings), "paginated": False}
 

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -144,47 +144,22 @@ class DependencyTrackClient:
     # Dependency-Track's version endpoint sits at a different path across major
     # versions: v4 serves it at /api/version, v5 at /api/v1/version. Both lines
     # are maintained upstream, so probe them in order and use whichever answers.
-    VERSION_ENDPOINTS = ("/version", "/v1/version")
-
-    def _request_version(self) -> dict[str, Any]:
-        """Return DT's version metadata, trying each supported version path.
-
-        A 404/405 just means this DT version doesn't serve that path, so probing
-        continues. Any other error (401 bad key, 5xx, connection failure) is a
-        real fault and is surfaced ahead of a later "path not found" so the
-        health check reports the true cause rather than a misleading 404.
-        """
-        real_fault: DependencyTrackAPIError | None = None
-        last_error: DependencyTrackAPIError | None = None
-        for endpoint in self.VERSION_ENDPOINTS:
-            try:
-                return self._make_request("GET", endpoint)
-            except DependencyTrackAPIError as e:
-                last_error = e
-                if real_fault is None and e.status_code not in (404, 405):
-                    real_fault = e
-        if real_fault is not None:
-            raise real_fault
-        if last_error is not None:
-            # Every path 404/405'd: none of the known version endpoints exist on
-            # this server. Say so explicitly rather than surfacing a bare 404.
-            raise DependencyTrackAPIError(
-                f"No Dependency Track version endpoint found (tried {', '.join(self.VERSION_ENDPOINTS)})",
-                status_code=last_error.status_code,
-            )
-        raise DependencyTrackAPIError("No Dependency Track version endpoint responded")
+    # DT serves its version at the unversioned /api/version — the Alpine
+    # framework's VersionResource (@Path("/version") under the /api/* servlet),
+    # identical on DT 4 and DT 5. There is no /api/v1/version on any version;
+    # the /v1 prefix only applies to DT's own domain resources.
+    VERSION_ENDPOINT = "/version"
 
     def health_check(self) -> dict[str, Any]:
         """Check the health status of the Dependency Track server.
 
-        Uses the version endpoint as the reachability indicator, probing both
-        the DT 4 (/api/version) and DT 5 (/api/v1/version) paths. The /health/*
-        endpoints are unauthenticated management endpoints that are typically
-        not exposed through reverse proxies in production, so we don't rely on
-        them.
+        Uses /api/version as the reachability indicator: it's served on the API
+        port and present on both DT 4 and DT 5. The /health/* endpoints live on
+        a separate management port that isn't exposed through reverse proxies in
+        production, so we don't rely on them.
         """
         try:
-            return {"status": "healthy", "details": {"version": self._request_version()}}
+            return {"status": "healthy", "details": {"version": self._make_request("GET", self.VERSION_ENDPOINT)}}
         except DependencyTrackAPIError as e:
             result: dict[str, Any] = {"status": "unhealthy", "error": str(e)}
             if e.status_code:
@@ -193,7 +168,7 @@ class DependencyTrackClient:
 
     def get_version(self) -> dict[str, Any]:
         """Get the version information of the Dependency Track server."""
-        return self._request_version()
+        return self._make_request("GET", self.VERSION_ENDPOINT)
 
     def create_project(
         self, name: str, version: str = "1.0.0", description: Optional[str] = None, tags: Optional[list[str]] = None

--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -163,7 +163,16 @@ class DependencyTrackClient:
                 last_error = e
                 if real_fault is None and e.status_code not in (404, 405):
                     real_fault = e
-        raise real_fault or last_error or DependencyTrackAPIError("No Dependency Track version endpoint responded")
+        if real_fault is not None:
+            raise real_fault
+        if last_error is not None:
+            # Every path 404/405'd: none of the known version endpoints exist on
+            # this server. Say so explicitly rather than surfacing a bare 404.
+            raise DependencyTrackAPIError(
+                f"No Dependency Track version endpoint found (tried {', '.join(self.VERSION_ENDPOINTS)})",
+                status_code=last_error.status_code,
+            )
+        raise DependencyTrackAPIError("No Dependency Track version endpoint responded")
 
     def health_check(self) -> dict[str, Any]:
         """Check the health status of the Dependency Track server.
@@ -369,8 +378,8 @@ class DependencyTrackClient:
 
         findings: list[Any] = []
         page_offset = 0
-        # ponytail: bounded loop so a server that never reports completion can't
-        # spin forever; MAX_FINDING_PAGES pages of FINDINGS_PAGE_SIZE covers any
+        # Bounded loop so a server that never reports completion can't spin
+        # forever; MAX_FINDING_PAGES pages of FINDINGS_PAGE_SIZE covers any
         # realistic project. Advance by rows *returned*, not the requested size,
         # so a server that caps the page below FINDINGS_PAGE_SIZE isn't skipped.
         for _ in range(self.MAX_FINDING_PAGES):
@@ -393,13 +402,13 @@ class DependencyTrackClient:
                 break
             page_offset += len(rows)
         else:
-            # Loop exhausted without a natural stop — surface it instead of
-            # silently returning a partial set.
-            logger.warning(
-                "DT finding pagination hit the %d-page cap for project %s (collected %d)",
-                self.MAX_FINDING_PAGES,
-                project_uuid,
-                len(findings),
+            # Loop exhausted without a natural stop. Returning what we have would
+            # be a partial finding set masquerading as complete, so a scan could
+            # silently miss vulnerabilities — fail fast so the caller treats it
+            # as a scan error.
+            raise DependencyTrackAPIError(
+                f"Dependency Track returned more than {self.MAX_FINDING_PAGES} finding pages "
+                f"for project {project_uuid}; refusing to report a partial finding set"
             )
 
         return {"content": findings, "totalElements": len(findings), "paginated": False}

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -94,6 +94,19 @@ class TestDependencyTrackClient:
         assert "Unauthorized" in result["error"]
         assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
 
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
+    def test_health_check_both_paths_404_reports_dedicated_message(self, mock_make_request):
+        """When every version path 404s, report that both were tried, not a bare 404."""
+        mock_make_request.side_effect = DependencyTrackAPIError("not found", status_code=404)
+
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert result["status_code"] == 404
+        assert "No Dependency Track version endpoint found" in result["error"]
+        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
+
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
     def test_get_project_vulnerabilities_dt4_all_in_one(self, mock_paginated):
         """DT 4 ignores the page size and returns every finding in one response."""
@@ -169,6 +182,25 @@ class TestDependencyTrackClient:
             call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 200),
             call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 400),
         ]
+
+    @patch.object(DependencyTrackClient, "MAX_FINDING_PAGES", 2)
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_fails_fast_at_page_cap(self, mock_paginated):
+        """Hitting the page cap raises instead of returning a partial finding set.
+
+        A partial set reported as complete would let a scan silently miss vulns.
+        """
+        # Every page is full and total is never reached, so the loop runs to the cap.
+        mock_paginated.return_value = {
+            "content": [{"n": i} for i in range(500)],
+            "totalElements": 10_000_000,
+            "paginated": True,
+        }
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+
+        with pytest.raises(DependencyTrackAPIError, match="partial finding set"):
+            client.get_project_vulnerabilities("proj-uuid")
+        assert mock_paginated.call_count == 2
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_create_project_success(self, mock_make_request):

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -74,6 +74,26 @@ class TestDependencyTrackClient:
         assert result["status_code"] == 401
         assert "Unauthorized" in result["error"]
 
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
+    def test_health_check_surfaces_real_fault_over_probe_404(self, mock_make_request):
+        """A 401 on the first path must win over a 404 on the fallback path.
+
+        A 404 only means the path is absent on this DT version; the 401 is the
+        real fault and is what the health check should report.
+        """
+        mock_make_request.side_effect = [
+            DependencyTrackAPIError("Unauthorized", status_code=401),
+            DependencyTrackAPIError("not found", status_code=404),
+        ]
+
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.health_check()
+
+        assert result["status"] == "unhealthy"
+        assert result["status_code"] == 401
+        assert "Unauthorized" in result["error"]
+        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
+
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
     def test_get_project_vulnerabilities_dt4_all_in_one(self, mock_paginated):
         """DT 4 ignores the page size and returns every finding in one response."""
@@ -127,6 +147,28 @@ class TestDependencyTrackClient:
 
         assert result["totalElements"] == 42
         mock_paginated.assert_called_once_with("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 10, 5)
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_advances_by_rows_returned(self, mock_paginated):
+        """A server that caps the page below the requested size must not skip rows.
+
+        We ask for 500 but the server returns 200 per page; the offset advances by
+        the rows actually returned (200), so all 500 findings are collected.
+        """
+        mock_paginated.side_effect = [
+            {"content": [{"n": i} for i in range(0, 200)], "totalElements": 500, "paginated": True},
+            {"content": [{"n": i} for i in range(200, 400)], "totalElements": 500, "paginated": True},
+            {"content": [{"n": i} for i in range(400, 500)], "totalElements": 500, "paginated": True},
+        ]
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.get_project_vulnerabilities("proj-uuid")
+
+        assert len(result["content"]) == 500
+        assert mock_paginated.call_args_list == [
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 0),
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 200),
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 400),
+        ]
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_create_project_success(self, mock_make_request):

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -25,8 +25,8 @@ class TestDependencyTrackClient:
         assert client.timeout == 60
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_success_dt4(self, mock_make_request):
-        """DT 4 serves the version at /api/version, which is probed first."""
+    def test_health_check_success(self, mock_make_request):
+        """Healthy when /api/version responds — the unversioned endpoint on DT 4 and DT 5."""
         version_response = {"version": "4.14.1", "application": "Dependency-Track"}
         mock_make_request.return_value = version_response
 
@@ -38,21 +38,8 @@ class TestDependencyTrackClient:
         mock_make_request.assert_called_once_with("GET", "/version")
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_success_dt5_falls_back_to_v1(self, mock_make_request):
-        """DT 5 404s /api/version, so the client falls back to /api/v1/version."""
-        version_response = {"version": "5.0.0", "application": "Dependency-Track"}
-        mock_make_request.side_effect = [DependencyTrackAPIError("not found", status_code=404), version_response]
-
-        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
-        result = client.health_check()
-
-        assert result["status"] == "healthy"
-        assert result["details"]["version"] == version_response
-        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
-
-    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_failure_probes_both_paths(self, mock_make_request):
-        """Unhealthy only when every version path fails; both are attempted."""
+    def test_health_check_failure(self, mock_make_request):
+        """Unhealthy when /api/version fails."""
         mock_make_request.side_effect = DependencyTrackAPIError("Connection failed")
 
         client = DependencyTrackClient("https://dt.example.com", "test-api-key")
@@ -60,11 +47,11 @@ class TestDependencyTrackClient:
 
         assert result["status"] == "unhealthy"
         assert "Connection failed" in str(result["error"])
-        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
+        mock_make_request.assert_called_once_with("GET", "/version")
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_health_check_includes_status_code(self, mock_make_request):
-        """Test health check error includes HTTP status code as separate field."""
+        """Health check error includes the HTTP status code as a separate field."""
         mock_make_request.side_effect = DependencyTrackAPIError("Unauthorized", status_code=401)
 
         client = DependencyTrackClient("https://dt.example.com", "test-api-key")
@@ -73,39 +60,6 @@ class TestDependencyTrackClient:
         assert result["status"] == "unhealthy"
         assert result["status_code"] == 401
         assert "Unauthorized" in result["error"]
-
-    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_surfaces_real_fault_over_probe_404(self, mock_make_request):
-        """A 401 on the first path must win over a 404 on the fallback path.
-
-        A 404 only means the path is absent on this DT version; the 401 is the
-        real fault and is what the health check should report.
-        """
-        mock_make_request.side_effect = [
-            DependencyTrackAPIError("Unauthorized", status_code=401),
-            DependencyTrackAPIError("not found", status_code=404),
-        ]
-
-        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
-        result = client.health_check()
-
-        assert result["status"] == "unhealthy"
-        assert result["status_code"] == 401
-        assert "Unauthorized" in result["error"]
-        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
-
-    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_both_paths_404_reports_dedicated_message(self, mock_make_request):
-        """When every version path 404s, report that both were tried, not a bare 404."""
-        mock_make_request.side_effect = DependencyTrackAPIError("not found", status_code=404)
-
-        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
-        result = client.health_check()
-
-        assert result["status"] == "unhealthy"
-        assert result["status_code"] == 404
-        assert "No Dependency Track version endpoint found" in result["error"]
-        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
     def test_get_project_vulnerabilities_dt4_all_in_one(self, mock_paginated):

--- a/sbomify/apps/vulnerability_scanning/tests/test_clients.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_clients.py
@@ -1,7 +1,7 @@
 """Tests for vulnerability scanning clients using real Dependency Track API schemas."""
 
 import uuid
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -25,9 +25,9 @@ class TestDependencyTrackClient:
         assert client.timeout == 60
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_success(self, mock_make_request):
-        """Test successful health check via /api/v1/version."""
-        version_response = {"version": "4.12.0", "timestamp": "2024-01-01T00:00:00Z"}
+    def test_health_check_success_dt4(self, mock_make_request):
+        """DT 4 serves the version at /api/version, which is probed first."""
+        version_response = {"version": "4.14.1", "application": "Dependency-Track"}
         mock_make_request.return_value = version_response
 
         client = DependencyTrackClient("https://dt.example.com", "test-api-key")
@@ -35,20 +35,32 @@ class TestDependencyTrackClient:
 
         assert result["status"] == "healthy"
         assert result["details"]["version"] == version_response
-        mock_make_request.assert_called_once_with("GET", "/v1/version")
+        mock_make_request.assert_called_once_with("GET", "/version")
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
-    def test_health_check_failure(self, mock_make_request):
-        """Test health check returns unhealthy when /api/v1/version fails."""
+    def test_health_check_success_dt5_falls_back_to_v1(self, mock_make_request):
+        """DT 5 404s /api/version, so the client falls back to /api/v1/version."""
+        version_response = {"version": "5.0.0", "application": "Dependency-Track"}
+        mock_make_request.side_effect = [DependencyTrackAPIError("not found", status_code=404), version_response]
+
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.health_check()
+
+        assert result["status"] == "healthy"
+        assert result["details"]["version"] == version_response
+        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
+    def test_health_check_failure_probes_both_paths(self, mock_make_request):
+        """Unhealthy only when every version path fails; both are attempted."""
         mock_make_request.side_effect = DependencyTrackAPIError("Connection failed")
 
         client = DependencyTrackClient("https://dt.example.com", "test-api-key")
         result = client.health_check()
 
         assert result["status"] == "unhealthy"
-        assert "error" in result
         assert "Connection failed" in str(result["error"])
-        mock_make_request.assert_called_once_with("GET", "/v1/version")
+        assert mock_make_request.call_args_list == [call("GET", "/version"), call("GET", "/v1/version")]
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_health_check_includes_status_code(self, mock_make_request):
@@ -61,6 +73,60 @@ class TestDependencyTrackClient:
         assert result["status"] == "unhealthy"
         assert result["status_code"] == 401
         assert "Unauthorized" in result["error"]
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_dt4_all_in_one(self, mock_paginated):
+        """DT 4 ignores the page size and returns every finding in one response."""
+        mock_paginated.return_value = {
+            "content": [{"n": i} for i in range(700)],
+            "totalElements": 700,
+            "paginated": True,
+        }
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.get_project_vulnerabilities("proj-uuid")
+
+        assert len(result["content"]) == 700
+        assert result["totalElements"] == 700
+        mock_paginated.assert_called_once_with("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 0)
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_dt5_pages_through_all(self, mock_paginated):
+        """DT 5 enforces a page size, so the client must page to get every finding."""
+        mock_paginated.side_effect = [
+            {"content": [{"n": i} for i in range(0, 500)], "totalElements": 1200, "paginated": True},
+            {"content": [{"n": i} for i in range(500, 1000)], "totalElements": 1200, "paginated": True},
+            {"content": [{"n": i} for i in range(1000, 1200)], "totalElements": 1200, "paginated": True},
+        ]
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.get_project_vulnerabilities("proj-uuid")
+
+        assert len(result["content"]) == 1200
+        assert result["totalElements"] == 1200
+        assert mock_paginated.call_args_list == [
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 0),
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 500),
+            call("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 500, 1000),
+        ]
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_single_page(self, mock_paginated):
+        """A result set within one page is fetched in a single request."""
+        mock_paginated.return_value = {"content": [{"n": i} for i in range(80)], "totalElements": 80, "paginated": True}
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.get_project_vulnerabilities("proj-uuid")
+
+        assert len(result["content"]) == 80
+        mock_paginated.assert_called_once()
+
+    @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_paginated_request")
+    def test_get_project_vulnerabilities_explicit_paging_single_request(self, mock_paginated):
+        """An explicit limit/offset is honoured verbatim (no auto-paging)."""
+        mock_paginated.return_value = {"content": [{"n": 1}], "totalElements": 42, "paginated": True}
+        client = DependencyTrackClient("https://dt.example.com", "test-api-key")
+        result = client.get_project_vulnerabilities("proj-uuid", limit=10, offset=5)
+
+        assert result["totalElements"] == 42
+        mock_paginated.assert_called_once_with("/v1/finding/project/proj-uuid", {"suppressed": "false"}, 10, 5)
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")
     def test_create_project_success(self, mock_make_request):
@@ -308,8 +374,10 @@ class TestDependencyTrackClient:
         assert result["content"][0]["vulnerability"]["severity"] == "CRITICAL"
         assert result["content"][0]["component"]["name"] == "log4j-core"
 
+        # No explicit paging -> the client fetches the full set by page; a
+        # single-page result completes in one request.
         mock_make_paginated_request.assert_called_once_with(
-            f"/v1/finding/project/{project_uuid}", {"suppressed": "false"}, None, None
+            f"/v1/finding/project/{project_uuid}", {"suppressed": "false"}, 500, 0
         )
 
     @patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient._make_request")


### PR DESCRIPTION
## What

Makes the Dependency-Track client work against both DT 4 and DT 5. Verified against the DT/Alpine source on both branches and the [v5 breaking-changes reference](https://dependencytrack.github.io/docs/next/reference/api/v5-breaking-changes/).

### 1. Version / health-check endpoint (the "DT scan error" cause)

`health_check()` hit `GET /api/v1/version`, which **no DT version serves**. The version endpoint is the Alpine framework's `VersionResource`, annotated `@Path("/version")` under DT's `/api/*` servlet, so it resolves to **`/api/version`** on both DT 4 (`master`) and DT 5 (`main`) — Alpine is shared and the servlet mapping is identical across the major. The `/v1` prefix only exists because DT's own domain resources use it (e.g. `@Path("/v1/bom")`); `VersionResource` has no `/v1`, so `/api/v1/version` 404s everywhere.

That 404 marked every server unhealthy → `select_dependency_track_server` found none → scans errored with *"No available Dependency Track servers"* (staging logged it 864×; reproduced live in a fresh scan on DT 4.14).

Fix: call `/api/version` directly.

### 2. Findings pagination (silent truncation on DT 5)

DT 4's `/api/v1/finding/project/{uuid}` returned every finding in one response; DT 5 enforces a default page size (100), so the un-paged scan call would silently drop findings past the first 100. `get_project_vulnerabilities()` now pages through the complete set when called without an explicit limit — advancing by the rows actually returned (so a server that caps the page below the request doesn't skip rows), and raising rather than silently truncating if it ever hits the page cap. It's version-agnostic: no version sniffing.

### Not affected

We don't read `vulnerability.cwes`, so the v5 int→object `cwes` change doesn't touch us. The other scan endpoints match the DT 4.14.1 OpenAPI unchanged. DT 5 adds a separate `/api/v2/*` servlet, but the version endpoint stays unversioned at `/api/version`.

## On the review feedback

The earlier revision probed `/api/version` then `/api/v1/version` as a fallback. Since `/api/v1/version` is never a real endpoint on any DT version, that fallback added no coverage — so this is simpler than both the two-path probe *and* a DT4/DT5 conditional: just hit `/api/version`. Pagination is handled version-agnostically by auto-paging rather than branching on the detected version.

## Tests

Health check succeeds and fails on the single `/api/version` call. Findings paging covers DT 4 all-in-one (one request), DT 5 multi-page, advance-by-rows when the server caps the page, fail-fast at the page cap, and explicit limit/offset passthrough.
