### PR TITLE
fix(dt): triage-VEX sync opt-in (default off); one line, not a traceback, on permission 403

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -510,10 +510,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
         # Pull DT's triage decisions back as a VEX so analysts' judgments made
         # in DT reach sbomify without a manual export/upload. Best-effort: a
         # missing permission or endpoint error must never fail the scan.
-        try:
-            self._sync_triage_vex(client, version_row)
-        except Exception:
-            logger.warning("[DT] VEX triage sync failed for project %s", version_uuid, exc_info=True)
+        self._sync_triage_vex_safely(client, version_row)
 
         now = dj_timezone.now()
         version_row.last_metrics_sync = now
@@ -574,6 +571,29 @@ class DependencyTrackPlugin(AssessmentPlugin):
     # (and vulnerabilities with no analysis at all) mean "not judged yet" —
     # nothing worth publishing as a VEX.
     _VEX_DECISION_STATES = {"not_affected", "false_positive", "resolved", "exploitable"}
+
+    def _sync_triage_vex_safely(self, client: Any, version_row: Any) -> None:
+        """Best-effort wrapper around :meth:`_sync_triage_vex` — a sync failure
+        must never fail the scan. A 403 means the DT API key lacks the
+        VULNERABILITY_ANALYSIS permission: that is server configuration which
+        repeats identically on every scan, so it logs one actionable line
+        instead of a traceback."""
+        from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
+
+        version_uuid = str(version_row.dt_project_version_uuid)
+        try:
+            self._sync_triage_vex(client, version_row)
+        except DependencyTrackAPIError as e:
+            if e.status_code == 403:
+                logger.warning(
+                    "[DT] VEX triage sync skipped for project %s: the DT API key lacks the "
+                    "VULNERABILITY_ANALYSIS permission (403). Grant it to enable triage sync.",
+                    version_uuid,
+                )
+            else:
+                logger.warning("[DT] VEX triage sync failed for project %s", version_uuid, exc_info=True)
+        except Exception:
+            logger.warning("[DT] VEX triage sync failed for project %s", version_uuid, exc_info=True)
 
     def _sync_triage_vex(self, client: Any, version_row: Any) -> None:
         """Store DT's triage decisions as the component's VEX artifact.

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -507,9 +507,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
         vulnerabilities_response = client.get_project_vulnerabilities(version_uuid)
         vulnerabilities = vulnerabilities_response.get("content", [])
 
-        # Pull DT's triage decisions back as a VEX so analysts' judgments made
-        # in DT reach sbomify without a manual export/upload. Best-effort: a
-        # missing permission or endpoint error must never fail the scan.
+        # Opt-in: pull DT's triage decisions back as a VEX so analysts'
+        # judgments made in DT reach sbomify without a manual export/upload.
+        # Off by default — the hosted DT is a scanner backend, not a VEX
+        # source. Best-effort when on: a failure must never fail the scan.
         self._sync_triage_vex_safely(client, version_row)
 
         now = dj_timezone.now()
@@ -574,10 +575,19 @@ class DependencyTrackPlugin(AssessmentPlugin):
 
     def _sync_triage_vex_safely(self, client: Any, version_row: Any) -> None:
         """Best-effort wrapper around :meth:`_sync_triage_vex` — a sync failure
-        must never fail the scan. A 403 means the DT API key lacks the
-        VULNERABILITY_ANALYSIS permission: that is server configuration which
-        repeats identically on every scan, so it logs one actionable line
-        instead of a traceback."""
+        must never fail the scan.
+
+        Opt-in via the plugin config flag ``sync_triage_vex`` (default off):
+        the hosted DT is a scanner backend, not a VEX source, so sbomify does
+        not read analysis decisions out of it unless a workspace explicitly
+        turns the sync on (bring-your-own-DT, where the analyst triages in DT
+        and wants those decisions back). When enabled, the DT API key must
+        hold the VULNERABILITY_ANALYSIS permission; a 403 is server
+        configuration that repeats identically on every scan, so it logs one
+        actionable line instead of a traceback."""
+        if not self.config.get("sync_triage_vex"):
+            return
+
         from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
 
         version_uuid = str(version_row.dt_project_version_uuid)

--- a/sbomify/apps/plugins/tests/test_dt_vex_sync.py
+++ b/sbomify/apps/plugins/tests/test_dt_vex_sync.py
@@ -70,14 +70,26 @@ class TestTriageVexSync:
             plugin._sync_triage_vex(client, _version_row(sbom))
         return reapply
 
+    def test_sync_is_off_by_default(self, sample_team_with_owner_member):
+        """The hosted DT is a scanner backend, not a VEX source: without the
+        sync_triage_vex config flag, no scan ever reads analysis decisions."""
+        _, sbom = _component_with_sbom(sample_team_with_owner_member.team)
+        plugin = DependencyTrackPlugin()
+        client = MagicMock()
+
+        plugin._sync_triage_vex_safely(client, _version_row(sbom))
+
+        client.get_project_vex.assert_not_called()
+
     def test_permission_403_logs_one_line_without_traceback(self, sample_team_with_owner_member, mocker):
-        """A missing VULNERABILITY_ANALYSIS permission repeats identically on
-        every scan — one actionable line, no traceback spam, scan unaffected."""
+        """With the sync enabled, a missing VULNERABILITY_ANALYSIS permission
+        repeats identically on every scan — one actionable line, no traceback
+        spam, scan unaffected."""
         from sbomify.apps.plugins.builtins import dependency_track as dt_module
         from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
 
         _, sbom = _component_with_sbom(sample_team_with_owner_member.team)
-        plugin = DependencyTrackPlugin()
+        plugin = DependencyTrackPlugin({"sync_triage_vex": True})
         client = MagicMock()
         client.get_project_vex.side_effect = DependencyTrackAPIError("DT API request failed (403):", status_code=403)
         warn = mocker.patch.object(dt_module.logger, "warning")
@@ -94,7 +106,7 @@ class TestTriageVexSync:
         from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
 
         _, sbom = _component_with_sbom(sample_team_with_owner_member.team)
-        plugin = DependencyTrackPlugin()
+        plugin = DependencyTrackPlugin({"sync_triage_vex": True})
         client = MagicMock()
         client.get_project_vex.side_effect = DependencyTrackAPIError("boom", status_code=500)
         warn = mocker.patch.object(dt_module.logger, "warning")

--- a/sbomify/apps/plugins/tests/test_dt_vex_sync.py
+++ b/sbomify/apps/plugins/tests/test_dt_vex_sync.py
@@ -70,6 +70,40 @@ class TestTriageVexSync:
             plugin._sync_triage_vex(client, _version_row(sbom))
         return reapply
 
+    def test_permission_403_logs_one_line_without_traceback(self, sample_team_with_owner_member, mocker):
+        """A missing VULNERABILITY_ANALYSIS permission repeats identically on
+        every scan — one actionable line, no traceback spam, scan unaffected."""
+        from sbomify.apps.plugins.builtins import dependency_track as dt_module
+        from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
+
+        _, sbom = _component_with_sbom(sample_team_with_owner_member.team)
+        plugin = DependencyTrackPlugin()
+        client = MagicMock()
+        client.get_project_vex.side_effect = DependencyTrackAPIError("DT API request failed (403):", status_code=403)
+        warn = mocker.patch.object(dt_module.logger, "warning")
+
+        plugin._sync_triage_vex_safely(client, _version_row(sbom))
+
+        assert warn.call_count == 1
+        args, kwargs = warn.call_args
+        assert "VULNERABILITY_ANALYSIS" in args[0]
+        assert "exc_info" not in kwargs
+
+    def test_unexpected_sync_error_keeps_traceback(self, sample_team_with_owner_member, mocker):
+        from sbomify.apps.plugins.builtins import dependency_track as dt_module
+        from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
+
+        _, sbom = _component_with_sbom(sample_team_with_owner_member.team)
+        plugin = DependencyTrackPlugin()
+        client = MagicMock()
+        client.get_project_vex.side_effect = DependencyTrackAPIError("boom", status_code=500)
+        warn = mocker.patch.object(dt_module.logger, "warning")
+
+        plugin._sync_triage_vex_safely(client, _version_row(sbom))
+
+        assert warn.call_count == 1
+        assert warn.call_args.kwargs.get("exc_info") is True
+
     def test_triaged_export_creates_vex_artifact(self, sample_team_with_owner_member):
         component, sbom = _component_with_sbom(sample_team_with_owner_member.team)
 


### PR DESCRIPTION
## What

Two changes to the DT triage-VEX sync, from the staging 403 tracebacks and Viktor's call that we are not pulling VEX from DT.

### 1. Triage sync is now opt-in, default off

The scanning plugin pulled every project's VEX (its analysis decisions) on every scan poll. The hosted DT is a scanner backend, not a VEX source: its API key holds no VULNERABILITY_ANALYSIS permission, so on staging every scan 403'd and logged a 12-line traceback. `_sync_triage_vex_safely` now returns unless the team's DT plugin config sets `sync_triage_vex: true`. Default posture: sbomify does not read analysis decisions out of DT. A bring-your-own-DT workspace that triages in DT and wants those decisions back sets the flag (their key then needs VULNERABILITY_ANALYSIS on their server).

With the flag off nothing calls the VEX export, so the staging 403s stop without granting the hosted key anything.

### 2. When the sync is on and the permission is missing, one line instead of a traceback

A permission gap is server configuration that repeats identically on every scan. A 403 now logs one actionable line naming the missing permission; other failures keep their traceback. Scans stay unaffected either way.

## Tests

Three tests on the wrapper: default-off never calls the VEX export; with the flag on, a 403 logs once without `exc_info` and an unexpected error keeps the traceback. Full test_dt_vex_sync suite green.

## Validated live (self-hosted DT)

Ran the full loop against a local DT 4.14.1 with `sync_triage_vex: true` on one workspace: SBOM scanned (36 findings), CVE-2021-44228 triaged `NOT_AFFECTED`/`CODE_NOT_REACHABLE` in DT, next scan poll stored the export as a `source="dependency-track"` VEX artifact, auto-pinned it to the release, and the reapply suppressed the finding in the OSV run under its GHSA id via the alias bridge, carrying DT's justification and detail text. With the flag off (the hosted DT), no VEX call fires.

Repeated the loop against DT 5.0.2 (fresh quickstart stack, Postgres-only): same endpoints, same permission name, same product-scoped VEX shape. Upload, poll, triage, VEX pull, auto-pin, and suppression all worked unchanged; the run shows the finding `not_affected` with the analyst's detail. The v5 granular permissions coexist with the v4 names, so `VULNERABILITY_ANALYSIS` still gates the export.
