### PR TITLE
feat(sboms): VEX upload from the component page UI

### DIFF
--- a/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
@@ -4,9 +4,11 @@
 <div x-data="componentVisibilitySelector({ itemId: '{{ component.id|escapejs }}', publicUrl: '{{ component_public_url|escapejs }}', currentVisibility: '{{ component.visibility|escapejs }}', gatedVisibilityAllowed: {{ gated_visibility_allowed|yesno:'true,false' }} })"
      class="inline-flex items-center gap-3 flex-wrap px-3 py-2 bg-background border border-border rounded-lg">
     <div class="relative" :class="{ 'opacity-50': isLoading }">
-        {# Plain "change" scopes the trigger to this form's own select via
-           bubbling; "from:select" would listen on every select in the
-           document and fire visibility POSTs from unrelated dropdowns. #}
+        {% comment %}
+        Plain "change" scopes the trigger to this form's own select via
+        bubbling; "from:select" would listen on every select in the
+        document and fire visibility POSTs from unrelated dropdowns.
+        {% endcomment %}
         <form hx-post="{% url 'core:toggle_public_status' 'component' component.id %}"
               hx-trigger="change"
               hx-swap="none"

--- a/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
@@ -4,8 +4,11 @@
 <div x-data="componentVisibilitySelector({ itemId: '{{ component.id|escapejs }}', publicUrl: '{{ component_public_url|escapejs }}', currentVisibility: '{{ component.visibility|escapejs }}', gatedVisibilityAllowed: {{ gated_visibility_allowed|yesno:'true,false' }} })"
      class="inline-flex items-center gap-3 flex-wrap px-3 py-2 bg-background border border-border rounded-lg">
     <div class="relative" :class="{ 'opacity-50': isLoading }">
+        {# Plain "change" scopes the trigger to this form's own select via
+           bubbling; "from:select" would listen on every select in the
+           document and fire visibility POSTs from unrelated dropdowns. #}
         <form hx-post="{% url 'core:toggle_public_status' 'component' component.id %}"
-              hx-trigger="change from:select"
+              hx-trigger="change"
               hx-swap="none"
               @htmx:before-request="beforeRequestHandler()"
               @htmx:after-request="afterRequestHandler($event)">

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -9,7 +9,10 @@ export function bomTypeLabel(bomType: UploadBomType): string {
 }
 
 export function buildUploadEndpoint(componentId: string, bomType: UploadBomType): string {
-    return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
+    // The default SBOM case must omit bom_type: the server's CBOM
+    // auto-detection only runs when the caller leaves it unset.
+    const base = `/api/v1/sboms/upload-file/${componentId}`
+    return bomType === 'sbom' ? base : `${base}?bom_type=${encodeURIComponent(bomType)}`
 }
 
 export function validateUploadFile(file: File, bomType: UploadBomType): string | null {

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -1,0 +1,34 @@
+export const MAX_SBOM_SIZE = 100 * 1024 * 1024;
+export const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
+export const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
+
+export type UploadBomType = 'sbom' | 'vex'
+
+export function bomTypeLabel(bomType: UploadBomType): string {
+    return bomType === 'vex' ? 'VEX' : 'SBOM'
+}
+
+export function buildUploadEndpoint(componentId: string, bomType: UploadBomType): string {
+    return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
+}
+
+export function validateUploadFile(file: File, bomType: UploadBomType): string | null {
+    if (file.size > MAX_SBOM_SIZE) {
+        return 'File size must be 100MB or smaller'
+    }
+
+    const fileExtension = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
+    const hasValidType = ALLOWED_MIME_TYPES.includes(file.type);
+    const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
+
+    if (!hasValidType && !hasValidExtension) {
+        const allowed = bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
+        return `Please select a valid ${bomTypeLabel(bomType)} file (${allowed})`
+    }
+
+    if (bomType === 'vex' && fileExtension === '.spdx') {
+        return 'VEX documents must be CycloneDX (.json or .cdx)'
+    }
+
+    return null
+}

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -26,7 +26,9 @@ export function validateUploadFile(file: File, bomType: UploadBomType): string |
         return `Please select a valid ${bomTypeLabel(bomType)} file (${allowed})`
     }
 
-    if (bomType === 'vex' && fileExtension === '.spdx') {
+    // Catch both bare ".spdx" and the common ".spdx.json" naming. The server
+    // inspects the content either way; this just fails obvious cases early.
+    if (bomType === 'vex' && /\.spdx(\.|$)/.test(file.name.toLowerCase())) {
         return 'VEX documents must be CycloneDX (.json or .cdx)'
     }
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -245,7 +245,8 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            // No bom_type for plain SBOMs — its presence disables server-side CBOM auto-detection.
+            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123')
             expect(buildUploadEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
         })
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -244,12 +244,19 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            const buildEndpoint = (componentId: string): string => {
-                return `/api/v1/sboms/upload-file/${componentId}`
+            const buildEndpoint = (componentId: string, bomType: string = 'sbom'): string => {
+                return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
             }
 
-            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123')
-            expect(buildEndpoint('my-component')).toBe('/api/v1/sboms/upload-file/my-component')
+            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            expect(buildEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
+        })
+
+        test('should label the artifact type for user-facing messages', () => {
+            const bomTypeLabel = (bomType: string): string => (bomType === 'vex' ? 'VEX' : 'SBOM')
+
+            expect(bomTypeLabel('sbom')).toBe('SBOM')
+            expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
         test('should build FormData correctly', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -256,11 +256,14 @@ describe('SBOM Upload Business Logic', () => {
 
         test('should reject SPDX files when uploading a VEX', () => {
             const spdxFile = createMockFile('doc.spdx', 1024, 'application/json')
+            const spdxJsonFile = createMockFile('doc.spdx.json', 1024, 'application/json')
             const cdxFile = createMockFile('doc.vex.cdx.json', 1024, 'application/json')
 
             expect(validateUploadFile(spdxFile, 'vex')).toContain('CycloneDX')
+            expect(validateUploadFile(spdxJsonFile, 'vex')).toContain('CycloneDX')
             expect(validateUploadFile(cdxFile, 'vex')).toBeNull()
             expect(validateUploadFile(spdxFile, 'sbom')).toBeNull()
+            expect(validateUploadFile(spdxJsonFile, 'sbom')).toBeNull()
         })
 
         test('should name the selected type in the invalid-file message', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -259,6 +259,20 @@ describe('SBOM Upload Business Logic', () => {
             expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
+        test('should reject SPDX files when uploading a VEX', () => {
+            const validateForBomType = (bomType: string, fileName: string): string | null => {
+                const ext = fileName.toLowerCase().slice(fileName.lastIndexOf('.'))
+                if (bomType === 'vex' && ext === '.spdx') {
+                    return 'VEX documents must be CycloneDX (.json or .cdx)'
+                }
+                return null
+            }
+
+            expect(validateForBomType('vex', 'doc.spdx')).toContain('CycloneDX')
+            expect(validateForBomType('vex', 'doc.vex.cdx.json')).toBeNull()
+            expect(validateForBomType('sbom', 'doc.spdx')).toBeNull()
+        })
+
         test('should build FormData correctly', () => {
             const mockFile = createMockFile('sbom.json', 1024, 'application/json')
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { getCsrfTokenFromSources, parseCsrfFromCookie } from '../../core/js/test-utils'
+import { bomTypeLabel, buildUploadEndpoint, validateUploadFile } from './sbom-upload-helpers'
 
 const MAX_SBOM_SIZE = 100 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
@@ -244,33 +245,29 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            const buildEndpoint = (componentId: string, bomType: string = 'sbom'): string => {
-                return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
-            }
-
-            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
-            expect(buildEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
+            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            expect(buildUploadEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
         })
 
         test('should label the artifact type for user-facing messages', () => {
-            const bomTypeLabel = (bomType: string): string => (bomType === 'vex' ? 'VEX' : 'SBOM')
-
             expect(bomTypeLabel('sbom')).toBe('SBOM')
             expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
         test('should reject SPDX files when uploading a VEX', () => {
-            const validateForBomType = (bomType: string, fileName: string): string | null => {
-                const ext = fileName.toLowerCase().slice(fileName.lastIndexOf('.'))
-                if (bomType === 'vex' && ext === '.spdx') {
-                    return 'VEX documents must be CycloneDX (.json or .cdx)'
-                }
-                return null
-            }
+            const spdxFile = createMockFile('doc.spdx', 1024, 'application/json')
+            const cdxFile = createMockFile('doc.vex.cdx.json', 1024, 'application/json')
 
-            expect(validateForBomType('vex', 'doc.spdx')).toContain('CycloneDX')
-            expect(validateForBomType('vex', 'doc.vex.cdx.json')).toBeNull()
-            expect(validateForBomType('sbom', 'doc.spdx')).toBeNull()
+            expect(validateUploadFile(spdxFile, 'vex')).toContain('CycloneDX')
+            expect(validateUploadFile(cdxFile, 'vex')).toBeNull()
+            expect(validateUploadFile(spdxFile, 'sbom')).toBeNull()
+        })
+
+        test('should name the selected type in the invalid-file message', () => {
+            const badFile = createMockFile('archive.tar', 1024, 'application/x-tar')
+
+            expect(validateUploadFile(badFile, 'vex')).toBe('Please select a valid VEX file (.json, .cdx)')
+            expect(validateUploadFile(badFile, 'sbom')).toBe('Please select a valid SBOM file (.json, .spdx, .cdx)')
         })
 
         test('should build FormData correctly', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -11,7 +11,9 @@ interface SbomUploadState {
     isDragOver: boolean
     isUploading: boolean
     componentId: string
+    bomType: string
     abortController: AbortController | null
+    readonly bomTypeLabel: string
     handleDrop: (event: DragEvent) => void
     handleFileSelect: (event: Event) => void
     validateFile: (file: File) => string | null
@@ -25,7 +27,12 @@ export function registerSbomUpload(): void {
         isDragOver: false,
         isUploading: false,
         componentId: componentId,
+        bomType: 'sbom',
         abortController: null,
+
+        get bomTypeLabel(): string {
+            return this.bomType === 'vex' ? 'VEX' : 'SBOM'
+        },
 
         validateFile(file: File): string | null {
             if (file.size > MAX_SBOM_SIZE) {
@@ -65,7 +72,7 @@ export function registerSbomUpload(): void {
 
                 const csrfToken = getCsrfToken()
 
-                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}`, {
+                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}?bom_type=${encodeURIComponent(this.bomType)}`, {
                     method: 'POST',
                     body: formData,
                     headers: {
@@ -86,7 +93,7 @@ export function registerSbomUpload(): void {
                 }
 
                 if (response.ok) {
-                    showSuccess('SBOM uploaded successfully! Reloading page...')
+                    showSuccess(`${this.bomTypeLabel} uploaded successfully! Reloading page...`)
                     window.dispatchEvent(new CustomEvent('sbom-uploaded'))
                 } else {
                     const errorMessage = (data.detail as string) || `Upload failed with status ${response.status}`

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -46,7 +46,8 @@ export function registerSbomUpload(): void {
             const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
 
             if (!hasValidType && !hasValidExtension) {
-                return 'Please select a valid SBOM file (.json, .spdx, .cdx)'
+                const allowed = this.bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
+                return `Please select a valid ${this.bomTypeLabel} file (${allowed})`
             }
 
             if (this.bomType === 'vex' && fileExtension === '.spdx') {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -1,12 +1,7 @@
 import Alpine from '../../core/js/alpine-init'
 import { showSuccess, showError } from '../../core/js/alerts'
 import { getCsrfToken } from '../../core/js/csrf'
-
-const MAX_SBOM_SIZE = 100 * 1024 * 1024;
-const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
-const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
-
-type UploadBomType = 'sbom' | 'vex'
+import { bomTypeLabel, buildUploadEndpoint, validateUploadFile, type UploadBomType } from './sbom-upload-helpers'
 
 interface SbomUploadState {
     expanded: boolean
@@ -33,28 +28,11 @@ export function registerSbomUpload(): void {
         abortController: null,
 
         get bomTypeLabel(): string {
-            return this.bomType === 'vex' ? 'VEX' : 'SBOM'
+            return bomTypeLabel(this.bomType)
         },
 
         validateFile(file: File): string | null {
-            if (file.size > MAX_SBOM_SIZE) {
-                return 'File size must be 100MB or smaller'
-            }
-
-            const fileExtension = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
-            const hasValidType = ALLOWED_MIME_TYPES.includes(file.type);
-            const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
-
-            if (!hasValidType && !hasValidExtension) {
-                const allowed = this.bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
-                return `Please select a valid ${this.bomTypeLabel} file (${allowed})`
-            }
-
-            if (this.bomType === 'vex' && fileExtension === '.spdx') {
-                return 'VEX documents must be CycloneDX (.json or .cdx)'
-            }
-
-            return null
+            return validateUploadFile(file, this.bomType)
         },
 
         async uploadFile(file: File): Promise<void> {
@@ -79,7 +57,7 @@ export function registerSbomUpload(): void {
 
                 const csrfToken = getCsrfToken()
 
-                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}?bom_type=${encodeURIComponent(this.bomType)}`, {
+                const response = await fetch(buildUploadEndpoint(this.componentId, this.bomType), {
                     method: 'POST',
                     body: formData,
                     headers: {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -6,12 +6,14 @@ const MAX_SBOM_SIZE = 100 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
 const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
 
+type UploadBomType = 'sbom' | 'vex'
+
 interface SbomUploadState {
     expanded: boolean
     isDragOver: boolean
     isUploading: boolean
     componentId: string
-    bomType: string
+    bomType: UploadBomType
     abortController: AbortController | null
     readonly bomTypeLabel: string
     handleDrop: (event: DragEvent) => void
@@ -27,7 +29,7 @@ export function registerSbomUpload(): void {
         isDragOver: false,
         isUploading: false,
         componentId: componentId,
-        bomType: 'sbom',
+        bomType: 'sbom' as UploadBomType,
         abortController: null,
 
         get bomTypeLabel(): string {
@@ -45,6 +47,10 @@ export function registerSbomUpload(): void {
 
             if (!hasValidType && !hasValidExtension) {
                 return 'Please select a valid SBOM file (.json, .spdx, .cdx)'
+            }
+
+            if (this.bomType === 'vex' && fileExtension === '.spdx') {
+                return 'VEX documents must be CycloneDX (.json or .cdx)'
             }
 
             return null

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -18,7 +18,7 @@
             <div class="flex items-start gap-3 p-4 bg-info/10 rounded-lg mb-4">
                 <i class="fas fa-info-circle text-info mt-0.5"></i>
                 <div class="text-text text-sm">
-                    <strong>Recommended:</strong> Use the CI/CD Integration section below for automated SBOM uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
+                    <strong>Recommended:</strong> Use the CI/CD Integration section below for automated uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
                 </div>
             </div>
             <!-- Artifact Type -->
@@ -59,6 +59,7 @@
                         <input type="file"
                                x-ref="fileInput"
                                accept=".json,.spdx,.cdx"
+                               :accept="bomType === 'vex' ? '.json,.cdx' : '.json,.spdx,.cdx'"
                                class="hidden"
                                @change="handleFileSelect($event)"
                                @click.stop>

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -58,7 +58,6 @@
                         </p>
                         <input type="file"
                                x-ref="fileInput"
-                               accept=".json,.spdx,.cdx"
                                :accept="bomType === 'vex' ? '.json,.cdx' : '.json,.spdx,.cdx'"
                                class="hidden"
                                @change="handleFileSelect($event)"

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -7,7 +7,7 @@
                 :aria-expanded="expanded"
                 @click="expanded = !expanded">
             <h4 class="text-lg font-semibold text-text m-0 flex items-center gap-2">
-                <i class="fas fa-upload text-primary" aria-hidden="true"></i>Upload SBOM File
+                <i class="fas fa-upload text-primary" aria-hidden="true"></i>Upload Artifact
                 <i class="fas ml-2 transition-transform"
                    :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'"
                    aria-hidden="true"></i>
@@ -21,11 +21,22 @@
                     <strong>Recommended:</strong> Use the CI/CD Integration section below for automated SBOM uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
                 </div>
             </div>
+            <!-- Artifact Type -->
+            <div class="mb-4 flex items-center gap-3">
+                <label for="upload-bom-type" class="text-text text-sm font-medium">Artifact type</label>
+                <select id="upload-bom-type"
+                        class="tw-form-select w-auto"
+                        x-model="bomType"
+                        :disabled="isUploading">
+                    <option value="sbom">SBOM</option>
+                    <option value="vex">VEX</option>
+                </select>
+            </div>
             <!-- Upload Area -->
             <div class="border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer"
                  :class="{ 'border-primary bg-primary/5': isDragOver, 'border-border hover:border-primary/50': !isDragOver && !isUploading, 'border-border opacity-75': isUploading }"
                  role="button"
-                 aria-label="Upload SBOM file by dropping or clicking"
+                 aria-label="Upload artifact file by dropping or clicking"
                  :aria-busy="isUploading"
                  tabindex="0"
                  @drop.prevent="!isUploading && handleDrop($event)"
@@ -42,7 +53,7 @@
                             <i class="fas fa-cloud-upload-alt text-3xl text-primary"></i>
                         </div>
                         <p class="text-text mb-2">
-                            <strong>Drop your SBOM file here</strong> or
+                            <strong>Drop your <span x-text="bomTypeLabel"></span> file here</strong> or
                             <span class="text-primary underline">click to browse</span>
                         </p>
                         <input type="file"
@@ -51,16 +62,16 @@
                                class="hidden"
                                @change="handleFileSelect($event)"
                                @click.stop>
-                        <p class="text-text-muted text-sm m-0">
-                            Supports CycloneDX (.json, .cdx) — SBOM, VEX, CBOM, and other BOM types; and SPDX (.json, .spdx) SBOMs
-                        </p>
+                        <p class="text-text-muted text-sm m-0">SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX only.</p>
                     </div>
                 </template>
                 <!-- Uploading state -->
                 <template x-if="isUploading">
                     <div class="text-center">
                         {% include "components/tw/spinner.html.j2" with size="lg" class="mx-auto mb-4" %}
-                        <p class="text-text m-0">Uploading and processing SBOM...</p>
+                        <p class="text-text m-0">
+                            Uploading and processing <span x-text="bomTypeLabel"></span>...
+                        </p>
                     </div>
                 </template>
             </div>


### PR DESCRIPTION
## What

The component page's upload panel can now upload VEX documents, not just SBOMs.

The `upload-file` API has accepted `bom_type=vex` all along; the web UI just never sent it, so an analyst with a hand-written VEX needed curl or the CI action. The panel gains an artifact-type select (SBOM by default, VEX) passed as the `bom_type` query parameter. Copy and the success toast follow the selection.

## Verified in the browser

- Selecting VEX and uploading a CycloneDX VEX stores it as `bom_type=vex`, `source=manual_upload`
- The existing automation fires unchanged: the reapply task re-annotated stored scan results and re-pointed the auto VEX pins on all 4 releases (3 products) shipping the component's SBOM
- SPDX files uploaded as VEX are rejected by the existing server validation with a clear message

## Scope notes

- CBOM stays out of the selector on purpose (matches the earlier call to hold off surfacing CBOM in release/upload UI)
- The SBOMs dashboard has a separate Django-form upload flow that remains SBOM-only; this PR touches only the component panel
