### PR TITLE
ci: add OpenGrep SAST workflow and README badge

### DIFF
--- a/.github/workflows/opengrep.yaml
+++ b/.github/workflows/opengrep.yaml
@@ -1,0 +1,92 @@
+---
+name: OpenGrep
+
+# Static analysis (SAST) with OpenGrep — an open-source, registry-free fork of
+# Semgrep. Findings are uploaded as SARIF to the GitHub Security tab
+# (Code Scanning), so this scan is non-blocking and surfaces alerts on PRs.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # Weekly re-scan (Mondays 06:00 UTC) to catch new rules against existing code.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+env:
+  # OpenGrep release to install (https://github.com/opengrep/opengrep/releases).
+  OPENGREP_VERSION: v1.22.0
+  # SHA-256 of the opengrep_manylinux_x86 asset for OPENGREP_VERSION. The binary
+  # is verified against this before it is made executable, so a tampered/MITM'd
+  # or silently re-uploaded asset fails the build. Update both when bumping.
+  OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
+
+jobs:
+  opengrep:
+    name: OpenGrep Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required to upload SARIF to the Security tab
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Checkout OpenGrep rules
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: opengrep/opengrep-rules
+          ref: f1d2b562b414783763fd02a6ed2736eaed622efa  # archived repo, pinned for reproducibility
+          path: .opengrep-rules
+          persist-credentials: false
+
+      - name: Install OpenGrep
+        run: |
+          mkdir -p "$HOME/bin"
+          curl -fsSL -o "$HOME/bin/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          # Verify integrity before the binary is ever marked executable.
+          echo "${OPENGREP_SHA256}  ${HOME}/bin/opengrep" | sha256sum -c -
+          chmod +x "$HOME/bin/opengrep"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          "$HOME/bin/opengrep" --version
+
+      - name: Run OpenGrep scan
+        run: |
+          opengrep scan \
+            --config .opengrep-rules/python/lang/security \
+            --config .opengrep-rules/python/django/security \
+            --config .opengrep-rules/javascript/lang/security \
+            --config .opengrep-rules/generic/secrets \
+            --config .opengrep-rules/dockerfile/security \
+            --config .opengrep-rules/bash/curl \
+            --sarif-output=opengrep.sarif \
+            --exclude .opengrep-rules \
+            --exclude sbomify/apps/sboms/tests/test_data \
+            --exclude sbomify/apps/core/tests/e2e/__snapshots__ \
+            --exclude '*/migrations/*' \
+            --exclude keycloak/themes \
+            .
+
+      - name: Upload SARIF to GitHub Security
+        # always() so findings still publish when the scan step reports them, but
+        # skip when there's no SARIF (scan failed early) or the PR is from a fork
+        # (GITHUB_TOKEN is read-only there, so the upload would 403 and turn this
+        # non-blocking scan into a failing check).
+        if: >-
+          always()
+          && hashFiles('opengrep.sarif') != ''
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: opengrep.sarif
+          category: opengrep

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10952/badge)](https://www.bestpractices.dev/projects/10952)
 [![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/sbomify/shared_invite/zt-3na54pa1f-MXrFWhotmZr0YxXc8sABTw)
 [![CI/CD Pipeline](https://github.com/sbomify/sbomify/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/sbomify/sbomify/actions/workflows/ci-cd.yml)
+[![OpenGrep](https://github.com/sbomify/sbomify/actions/workflows/opengrep.yaml/badge.svg)](https://github.com/sbomify/sbomify/actions/workflows/opengrep.yaml)
 
 sbomify is a Software Bill of Materials (SBOM) and document management platform that can be self-hosted or accessed through [app.sbomify.com](https://app.sbomify.com). The platform provides a centralized location to upload and manage your SBOMs and related documentation, allowing you to share them with stakeholders or make them publicly accessible.
 


### PR DESCRIPTION
## Summary

Ports the OpenGrep SAST workflow from [sbomify-action](https://github.com/sbomify/sbomify-action/blob/master/.github/workflows/opengrep.yaml) to this repo, plus the README badge.

- Runs on push/PR to `master` and a weekly Monday re-scan
- Installs OpenGrep v1.22.0 with SHA-256 verification before the binary is made executable
- Scans against the pinned `opengrep-rules` ref (archived repo, pinned for reproducibility)
- Uploads SARIF to the GitHub Security tab (Code Scanning) — non-blocking; fork PRs skip the upload since `GITHUB_TOKEN` is read-only there

### Adaptations for this repo

- Rule sets: kept `python/lang/security`, `generic/secrets`, `dockerfile/security`, `bash/curl`; added `python/django/security` and `javascript/lang/security` for the Django backend and TypeScript frontend
- SARIF upload pinned to the same `codeql-action` SHA (v4.37.1) already used by `codeql.yml`
- Excludes SBOM test fixtures, e2e snapshots, Django migrations (raw SQL noise), and Keycloak theme templates (gitleaks false positives on password-field names)

## Test plan

- [x] Ran the exact scan locally with the pinned binary and rules: 413 rules on 969 files, 94 findings, exit code 0 (non-blocking, findings land as Code Scanning alerts)
- [x] Verified the migration/Keycloak exclusions take effect (104 → 94 findings, none remaining in those paths)
- [x] Verified all four error-level findings are false positives or intentional (comment URL match, defusedxml-backed import, deliberate `shell=False` subprocess calls, dev-stage Dockerfile CMD)
- [ ] Badge shows status after first run on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)