### PR TITLE
perf(vuln): annotate only the DISTINCT ON winners — fixes component-page 504s at scale

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4206,15 +4206,23 @@ def list_component_sboms(
         runs_by_sbom: dict[str, list[AssessmentRun]] = defaultdict(list)
         plugin_names_seen: set[str] = set()
         try:
-            latest_runs = list(
+            # Two-phase on purpose: the summary annotations extract JSON keys
+            # from ``result``, and computing them on the DISTINCT ON input made
+            # Postgres de-TOAST every historical run's multi-MB blob only to
+            # discard the losers — >100s for a component with hundreds of SBOM
+            # versions. Phase 1 picks the winning run ids touching no JSON;
+            # phase 2 annotates just those winners.
+            winner_ids = list(
                 AssessmentRun.objects.filter(sbom_id__in=sbom_ids)
-                .defer("result")
-                .annotate(**RESULT_SUMMARY_ANNOTATIONS)
                 # -id breaks created_at ties deterministically (newest row wins),
                 # matching vulnerability_trends so both surfaces agree on which
                 # run is "latest" when two share a timestamp.
                 .order_by("sbom_id", "plugin_name", "-created_at", "-id")
                 .distinct("sbom_id", "plugin_name")
+                .values_list("id", flat=True)
+            )
+            latest_runs = list(
+                AssessmentRun.objects.filter(id__in=winner_ids).defer("result").annotate(**RESULT_SUMMARY_ANNOTATIONS)
             )
             for run in latest_runs:
                 # Rebuild the small summary slice from the SQL annotations so the

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4212,6 +4212,12 @@ def list_component_sboms(
             # discard the losers — >100s for a component with hundreds of SBOM
             # versions. Phase 1 picks the winning run ids touching no JSON;
             # phase 2 annotates just those winners.
+            #
+            # The ids are materialised deliberately: passed lazily to ``id__in``,
+            # Django strips the subquery's ORDER BY, and DISTINCT ON without its
+            # ORDER BY returns an arbitrary row per group instead of the latest.
+            # The list is bounded by (sboms x plugins), the same magnitude as the
+            # ``sbom_ids`` IN-list already used above.
             winner_ids = list(
                 AssessmentRun.objects.filter(sbom_id__in=sbom_ids)
                 # -id breaks created_at ties deterministically (newest row wins),
@@ -4222,7 +4228,12 @@ def list_component_sboms(
                 .values_list("id", flat=True)
             )
             latest_runs = list(
-                AssessmentRun.objects.filter(id__in=winner_ids).defer("result").annotate(**RESULT_SUMMARY_ANNOTATIONS)
+                AssessmentRun.objects.filter(id__in=winner_ids)
+                .defer("result")
+                .annotate(**RESULT_SUMMARY_ANNOTATIONS)
+                # id__in has undefined row order; keep the per-SBOM plugin lists
+                # stable across requests.
+                .order_by("sbom_id", "plugin_name")
             )
             for run in latest_runs:
                 # Rebuild the small summary slice from the SQL annotations so the

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -288,10 +288,18 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # Postgres resolves the latest run per pair in one indexed pass
                 # via DISTINCT ON — no client-side scan of the whole history. The
                 # -id secondary sort breaks created_at ties deterministically.
-                for snap in (
-                    snapshot_scope.annotate(**RESULT_SUMMARY_ANNOTATIONS)
-                    .order_by("sbom_id", "plugin_name", "-created_at", "-id")
+                # Two-phase on purpose: computing the JSON-extracting summary
+                # annotations on the DISTINCT ON input de-TOASTs every historical
+                # run's blob only to discard the losers; picking the winner ids
+                # first keeps the JSON work proportional to (sboms x plugins).
+                snapshot_winner_ids = list(
+                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")
+                    .values_list("id", flat=True)
+                )
+                for snap in (
+                    AssessmentRun.objects.filter(id__in=snapshot_winner_ids)
+                    .annotate(**RESULT_SUMMARY_ANNOTATIONS)
                     .values("plugin_name", "sbom_id", *RESULT_SUMMARY_FIELDS)
                     .iterator()
                 ):

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -292,6 +292,10 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # annotations on the DISTINCT ON input de-TOASTs every historical
                 # run's blob only to discard the losers; picking the winner ids
                 # first keeps the JSON work proportional to (sboms x plugins).
+                # Materialised deliberately: passed lazily to ``id__in``, Django
+                # strips the subquery's ORDER BY and DISTINCT ON then returns an
+                # arbitrary row per group instead of the latest. Row order of the
+                # second query doesn't matter — rows land in a dict.
                 snapshot_winner_ids = list(
                     snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -293,9 +293,10 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # run's blob only to discard the losers; picking the winner ids
                 # first keeps the JSON work proportional to (sboms x plugins).
                 # Materialised deliberately: passed lazily to ``id__in``, Django
-                # strips the subquery's ORDER BY and DISTINCT ON then returns an
-                # arbitrary row per group instead of the latest. Row order of the
-                # second query doesn't matter — rows land in a dict.
+                # strips the subquery's ORDER BY, and DISTINCT ON without its
+                # ORDER BY returns an arbitrary row per group instead of the
+                # latest. Row order of the second query doesn't matter — rows
+                # land in a dict.
                 snapshot_winner_ids = list(
                     snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
                     .distinct("sbom_id", "plugin_name")


### PR DESCRIPTION
## What

Fixes the staging 504s on the component page (SBOM list + vulnerability trends), which persisted after #1118.

Caught live on staging: `GET /component/FoKftlVn4uyq/sboms/` (sbomify - Python Stack, **599 BOMs**) runs past the reverse proxy's ~100s timeout → Cloudflare 504 ("Host: Error"). Intermittent because the origin sometimes finishes just under the limit.

## Root cause

#1118 replaced "transfer + parse the multi-MB `result` blob in Python" with SQL summary annotations — but both DISTINCT ON call sites computed those JSON-extracting annotations **on the same query that picks the winners**. Postgres evaluates the projection before the sort/unique step, so it **de-TOASTs every historical run's blob only to discard the losers**. The endpoint's cost stayed proportional to the component's entire scan history, not to its current state.

`EXPLAIN (ANALYZE, BUFFERS)` shows it: the scan node emits `result`-carrying tuples (width 609) and the sort input already contains the computed annotation columns (width 438) — the extraction happens below the `Unique` node.

## Fix

Two phases at both call sites (`list_component_sboms` and the trends snapshot):

1. Pick the winning run ids with DISTINCT ON, selecting only `id` — touches no JSON.
2. Compute the annotations on just those winners.

JSON work drops from O(full history) to O(sboms × plugins). No behaviour change — same rows, same tiebreak (`-created_at, -id`).

## Measured (local reproduction at scale)

Seeded 50 SBOMs + 1,500 completed runs with incompressible ~270 KB result blobs (134 MB of history) on one component:

| | before | after |
|---|---|---|
| latest-runs query (300 winners) | ~840 ms | ~85 ms |
| `/component/<id>/sboms/` endpoint | 0.6–1.6 s | **~0.2 s** |

Both scale linearly with history size — at the Python Stack's 599-SBOM scale the before-case lands in the >100 s range that Cloudflare kills.

## What this does not fix

The trends **timeline** reads every run in the selected window by design (per-day sums). That per-row de-TOAST is irreducible until the summary lives in real columns — that's #1120 (denormalised summary + run retention). Pruning `plugins_assessment_runs` on staging (keep latest N per sbom+plugin) + `VACUUM` remains the strongest ops-side lever in the meantime.

## Tests

Full `vulnerability_scanning` suite + component-SBOM access tests pass (170). The existing annotation-parity tests cover the reconstruction; the two-phase split returns identical rows so no new behaviour to pin.
