### PR TITLE
chore(deps): exclude test_data fixtures from Dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "**/test_data/**"
     groups:
       bun:
         patterns:
@@ -21,6 +23,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "**/test_data/**"
     groups:
       uv:
         patterns:
@@ -29,6 +33,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "**/test_data/**"
     groups:
       docker:
         patterns:


### PR DESCRIPTION
## Summary

The SBOM fixture files under `sbomify/apps/sboms/tests/test_data/` were generating Dependabot noise. This adds `exclude-paths: ["**/test_data/**"]` to the `bun`, `uv`, and `docker` update blocks in `.github/dependabot.yml` so test fixtures are ignored during version-update scans.

The `github-actions` block is untouched since it only scans `.github/workflows`.

Note: `exclude-paths` only applies to Dependabot version updates — security alerts from the dependency graph are not affected by dependabot.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)