### PR TITLE
chore(deps): switch Dependabot to bun and uv ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -10,20 +9,20 @@ updates:
       github-actions:
         patterns:
           - "*"
-  - package-ecosystem: 'npm'
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "daily"
     groups:
-      npm:
+      bun:
         patterns:
           - "*"
-  - package-ecosystem: 'pip'
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"
     groups:
-      pip:
+      uv:
         patterns:
           - "*"
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
- Replace the `npm` Dependabot ecosystem with `bun` so updates regenerate `bun.lock` instead of writing a `package-lock.json`
- Replace `pip` with `uv` so updates go through `pyproject.toml`/`uv.lock`
- Drop `enable-beta-ecosystems: true` — both bun and uv are GA ecosystems now

🤖 Generated with [Claude Code](https://claude.com/claude-code)