### PR TITLE
fix(vuln): component and dashboard vuln counts report current posture, not all historical SBOM versions

### DIFF
--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -435,6 +435,134 @@ class TestVulnerabilityTrendsView:
         assert response.context["summary"]["critical"] == 2
         assert response.context["summary"]["total"] == 2
 
+    def _run_for(self, sbom: SBOM, *, critical: int = 0, high: int = 0, plugin: str = "grype", days_ago: int = 0):
+        run = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name=plugin,
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(critical=critical, high=high),
+        )
+        if days_ago:
+            AssessmentRun.objects.filter(pk=run.pk).update(created_at=timezone.now() - timedelta(days=days_ago))
+        return run
+
+    def _sbom_version(self, component: Component, version: str, days_ago: int) -> SBOM:
+        sbom = SBOM.objects.create(
+            name="test-sbom",
+            version=version,
+            format="spdx",
+            sbom_filename=f"test-sbom-{version}.json",
+            component=component,
+            source="test",
+            format_version="2.3",
+        )
+        SBOM.objects.filter(pk=sbom.pk).update(created_at=timezone.now() - timedelta(days=days_ago))
+        return sbom
+
+    def test_component_summary_reflects_only_latest_sbom_version(self, team_with_member, component_with_sbom):
+        """A component's summary is its CURRENT posture — the latest SBOM's
+        counts — not the sum over every historical version (which counted the
+        same vulnerabilities once per uploaded version)."""
+        team, user = team_with_member
+        old_sbom, component = component_with_sbom
+        SBOM.objects.filter(pk=old_sbom.pk).update(created_at=timezone.now() - timedelta(days=30))
+        self._run_for(old_sbom, high=5, days_ago=10)
+        new_sbom = self._sbom_version(component, "2.0.0", days_ago=1)
+        self._run_for(new_sbom, high=1, days_ago=1)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(component_id=component.id))
+        assert response.status_code == 200
+        assert response.context["summary"]["high"] == 1
+        assert response.context["summary"]["total"] == 1
+
+    def test_workspace_summary_sums_each_components_latest_sbom(self, team_with_member, component_with_sbom):
+        """The workspace view sums the latest SBOM of EACH component — never a
+        component's historical versions."""
+        team, user = team_with_member
+        old_sbom, component = component_with_sbom
+        SBOM.objects.filter(pk=old_sbom.pk).update(created_at=timezone.now() - timedelta(days=30))
+        self._run_for(old_sbom, high=50, days_ago=10)
+        new_sbom = self._sbom_version(component, "2.0.0", days_ago=1)
+        self._run_for(new_sbom, high=2, days_ago=1)
+
+        other = Component.objects.create(name="Other Component", team=team)
+        other_sbom = self._sbom_version(other, "1.0.0", days_ago=2)
+        self._run_for(other_sbom, critical=3, days_ago=2)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url())
+        assert response.status_code == 200
+        assert response.context["summary"]["high"] == 2
+        assert response.context["summary"]["critical"] == 3
+        assert response.context["summary"]["total"] == 5
+
+    def test_timeline_collapses_same_day_rescans_per_provider(self, team_with_member, component_with_sbom):
+        """A day's chart point is the latest run per (sbom, provider) that day —
+        hourly re-scans of one unchanged SBOM must not multiply the point."""
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+        now = timezone.now()
+        for hours_ago, high in ((6, 2), (4, 5), (2, 7)):
+            run = self._run_for(sbom, high=high)
+            AssessmentRun.objects.filter(pk=run.pk).update(created_at=now - timedelta(hours=hours_ago))
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(days="7"))
+        assert response.status_code == 200
+        today = now.date().isoformat()
+        day_point = next(point for point in response.context["time_series"] if point["date"] == today)
+        assert day_point["high"] == 7
+        assert day_point["total"] == 7
+
+    def test_release_scope_uses_pinned_sbom_not_component_latest(self, team_with_member, component_with_sbom):
+        """Release scoping keeps the release's own SBOM set: the pinned SBOM is
+        what is current FOR THAT RELEASE, even when the component has newer
+        uploads."""
+        from sbomify.apps.core.models import Release, ReleaseArtifact
+
+        team, user = team_with_member
+        pinned_sbom, component = component_with_sbom
+        SBOM.objects.filter(pk=pinned_sbom.pk).update(created_at=timezone.now() - timedelta(days=30))
+        self._run_for(pinned_sbom, high=9, days_ago=10)
+        newer_sbom = self._sbom_version(component, "2.0.0", days_ago=1)
+        self._run_for(newer_sbom, high=1, days_ago=1)
+
+        product = Product.objects.get(team=team, name="Test Product")
+        release = Release.objects.create(product=product, name="v1")
+        ReleaseArtifact.objects.create(release=release, sbom=pinned_sbom)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(product_id=product.id, release_id=release.id))
+        assert response.status_code == 200
+        assert response.context["summary"]["high"] == 9
+        assert response.context["summary"]["total"] == 9
+
+    def test_history_keeps_chart_visible_when_latest_is_clean(self, team_with_member, component_with_sbom):
+        """A clean latest SBOM zeroes the cards but the windowed history still
+        renders (has_data), so the improvement is visible instead of a blank."""
+        team, user = team_with_member
+        old_sbom, component = component_with_sbom
+        SBOM.objects.filter(pk=old_sbom.pk).update(created_at=timezone.now() - timedelta(days=30))
+        self._run_for(old_sbom, high=5, days_ago=3)
+        new_sbom = self._sbom_version(component, "2.0.0", days_ago=1)
+        self._run_for(new_sbom, high=0, days_ago=1)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(component_id=component.id, days="7"))
+        assert response.status_code == 200
+        assert response.context["summary"]["total"] == 0
+        assert response.context["has_data"] is True
+
     def test_days_parameter_clamped(self, team_with_member):
         """Days parameter is clamped between 7 and 365."""
         team, user = team_with_member
@@ -826,6 +954,8 @@ class TestVulnerabilityTrendsView:
             format_version="2.3",
         )
 
+        SBOM.objects.filter(pk=sbom_in_release.pk).update(created_at=timezone.now() - timedelta(days=5))
+
         release = Release.objects.create(product=product, name="v1.0", version="1.0")
         ReleaseArtifact.objects.create(release=release, sbom=sbom_in_release)
 
@@ -843,9 +973,10 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        # Explicit "All Releases" (release_id="" present) counts both SBOMs (3 + 9 = 12).
+        # Explicit "All Releases" (release_id="" present) reports the component's
+        # CURRENT posture — its latest SBOM only (9), never historical versions summed.
         unfiltered = client.get(self._get_url(product_id=product.id, release_id=""))
-        assert unfiltered.context["summary"]["critical"] == 12
+        assert unfiltered.context["summary"]["critical"] == 9
 
         # With the release filter: only the in-release SBOM counted (3).
         filtered = client.get(self._get_url(product_id=product.id, release_id=release.id))

--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -508,17 +508,19 @@ class TestVulnerabilityTrendsView:
         hourly re-scans of one unchanged SBOM must not multiply the point."""
         team, user = team_with_member
         sbom, _ = component_with_sbom
-        now = timezone.now()
+        # Anchor to midday so the hour offsets below never straddle midnight
+        # (which would split the three rescans across two days and flake).
+        base = timezone.now().replace(hour=12, minute=0, second=0, microsecond=0)
         for hours_ago, high in ((6, 2), (4, 5), (2, 7)):
             run = self._run_for(sbom, high=high)
-            AssessmentRun.objects.filter(pk=run.pk).update(created_at=now - timedelta(hours=hours_ago))
+            AssessmentRun.objects.filter(pk=run.pk).update(created_at=base - timedelta(hours=hours_ago))
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
         response = client.get(self._get_url(days="7"))
         assert response.status_code == 200
-        today = now.date().isoformat()
-        day_point = next(point for point in response.context["time_series"] if point["date"] == today)
+        day = base.date().isoformat()
+        day_point = next(point for point in response.context["time_series"] if point["date"] == day)
         assert day_point["high"] == 7
         assert day_point["total"] == 7
 

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -241,7 +241,17 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # cards are independent of the selected time range (a SBOM whose latest
         # scan predates the window still contributes its current counts). Only
         # created_at__lte (now) is applied — no lower bound.
+        #
+        # Without release scoping, "current" also means each in-scope
+        # component's LATEST SBOM: a component with many uploaded versions must
+        # not report every historical version's findings (the same
+        # vulnerabilities counted once per version — a 100-version component
+        # showed thousands where its latest SBOM had seven). Release scoping
+        # keeps its own SBOM set: the release names exactly which SBOM is
+        # current for it, even when the component has newer uploads.
         snapshot_scope = scoped_query.filter(created_at__lte=end_date)
+        if not release_id:
+            snapshot_scope = snapshot_scope.filter(sbom_id__in=self._latest_sbom_ids(team, component_id, product_id))
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result
@@ -267,15 +277,26 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # or parsed, which is what let a component with many historical runs push
         # this endpoint into a 60-90s timeout.
         with transaction.atomic():
+            # Timeline chart: the latest run per (sbom, provider, day). Summing
+            # every run made a day's point scale with scan FREQUENCY — hourly
+            # re-scans of one unchanged SBOM multiplied its counts by 24.
+            # Distinct SBOMs and providers scanned on a day still stack: the
+            # chart is that day's scanned surface, not a single-SBOM history.
+            timeline_winners: dict[tuple[str, Any, str], tuple[tuple[Any, Any], dict[str, int]]] = {}
             for run in (
                 timeline_query.annotate(**RESULT_SUMMARY_ANNOTATIONS)
-                .values("created_at", *RESULT_SUMMARY_FIELDS)
+                .values("id", "created_at", "sbom_id", "plugin_name", *RESULT_SUMMARY_FIELDS)
                 .iterator()
             ):
                 day_key = run["created_at"].date().isoformat()
                 counts = extract_severity_counts(reconstruct_result_summary(run))
+                winner_key = (day_key, run["sbom_id"], run["plugin_name"] or "unknown")
+                order = (run["created_at"], run["id"])
+                current = timeline_winners.get(winner_key)
+                if current is None or order > current[0]:
+                    timeline_winners[winner_key] = (order, counts)
 
-                # Timeline chart: per-day scan activity (a trend, not a snapshot).
+            for (day_key, _sbom_id, _plugin), (_order, counts) in timeline_winners.items():
                 if day_key not in daily_data:
                     daily_data[day_key] = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
                 daily_data[day_key]["total"] += counts["total"]
@@ -434,9 +455,36 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             "time_series": time_series,
             "chart_labels": chart_labels,
             "chart_data": chart_data,
-            "has_data": summary["total"] > 0,
+            # A clean latest SBOM must not blank the page when the window still
+            # holds history worth charting.
+            "has_data": summary["total"] > 0 or any(point["total"] for point in time_series),
             "recent_scans": formatted_scans,
         }
+
+    def _latest_sbom_ids(self, team: Team, component_id: str | None, product_id: str | None) -> list[Any]:
+        """Each in-scope component's newest ``bom_type=sbom`` row — the SBOM that
+        IS the component right now (mirrors ``get_latest_sbom_id_for_component``,
+        resolved for every component in one query). Postgres uses DISTINCT ON;
+        the SQLite test backend takes a Python pass."""
+        from sbomify.apps.sboms.models import SBOM
+
+        sboms = SBOM.objects.filter(component__team=team, bom_type=SBOM.BomType.SBOM)
+        if component_id:
+            sboms = sboms.filter(component_id=component_id)
+        if product_id:
+            sboms = sboms.filter(component__products__id=product_id)
+        if connection.vendor == "postgresql":
+            return list(
+                sboms.order_by("component_id", "-created_at", "-id")
+                .distinct("component_id")
+                .values_list("id", flat=True)
+            )
+        newest: dict[Any, tuple[Any, Any]] = {}
+        for sbom_id, comp_id, created in sboms.values_list("id", "component_id", "created_at").iterator():
+            value = (created, sbom_id)
+            if comp_id not in newest or value > newest[comp_id]:
+                newest[comp_id] = value
+        return [sbom_id for _, sbom_id in newest.values()]
 
     def _build_workspace_hierarchy(self, team: Team) -> tuple[list[dict[str, Any]], str | None]:
         """Build product → component hierarchy for the zero-state tree.


### PR DESCRIPTION
## What

The component page's vulnerability summary summed every historical SBOM version instead of reporting the component's current posture. A 107-version demo component showed 16,685 findings (2,312 critical, 7,023 high) where its latest SBOM has 7 (3 critical, 1 high). Verified live before and after on that component.

## Why it happened

The snapshot cards take the latest run per (sbom, provider), and every historical SBOM version of a component contributes its own pair. The same vulnerabilities count once per uploaded version. On staging, where every merge uploads a new SBOM batch, the numbers only grow.

## The fix

- Without release scoping, the snapshot covers each in-scope component's latest SBOM only, on the component page and the workspace dashboard alike. Same semantic the stats API already uses (`latest_sbom_only`).
- Release scoping keeps its own SBOM set: the release names exactly which SBOM is current for it, even when the component has newer uploads.
- The timeline had the sibling defect on the scan-frequency axis: a day's point summed every run, so hourly DT re-scans of one unchanged SBOM multiplied its counts by 24. Each (sbom, provider) now contributes its latest run per day.
- A clean latest SBOM keeps the windowed history visible instead of blanking to the zero state.

## Tests

Five new tests: component summary reflects only the latest version, workspace sums each component's latest, timeline collapses same-day re-scans per provider, release scoping keeps the pinned SBOM's counts, clean-latest keeps the chart visible. One existing test's "All Releases sums both versions" expectation was the bug and now asserts current posture. 34/34 view tests green.
