### PR TITLE
fix(plugins): tolerate a malformed run result instead of blanking the assessments section

### DIFF
--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -25,6 +26,8 @@ from sbomify.apps.plugins.public_assessment_utils import get_sbom_passing_assess
 from sbomify.apps.sboms.services.sboms import get_sbom_detail
 from sbomify.apps.teams.branding import build_branding_context
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
+
+logger = logging.getLogger(__name__)
 
 
 class ComponentItemPublicView(View):
@@ -169,7 +172,9 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 # Use mode='json' to ensure datetime objects are serialized as ISO strings
                 assessment_runs = assessment_response.model_dump(mode="json")
             except Exception:
-                # If assessment fetch fails, continue without it
+                # Degrade to no assessments section rather than failing the page,
+                # but leave a trace — a silent None here hides real data problems.
+                logger.exception("Failed to fetch assessments for SBOM %s; rendering without them", item_id)
                 assessment_runs = None
 
         elif item_type == "documents":

--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -1,5 +1,6 @@
 """API endpoints for the plugins framework."""
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -8,6 +9,7 @@ from django.http import HttpRequest
 from ninja import Router
 from ninja.decorators import decorate_view
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from sbomify.apps.access_tokens.auth import optional_auth
 from sbomify.apps.core.authz import can
@@ -22,6 +24,8 @@ from .schemas import (
     SBOMAssessmentsResponse,
 )
 from .sdk.enums import RunStatus
+
+logger = logging.getLogger(__name__)
 
 router = Router(tags=["plugins"])
 
@@ -152,23 +156,37 @@ def _run_to_schema(
     release_ids = [str(rel.id) for rel in releases]
     release_names = [rel.name for rel in releases]
 
-    return AssessmentRunSchema(
-        id=str(run.id),
-        sbom_id=str(run.sbom_id),
-        release_ids=release_ids,
-        release_names=release_names,
-        plugin_name=run.plugin_name,
-        plugin_version=run.plugin_version,
-        plugin_display_name=display_name,
-        category=run.category,
-        run_reason=run.run_reason,
-        status=run.status,
-        started_at=run.started_at,
-        completed_at=run.completed_at,
-        error_message=run.error_message or None,
-        result=run.result,
-        created_at=run.created_at,
-    )
+    fields: dict[str, Any] = {
+        "id": str(run.id),
+        "sbom_id": str(run.sbom_id),
+        "release_ids": release_ids,
+        "release_names": release_names,
+        "plugin_name": run.plugin_name,
+        "plugin_version": run.plugin_version,
+        "plugin_display_name": display_name,
+        "category": run.category,
+        "run_reason": run.run_reason,
+        "status": run.status,
+        "started_at": run.started_at,
+        "completed_at": run.completed_at,
+        "error_message": run.error_message or None,
+        "result": run.result,
+        "created_at": run.created_at,
+    }
+    try:
+        return AssessmentRunSchema(**fields)
+    except PydanticValidationError:
+        # A result blob that predates (or drifted from) the current schema must
+        # not fail the whole response — every batch caller serializes many runs,
+        # so one bad row would blank the assessments for the entire SBOM.
+        # Degrade this run to result=None; its status/plugin metadata still show.
+        logger.warning(
+            "AssessmentRun %s (plugin %s) has a result that fails schema validation; serialising without it",
+            run.id,
+            run.plugin_name,
+        )
+        fields["result"] = None
+        return AssessmentRunSchema(**fields)
 
 
 def _compute_status_summary(runs: list[AssessmentRun]) -> AssessmentStatusSummary:

--- a/sbomify/apps/plugins/tests/test_assessments_malformed_result.py
+++ b/sbomify/apps/plugins/tests/test_assessments_malformed_result.py
@@ -1,0 +1,84 @@
+"""One malformed AssessmentRun.result must not blank the whole assessments response.
+
+A legacy or hand-written result blob that predates the current schema (or drifts
+from it) used to raise a ValidationError inside serialization, failing the
+entire endpoint — and the component-item view swallowed that exception, so the
+Assessment Results section silently disappeared for every run of the SBOM.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import RequestFactory
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.plugins.apis import get_sbom_assessments
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+
+VALID_RESULT = {
+    "plugin_name": "osv",
+    "plugin_version": "1.0.0",
+    "category": "security",
+    "assessed_at": "2026-07-14T00:00:00Z",
+    "schema_version": "1.0",
+    "summary": {"total_findings": 1, "by_severity": {"critical": 1}},
+    "findings": [
+        {
+            "id": "CVE-2026-0001",
+            "title": "example",
+            "description": "example finding",
+            "severity": "critical",
+        }
+    ],
+}
+
+# Missing the required envelope (plugin_name/category/assessed_at, ...) — the
+# shape a legacy plugin version or external writer can leave behind.
+MALFORMED_RESULT = {
+    "summary": {"total_findings": 2},
+    "findings": [{"id": "chk-1", "title": "no description key"}],
+}
+
+
+def _make_run(sbom: SBOM, plugin: str, result: dict) -> AssessmentRun:
+    return AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name=plugin,
+        plugin_version="1.0.0",
+        plugin_config_hash="",
+        category="security",
+        run_reason="on_upload",
+        status="completed",
+        result=result,
+    )
+
+
+@pytest.mark.django_db
+def test_malformed_result_degrades_that_run_only(sample_team_with_owner_member):
+    component = Component.objects.create(name="malformed-result-c", team=sample_team_with_owner_member.team)
+    sbom = SBOM.objects.create(
+        name="app",
+        version="1.0.0",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="a.json",
+        component=component,
+    )
+    _make_run(sbom, "osv", VALID_RESULT)
+    _make_run(sbom, "legacy-plugin", MALFORMED_RESULT)
+
+    request = RequestFactory().get(f"/api/v1/plugins/assessments/{sbom.id}")
+    request.user = sample_team_with_owner_member.user
+
+    response = get_sbom_assessments(request, str(sbom.id))
+    data = response.model_dump(mode="json")
+
+    by_plugin = {run["plugin_name"]: run for run in data["latest_runs"]}
+    assert set(by_plugin) == {"osv", "legacy-plugin"}
+    # The valid run keeps its result; the malformed one degrades to result=None
+    # instead of failing the whole response.
+    assert by_plugin["osv"]["result"]["summary"]["total_findings"] == 1
+    assert by_plugin["legacy-plugin"]["result"] is None
+    assert by_plugin["legacy-plugin"]["status"] == "completed"
+    assert data["status_summary"]["total_assessments"] == 2


### PR DESCRIPTION
## What

A single `AssessmentRun.result` blob that doesn't match the current result schema (legacy plugin version, external writer, schema drift) made `get_sbom_assessments` raise a `ValidationError` for the **whole** response — and the component-item view swallowed that exception with a bare `except`, so the Assessment Results section silently vanished for every run of the SBOM. Nothing in the logs; it looks exactly like "plugins never completed".

## Fix

- `_run_to_schema` catches the per-run validation failure, logs which run/plugin failed, and serialises that run with `result=None` — its status, plugin name, and dates still render; only the unreadable findings payload is dropped. All batch callers (assessments endpoint, badge) inherit the behaviour.
- The component-item fallback still degrades gracefully but now logs the exception instead of hiding it.

## Verified

- TDD: new test seeds one valid + one malformed run and asserts both are returned, the malformed one degraded, summary counting both (fails on master with the ValidationError).
- Live: injected a malformed run next to valid ones on a local SBOM — page renders all runs, warning names the offending run id. Removing the run restores full detail.
- Full `plugins` suite passes (759).

## Note

Found while diagnosing an SBOM detail page that showed no assessments despite 30 completed runs — the blank section was this silent failure, not stuck plugins.
