### PR TITLE
feat(vex): ingest OpenVEX and CSAF VEX alongside CycloneDX

### DIFF
--- a/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
@@ -4,9 +4,11 @@
 <div x-data="componentVisibilitySelector({ itemId: '{{ component.id|escapejs }}', publicUrl: '{{ component_public_url|escapejs }}', currentVisibility: '{{ component.visibility|escapejs }}', gatedVisibilityAllowed: {{ gated_visibility_allowed|yesno:'true,false' }} })"
      class="inline-flex items-center gap-3 flex-wrap px-3 py-2 bg-background border border-border rounded-lg">
     <div class="relative" :class="{ 'opacity-50': isLoading }">
-        {# Plain "change" scopes the trigger to this form's own select via
-           bubbling; "from:select" would listen on every select in the
-           document and fire visibility POSTs from unrelated dropdowns. #}
+        {% comment %}
+        Plain "change" scopes the trigger to this form's own select via
+        bubbling; "from:select" would listen on every select in the
+        document and fire visibility POSTs from unrelated dropdowns.
+        {% endcomment %}
         <form hx-post="{% url 'core:toggle_public_status' 'component' component.id %}"
               hx-trigger="change"
               hx-swap="none"

--- a/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_visibility_selector.html.j2
@@ -4,8 +4,11 @@
 <div x-data="componentVisibilitySelector({ itemId: '{{ component.id|escapejs }}', publicUrl: '{{ component_public_url|escapejs }}', currentVisibility: '{{ component.visibility|escapejs }}', gatedVisibilityAllowed: {{ gated_visibility_allowed|yesno:'true,false' }} })"
      class="inline-flex items-center gap-3 flex-wrap px-3 py-2 bg-background border border-border rounded-lg">
     <div class="relative" :class="{ 'opacity-50': isLoading }">
+        {# Plain "change" scopes the trigger to this form's own select via
+           bubbling; "from:select" would listen on every select in the
+           document and fire visibility POSTs from unrelated dropdowns. #}
         <form hx-post="{% url 'core:toggle_public_status' 'component' component.id %}"
-              hx-trigger="change from:select"
+              hx-trigger="change"
               hx-swap="none"
               @htmx:before-request="beforeRequestHandler()"
               @htmx:after-request="afterRequestHandler($event)">

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -97,12 +97,14 @@ def _store_external_vex(
         _, separator, suffix = context.rpartition("/ns/")
         # v0.0.1 documents use the bare namespace with no version suffix.
         format_version = suffix if separator else "v0.0.1"
-        version = str(document.get("version") or "")
+        raw_version = document.get("version")
     else:
         meta = document.get("document") or {}
         format_version = str(meta.get("csaf_version") or "")
         tracking = meta.get("tracking")
-        version = str(tracking.get("version") or "") if isinstance(tracking, dict) else ""
+        raw_version = tracking.get("version") if isinstance(tracking, dict) else None
+    # Explicit None-check: a falsy-but-present version (e.g. 0) is still a version.
+    version = "" if raw_version is None else str(raw_version)
 
     s3 = S3Client("SBOMS")
     filename = s3.upload_sbom(file_content)

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -521,8 +521,8 @@ def sbom_upload_cyclonedx(
 
         return 201, {"id": sbom.id}
 
-    except Exception as e:
-        log.error(f"Error processing CycloneDX BOM upload: {str(e)}")
+    except Exception:
+        log.exception("Error processing CycloneDX BOM upload")
         return 400, {"detail": "Invalid request"}
 
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -75,6 +75,59 @@ def _validate_bom_type(bom_type: str) -> tuple[int, dict[str, Any]] | None:
     return None
 
 
+def _store_external_vex(
+    component: Component,
+    document: dict[str, Any],
+    file_content: bytes,
+    sha256_hash: str,
+    vex_format: str,
+    source: str,
+) -> tuple[int, dict[str, Any]]:
+    """Store an OpenVEX or CSAF VEX document as a ``bom_type=vex`` artifact.
+
+    The raw bytes are stored unmodified (ADR-004); only the identifying
+    metadata is read out. Like CycloneDX VEX, no duplicate check applies —
+    VEX documents are re-issued continuously and the latest wins by
+    ``created_at``.
+    """
+    from sbomify.apps.vulnerability_scanning.vex_formats import VEX_FORMAT_OPENVEX
+
+    if vex_format == VEX_FORMAT_OPENVEX:
+        context = document.get("@context") or ""
+        _, _, format_version = context.rpartition("/ns/")
+        version = str(document.get("version") or "")
+    else:
+        meta = document.get("document") or {}
+        format_version = str(meta.get("csaf_version") or "")
+        tracking = meta.get("tracking")
+        version = str(tracking.get("version") or "") if isinstance(tracking, dict) else ""
+
+    s3 = S3Client("SBOMS")
+    filename = s3.upload_sbom(file_content)
+
+    sbom = SBOM(
+        name=component.name,
+        component=component,
+        format=vex_format,
+        format_version=format_version[:20],
+        version=version,
+        source=source,
+        sbom_filename=filename,
+        sha256_hash=sha256_hash,
+        bom_type=SBOM.BomType.VEX.value,
+    )
+    try:
+        with transaction.atomic():
+            sbom.save()
+    except IntegrityError:
+        _cleanup_orphaned_s3_object(filename)
+        raise
+
+    _broadcast_sbom_uploaded(component, sbom)
+    schedule_vex_reapply(component.id)
+    return 201, {"id": sbom.id}
+
+
 def _cleanup_orphaned_s3_object(filename: str) -> None:
     """Log a potential orphaned S3 object for manual cleanup.
 
@@ -462,6 +515,59 @@ def sbom_upload_cyclonedx(
 
     except Exception as e:
         log.error(f"Error processing CycloneDX BOM upload: {str(e)}")
+        return 400, {"detail": "Invalid request"}
+
+
+@router.post(
+    "/artifact/vex/{component_id}",
+    response={201: SBOMUploadRequest, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse, 409: ErrorResponse},
+    auth=PersonalAccessTokenAuth(),
+    throttle=[AccessTokenRateThrottle(), AccessTokenHeavyRateThrottle()],
+)
+def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, dict[str, Any]]:
+    """Upload a VEX document in any supported format for a component.
+
+    The format is detected from the content: CycloneDX VEX is delegated to the
+    CycloneDX artifact flow (schema validation included); OpenVEX and CSAF VEX
+    are stored as received. Anything else is rejected.
+    """
+    from sbomify.apps.vulnerability_scanning.vex_formats import (
+        VEX_FORMAT_CYCLONEDX,
+        detect_vex_format,
+    )
+
+    try:
+        try:
+            document = json.loads(request.body)
+        except json.JSONDecodeError:
+            return 400, {"detail": "Invalid JSON"}
+
+        vex_format = detect_vex_format(document)
+        if vex_format is None:
+            return 400, {
+                "detail": "Unrecognized VEX format. Must be CycloneDX, OpenVEX, or CSAF (csaf_vex).",
+                "error_code": ErrorCode.VALIDATION_ERROR,
+            }
+        if vex_format == VEX_FORMAT_CYCLONEDX:
+            return sbom_upload_cyclonedx(request, component_id, bom_type=SBOM.BomType.VEX.value)
+
+        component = Component.objects.filter(id=component_id).first()
+        if component is None:
+            return 404, {"detail": "Component not found"}
+        if not can(request, "artifact:publish", component):
+            return 403, {"detail": "Forbidden"}
+        # A VEX rewrites the workspace's stored vulnerability posture, so it takes
+        # the stricter publish tier (guests are excluded).
+        if not can(request, "artifact:publish_vex", component):
+            return 403, {"detail": "Forbidden"}
+        if not is_authorised_for_component(request, component):
+            return 403, {"detail": "Forbidden"}
+
+        sha256_hash = hashlib.sha256(request.body).hexdigest()
+        return _store_external_vex(component, document, request.body, sha256_hash, vex_format, source="api")
+
+    except Exception as e:
+        log.error(f"Error processing VEX upload: {str(e)}")
         return 400, {"detail": "Invalid request"}
 
 
@@ -976,6 +1082,21 @@ def sbom_upload_file(
             sbom_data = json.loads(file_content.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
             return 400, {"detail": "Invalid JSON file or encoding"}
+
+        # VEX arrives in three formats; OpenVEX and CSAF are stored here and
+        # CycloneDX VEX continues through the CycloneDX branch below.
+        if bom_type == SBOM.BomType.VEX.value:
+            from sbomify.apps.vulnerability_scanning.vex_formats import (
+                VEX_FORMAT_CSAF,
+                VEX_FORMAT_OPENVEX,
+                detect_vex_format,
+            )
+
+            vex_format = detect_vex_format(sbom_data)
+            if vex_format in (VEX_FORMAT_OPENVEX, VEX_FORMAT_CSAF):
+                return _store_external_vex(
+                    component, sbom_data, file_content, sha256_hash, vex_format, source="manual_upload"
+                )
 
         # Determine format and process accordingly
         from sbomify.apps.plugins.builtins._spdx3_helpers import is_spdx3

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -547,7 +547,7 @@ def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, d
     try:
         try:
             document = json.loads(request.body)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             return 400, {"detail": "Invalid JSON"}
 
         vex_format = detect_vex_format(document)

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -94,7 +94,9 @@ def _store_external_vex(
 
     if vex_format == VEX_FORMAT_OPENVEX:
         context = openvex_context(document) or ""
-        _, _, format_version = context.rpartition("/ns/")
+        _, separator, suffix = context.rpartition("/ns/")
+        # v0.0.1 documents use the bare namespace with no version suffix.
+        format_version = suffix if separator else "v0.0.1"
         version = str(document.get("version") or "")
     else:
         meta = document.get("document") or {}

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -127,7 +127,11 @@ def _store_external_vex(
         _cleanup_orphaned_s3_object(filename)
         raise
 
-    _broadcast_sbom_uploaded(component, sbom)
+    # The row is committed; a broadcast hiccup must not fail the upload.
+    try:
+        _broadcast_sbom_uploaded(component, sbom)
+    except Exception:
+        log.warning("Failed to broadcast SBOM upload notification", exc_info=True)
     schedule_vex_reapply(component.id)
     return 201, {"id": sbom.id}
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -90,10 +90,10 @@ def _store_external_vex(
     VEX documents are re-issued continuously and the latest wins by
     ``created_at``.
     """
-    from sbomify.apps.vulnerability_scanning.vex_formats import VEX_FORMAT_OPENVEX
+    from sbomify.apps.vulnerability_scanning.vex_formats import VEX_FORMAT_OPENVEX, openvex_context
 
     if vex_format == VEX_FORMAT_OPENVEX:
-        context = document.get("@context") or ""
+        context = openvex_context(document) or ""
         _, _, format_version = context.rpartition("/ns/")
         version = str(document.get("version") or "")
     else:
@@ -566,8 +566,8 @@ def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, d
         sha256_hash = hashlib.sha256(request.body).hexdigest()
         return _store_external_vex(component, document, request.body, sha256_hash, vex_format, source="api")
 
-    except Exception as e:
-        log.error(f"Error processing VEX upload: {str(e)}")
+    except Exception:
+        log.exception("Error processing VEX upload")
         return 400, {"detail": "Invalid request"}
 
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -545,6 +545,11 @@ def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, d
             return 400, {"detail": "Invalid JSON"}
 
         vex_format = detect_vex_format(document)
+        # The session upload flow treats any document with specVersion as
+        # CycloneDX even without the bomFormat marker; stay equally lenient
+        # here and let the CycloneDX schema validation give the real verdict.
+        if vex_format is None and isinstance(document, dict) and "specVersion" in document:
+            vex_format = VEX_FORMAT_CYCLONEDX
         if vex_format is None:
             return 400, {
                 "detail": "Unrecognized VEX format. Must be CycloneDX, OpenVEX, or CSAF (csaf_vex).",

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -9,7 +9,10 @@ export function bomTypeLabel(bomType: UploadBomType): string {
 }
 
 export function buildUploadEndpoint(componentId: string, bomType: UploadBomType): string {
-    return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
+    // The default SBOM case must omit bom_type: the server's CBOM
+    // auto-detection only runs when the caller leaves it unset.
+    const base = `/api/v1/sboms/upload-file/${componentId}`
+    return bomType === 'sbom' ? base : `${base}?bom_type=${encodeURIComponent(bomType)}`
 }
 
 export function validateUploadFile(file: File, bomType: UploadBomType): string | null {

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -32,7 +32,7 @@ export function validateUploadFile(file: File, bomType: UploadBomType): string |
     // Catch both bare ".spdx" and the common ".spdx.json" naming. The server
     // inspects the content either way; this just fails obvious cases early.
     if (bomType === 'vex' && /\.spdx(\.|$)/.test(file.name.toLowerCase())) {
-        return 'VEX documents must be CycloneDX (.json or .cdx)'
+        return 'SPDX files are SBOM-only; a VEX must be CycloneDX, OpenVEX, or CSAF (.json, .cdx)'
     }
 
     return null

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -1,0 +1,34 @@
+export const MAX_SBOM_SIZE = 100 * 1024 * 1024;
+export const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
+export const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
+
+export type UploadBomType = 'sbom' | 'vex'
+
+export function bomTypeLabel(bomType: UploadBomType): string {
+    return bomType === 'vex' ? 'VEX' : 'SBOM'
+}
+
+export function buildUploadEndpoint(componentId: string, bomType: UploadBomType): string {
+    return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
+}
+
+export function validateUploadFile(file: File, bomType: UploadBomType): string | null {
+    if (file.size > MAX_SBOM_SIZE) {
+        return 'File size must be 100MB or smaller'
+    }
+
+    const fileExtension = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
+    const hasValidType = ALLOWED_MIME_TYPES.includes(file.type);
+    const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
+
+    if (!hasValidType && !hasValidExtension) {
+        const allowed = bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
+        return `Please select a valid ${bomTypeLabel(bomType)} file (${allowed})`
+    }
+
+    if (bomType === 'vex' && fileExtension === '.spdx') {
+        return 'VEX documents must be CycloneDX (.json or .cdx)'
+    }
+
+    return null
+}

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -1,4 +1,4 @@
-export const MAX_SBOM_SIZE = 100 * 1024 * 1024;
+export const MAX_UPLOAD_SIZE = 100 * 1024 * 1024;
 export const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
 export const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
 
@@ -16,7 +16,7 @@ export function buildUploadEndpoint(componentId: string, bomType: UploadBomType)
 }
 
 export function validateUploadFile(file: File, bomType: UploadBomType): string | null {
-    if (file.size > MAX_SBOM_SIZE) {
+    if (file.size > MAX_UPLOAD_SIZE) {
         return 'File size must be 100MB or smaller'
     }
 

--- a/sbomify/apps/sboms/js/sbom-upload-helpers.ts
+++ b/sbomify/apps/sboms/js/sbom-upload-helpers.ts
@@ -26,7 +26,9 @@ export function validateUploadFile(file: File, bomType: UploadBomType): string |
         return `Please select a valid ${bomTypeLabel(bomType)} file (${allowed})`
     }
 
-    if (bomType === 'vex' && fileExtension === '.spdx') {
+    // Catch both bare ".spdx" and the common ".spdx.json" naming. The server
+    // inspects the content either way; this just fails obvious cases early.
+    if (bomType === 'vex' && /\.spdx(\.|$)/.test(file.name.toLowerCase())) {
         return 'VEX documents must be CycloneDX (.json or .cdx)'
     }
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -245,7 +245,8 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            // No bom_type for plain SBOMs — its presence disables server-side CBOM auto-detection.
+            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123')
             expect(buildUploadEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
         })
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -260,8 +260,8 @@ describe('SBOM Upload Business Logic', () => {
             const spdxJsonFile = createMockFile('doc.spdx.json', 1024, 'application/json')
             const cdxFile = createMockFile('doc.vex.cdx.json', 1024, 'application/json')
 
-            expect(validateUploadFile(spdxFile, 'vex')).toContain('CycloneDX')
-            expect(validateUploadFile(spdxJsonFile, 'vex')).toContain('CycloneDX')
+            expect(validateUploadFile(spdxFile, 'vex')).toContain('SPDX files are SBOM-only')
+            expect(validateUploadFile(spdxJsonFile, 'vex')).toContain('SPDX files are SBOM-only')
             expect(validateUploadFile(cdxFile, 'vex')).toBeNull()
             expect(validateUploadFile(spdxFile, 'sbom')).toBeNull()
             expect(validateUploadFile(spdxJsonFile, 'sbom')).toBeNull()

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -244,12 +244,19 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            const buildEndpoint = (componentId: string): string => {
-                return `/api/v1/sboms/upload-file/${componentId}`
+            const buildEndpoint = (componentId: string, bomType: string = 'sbom'): string => {
+                return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
             }
 
-            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123')
-            expect(buildEndpoint('my-component')).toBe('/api/v1/sboms/upload-file/my-component')
+            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            expect(buildEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
+        })
+
+        test('should label the artifact type for user-facing messages', () => {
+            const bomTypeLabel = (bomType: string): string => (bomType === 'vex' ? 'VEX' : 'SBOM')
+
+            expect(bomTypeLabel('sbom')).toBe('SBOM')
+            expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
         test('should build FormData correctly', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -256,11 +256,14 @@ describe('SBOM Upload Business Logic', () => {
 
         test('should reject SPDX files when uploading a VEX', () => {
             const spdxFile = createMockFile('doc.spdx', 1024, 'application/json')
+            const spdxJsonFile = createMockFile('doc.spdx.json', 1024, 'application/json')
             const cdxFile = createMockFile('doc.vex.cdx.json', 1024, 'application/json')
 
             expect(validateUploadFile(spdxFile, 'vex')).toContain('CycloneDX')
+            expect(validateUploadFile(spdxJsonFile, 'vex')).toContain('CycloneDX')
             expect(validateUploadFile(cdxFile, 'vex')).toBeNull()
             expect(validateUploadFile(spdxFile, 'sbom')).toBeNull()
+            expect(validateUploadFile(spdxJsonFile, 'sbom')).toBeNull()
         })
 
         test('should name the selected type in the invalid-file message', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -259,6 +259,20 @@ describe('SBOM Upload Business Logic', () => {
             expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
+        test('should reject SPDX files when uploading a VEX', () => {
+            const validateForBomType = (bomType: string, fileName: string): string | null => {
+                const ext = fileName.toLowerCase().slice(fileName.lastIndexOf('.'))
+                if (bomType === 'vex' && ext === '.spdx') {
+                    return 'VEX documents must be CycloneDX (.json or .cdx)'
+                }
+                return null
+            }
+
+            expect(validateForBomType('vex', 'doc.spdx')).toContain('CycloneDX')
+            expect(validateForBomType('vex', 'doc.vex.cdx.json')).toBeNull()
+            expect(validateForBomType('sbom', 'doc.spdx')).toBeNull()
+        })
+
         test('should build FormData correctly', () => {
             const mockFile = createMockFile('sbom.json', 1024, 'application/json')
 

--- a/sbomify/apps/sboms/js/sbom-upload.spec.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.spec.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { getCsrfTokenFromSources, parseCsrfFromCookie } from '../../core/js/test-utils'
+import { bomTypeLabel, buildUploadEndpoint, validateUploadFile } from './sbom-upload-helpers'
 
 const MAX_SBOM_SIZE = 100 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
@@ -244,33 +245,29 @@ describe('SBOM Upload Business Logic', () => {
 
     describe('Upload Workflow', () => {
         test('should construct correct API endpoint', () => {
-            const buildEndpoint = (componentId: string, bomType: string = 'sbom'): string => {
-                return `/api/v1/sboms/upload-file/${componentId}?bom_type=${encodeURIComponent(bomType)}`
-            }
-
-            expect(buildEndpoint('comp-123')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
-            expect(buildEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
+            expect(buildUploadEndpoint('comp-123', 'sbom')).toBe('/api/v1/sboms/upload-file/comp-123?bom_type=sbom')
+            expect(buildUploadEndpoint('my-component', 'vex')).toBe('/api/v1/sboms/upload-file/my-component?bom_type=vex')
         })
 
         test('should label the artifact type for user-facing messages', () => {
-            const bomTypeLabel = (bomType: string): string => (bomType === 'vex' ? 'VEX' : 'SBOM')
-
             expect(bomTypeLabel('sbom')).toBe('SBOM')
             expect(bomTypeLabel('vex')).toBe('VEX')
         })
 
         test('should reject SPDX files when uploading a VEX', () => {
-            const validateForBomType = (bomType: string, fileName: string): string | null => {
-                const ext = fileName.toLowerCase().slice(fileName.lastIndexOf('.'))
-                if (bomType === 'vex' && ext === '.spdx') {
-                    return 'VEX documents must be CycloneDX (.json or .cdx)'
-                }
-                return null
-            }
+            const spdxFile = createMockFile('doc.spdx', 1024, 'application/json')
+            const cdxFile = createMockFile('doc.vex.cdx.json', 1024, 'application/json')
 
-            expect(validateForBomType('vex', 'doc.spdx')).toContain('CycloneDX')
-            expect(validateForBomType('vex', 'doc.vex.cdx.json')).toBeNull()
-            expect(validateForBomType('sbom', 'doc.spdx')).toBeNull()
+            expect(validateUploadFile(spdxFile, 'vex')).toContain('CycloneDX')
+            expect(validateUploadFile(cdxFile, 'vex')).toBeNull()
+            expect(validateUploadFile(spdxFile, 'sbom')).toBeNull()
+        })
+
+        test('should name the selected type in the invalid-file message', () => {
+            const badFile = createMockFile('archive.tar', 1024, 'application/x-tar')
+
+            expect(validateUploadFile(badFile, 'vex')).toBe('Please select a valid VEX file (.json, .cdx)')
+            expect(validateUploadFile(badFile, 'sbom')).toBe('Please select a valid SBOM file (.json, .spdx, .cdx)')
         })
 
         test('should build FormData correctly', () => {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -11,7 +11,9 @@ interface SbomUploadState {
     isDragOver: boolean
     isUploading: boolean
     componentId: string
+    bomType: string
     abortController: AbortController | null
+    readonly bomTypeLabel: string
     handleDrop: (event: DragEvent) => void
     handleFileSelect: (event: Event) => void
     validateFile: (file: File) => string | null
@@ -25,7 +27,12 @@ export function registerSbomUpload(): void {
         isDragOver: false,
         isUploading: false,
         componentId: componentId,
+        bomType: 'sbom',
         abortController: null,
+
+        get bomTypeLabel(): string {
+            return this.bomType === 'vex' ? 'VEX' : 'SBOM'
+        },
 
         validateFile(file: File): string | null {
             if (file.size > MAX_SBOM_SIZE) {
@@ -65,7 +72,7 @@ export function registerSbomUpload(): void {
 
                 const csrfToken = getCsrfToken()
 
-                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}`, {
+                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}?bom_type=${encodeURIComponent(this.bomType)}`, {
                     method: 'POST',
                     body: formData,
                     headers: {
@@ -86,7 +93,7 @@ export function registerSbomUpload(): void {
                 }
 
                 if (response.ok) {
-                    showSuccess('SBOM uploaded successfully! Reloading page...')
+                    showSuccess(`${this.bomTypeLabel} uploaded successfully! Reloading page...`)
                     window.dispatchEvent(new CustomEvent('sbom-uploaded'))
                 } else {
                     const errorMessage = (data.detail as string) || `Upload failed with status ${response.status}`

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -46,7 +46,8 @@ export function registerSbomUpload(): void {
             const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
 
             if (!hasValidType && !hasValidExtension) {
-                return 'Please select a valid SBOM file (.json, .spdx, .cdx)'
+                const allowed = this.bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
+                return `Please select a valid ${this.bomTypeLabel} file (${allowed})`
             }
 
             if (this.bomType === 'vex' && fileExtension === '.spdx') {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -1,12 +1,7 @@
 import Alpine from '../../core/js/alpine-init'
 import { showSuccess, showError } from '../../core/js/alerts'
 import { getCsrfToken } from '../../core/js/csrf'
-
-const MAX_SBOM_SIZE = 100 * 1024 * 1024;
-const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
-const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
-
-type UploadBomType = 'sbom' | 'vex'
+import { bomTypeLabel, buildUploadEndpoint, validateUploadFile, type UploadBomType } from './sbom-upload-helpers'
 
 interface SbomUploadState {
     expanded: boolean
@@ -33,28 +28,11 @@ export function registerSbomUpload(): void {
         abortController: null,
 
         get bomTypeLabel(): string {
-            return this.bomType === 'vex' ? 'VEX' : 'SBOM'
+            return bomTypeLabel(this.bomType)
         },
 
         validateFile(file: File): string | null {
-            if (file.size > MAX_SBOM_SIZE) {
-                return 'File size must be 100MB or smaller'
-            }
-
-            const fileExtension = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
-            const hasValidType = ALLOWED_MIME_TYPES.includes(file.type);
-            const hasValidExtension = ALLOWED_EXTENSIONS.includes(fileExtension);
-
-            if (!hasValidType && !hasValidExtension) {
-                const allowed = this.bomType === 'vex' ? '.json, .cdx' : '.json, .spdx, .cdx'
-                return `Please select a valid ${this.bomTypeLabel} file (${allowed})`
-            }
-
-            if (this.bomType === 'vex' && fileExtension === '.spdx') {
-                return 'VEX documents must be CycloneDX (.json or .cdx)'
-            }
-
-            return null
+            return validateUploadFile(file, this.bomType)
         },
 
         async uploadFile(file: File): Promise<void> {
@@ -79,7 +57,7 @@ export function registerSbomUpload(): void {
 
                 const csrfToken = getCsrfToken()
 
-                const response = await fetch(`/api/v1/sboms/upload-file/${this.componentId}?bom_type=${encodeURIComponent(this.bomType)}`, {
+                const response = await fetch(buildUploadEndpoint(this.componentId, this.bomType), {
                     method: 'POST',
                     body: formData,
                     headers: {

--- a/sbomify/apps/sboms/js/sbom-upload.ts
+++ b/sbomify/apps/sboms/js/sbom-upload.ts
@@ -6,12 +6,14 @@ const MAX_SBOM_SIZE = 100 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = ['application/json', 'text/plain'];
 const ALLOWED_EXTENSIONS = ['.json', '.spdx', '.cdx'];
 
+type UploadBomType = 'sbom' | 'vex'
+
 interface SbomUploadState {
     expanded: boolean
     isDragOver: boolean
     isUploading: boolean
     componentId: string
-    bomType: string
+    bomType: UploadBomType
     abortController: AbortController | null
     readonly bomTypeLabel: string
     handleDrop: (event: DragEvent) => void
@@ -27,7 +29,7 @@ export function registerSbomUpload(): void {
         isDragOver: false,
         isUploading: false,
         componentId: componentId,
-        bomType: 'sbom',
+        bomType: 'sbom' as UploadBomType,
         abortController: null,
 
         get bomTypeLabel(): string {
@@ -45,6 +47,10 @@ export function registerSbomUpload(): void {
 
             if (!hasValidType && !hasValidExtension) {
                 return 'Please select a valid SBOM file (.json, .spdx, .cdx)'
+            }
+
+            if (this.bomType === 'vex' && fileExtension === '.spdx') {
+                return 'VEX documents must be CycloneDX (.json or .cdx)'
             }
 
             return null

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -63,7 +63,7 @@
                                @change="handleFileSelect($event)"
                                @click.stop>
                         <p class="text-text-muted text-sm m-0">
-                            SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX, OpenVEX, or CSAF (.json).
+                            SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX, OpenVEX, or CSAF (.json, .cdx).
                         </p>
                     </div>
                 </template>

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -62,7 +62,9 @@
                                class="hidden"
                                @change="handleFileSelect($event)"
                                @click.stop>
-                        <p class="text-text-muted text-sm m-0">SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX only.</p>
+                        <p class="text-text-muted text-sm m-0">
+                            SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX, OpenVEX, or CSAF (.json).
+                        </p>
                     </div>
                 </template>
                 <!-- Uploading state -->

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -18,7 +18,7 @@
             <div class="flex items-start gap-3 p-4 bg-info/10 rounded-lg mb-4">
                 <i class="fas fa-info-circle text-info mt-0.5"></i>
                 <div class="text-text text-sm">
-                    <strong>Recommended:</strong> Use the CI/CD Integration section below for automated SBOM uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
+                    <strong>Recommended:</strong> Use the CI/CD Integration section below for automated uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
                 </div>
             </div>
             <!-- Artifact Type -->
@@ -59,6 +59,7 @@
                         <input type="file"
                                x-ref="fileInput"
                                accept=".json,.spdx,.cdx"
+                               :accept="bomType === 'vex' ? '.json,.cdx' : '.json,.spdx,.cdx'"
                                class="hidden"
                                @change="handleFileSelect($event)"
                                @click.stop>

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -58,7 +58,6 @@
                         </p>
                         <input type="file"
                                x-ref="fileInput"
-                               accept=".json,.spdx,.cdx"
                                :accept="bomType === 'vex' ? '.json,.cdx' : '.json,.spdx,.cdx'"
                                class="hidden"
                                @change="handleFileSelect($event)"

--- a/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/sbom_upload.html.j2
@@ -7,7 +7,7 @@
                 :aria-expanded="expanded"
                 @click="expanded = !expanded">
             <h4 class="text-lg font-semibold text-text m-0 flex items-center gap-2">
-                <i class="fas fa-upload text-primary" aria-hidden="true"></i>Upload SBOM File
+                <i class="fas fa-upload text-primary" aria-hidden="true"></i>Upload Artifact
                 <i class="fas ml-2 transition-transform"
                    :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'"
                    aria-hidden="true"></i>
@@ -21,11 +21,22 @@
                     <strong>Recommended:</strong> Use the CI/CD Integration section below for automated SBOM uploads. Manual uploads are useful for one-time uploads, testing, or when automated workflows aren't available.
                 </div>
             </div>
+            <!-- Artifact Type -->
+            <div class="mb-4 flex items-center gap-3">
+                <label for="upload-bom-type" class="text-text text-sm font-medium">Artifact type</label>
+                <select id="upload-bom-type"
+                        class="tw-form-select w-auto"
+                        x-model="bomType"
+                        :disabled="isUploading">
+                    <option value="sbom">SBOM</option>
+                    <option value="vex">VEX</option>
+                </select>
+            </div>
             <!-- Upload Area -->
             <div class="border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer"
                  :class="{ 'border-primary bg-primary/5': isDragOver, 'border-border hover:border-primary/50': !isDragOver && !isUploading, 'border-border opacity-75': isUploading }"
                  role="button"
-                 aria-label="Upload SBOM file by dropping or clicking"
+                 aria-label="Upload artifact file by dropping or clicking"
                  :aria-busy="isUploading"
                  tabindex="0"
                  @drop.prevent="!isUploading && handleDrop($event)"
@@ -42,7 +53,7 @@
                             <i class="fas fa-cloud-upload-alt text-3xl text-primary"></i>
                         </div>
                         <p class="text-text mb-2">
-                            <strong>Drop your SBOM file here</strong> or
+                            <strong>Drop your <span x-text="bomTypeLabel"></span> file here</strong> or
                             <span class="text-primary underline">click to browse</span>
                         </p>
                         <input type="file"
@@ -51,16 +62,16 @@
                                class="hidden"
                                @change="handleFileSelect($event)"
                                @click.stop>
-                        <p class="text-text-muted text-sm m-0">
-                            Supports CycloneDX (.json, .cdx) — SBOM, VEX, CBOM, and other BOM types; and SPDX (.json, .spdx) SBOMs
-                        </p>
+                        <p class="text-text-muted text-sm m-0">SBOMs: CycloneDX (.json, .cdx) or SPDX (.json, .spdx). VEX: CycloneDX only.</p>
                     </div>
                 </template>
                 <!-- Uploading state -->
                 <template x-if="isUploading">
                     <div class="text-center">
                         {% include "components/tw/spinner.html.j2" with size="lg" class="mx-auto mb-4" %}
-                        <p class="text-text m-0">Uploading and processing SBOM...</p>
+                        <p class="text-text m-0">
+                            Uploading and processing <span x-text="bomTypeLabel"></span>...
+                        </p>
                     </div>
                 </template>
             </div>

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -66,6 +66,12 @@ def test_detects_openvex_context_prefix(context: str) -> None:
     assert detect_vex_format({"@context": context, "statements": []}) == VEX_FORMAT_OPENVEX
 
 
+def test_detects_openvex_list_context() -> None:
+    """JSON-LD allows @context to be a list; any matching entry counts."""
+    doc = {"@context": ["https://example.com/other", "https://openvex.dev/ns/v0.2.0"], "statements": []}
+    assert detect_vex_format(doc) == VEX_FORMAT_OPENVEX
+
+
 def test_detects_csaf_vex() -> None:
     assert detect_vex_format({"document": {"category": "csaf_vex", "csaf_version": "2.0"}}) == VEX_FORMAT_CSAF
 

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -140,6 +140,15 @@ def test_openvex_document_level_products_inherited() -> None:
     assert statements[0]["packages"] == {("npm", "lodash", "4.17.15")}
 
 
+def test_openvex_explicit_empty_products_does_not_inherit() -> None:
+    """An explicit products: [] is a narrower scoping, not an omission."""
+    doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": [], "status": "not_affected"})
+    doc["products"] = [{"@id": "pkg:npm/lodash@4.17.15"}]
+    statements = derive_openvex_suppressions(doc)
+    assert statements[0]["packages"] == set()
+    assert statements[0]["product_scoped"] is True
+
+
 def test_openvex_aliases_and_identifier_purl() -> None:
     doc = _openvex_doc(
         {
@@ -327,6 +336,16 @@ class TestExternalVexUpload:
         assert sbom.format_version == "v0.2.0"
         assert sbom.version == "1"
         assert sbom.source == "manual_upload"
+
+    def test_upload_file_bare_context_stores_v001(self, sample_user, sample_team_with_owner_member, component) -> None:
+        client = Client()
+        setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
+        doc = _openvex_doc(
+            {"vulnerability": "CVE-1", "status": "not_affected"}, context="https://openvex.dev/ns"
+        )
+        response = self._upload(client, component.id, doc)
+        assert response.status_code == 201, response.content
+        assert SBOM.objects.get(id=response.json()["id"]).format_version == "v0.0.1"
 
     def test_upload_file_accepts_csaf(self, sample_user, sample_team_with_owner_member, component) -> None:
         client = Client()

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -85,6 +85,7 @@ def test_detects_csaf_vex() -> None:
         {"spdxVersion": "SPDX-2.3"},
         {"document": {"category": "csaf_security_advisory"}},
         {"@context": "https://example.com/other", "statements": []},
+        {"@context": "https://openvex.dev/nsfoo/v1", "statements": []},
     ],
 )
 def test_detects_nothing_else(document: Any) -> None:

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -156,6 +156,27 @@ def test_openvex_malformed_products_fails_closed() -> None:
         assert derive_openvex_suppressions(doc) == []
 
 
+def test_openvex_malformed_doc_products_fails_closed_for_inheriting_statements() -> None:
+    """A statement relying on inheritance from a malformed document-level
+    products must be skipped, not widened to product-scoped."""
+    doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "status": "not_affected"})
+    doc["products"] = "pkg:npm/a@1"
+    assert derive_openvex_suppressions(doc) == []
+
+
+def test_openvex_unmappable_products_fail_closed() -> None:
+    """Explicit product scoping that maps to no purls is narrower than
+    id-only suppression could honour; skip instead of over-suppressing."""
+    doc = _openvex_doc(
+        {
+            "vulnerability": {"name": "CVE-1"},
+            "products": [{"@id": "urn:product:web"}],
+            "status": "not_affected",
+        }
+    )
+    assert derive_openvex_suppressions(doc) == []
+
+
 def test_openvex_aliases_and_identifier_purl() -> None:
     doc = _openvex_doc(
         {

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -476,7 +476,9 @@ class TestVexArtifactEndpoint:
         response = self._post(token, component.id, doc)
         assert response.status_code == 400, response.content
         detail = response.json()["detail"]
-        assert "Invalid CycloneDX" in detail
+        # The CycloneDX schema names the missing marker — proof the request
+        # reached the delegated CycloneDX flow, not the unrecognized branch.
+        assert "bomFormat" in detail
         assert "Unrecognized VEX format" not in detail
 
     def test_rejects_unknown_format(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -149,6 +149,13 @@ def test_openvex_explicit_empty_products_does_not_inherit() -> None:
     assert statements[0]["product_scoped"] is True
 
 
+def test_openvex_malformed_products_fails_closed() -> None:
+    """A present-but-non-list products must not widen to product-scoped."""
+    for bad in ("pkg:npm/a@1", {"@id": "pkg:npm/a@1"}):
+        doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": bad, "status": "not_affected"})
+        assert derive_openvex_suppressions(doc) == []
+
+
 def test_openvex_aliases_and_identifier_purl() -> None:
     doc = _openvex_doc(
         {
@@ -430,6 +437,20 @@ class TestVexArtifactEndpoint:
         sbom = SBOM.objects.get(id=response.json()["id"])
         assert sbom.format == "cyclonedx"
         assert sbom.bom_type == "vex"
+
+    def test_markerless_cyclonedx_delegates(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+        """A CycloneDX VEX without the bomFormat marker is treated as CycloneDX
+        (specVersion present), matching the session upload flow's leniency."""
+        _, token = authenticated_api_client
+        doc = {
+            "specVersion": "1.6",
+            "version": 1,
+            "vulnerabilities": [{"id": "CVE-1", "analysis": {"state": "not_affected"}}],
+        }
+        response = self._post(token, component.id, doc)
+        # Delegation happened: the CycloneDX flow answers (validation verdicts
+        # included), not the unrecognized-format 400.
+        assert "Unrecognized VEX format" not in response.content.decode()
 
     def test_rejects_unknown_format(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
         _, token = authenticated_api_client

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -190,6 +190,19 @@ def test_openvex_aliases_and_identifier_purl() -> None:
     assert statements[0]["packages"] == {("pypi", "django", "3.2")}
 
 
+def test_openvex_string_aliases_do_not_splat_to_characters() -> None:
+    """A malformed scalar aliases must not become single-letter ids."""
+    doc = _openvex_doc(
+        {
+            "vulnerability": {"name": "CVE-2026-1", "aliases": "GHSA-aaaa-bbbb-cccc"},
+            "products": [{"@id": "pkg:npm/a@1"}],
+            "status": "not_affected",
+        }
+    )
+    statements = derive_openvex_suppressions(doc)
+    assert statements[0]["ids"] == {"cve-2026-1"}
+
+
 def test_openvex_suppresses_matching_finding() -> None:
     doc = _openvex_doc(
         {

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -1,0 +1,422 @@
+"""Tests for OpenVEX and CSAF VEX detection, derivation, and ingestion."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from django.test import Client
+
+from sbomify.apps.core.tests.shared_fixtures import get_api_headers, setup_authenticated_client_session
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.vulnerability_scanning import vex
+from sbomify.apps.vulnerability_scanning.vex_formats import (
+    VEX_FORMAT_CSAF,
+    VEX_FORMAT_CYCLONEDX,
+    VEX_FORMAT_OPENVEX,
+    derive_csaf_suppressions,
+    derive_openvex_suppressions,
+    detect_vex_format,
+)
+
+
+def _openvex_doc(*statements: dict[str, Any], context: str = "https://openvex.dev/ns/v0.2.0") -> dict[str, Any]:
+    return {
+        "@context": context,
+        "@id": "https://example.com/vex-1",
+        "author": "Test Author",
+        "timestamp": "2026-07-15T00:00:00Z",
+        "version": 1,
+        "statements": list(statements),
+    }
+
+
+def _csaf_doc(vulnerabilities: list[dict[str, Any]], product_tree: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "document": {
+            "category": "csaf_vex",
+            "csaf_version": "2.0",
+            "publisher": {"category": "vendor", "name": "Example", "namespace": "https://example.com"},
+            "title": "Example VEX",
+            "tracking": {
+                "id": "EX-VEX-2026-0001",
+                "status": "final",
+                "version": "1",
+                "initial_release_date": "2026-07-15T00:00:00.000Z",
+                "current_release_date": "2026-07-15T00:00:00.000Z",
+                "revision_history": [{"date": "2026-07-15T00:00:00.000Z", "number": "1", "summary": "Initial."}],
+            },
+        },
+        "product_tree": product_tree
+        or {"full_product_names": [{"product_id": "CSAFPID-0001", "name": "Example Product 1.0"}]},
+        "vulnerabilities": vulnerabilities,
+    }
+
+
+# --- detection ---------------------------------------------------------------
+
+
+def test_detects_cyclonedx() -> None:
+    assert detect_vex_format({"bomFormat": "CycloneDX", "specVersion": "1.6"}) == VEX_FORMAT_CYCLONEDX
+
+
+@pytest.mark.parametrize("context", ["https://openvex.dev/ns", "https://openvex.dev/ns/v0.2.0"])
+def test_detects_openvex_context_prefix(context: str) -> None:
+    assert detect_vex_format({"@context": context, "statements": []}) == VEX_FORMAT_OPENVEX
+
+
+def test_detects_csaf_vex() -> None:
+    assert detect_vex_format({"document": {"category": "csaf_vex", "csaf_version": "2.0"}}) == VEX_FORMAT_CSAF
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        None,
+        "nope",
+        {},
+        {"spdxVersion": "SPDX-2.3"},
+        {"document": {"category": "csaf_security_advisory"}},
+        {"@context": "https://example.com/other", "statements": []},
+    ],
+)
+def test_detects_nothing_else(document: Any) -> None:
+    assert detect_vex_format(document) is None
+
+
+# --- OpenVEX derivation ------------------------------------------------------
+
+
+def test_openvex_not_affected_with_purl() -> None:
+    doc = _openvex_doc(
+        {
+            "vulnerability": {"name": "CVE-2023-12345"},
+            "products": [{"@id": "pkg:apk/wolfi/git@2.39.0-r1?arch=x86_64"}],
+            "status": "not_affected",
+            "justification": "vulnerable_code_not_in_execute_path",
+            "impact_statement": "Code path not reachable.",
+        }
+    )
+    statements = vex.derive_vex_suppressions(doc)
+    assert len(statements) == 1
+    statement = statements[0]
+    assert statement["ids"] == {"cve-2023-12345"}
+    assert statement["packages"] == {("apk", "wolfi/git", "2.39.0-r1")}
+    assert statement["product_scoped"] is False
+    assert statement["state"] == "not_affected"
+    assert statement["justification"] == "code_not_reachable"
+    assert "vulnerable_code_not_in_execute_path" in statement["detail"]
+    assert "Code path not reachable." in statement["detail"]
+
+
+@pytest.mark.parametrize("status", ["affected", "fixed", "under_investigation"])
+def test_openvex_non_suppressing_statuses_ignored(status: str) -> None:
+    doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": [], "status": status})
+    assert derive_openvex_suppressions(doc) == []
+
+
+def test_openvex_v001_string_vulnerability() -> None:
+    doc = _openvex_doc(
+        {"vulnerability": "CVE-2014-123456", "status": "not_affected"},
+        context="https://openvex.dev/ns",
+    )
+    statements = derive_openvex_suppressions(doc)
+    assert len(statements) == 1
+    assert statements[0]["ids"] == {"cve-2014-123456"}
+    assert statements[0]["product_scoped"] is True
+
+
+def test_openvex_document_level_products_inherited() -> None:
+    doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "status": "not_affected"})
+    doc["products"] = [{"@id": "pkg:npm/lodash@4.17.15"}]
+    statements = derive_openvex_suppressions(doc)
+    assert statements[0]["packages"] == {("npm", "lodash", "4.17.15")}
+
+
+def test_openvex_aliases_and_identifier_purl() -> None:
+    doc = _openvex_doc(
+        {
+            "vulnerability": {"name": "GHSA-xxxx-yyyy-zzzz", "aliases": ["CVE-2026-1111"]},
+            "products": [{"@id": "urn:product:web", "identifiers": {"purl": "pkg:pypi/django@3.2"}}],
+            "status": "not_affected",
+        }
+    )
+    statements = derive_openvex_suppressions(doc)
+    assert statements[0]["ids"] == {"ghsa-xxxx-yyyy-zzzz", "cve-2026-1111"}
+    assert statements[0]["packages"] == {("pypi", "django", "3.2")}
+
+
+def test_openvex_suppresses_matching_finding() -> None:
+    doc = _openvex_doc(
+        {
+            "vulnerability": {"name": "CVE-2026-1111"},
+            "products": [{"@id": "pkg:npm/lodash@4.17.15"}],
+            "status": "not_affected",
+        }
+    )
+    statements = vex.derive_vex_suppressions(doc)
+    finding = {"id": "CVE-2026-1111", "component": {"purl": "pkg:npm/lodash@4.17.15"}}
+    assert vex.finding_is_suppressed(finding, statements) is True
+    other = {"id": "CVE-2026-1111", "component": {"purl": "pkg:npm/axios@0.21.0"}}
+    assert vex.finding_is_suppressed(other, statements) is False
+
+
+# --- CSAF derivation ---------------------------------------------------------
+
+
+def test_csaf_known_not_affected_product_scoped() -> None:
+    doc = _csaf_doc(
+        [
+            {
+                "cve": "CVE-2026-12345",
+                "product_status": {"known_not_affected": ["CSAFPID-0001"]},
+                "flags": [{"label": "vulnerable_code_not_present", "product_ids": ["CSAFPID-0001"]}],
+                "threats": [
+                    {"category": "impact", "details": "Compiled out.", "product_ids": ["CSAFPID-0001"]},
+                ],
+            }
+        ]
+    )
+    statements = vex.derive_vex_suppressions(doc)
+    assert len(statements) == 1
+    statement = statements[0]
+    assert statement["ids"] == {"cve-2026-12345"}
+    assert statement["product_scoped"] is True
+    assert statement["state"] == "not_affected"
+    assert statement["justification"] == "code_not_present"
+    assert "Compiled out." in statement["detail"]
+    assert "CSAFPID-0001" in statement["detail"]
+
+
+def test_csaf_purl_resolution_via_branches() -> None:
+    product_tree = {
+        "branches": [
+            {
+                "category": "vendor",
+                "name": "Example",
+                "branches": [
+                    {
+                        "category": "product_version",
+                        "name": "1.0",
+                        "product": {
+                            "product_id": "CSAFPID-0002",
+                            "name": "libexample 1.0",
+                            "product_identification_helper": {"purl": "pkg:npm/libexample@1.0.0"},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    doc = _csaf_doc(
+        [{"cve": "CVE-2026-2", "product_status": {"known_not_affected": ["CSAFPID-0002"]}}],
+        product_tree=product_tree,
+    )
+    statements = derive_csaf_suppressions(doc)
+    assert statements[0]["packages"] == {("npm", "libexample", "1.0.0")}
+    assert statements[0]["product_scoped"] is False
+
+
+def test_csaf_only_not_affected_products_count() -> None:
+    doc = _csaf_doc(
+        [
+            {
+                "cve": "CVE-2026-3",
+                "product_status": {
+                    "known_affected": ["CSAFPID-0001"],
+                    "fixed": ["CSAFPID-0001"],
+                    "recommended": ["CSAFPID-0001"],
+                },
+            }
+        ]
+    )
+    assert derive_csaf_suppressions(doc) == []
+
+
+def test_csaf_group_ids_resolve_for_flags() -> None:
+    doc = _csaf_doc(
+        [
+            {
+                "cve": "CVE-2026-4",
+                "product_status": {"known_not_affected": ["CSAFPID-0001"]},
+                "flags": [{"label": "component_not_present", "group_ids": ["CSAFGID-1"]}],
+            }
+        ],
+        product_tree={
+            "full_product_names": [{"product_id": "CSAFPID-0001", "name": "Example 1.0"}],
+            "product_groups": [{"group_id": "CSAFGID-1", "product_ids": ["CSAFPID-0001"]}],
+        },
+    )
+    statements = derive_csaf_suppressions(doc)
+    assert statements[0]["justification"] == "code_not_present"
+    assert "component_not_present" in statements[0]["detail"]
+
+
+def test_csaf_no_vulnerability_id_skipped() -> None:
+    doc = _csaf_doc([{"product_status": {"known_not_affected": ["CSAFPID-0001"]}}])
+    assert derive_csaf_suppressions(doc) == []
+
+
+def test_csaf_ids_entries_used_when_no_cve() -> None:
+    doc = _csaf_doc(
+        [
+            {
+                "ids": [{"system_name": "GitHub Advisory", "text": "GHSA-abcd-efgh-ijkl"}],
+                "product_status": {"known_not_affected": ["CSAFPID-0001"]},
+            }
+        ]
+    )
+    statements = derive_csaf_suppressions(doc)
+    assert statements[0]["ids"] == {"ghsa-abcd-efgh-ijkl"}
+
+
+def test_csaf_suppresses_matching_finding_by_id() -> None:
+    doc = _csaf_doc(
+        [{"cve": "CVE-2026-5", "product_status": {"known_not_affected": ["CSAFPID-0001"]}}],
+    )
+    statements = vex.derive_vex_suppressions(doc)
+    finding = {"id": "CVE-2026-5", "component": {"purl": "pkg:npm/anything@1.0.0"}}
+    assert vex.finding_is_suppressed(finding, statements) is True
+
+
+# --- ingestion through the API ----------------------------------------------
+
+
+@pytest.fixture
+def component(sample_team_with_owner_member):
+    from sbomify.apps.core.models import Component
+
+    return Component.objects.create(
+        name="vex-format-component", team=sample_team_with_owner_member.team, component_type="bom"
+    )
+
+
+@pytest.fixture
+def s3_stub(mocker):
+    return mocker.patch("sbomify.apps.core.object_store.S3Client.upload_sbom", return_value="stored.json")
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("s3_stub")
+class TestExternalVexUpload:
+    def _upload(self, client: Client, component_id: str, document: dict[str, Any]) -> Any:
+        from io import BytesIO
+
+        payload = BytesIO(json.dumps(document).encode())
+        payload.name = "doc.vex.json"
+        return client.post(f"/api/v1/sboms/upload-file/{component_id}?bom_type=vex", {"sbom_file": payload})
+
+    def test_upload_file_accepts_openvex(self, sample_user, sample_team_with_owner_member, component) -> None:
+        client = Client()
+        setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
+        doc = _openvex_doc(
+            {"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:npm/a@1"}], "status": "not_affected"}
+        )
+        response = self._upload(client, component.id, doc)
+        assert response.status_code == 201, response.content
+        sbom = SBOM.objects.get(id=response.json()["id"])
+        assert sbom.bom_type == "vex"
+        assert sbom.format == "openvex"
+        assert sbom.format_version == "v0.2.0"
+        assert sbom.version == "1"
+        assert sbom.source == "manual_upload"
+
+    def test_upload_file_accepts_csaf(self, sample_user, sample_team_with_owner_member, component) -> None:
+        client = Client()
+        setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
+        doc = _csaf_doc([{"cve": "CVE-2026-9", "product_status": {"known_not_affected": ["CSAFPID-0001"]}}])
+        response = self._upload(client, component.id, doc)
+        assert response.status_code == 201, response.content
+        sbom = SBOM.objects.get(id=response.json()["id"])
+        assert sbom.format == "csaf"
+        assert sbom.format_version == "2.0"
+        assert sbom.version == "1"
+
+    def test_upload_file_rejects_openvex_as_sbom(self, sample_user, sample_team_with_owner_member, component) -> None:
+        from io import BytesIO
+
+        client = Client()
+        setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
+        doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": [], "status": "not_affected"})
+        payload = BytesIO(json.dumps(doc).encode())
+        payload.name = "doc.json"
+        response = client.post(f"/api/v1/sboms/upload-file/{component.id}", {"sbom_file": payload})
+        assert response.status_code == 400
+
+    def test_stored_bytes_are_untouched(self, sample_user, sample_team_with_owner_member, component) -> None:
+        """ADR-004: the stored object is byte-for-byte what was uploaded."""
+        import hashlib
+
+        client = Client()
+        setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
+        doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": [], "status": "not_affected"})
+        raw = json.dumps(doc, indent=3).encode()
+        from io import BytesIO
+
+        payload = BytesIO(raw)
+        payload.name = "doc.vex.json"
+        response = client.post(f"/api/v1/sboms/upload-file/{component.id}?bom_type=vex", {"sbom_file": payload})
+        assert response.status_code == 201, response.content
+        sbom = SBOM.objects.get(id=response.json()["id"])
+        assert sbom.sha256_hash == hashlib.sha256(raw).hexdigest()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("s3_stub")
+class TestVexArtifactEndpoint:
+    def _post(self, token, component_id: str, document: dict[str, Any]) -> Any:
+        client = Client()
+        return client.post(
+            f"/api/v1/sboms/artifact/vex/{component_id}",
+            data=json.dumps(document),
+            content_type="application/json",
+            **get_api_headers(token),
+        )
+
+    def test_accepts_openvex(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+        _, token = authenticated_api_client
+        doc = _openvex_doc(
+            {"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:npm/a@1"}], "status": "not_affected"}
+        )
+        response = self._post(token, component.id, doc)
+        assert response.status_code == 201, response.content
+        sbom = SBOM.objects.get(id=response.json()["id"])
+        assert sbom.format == "openvex"
+        assert sbom.source == "api"
+
+    def test_accepts_csaf(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+        _, token = authenticated_api_client
+        doc = _csaf_doc([{"cve": "CVE-2026-9", "product_status": {"known_not_affected": ["CSAFPID-0001"]}}])
+        response = self._post(token, component.id, doc)
+        assert response.status_code == 201, response.content
+        assert SBOM.objects.get(id=response.json()["id"]).format == "csaf"
+
+    def test_delegates_cyclonedx(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+        _, token = authenticated_api_client
+        doc = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "vulnerabilities": [{"id": "CVE-1", "analysis": {"state": "not_affected"}}],
+        }
+        response = self._post(token, component.id, doc)
+        assert response.status_code == 201, response.content
+        sbom = SBOM.objects.get(id=response.json()["id"])
+        assert sbom.format == "cyclonedx"
+        assert sbom.bom_type == "vex"
+
+    def test_rejects_unknown_format(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+        _, token = authenticated_api_client
+        response = self._post(token, component.id, {"hello": "world"})
+        assert response.status_code == 400
+        assert "Unrecognized VEX format" in response.json()["detail"]
+
+    def test_rejects_unauthenticated(self, component) -> None:
+        client = Client()
+        response = client.post(
+            f"/api/v1/sboms/artifact/vex/{component.id}",
+            data=json.dumps(_openvex_doc()),
+            content_type="application/json",
+        )
+        assert response.status_code == 401

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -296,6 +296,29 @@ def test_csaf_group_ids_resolve_for_flags() -> None:
     assert "component_not_present" in statements[0]["detail"]
 
 
+def test_csaf_malformed_scalar_fields_fail_closed() -> None:
+    """String-typed product-id fields must not iterate as characters."""
+    doc = _csaf_doc(
+        [{"cve": "CVE-2026-6", "product_status": {"known_not_affected": "CSAFPID-0001"}}],
+    )
+    assert derive_csaf_suppressions(doc) == []
+
+    doc = _csaf_doc(
+        [
+            {
+                "cve": "CVE-2026-7",
+                "product_status": {"known_not_affected": ["CSAFPID-0001"]},
+                "flags": [{"label": "component_not_present", "product_ids": "CSAFPID-0001"}],
+            }
+        ]
+    )
+    statements = derive_csaf_suppressions(doc)
+    # The malformed flag matches nothing... but an empty target set means
+    # "no restriction", so the label still applies. Assert no crash and a
+    # coherent statement either way.
+    assert len(statements) == 1
+
+
 def test_csaf_no_vulnerability_id_skipped() -> None:
     doc = _csaf_doc([{"product_status": {"known_not_affected": ["CSAFPID-0001"]}}])
     assert derive_csaf_suppressions(doc) == []

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -149,13 +149,12 @@ def test_openvex_document_level_products_inherited() -> None:
     assert statements[0]["packages"] == {("npm", "lodash", "4.17.15")}
 
 
-def test_openvex_explicit_empty_products_does_not_inherit() -> None:
-    """An explicit products: [] is a narrower scoping, not an omission."""
+def test_openvex_explicit_empty_products_fails_closed() -> None:
+    """An explicit products: [] scopes the statement to nothing: it neither
+    inherits the document-level products nor widens to id-only suppression."""
     doc = _openvex_doc({"vulnerability": {"name": "CVE-1"}, "products": [], "status": "not_affected"})
     doc["products"] = [{"@id": "pkg:npm/lodash@4.17.15"}]
-    statements = derive_openvex_suppressions(doc)
-    assert statements[0]["packages"] == set()
-    assert statements[0]["product_scoped"] is True
+    assert derive_openvex_suppressions(doc) == []
 
 
 def test_openvex_malformed_products_fails_closed() -> None:

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -461,7 +461,12 @@ class TestVexArtifactEndpoint:
 
     def test_markerless_cyclonedx_delegates(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
         """A CycloneDX VEX without the bomFormat marker is treated as CycloneDX
-        (specVersion present), matching the session upload flow's leniency."""
+        (specVersion present), matching the session upload flow's leniency.
+
+        The CycloneDX schema itself requires bomFormat, so the delegated flow
+        answers with its own validation verdict — which is exactly the point:
+        the caller gets a precise schema error, not "unrecognized format".
+        """
         _, token = authenticated_api_client
         doc = {
             "specVersion": "1.6",
@@ -469,9 +474,10 @@ class TestVexArtifactEndpoint:
             "vulnerabilities": [{"id": "CVE-1", "analysis": {"state": "not_affected"}}],
         }
         response = self._post(token, component.id, doc)
-        # Delegation happened: the CycloneDX flow answers (validation verdicts
-        # included), not the unrecognized-format 400.
-        assert "Unrecognized VEX format" not in response.content.decode()
+        assert response.status_code == 400, response.content
+        detail = response.json()["detail"]
+        assert "Invalid CycloneDX" in detail
+        assert "Unrecognized VEX format" not in detail
 
     def test_rejects_unknown_format(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
         _, token = authenticated_api_client

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -86,6 +86,7 @@ def test_detects_csaf_vex() -> None:
         {"document": {"category": "csaf_security_advisory"}},
         {"@context": "https://example.com/other", "statements": []},
         {"@context": "https://openvex.dev/nsfoo/v1", "statements": []},
+        {"@context": "https://openvex.dev/ns/", "statements": []},
     ],
 )
 def test_detects_nothing_else(document: Any) -> None:

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -72,6 +72,13 @@ def test_detects_openvex_list_context() -> None:
     assert detect_vex_format(doc) == VEX_FORMAT_OPENVEX
 
 
+def test_openvex_versioned_context_preferred_over_bare() -> None:
+    from sbomify.apps.vulnerability_scanning.vex_formats import openvex_context
+
+    doc = {"@context": ["https://openvex.dev/ns", "https://openvex.dev/ns/v0.2.0"]}
+    assert openvex_context(doc) == "https://openvex.dev/ns/v0.2.0"
+
+
 def test_detects_csaf_vex() -> None:
     assert detect_vex_format({"document": {"category": "csaf_vex", "csaf_version": "2.0"}}) == VEX_FORMAT_CSAF
 

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -71,7 +71,7 @@ _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
 def derive_vex_suppressions(document: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Extract the suppressing statements from a VEX document of any supported format.
 
-    Returns a list of ``{"ids": set[str], "packages": set[(name, version)], "product_scoped": bool,
+    Returns a list of ``{"ids": set[str], "packages": set[(ptype, name, version)], "product_scoped": bool,
     "state": str, ...}`` where ``version`` is normalised (lower-cased, leading ``v`` stripped) or
     ``None`` and ``state`` is the CycloneDX analysis state that cleared the finding.
 

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -1,4 +1,4 @@
-"""Apply a component's uploaded CycloneDX VEX to its vulnerability scan results.
+"""Apply a component's uploaded VEX to its vulnerability scan results.
 
 Provider-agnostic and applied server-side at the scanner-plugin return layer (the
 orchestrator), so both OSV and Dependency Track share one path. When a component
@@ -31,44 +31,22 @@ import json
 import logging
 import uuid
 from typing import Any
-from urllib.parse import unquote
+
+from sbomify.apps.vulnerability_scanning.vex_formats import (
+    MAX_VEX_STATEMENTS,
+    VEX_FORMAT_CSAF,
+    VEX_FORMAT_OPENVEX,
+    derive_csaf_suppressions,
+    derive_openvex_suppressions,
+    detect_vex_format,
+)
+from sbomify.apps.vulnerability_scanning.vex_formats import norm_id as _norm_id
+from sbomify.apps.vulnerability_scanning.vex_formats import norm_version as _norm_version
+from sbomify.apps.vulnerability_scanning.vex_formats import pkg_from_purl as _pkg_from_purl
 
 logger = logging.getLogger(__name__)
 
 _SEVERITIES = ("critical", "high", "medium", "low", "info", "unknown")
-
-# Upper bound on suppressing statements read from one document, so a pathological
-# upload cannot make every subsequent scan pay for an unbounded statement list.
-MAX_VEX_STATEMENTS = 10_000
-
-
-def _norm_id(value: str | None) -> str | None:
-    return value.lower() if value else None
-
-
-def _norm_version(value: str | None) -> str | None:
-    return value.lower().lstrip("v") if value else None
-
-
-def _pkg_from_purl(purl: str) -> tuple[str | None, str, str | None]:
-    """(type, name, version) from a purl. name is the percent-decoded path after
-    ``pkg:<type>/`` so it matches the package name a scanner reports (e.g.
-    ``@scope/name``, ``github.com/docker/docker``); the type scopes matches per
-    ecosystem so a same-named package elsewhere is not suppressed.
-    """
-    body = purl[4:] if purl.startswith("pkg:") else purl
-    body = body.split("?", 1)[0].split("#", 1)[0]
-    # The version separator is the last "@" — but only when what follows is a
-    # version, not the tail of an unencoded scoped name like "@scope/name".
-    before, sep, after = body.rpartition("@")
-    if sep and "/" not in after:
-        name_part, version = before, after
-    else:
-        name_part, version = body, ""
-    ptype, slash, rest = name_part.partition("/")
-    if slash:
-        return (ptype.lower() or None), unquote(rest), (unquote(version) or None)
-    return None, unquote(name_part), (unquote(version) or None)
 
 
 def _statement_ids(vuln: dict[str, Any]) -> set[str]:
@@ -91,12 +69,17 @@ _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
 
 
 def derive_vex_suppressions(document: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Extract the suppressing statements (``not_affected`` / ``false_positive``) from a CycloneDX
-    VEX document.
+    """Extract the suppressing statements from a VEX document of any supported format.
 
     Returns a list of ``{"ids": set[str], "packages": set[(name, version)], "product_scoped": bool,
     "state": str, ...}`` where ``version`` is normalised (lower-cased, leading ``v`` stripped) or
     ``None`` and ``state`` is the CycloneDX analysis state that cleared the finding.
+
+    The format is detected from the document content: OpenVEX and CSAF VEX are
+    handled by :mod:`vex_formats` (only ``not_affected``/``known_not_affected``
+    can suppress there); CycloneDX — including documents without an explicit
+    marker, the historical default — is parsed below with suppressing states
+    ``not_affected`` and ``false_positive``.
 
     ``affects[].ref`` is a bom-ref. Hand-authored VEX uses ``bom-ref == purl`` (and
     declares the component in ``components[]``), so the package is read from there.
@@ -108,6 +91,11 @@ def derive_vex_suppressions(document: dict[str, Any] | None) -> list[dict[str, A
     """
     if not isinstance(document, dict):
         return []
+    detected = detect_vex_format(document)
+    if detected == VEX_FORMAT_OPENVEX:
+        return derive_openvex_suppressions(document)
+    if detected == VEX_FORMAT_CSAF:
+        return derive_csaf_suppressions(document)
     root_ref = ((document.get("metadata") or {}).get("component") or {}).get("bom-ref")
     component_purls: dict[str, str | None] = {}
     for component in document.get("components") or []:

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -1,0 +1,301 @@
+"""Detection and suppression-derivation for the three VEX document formats.
+
+sbomify stores VEX documents byte-for-byte as received and only *derives*
+suppression statements from them at read time. CycloneDX VEX is parsed in
+``vex.py``; this module adds OpenVEX (openvex.dev) and CSAF 2.0 VEX (OASIS)
+so a document from vexctl/Chainguard or a vendor advisory (Red Hat, Cisco)
+suppresses findings exactly like a Dependency-Track export.
+
+All parsers normalise to the same statement shape ``vex.py`` produces:
+``{"ids", "packages", "product_scoped", "state", "justification", "detail"}``
+with CycloneDX vocabulary. Only ``not_affected`` can suppress from these
+formats — neither OpenVEX nor CSAF can express ``false_positive``.
+"""
+
+import logging
+from typing import Any
+from urllib.parse import unquote
+
+logger = logging.getLogger(__name__)
+
+VEX_FORMAT_CYCLONEDX = "cyclonedx"
+VEX_FORMAT_OPENVEX = "openvex"
+VEX_FORMAT_CSAF = "csaf"
+
+_OPENVEX_CONTEXT_PREFIX = "https://openvex.dev/ns"
+
+# Upper bound on suppressing statements read from one document, so a pathological
+# upload cannot make every subsequent scan pay for an unbounded statement list.
+MAX_VEX_STATEMENTS = 10_000
+
+# OpenVEX justifications and CSAF flag labels share the five CISA labels.
+# CycloneDX has a different vocabulary, so two pairs collapse; the original
+# label is preserved in ``detail`` to keep the loss visible.
+_CISA_TO_CDX_JUSTIFICATION = {
+    "component_not_present": "code_not_present",
+    "vulnerable_code_not_present": "code_not_present",
+    "vulnerable_code_not_in_execute_path": "code_not_reachable",
+    "vulnerable_code_cannot_be_controlled_by_adversary": "protected_by_mitigating_control",
+    "inline_mitigations_already_exist": "protected_by_mitigating_control",
+}
+
+
+def norm_id(value: str | None) -> str | None:
+    return value.lower() if value else None
+
+
+def norm_version(value: str | None) -> str | None:
+    return value.lower().lstrip("v") if value else None
+
+
+def pkg_from_purl(purl: str) -> tuple[str | None, str, str | None]:
+    """(type, name, version) from a purl. name is the percent-decoded path after
+    ``pkg:<type>/`` so it matches the package name a scanner reports (e.g.
+    ``@scope/name``, ``github.com/docker/docker``); the type scopes matches per
+    ecosystem so a same-named package elsewhere is not suppressed.
+    """
+    body = purl[4:] if purl.startswith("pkg:") else purl
+    body = body.split("?", 1)[0].split("#", 1)[0]
+    # The version separator is the last "@" — but only when what follows is a
+    # version, not the tail of an unencoded scoped name like "@scope/name".
+    before, sep, after = body.rpartition("@")
+    if sep and "/" not in after:
+        name_part, version = before, after
+    else:
+        name_part, version = body, ""
+    ptype, slash, rest = name_part.partition("/")
+    if slash:
+        return (ptype.lower() or None), unquote(rest), (unquote(version) or None)
+    return None, unquote(name_part), (unquote(version) or None)
+
+
+def detect_vex_format(document: Any) -> str | None:
+    """Identify a VEX document's format from its content.
+
+    The three markers are mutually exclusive: CycloneDX requires a top-level
+    ``bomFormat``, OpenVEX a ``@context`` IRI under openvex.dev (prefix-matched —
+    v0.0.1 documents lack the version suffix), CSAF a ``document.category`` of
+    ``csaf_vex``. Returns ``None`` for anything else.
+    """
+    if not isinstance(document, dict):
+        return None
+    if document.get("bomFormat") == "CycloneDX":
+        return VEX_FORMAT_CYCLONEDX
+    context = document.get("@context")
+    if isinstance(context, str) and context.startswith(_OPENVEX_CONTEXT_PREFIX):
+        return VEX_FORMAT_OPENVEX
+    meta = document.get("document")
+    if isinstance(meta, dict) and meta.get("category") == "csaf_vex":
+        return VEX_FORMAT_CSAF
+    return None
+
+
+def _packages_from_purls(purls: list[str]) -> set[tuple[str | None, str, str | None]]:
+    packages: set[tuple[str | None, str, str | None]] = set()
+    for purl in purls:
+        if isinstance(purl, str) and purl.startswith("pkg:"):
+            ptype, name, version = pkg_from_purl(purl)
+            packages.add((ptype, name, norm_version(version)))
+    return packages
+
+
+def _openvex_statement_ids(vulnerability: Any) -> set[str]:
+    """Vulnerability ids from an OpenVEX statement. ``vulnerability`` is an
+    object with ``name``/``aliases`` since v0.2.0 but was a plain string in
+    v0.0.1 documents.
+    """
+    ids: set[str] = set()
+    if isinstance(vulnerability, str):
+        if normed := norm_id(vulnerability):
+            ids.add(normed)
+        return ids
+    if not isinstance(vulnerability, dict):
+        return ids
+    for value in [vulnerability.get("name"), vulnerability.get("@id"), *(vulnerability.get("aliases") or [])]:
+        if isinstance(value, str) and (normed := norm_id(value)):
+            ids.add(normed)
+    return ids
+
+
+def _mapped_justification(label: Any, detail: Any, format_word: str) -> tuple[str | None, str | None]:
+    """Map a CISA justification label to CycloneDX vocabulary, keeping the
+    original label in ``detail`` because the mapping collapses distinct labels.
+    """
+    detail_text = detail if isinstance(detail, str) and detail else None
+    if not isinstance(label, str) or label not in _CISA_TO_CDX_JUSTIFICATION:
+        return None, detail_text
+    prefix = f"[{format_word} justification: {label}]"
+    return _CISA_TO_CDX_JUSTIFICATION[label], f"{prefix} {detail_text}" if detail_text else prefix
+
+
+def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Suppressing statements from an OpenVEX document — status ``not_affected``
+    only; ``affected``/``fixed``/``under_investigation`` never suppress.
+    ``products`` may be inherited from the document level.
+    """
+    doc_products = document.get("products") if isinstance(document.get("products"), list) else []
+    statements: list[dict[str, Any]] = []
+    for statement in document.get("statements") or []:
+        if not isinstance(statement, dict) or statement.get("status") != "not_affected":
+            continue
+        ids = _openvex_statement_ids(statement.get("vulnerability"))
+        if not ids:
+            continue
+        if len(statements) >= MAX_VEX_STATEMENTS:
+            logger.warning(
+                "VEX document carries more than %d suppressing statements; ignoring the rest.",
+                MAX_VEX_STATEMENTS,
+            )
+            break
+        purls: list[str] = []
+        for product in statement.get("products") or doc_products or []:
+            if isinstance(product, str):
+                purls.append(product)
+            elif isinstance(product, dict):
+                identifiers = product.get("identifiers")
+                purl = identifiers.get("purl") if isinstance(identifiers, dict) else None
+                purls.append(purl or product.get("@id") or "")
+        packages = _packages_from_purls(purls)
+        justification, detail = _mapped_justification(
+            statement.get("justification"),
+            statement.get("impact_statement") or statement.get("status_notes"),
+            "openvex",
+        )
+        statements.append(
+            {
+                "ids": ids,
+                "packages": packages,
+                "product_scoped": not packages,
+                "state": "not_affected",
+                "justification": justification,
+                "detail": detail,
+            }
+        )
+    return statements
+
+
+def _csaf_product_purls(product_tree: Any) -> dict[str, str | None]:
+    """product_id -> purl (or None) from ``full_product_names``, recursive
+    ``branches`` and ``relationships``. purls are frequently absent — vendors
+    often publish name-only product trees.
+    """
+    mapping: dict[str, str | None] = {}
+    if not isinstance(product_tree, dict):
+        return mapping
+
+    def record(full_product_name: Any) -> None:
+        if not isinstance(full_product_name, dict):
+            return
+        product_id = full_product_name.get("product_id")
+        helper = full_product_name.get("product_identification_helper")
+        purl = helper.get("purl") if isinstance(helper, dict) else None
+        if isinstance(product_id, str):
+            mapping[product_id] = purl if isinstance(purl, str) else None
+
+    for entry in product_tree.get("full_product_names") or []:
+        record(entry)
+    stack = list(product_tree.get("branches") or [])
+    while stack:
+        branch = stack.pop()
+        if not isinstance(branch, dict):
+            continue
+        record(branch.get("product"))
+        stack.extend(branch.get("branches") or [])
+    for relationship in product_tree.get("relationships") or []:
+        if isinstance(relationship, dict):
+            record(relationship.get("full_product_name"))
+    return mapping
+
+
+def _csaf_group_members(product_tree: Any) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    if not isinstance(product_tree, dict):
+        return groups
+    for group in product_tree.get("product_groups") or []:
+        if isinstance(group, dict) and isinstance(group.get("group_id"), str):
+            groups[group["group_id"]] = [p for p in group.get("product_ids") or [] if isinstance(p, str)]
+    return groups
+
+
+def _csaf_targets(entry: dict[str, Any], groups: dict[str, list[str]]) -> set[str]:
+    """Product ids a flag/threat applies to, resolving ``group_ids``. Empty
+    means the entry carries no product restriction (applies to all).
+    """
+    targets = {p for p in entry.get("product_ids") or [] if isinstance(p, str)}
+    for group_id in entry.get("group_ids") or []:
+        targets.update(groups.get(group_id, []))
+    return targets
+
+
+def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Suppressing statements from a CSAF VEX document.
+
+    CSAF inverts the axis: ``product_status`` maps status to product-id arrays,
+    so one vulnerability can be ``known_not_affected`` for product A while
+    ``known_affected`` for product B. Only the products listed under
+    ``known_not_affected`` contribute; their ids resolve to purls through the
+    product tree, and when no purl resolves the statement is product-scoped
+    (id-only suppression within the component the VEX is attached to) with the
+    product ids recorded in ``detail``.
+    """
+    product_tree = document.get("product_tree")
+    purls_by_id = _csaf_product_purls(product_tree)
+    groups = _csaf_group_members(product_tree)
+    statements: list[dict[str, Any]] = []
+    for vulnerability in document.get("vulnerabilities") or []:
+        if not isinstance(vulnerability, dict):
+            continue
+        product_status = vulnerability.get("product_status")
+        if not isinstance(product_status, dict):
+            continue
+        not_affected_ids = [p for p in product_status.get("known_not_affected") or [] if isinstance(p, str)]
+        if not not_affected_ids:
+            continue
+        ids: set[str] = set()
+        if isinstance(vulnerability.get("cve"), str) and (cve := norm_id(vulnerability["cve"])):
+            ids.add(cve)
+        for id_entry in vulnerability.get("ids") or []:
+            if isinstance(id_entry, dict) and isinstance(id_entry.get("text"), str):
+                if normed := norm_id(id_entry["text"]):
+                    ids.add(normed)
+        if not ids:
+            logger.warning("CSAF VEX statement has known_not_affected products but no vulnerability id; skipping.")
+            continue
+        if len(statements) >= MAX_VEX_STATEMENTS:
+            logger.warning(
+                "VEX document carries more than %d suppressing statements; ignoring the rest.",
+                MAX_VEX_STATEMENTS,
+            )
+            break
+        packages = _packages_from_purls([purls_by_id.get(pid) or "" for pid in not_affected_ids])
+        flag_label = None
+        for flag in vulnerability.get("flags") or []:
+            if not isinstance(flag, dict):
+                continue
+            targets = _csaf_targets(flag, groups)
+            if not targets or targets & set(not_affected_ids):
+                flag_label = flag.get("label")
+                break
+        impact_detail = None
+        for threat in vulnerability.get("threats") or []:
+            if not isinstance(threat, dict) or threat.get("category") != "impact":
+                continue
+            targets = _csaf_targets(threat, groups)
+            if not targets or targets & set(not_affected_ids):
+                impact_detail = threat.get("details")
+                break
+        justification, detail = _mapped_justification(flag_label, impact_detail, "csaf")
+        if not packages:
+            scope_note = f"[csaf products: {', '.join(not_affected_ids)}]"
+            detail = f"{detail} {scope_note}" if detail else scope_note
+        statements.append(
+            {
+                "ids": ids,
+                "packages": packages,
+                "product_scoped": not packages,
+                "state": "not_affected",
+                "justification": justification,
+                "detail": detail,
+            }
+        )
+    return statements

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -78,13 +78,17 @@ def openvex_context(document: dict[str, Any]) -> str | None:
     context = document.get("@context")
     candidates = context if isinstance(context, list) else [context]
     versioned_prefix = _OPENVEX_CONTEXT_PREFIX + "/"
+    bare_match = None
     for entry in candidates:
-        if isinstance(entry, str) and (
-            entry == _OPENVEX_CONTEXT_PREFIX
-            or (entry.startswith(versioned_prefix) and len(entry) > len(versioned_prefix))
-        ):
+        if not isinstance(entry, str):
+            continue
+        if entry.startswith(versioned_prefix) and len(entry) > len(versioned_prefix):
+            # A versioned context wins over the bare namespace so the stored
+            # format_version reflects the declared spec version.
             return entry
-    return None
+        if entry == _OPENVEX_CONTEXT_PREFIX:
+            bare_match = entry
+    return bare_match
 
 
 def detect_vex_format(document: Any) -> str | None:

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -122,7 +122,7 @@ def _openvex_statement_ids(vulnerability: Any) -> set[str]:
         return ids
     if not isinstance(vulnerability, dict):
         return ids
-    for value in [vulnerability.get("name"), vulnerability.get("@id"), *(vulnerability.get("aliases") or [])]:
+    for value in [vulnerability.get("name"), vulnerability.get("@id"), *_as_list(vulnerability.get("aliases"))]:
         if isinstance(value, str) and (normed := norm_id(value)):
             ids.add(normed)
     return ids

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -197,7 +197,9 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
             elif isinstance(product, dict):
                 identifiers = product.get("identifiers")
                 purl = identifiers.get("purl") if isinstance(identifiers, dict) else None
-                purls.append(purl or product.get("@id") or "")
+                candidate = purl or product.get("@id")
+                if isinstance(candidate, str):
+                    purls.append(candidate)
         packages = _packages_from_purls(purls)
         if products and not packages:
             # Explicit product scoping that maps to no purls (e.g. bare IRIs,

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -143,8 +143,17 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
     """Suppressing statements from an OpenVEX document — status ``not_affected``
     only; ``affected``/``fixed``/``under_investigation`` never suppress.
     ``products`` may be inherited from the document level.
+
+    Product scoping fails closed: a statement whose declared products (own or
+    inherited) cannot be mapped to purls is skipped rather than widened to
+    id-only suppression, because over-suppression hides real findings. Only a
+    statement with no product declaration anywhere is treated as a
+    whole-document claim (``product_scoped``), matching the Dependency-Track
+    root-ref semantics in the CycloneDX parser.
     """
-    doc_products = document.get("products") if isinstance(document.get("products"), list) else []
+    raw_doc_products = document.get("products")
+    doc_products = raw_doc_products if isinstance(raw_doc_products, list) else []
+    doc_products_malformed = raw_doc_products is not None and not isinstance(raw_doc_products, list)
     statements: list[dict[str, Any]] = []
     for statement in document.get("statements") or []:
         if not isinstance(statement, dict) or statement.get("status") != "not_affected":
@@ -159,17 +168,19 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
             )
             break
         # Inherit document-level products only when the statement declares
-        # none at all; an explicit empty list is a narrower scoping, not an
-        # omission. A present-but-malformed products fails closed: iterating
-        # a dict or string would yield no packages and silently widen the
-        # statement to product-scoped.
-        products = statement.get("products")
-        if products is None:
+        # none at all. Malformed products — a dict or string where the spec
+        # requires a list — fail closed at either level.
+        own_products = statement.get("products")
+        if own_products is None:
+            if doc_products_malformed:
+                continue
             products = doc_products
-        elif not isinstance(products, list):
+        elif isinstance(own_products, list):
+            products = own_products
+        else:
             continue
         purls: list[str] = []
-        for product in products or []:
+        for product in products:
             if isinstance(product, str):
                 purls.append(product)
             elif isinstance(product, dict):
@@ -177,6 +188,11 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
                 purl = identifiers.get("purl") if isinstance(identifiers, dict) else None
                 purls.append(purl or product.get("@id") or "")
         packages = _packages_from_purls(purls)
+        if products and not packages:
+            # Explicit product scoping that maps to no purls (e.g. bare IRIs,
+            # cpe-only identifiers): honouring it as id-only suppression would
+            # apply the statement wider than its author scoped it.
+            continue
         justification, detail = _mapped_justification(
             statement.get("justification"),
             statement.get("impact_statement") or statement.get("status_notes"),

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -244,13 +244,21 @@ def _csaf_product_purls(product_tree: Any) -> dict[str, str | None]:
     return mapping
 
 
+def _as_list(value: Any) -> list[Any]:
+    """The value if it is a list, else empty. Product-id fields hold strings,
+    so iterating a malformed scalar string would yield characters that pass
+    ``isinstance(str)`` element filters and corrupt scoping.
+    """
+    return value if isinstance(value, list) else []
+
+
 def _csaf_group_members(product_tree: Any) -> dict[str, list[str]]:
     groups: dict[str, list[str]] = {}
     if not isinstance(product_tree, dict):
         return groups
-    for group in product_tree.get("product_groups") or []:
+    for group in _as_list(product_tree.get("product_groups")):
         if isinstance(group, dict) and isinstance(group.get("group_id"), str):
-            groups[group["group_id"]] = [p for p in group.get("product_ids") or [] if isinstance(p, str)]
+            groups[group["group_id"]] = [p for p in _as_list(group.get("product_ids")) if isinstance(p, str)]
     return groups
 
 
@@ -258,9 +266,10 @@ def _csaf_targets(entry: dict[str, Any], groups: dict[str, list[str]]) -> set[st
     """Product ids a flag/threat applies to, resolving ``group_ids``. Empty
     means the entry carries no product restriction (applies to all).
     """
-    targets = {p for p in entry.get("product_ids") or [] if isinstance(p, str)}
-    for group_id in entry.get("group_ids") or []:
-        targets.update(groups.get(group_id, []))
+    targets = {p for p in _as_list(entry.get("product_ids")) if isinstance(p, str)}
+    for group_id in _as_list(entry.get("group_ids")):
+        if isinstance(group_id, str):
+            targets.update(groups.get(group_id, []))
     return targets
 
 
@@ -285,7 +294,7 @@ def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
         product_status = vulnerability.get("product_status")
         if not isinstance(product_status, dict):
             continue
-        not_affected_ids = [p for p in product_status.get("known_not_affected") or [] if isinstance(p, str)]
+        not_affected_ids = [p for p in _as_list(product_status.get("known_not_affected")) if isinstance(p, str)]
         if not not_affected_ids:
             continue
         ids: set[str] = set()

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -101,6 +101,14 @@ def detect_vex_format(document: Any) -> str | None:
     return None
 
 
+def _as_list(value: Any) -> list[Any]:
+    """The value if it is a list, else empty. Product-id fields hold strings,
+    so iterating a malformed scalar string would yield characters that pass
+    ``isinstance(str)`` element filters and corrupt scoping.
+    """
+    return value if isinstance(value, list) else []
+
+
 def _packages_from_purls(purls: list[str]) -> set[tuple[str | None, str, str | None]]:
     packages: set[tuple[str | None, str, str | None]] = set()
     for purl in purls:
@@ -155,7 +163,7 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
     doc_products = raw_doc_products if isinstance(raw_doc_products, list) else []
     doc_products_malformed = raw_doc_products is not None and not isinstance(raw_doc_products, list)
     statements: list[dict[str, Any]] = []
-    for statement in document.get("statements") or []:
+    for statement in _as_list(document.get("statements")):
         if not isinstance(statement, dict) or statement.get("status") != "not_affected":
             continue
         ids = _openvex_statement_ids(statement.get("vulnerability"))
@@ -229,27 +237,19 @@ def _csaf_product_purls(product_tree: Any) -> dict[str, str | None]:
         if isinstance(product_id, str):
             mapping[product_id] = purl if isinstance(purl, str) else None
 
-    for entry in product_tree.get("full_product_names") or []:
+    for entry in _as_list(product_tree.get("full_product_names")):
         record(entry)
-    stack = list(product_tree.get("branches") or [])
+    stack = _as_list(product_tree.get("branches")).copy()
     while stack:
         branch = stack.pop()
         if not isinstance(branch, dict):
             continue
         record(branch.get("product"))
-        stack.extend(branch.get("branches") or [])
-    for relationship in product_tree.get("relationships") or []:
+        stack.extend(_as_list(branch.get("branches")))
+    for relationship in _as_list(product_tree.get("relationships")):
         if isinstance(relationship, dict):
             record(relationship.get("full_product_name"))
     return mapping
-
-
-def _as_list(value: Any) -> list[Any]:
-    """The value if it is a list, else empty. Product-id fields hold strings,
-    so iterating a malformed scalar string would yield characters that pass
-    ``isinstance(str)`` element filters and corrupt scoping.
-    """
-    return value if isinstance(value, list) else []
 
 
 def _csaf_group_members(product_tree: Any) -> dict[str, list[str]]:
@@ -288,7 +288,7 @@ def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
     purls_by_id = _csaf_product_purls(product_tree)
     groups = _csaf_group_members(product_tree)
     statements: list[dict[str, Any]] = []
-    for vulnerability in document.get("vulnerabilities") or []:
+    for vulnerability in _as_list(document.get("vulnerabilities")):
         if not isinstance(vulnerability, dict):
             continue
         product_status = vulnerability.get("product_status")
@@ -300,7 +300,7 @@ def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
         ids: set[str] = set()
         if isinstance(vulnerability.get("cve"), str) and (cve := norm_id(vulnerability["cve"])):
             ids.add(cve)
-        for id_entry in vulnerability.get("ids") or []:
+        for id_entry in _as_list(vulnerability.get("ids")):
             if isinstance(id_entry, dict) and isinstance(id_entry.get("text"), str):
                 if normed := norm_id(id_entry["text"]):
                     ids.add(normed)
@@ -315,7 +315,7 @@ def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
             break
         packages = _packages_from_purls([purls_by_id.get(pid) or "" for pid in not_affected_ids])
         flag_label = None
-        for flag in vulnerability.get("flags") or []:
+        for flag in _as_list(vulnerability.get("flags")):
             if not isinstance(flag, dict):
                 continue
             targets = _csaf_targets(flag, groups)
@@ -323,7 +323,7 @@ def derive_csaf_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
                 flag_label = flag.get("label")
                 break
         impact_detail = None
-        for threat in vulnerability.get("threats") or []:
+        for threat in _as_list(vulnerability.get("threats")):
             if not isinstance(threat, dict) or threat.get("category") != "impact":
                 continue
             targets = _csaf_targets(threat, groups)

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -158,8 +158,14 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
                 MAX_VEX_STATEMENTS,
             )
             break
+        # Inherit document-level products only when the statement declares
+        # none at all; an explicit empty list is a narrower scoping, not an
+        # omission.
+        products = statement.get("products")
+        if products is None:
+            products = doc_products
         purls: list[str] = []
-        for product in statement.get("products") or doc_products or []:
+        for product in products or []:
             if isinstance(product, str):
                 purls.append(product)
             elif isinstance(product, dict):

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -69,20 +69,31 @@ def pkg_from_purl(purl: str) -> tuple[str | None, str, str | None]:
     return None, unquote(name_part), (unquote(version) or None)
 
 
+def openvex_context(document: dict[str, Any]) -> str | None:
+    """The openvex.dev context IRI from ``@context``, which JSON-LD allows to
+    be a single string or a list; prefix-matched because v0.0.1 documents lack
+    the version suffix.
+    """
+    context = document.get("@context")
+    candidates = context if isinstance(context, list) else [context]
+    for entry in candidates:
+        if isinstance(entry, str) and entry.startswith(_OPENVEX_CONTEXT_PREFIX):
+            return entry
+    return None
+
+
 def detect_vex_format(document: Any) -> str | None:
     """Identify a VEX document's format from its content.
 
     The three markers are mutually exclusive: CycloneDX requires a top-level
-    ``bomFormat``, OpenVEX a ``@context`` IRI under openvex.dev (prefix-matched —
-    v0.0.1 documents lack the version suffix), CSAF a ``document.category`` of
-    ``csaf_vex``. Returns ``None`` for anything else.
+    ``bomFormat``, OpenVEX a ``@context`` IRI under openvex.dev, CSAF a
+    ``document.category`` of ``csaf_vex``. Returns ``None`` for anything else.
     """
     if not isinstance(document, dict):
         return None
     if document.get("bomFormat") == "CycloneDX":
         return VEX_FORMAT_CYCLONEDX
-    context = document.get("@context")
-    if isinstance(context, str) and context.startswith(_OPENVEX_CONTEXT_PREFIX):
+    if openvex_context(document) is not None:
         return VEX_FORMAT_OPENVEX
     meta = document.get("document")
     if isinstance(meta, dict) and meta.get("category") == "csaf_vex":

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -77,9 +77,11 @@ def openvex_context(document: dict[str, Any]) -> str | None:
     """
     context = document.get("@context")
     candidates = context if isinstance(context, list) else [context]
+    versioned_prefix = _OPENVEX_CONTEXT_PREFIX + "/"
     for entry in candidates:
         if isinstance(entry, str) and (
-            entry == _OPENVEX_CONTEXT_PREFIX or entry.startswith(_OPENVEX_CONTEXT_PREFIX + "/")
+            entry == _OPENVEX_CONTEXT_PREFIX
+            or (entry.startswith(versioned_prefix) and len(entry) > len(versioned_prefix))
         ):
             return entry
     return None

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -71,13 +71,16 @@ def pkg_from_purl(purl: str) -> tuple[str | None, str, str | None]:
 
 def openvex_context(document: dict[str, Any]) -> str | None:
     """The openvex.dev context IRI from ``@context``, which JSON-LD allows to
-    be a single string or a list; prefix-matched because v0.0.1 documents lack
-    the version suffix.
+    be a single string or a list. Matches the bare namespace (v0.0.1 documents
+    lack a version suffix) or a versioned ``.../ns/<version>`` — not arbitrary
+    strings that merely share the prefix (``.../nsfoo``).
     """
     context = document.get("@context")
     candidates = context if isinstance(context, list) else [context]
     for entry in candidates:
-        if isinstance(entry, str) and entry.startswith(_OPENVEX_CONTEXT_PREFIX):
+        if isinstance(entry, str) and (
+            entry == _OPENVEX_CONTEXT_PREFIX or entry.startswith(_OPENVEX_CONTEXT_PREFIX + "/")
+        ):
             return entry
     return None
 

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -160,10 +160,14 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
             break
         # Inherit document-level products only when the statement declares
         # none at all; an explicit empty list is a narrower scoping, not an
-        # omission.
+        # omission. A present-but-malformed products fails closed: iterating
+        # a dict or string would yield no packages and silently widen the
+        # statement to product-scoped.
         products = statement.get("products")
         if products is None:
             products = doc_products
+        elif not isinstance(products, list):
+            continue
         purls: list[str] = []
         for product in products or []:
             if isinstance(product, str):

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -207,10 +207,12 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
                 if isinstance(candidate, str):
                     purls.append(candidate)
         packages = _packages_from_purls(purls)
-        if products and not packages:
-            # Explicit product scoping that maps to no purls (e.g. bare IRIs,
-            # cpe-only identifiers): honouring it as id-only suppression would
-            # apply the statement wider than its author scoped it.
+        if not packages and (own_products is not None or products):
+            # Any explicit product scoping — including an empty list — that
+            # maps to no purls fails closed: honouring it as id-only
+            # suppression would apply the statement wider than its author
+            # scoped it. Only a statement with no declaration anywhere is a
+            # whole-document claim.
             continue
         justification, detail = _mapped_justification(
             statement.get("justification"),


### PR DESCRIPTION
## What

sbomify now ingests all three VEX formats in circulation, not just CycloneDX:

| Format | Emitted by | Detection marker |
|---|---|---|
| CycloneDX VEX | Dependency-Track, OWASP tooling | `bomFormat: "CycloneDX"` |
| OpenVEX | vexctl, Chainguard, OSSF tooling | `@context` under `https://openvex.dev/ns` (prefix-matched; v0.0.1 docs lack the version suffix) |
| CSAF 2.0 VEX | Vendor advisories (Red Hat, Cisco, Oracle) | `document.category: "csaf_vex"` |

The markers are mutually exclusive, so detection is content-based and unambiguous.

## How

- `vex_formats.py`: detection plus per-format derivation into the exact normalized statement shape the CycloneDX parser already produces (`{ids, packages, product_scoped, state, justification, detail}`). Everything downstream — finding matching, annotation, reannotation, release VEX pinning, Trust Center suppression display — works unchanged.
- Only `not_affected` (OpenVEX) / `known_not_affected` (CSAF) can suppress; neither format can express `false_positive`, which stays CycloneDX-only.
- The five CISA justification labels (shared verbatim by OpenVEX and CSAF flags) map onto the CycloneDX vocabulary; two pairs collapse, so the original label is preserved in `detail`.
- CSAF's inverted axis (`product_status` maps status → product-id arrays, per product not per vulnerability) is handled per product: purls resolve through the product tree (`full_product_names`, recursive `branches`, `relationships`, `product_groups` for flag/threat `group_ids`); products without purls fall back to product-scoped suppression with the ids recorded in `detail`.
- Spec quirks covered: OpenVEX v0.0.1 string-typed `vulnerability`, document-level `products` inheritance, CSAF statements with `ids[]` but no `cve`.

## Upload paths

- Web UI / session endpoint (`upload-file?bom_type=vex`): OpenVEX and CSAF are stored as received (ADR-004, raw bytes); `format` is `openvex`/`csaf` with the spec version in `format_version`.
- New PAT endpoint `POST /api/v1/sboms/artifact/vex/{component_id}`: accepts any of the three formats; CycloneDX delegates to the existing schema-validating artifact flow. Same permission tiers as CycloneDX VEX (`artifact:publish` + `artifact:publish_vex`).
- Upload panel copy updated.

## Verification

34 new tests (detection, per-format derivation against spec-shaped documents, end-to-end suppression matching, both upload paths, ADR-004 byte fidelity). Full `vulnerability_scanning` + `sboms` + `plugins` suites: 1,487 passed.

Spec facts (status vocabularies, detection markers, extraction paths) were verified against the OpenVEX v0.2.0 spec, the OASIS CSAF 2.0 OS spec, and cross-checked with how Grype and Trivy map the same vocabularies.

## Notes

- Stacked on #1128 (VEX upload from the component page UI) — merge that first.
- Companion change for `sbomify/github-action` follows: route `BOM_TYPE=vex` files through the new `/artifact/vex/` endpoint so OpenVEX/CSAF pass through CI too.
