### PR TITLE
feat(releases): VEX download button on the internal release page

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2753,6 +2753,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
                         "sbom_format": artifact.sbom.format,
                         "sbom_format_version": artifact.sbom.format_version,
                         "sbom_version": artifact.sbom.version or "",
+                        "bom_type": artifact.sbom.bom_type,
                         "document_type": None,
                         "document_version": None,
                     }
@@ -3380,6 +3381,7 @@ def list_release_artifacts(
                         "sbom_format": artifact.sbom.format,
                         "sbom_format_version": artifact.sbom.format_version,
                         "sbom_version": artifact.sbom.version or "",
+                        "bom_type": artifact.sbom.bom_type,
                         "document_type": None,
                         "document_version": None,
                         "component_slug": artifact.sbom.component.slug,
@@ -3449,6 +3451,7 @@ def list_release_artifacts(
                     "format": sbom.format,
                     "format_version": sbom.format_version,
                     "version": sbom.version or "",
+                    "bom_type": sbom.bom_type,
                     "created_at": sbom.created_at.isoformat(),
                 }
             )

--- a/sbomify/apps/core/js/components/release-artifacts.ts
+++ b/sbomify/apps/core/js/components/release-artifacts.ts
@@ -470,7 +470,7 @@ export function registerReleaseArtifacts() {
                     case 'sbom':
                         return 'fas fa-file-code';
                     case 'vex':
-                        return 'fas fa-shield-alt';
+                        return 'fas fa-file-contract';
                     case 'document':
                         return 'fas fa-file-alt';
                     default:
@@ -497,7 +497,7 @@ export function registerReleaseArtifacts() {
             // Available artifact methods
             getAvailableTypeIcon(artifact: AvailableArtifact): string {
                 if (artifact.artifact_type === 'sbom') {
-                    return artifact.bom_type === 'vex' ? 'fas fa-shield-alt' : 'fas fa-file-code';
+                    return artifact.bom_type === 'vex' ? 'fas fa-file-contract' : 'fas fa-file-code';
                 }
                 if (artifact.artifact_type === 'document') return 'fas fa-file-alt';
                 return 'fas fa-file';

--- a/sbomify/apps/core/js/components/release-artifacts.ts
+++ b/sbomify/apps/core/js/components/release-artifacts.ts
@@ -32,6 +32,7 @@ interface Artifact {
     sbom_format?: string;
     sbom_format_version?: string;
     sbom_version?: string;
+    bom_type?: string;
     document_type?: string;
     document_version?: string;
     component_id?: string;
@@ -50,6 +51,7 @@ interface AvailableArtifact {
     version?: string;
     format?: string;
     format_version?: string;
+    bom_type?: string;
     document_type?: string;
     created_at: string;
     component?: {
@@ -354,7 +356,11 @@ export function registerReleaseArtifacts() {
 
             // Artifact data extraction methods
             getArtifactType(artifact: Artifact): string {
-                if (artifact.sbom || artifact.artifact_type === 'sbom') return 'sbom';
+                if (artifact.sbom || artifact.artifact_type === 'sbom') {
+                    // A VEX is stored as an SBOM row with bom_type='vex'; badge it
+                    // as VEX so it doesn't read as a duplicate SBOM of the component.
+                    return artifact.bom_type === 'vex' ? 'vex' : 'sbom';
+                }
                 if (artifact.document || artifact.artifact_type === 'document') return 'document';
                 return artifact.type || 'unknown';
             },
@@ -463,6 +469,8 @@ export function registerReleaseArtifacts() {
                 switch (type.toLowerCase()) {
                     case 'sbom':
                         return 'fas fa-file-code';
+                    case 'vex':
+                        return 'fas fa-shield-alt';
                     case 'document':
                         return 'fas fa-file-alt';
                     default:
@@ -473,6 +481,7 @@ export function registerReleaseArtifacts() {
             getArtifactIconClass(artifact: Artifact): string {
                 const type = this.getArtifactType(artifact);
                 if (type === 'sbom') return 'bg-success/10 text-success';
+                if (type === 'vex') return 'bg-info/10 text-info';
                 if (type === 'document') return 'bg-warning/10 text-warning';
                 return 'bg-surface text-text-muted';
             },
@@ -480,19 +489,24 @@ export function registerReleaseArtifacts() {
             getArtifactBadgeClass(artifact: Artifact): string {
                 const type = this.getArtifactType(artifact);
                 if (type === 'sbom') return 'bg-success/10 text-success border border-success/30';
+                if (type === 'vex') return 'bg-info/10 text-info border border-info/30';
                 if (type === 'document') return 'bg-warning/10 text-warning border border-warning/30';
                 return 'bg-surface text-text-muted border border-border';
             },
 
             // Available artifact methods
             getAvailableTypeIcon(artifact: AvailableArtifact): string {
-                if (artifact.artifact_type === 'sbom') return 'fas fa-file-code';
+                if (artifact.artifact_type === 'sbom') {
+                    return artifact.bom_type === 'vex' ? 'fas fa-shield-alt' : 'fas fa-file-code';
+                }
                 if (artifact.artifact_type === 'document') return 'fas fa-file-alt';
                 return 'fas fa-file';
             },
 
             getAvailableArtifactIconClass(artifact: AvailableArtifact): string {
-                if (artifact.artifact_type === 'sbom') return 'bg-success/10 text-success';
+                if (artifact.artifact_type === 'sbom') {
+                    return artifact.bom_type === 'vex' ? 'bg-info/10 text-info' : 'bg-success/10 text-success';
+                }
                 if (artifact.artifact_type === 'document') return 'bg-warning/10 text-warning';
                 return 'bg-surface text-text-muted';
             },

--- a/sbomify/apps/core/schemas.py
+++ b/sbomify/apps/core/schemas.py
@@ -432,6 +432,7 @@ class ReleaseArtifactSchema(BaseModel):
     sbom_format: str | None = None
     sbom_format_version: str | None = None
     sbom_version: str | None = None
+    bom_type: str | None = Field(None, description="BOM type of an sbom artifact: 'sbom', 'vex', 'cbom', ...")
     document_type: str | None = None
     document_version: str | None = None
     component_slug: str | None = None
@@ -447,6 +448,7 @@ class AvailableArtifactSchema(BaseModel):
     format: str | None = None
     format_version: str | None = None
     version: str | None = None
+    bom_type: str | None = Field(None, description="BOM type of an sbom artifact: 'sbom', 'vex', 'cbom', ...")
     document_type: str | None = None
     created_at: str
 

--- a/sbomify/apps/core/templates/core/release_details_private.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_private.html.j2
@@ -55,28 +55,38 @@
                 </div>
             </div>
             {# Download Buttons - Desktop #}
-            {% if release.has_sboms %}
+            {% if release.has_sboms or release.has_vex %}
                 <div class="hidden lg:flex gap-2 flex-shrink-0">
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}"
-                       title="Download as CycloneDX">
-                        <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                             alt="CycloneDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download"></i>
-                    </a>
-                    <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
-                       href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                       title="Download as SPDX">
-                        <img src="{% static 'img/spdx-logo.svg' %}"
-                             alt="SPDX"
-                             class="h-4 w-auto dark:brightness-0 dark:invert"
-                             width="16"
-                             height="16">
-                        <i class="fas fa-download"></i>
-                    </a>
+                    {% if release.has_sboms %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}"
+                           title="Download as CycloneDX">
+                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                 alt="CycloneDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download"></i>
+                        </a>
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                           title="Download as SPDX">
+                            <img src="{% static 'img/spdx-logo.svg' %}"
+                                 alt="SPDX"
+                                 class="h-4 w-auto dark:brightness-0 dark:invert"
+                                 width="16"
+                                 height="16">
+                            <i class="fas fa-download"></i>
+                        </a>
+                    {% endif %}
+                    {% if release.has_vex %}
+                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                           href="{% url 'api-1:download_release_vex' release.id %}"
+                           title="Download latest VEX (CycloneDX)">
+                            <span class="text-sm font-semibold tracking-wide">VEX</span>
+                            <i class="fas fa-download"></i>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>
@@ -124,7 +134,7 @@
             </div>
         </div>
         {# Download Release Card - Mobile Only #}
-        {% if release.has_sboms %}
+        {% if release.has_sboms or release.has_vex %}
             <div class="tw-card lg:hidden">
                 <div class="px-6 py-4 border-b border-border">
                     <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
@@ -135,26 +145,36 @@
                 <div class="p-6 text-center">
                     <p class="text-text-muted mb-4">Download consolidated SBOM containing all artifacts in this release</p>
                     <div class="flex justify-center gap-3 flex-wrap">
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}"
-                           title="Download as CycloneDX">
-                            <img src="{% static 'img/cyclonedx-logo.svg' %}"
-                                 alt="CycloneDX"
-                                 class="h-[18px] w-auto dark:brightness-0 dark:invert"
-                                 width="18"
-                                 height="18">
-                            <i class="fas fa-download"></i>
-                        </a>
-                        <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
-                           href="{% url 'api-1:download_release' release.id %}?format=spdx"
-                           title="Download as SPDX">
-                            <img src="{% static 'img/spdx-logo.svg' %}"
-                                 alt="SPDX"
-                                 class="h-[18px] w-auto dark:brightness-0 dark:invert"
-                                 width="18"
-                                 height="18">
-                            <i class="fas fa-download"></i>
-                        </a>
+                        {% if release.has_sboms %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}"
+                               title="Download as CycloneDX">
+                                <img src="{% static 'img/cyclonedx-logo.svg' %}"
+                                     alt="CycloneDX"
+                                     class="h-[18px] w-auto dark:brightness-0 dark:invert"
+                                     width="18"
+                                     height="18">
+                                <i class="fas fa-download"></i>
+                            </a>
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                               href="{% url 'api-1:download_release' release.id %}?format=spdx"
+                               title="Download as SPDX">
+                                <img src="{% static 'img/spdx-logo.svg' %}"
+                                     alt="SPDX"
+                                     class="h-[18px] w-auto dark:brightness-0 dark:invert"
+                                     width="18"
+                                     height="18">
+                                <i class="fas fa-download"></i>
+                            </a>
+                        {% endif %}
+                        {% if release.has_vex %}
+                            <a class="tw-btn-secondary inline-flex items-center gap-2 no-underline"
+                               href="{% url 'api-1:download_release_vex' release.id %}"
+                               title="Download latest VEX (CycloneDX)">
+                                <span class="text-sm font-semibold tracking-wide">VEX</span>
+                                <i class="fas fa-download"></i>
+                            </a>
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## What

The public Trust Center release page has CycloneDX / SPDX / VEX download buttons; the internal release page only had CycloneDX and SPDX, so a workspace member couldn't download a release's VEX from inside the app.

Adds the VEX button to the internal release page (desktop button row + mobile download card), shown when `release.has_vex` — the flag `_build_release_response` already provides. Reuses the existing `download_release_vex` endpoint and the public page's markup verbatim. The download rows now also render for a VEX-only release (previously gated solely on `has_sboms`).

Template-only change; djlint clean. Verified in the browser against a release carrying SBOM + VEX artifacts: button renders, download returns the merged CycloneDX VEX (HTTP 200).
