### PR TITLE
feat(api): add version/format filtering to the component SBOMs list endpoint

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4079,8 +4079,17 @@ def list_component_sboms(
     component_id: str,
     page: int = Query(1),  # type: ignore[type-arg]
     page_size: int = Query(15),  # type: ignore[type-arg]
+    version: str | None = None,
+    format: str | None = None,
 ) -> Any:
-    """List all SBOMs for a specific component with pagination."""
+    """List all SBOMs for a specific component with pagination.
+
+    Optional `version` and `format` query parameters narrow the result to
+    exact matches (no prefix or fuzzy matching — 'v1.2.3' and '1.2.3' are
+    distinct versions). Filters are applied before pagination, so a filtered
+    miss returns an empty first page and a hit returns the newest match first.
+    Omitting both parameters returns the full, unfiltered listing.
+    """
     try:
         component = Component.objects.get(pk=component_id)
     except Component.DoesNotExist:
@@ -4132,9 +4141,12 @@ def list_component_sboms(
         from sbomify.apps.sboms.models import SBOM
 
         try:
-            sboms_queryset = SBOM.objects.filter(component_id=component_id, bom_type=SBOM.BomType.SBOM).order_by(
-                "-created_at"
-            )
+            sboms_queryset = SBOM.objects.filter(component_id=component_id, bom_type=SBOM.BomType.SBOM)
+            if version is not None:
+                sboms_queryset = sboms_queryset.filter(version=version)
+            if format is not None:
+                sboms_queryset = sboms_queryset.filter(format=format)
+            sboms_queryset = sboms_queryset.order_by("-created_at")
             # Apply pagination
             paginated_sboms, pagination_meta = _paginate_queryset(sboms_queryset, page, page_size)
         except (DatabaseError, OperationalError) as db_err:

--- a/sbomify/apps/core/tests/test_component_sbom_filters.py
+++ b/sbomify/apps/core/tests/test_component_sbom_filters.py
@@ -1,0 +1,221 @@
+"""
+Tests for server-side version/format filtering on the component SBOMs list endpoint.
+
+GET /api/v1/components/{component_id}/sboms accepts optional `version` and
+`format` query parameters that exact-match against SBOM.version and
+SBOM.format before pagination. These tests cover filter hits, misses,
+combined filters, unchanged no-param behavior, and the public/private auth
+matrix with filters applied.
+"""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.sboms.models import SBOM
+
+
+@pytest.fixture
+def component_sboms(sample_component):  # noqa: F811
+    """A component with SBOMs across several versions and formats."""
+    sboms = {
+        "tagged_cdx": SBOM.objects.create(
+            name="test-component",
+            version="v1.2.3",
+            format="cyclonedx",
+            sbom_filename="tagged-cdx.json",
+            component=sample_component,
+            source="test",
+        ),
+        "tagged_spdx": SBOM.objects.create(
+            name="test-component",
+            version="v1.2.3",
+            format="spdx",
+            sbom_filename="tagged-spdx.json",
+            component=sample_component,
+            source="test",
+        ),
+        "sha_cdx": SBOM.objects.create(
+            name="test-component",
+            version="8fae865",
+            format="cyclonedx",
+            sbom_filename="sha-cdx.json",
+            component=sample_component,
+            source="test",
+        ),
+        "untagged": SBOM.objects.create(
+            name="test-component",
+            version="1.2.3",
+            format="spdx",
+            sbom_filename="untagged.json",
+            component=sample_component,
+            source="test",
+        ),
+    }
+    yield sboms
+    for sbom in sboms.values():
+        sbom.delete()
+
+
+def _make_public(component) -> None:
+    from sbomify.apps.sboms.models import Component
+
+    component.visibility = Component.Visibility.PUBLIC
+    component.save()
+
+
+def _make_private(component) -> None:
+    from sbomify.apps.sboms.models import Component
+
+    component.visibility = Component.Visibility.PRIVATE
+    component.save()
+
+
+def _sboms_url(component_id: str) -> str:
+    return reverse("api-1:list_component_sboms", kwargs={"component_id": component_id})
+
+
+@pytest.mark.django_db
+class TestComponentSbomFilters:
+    """Test version/format filtering on the component SBOMs list endpoint."""
+
+    def test_version_hit(self, sample_component, component_sboms):  # noqa: F811
+        """Filtering by version returns only exact matches, newest first."""
+        _make_public(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id), {"version": "v1.2.3"})
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [item["sbom"]["id"] for item in data["items"]]
+        expected = sorted(
+            [component_sboms["tagged_cdx"], component_sboms["tagged_spdx"]],
+            key=lambda s: s.created_at,
+            reverse=True,
+        )
+        assert returned_ids == [s.id for s in expected]
+        assert data["pagination"]["total"] == 2
+        assert all(item["sbom"]["version"] == "v1.2.3" for item in data["items"])
+
+    def test_version_miss_returns_empty_items(self, sample_component, component_sboms):  # noqa: F811
+        """A version with no SBOMs returns 200 with an empty first page."""
+        _make_public(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id), {"version": "v9.9.9"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["pagination"]["total"] == 0
+
+    def test_version_is_exact_match_not_prefix(self, sample_component, component_sboms):  # noqa: F811
+        """'v1.2.3' and '1.2.3' are distinct versions — no fuzzy matching."""
+        _make_public(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id), {"version": "1.2.3"})
+
+        assert response.status_code == 200
+        returned_ids = [item["sbom"]["id"] for item in response.json()["items"]]
+        assert returned_ids == [component_sboms["untagged"].id]
+
+    def test_version_and_format_combined(self, sample_component, component_sboms):  # noqa: F811
+        """Combining version and format narrows to a single SBOM."""
+        _make_public(sample_component)
+
+        response = Client().get(
+            _sboms_url(sample_component.id),
+            {"version": "v1.2.3", "format": "cyclonedx"},
+        )
+
+        assert response.status_code == 200
+        returned_ids = [item["sbom"]["id"] for item in response.json()["items"]]
+        assert returned_ids == [component_sboms["tagged_cdx"].id]
+
+    def test_format_alone(self, sample_component, component_sboms):  # noqa: F811
+        """Filtering by format alone returns all SBOMs in that format."""
+        _make_public(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id), {"format": "cyclonedx"})
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = {item["sbom"]["id"] for item in data["items"]}
+        assert returned_ids == {component_sboms["tagged_cdx"].id, component_sboms["sha_cdx"].id}
+        assert all(item["sbom"]["format"] == "cyclonedx" for item in data["items"])
+
+    def test_no_params_behavior_unchanged(self, sample_component, component_sboms):  # noqa: F811
+        """Without filters the endpoint returns every SBOM, newest first."""
+        _make_public(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id))
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [item["sbom"]["id"] for item in data["items"]]
+        expected = sorted(component_sboms.values(), key=lambda s: s.created_at, reverse=True)
+        assert returned_ids == [s.id for s in expected]
+        assert data["pagination"]["total"] == len(component_sboms)
+
+    def test_filter_excludes_other_bom_types(self, sample_component, component_sboms):  # noqa: F811
+        """A VEX artifact at the same version is not returned by the SBOM listing."""
+        _make_public(sample_component)
+        vex = SBOM.objects.create(
+            name="test-component",
+            version="v1.2.3",
+            format="cyclonedx",
+            sbom_filename="vex.json",
+            component=sample_component,
+            source="test",
+            bom_type=SBOM.BomType.VEX,
+        )
+        try:
+            response = Client().get(_sboms_url(sample_component.id), {"version": "v1.2.3"})
+
+            assert response.status_code == 200
+            returned_ids = [item["sbom"]["id"] for item in response.json()["items"]]
+            assert vex.id not in returned_ids
+            assert len(returned_ids) == 2
+        finally:
+            vex.delete()
+
+    def test_public_component_anonymous_with_filters(self, sample_component, component_sboms):  # noqa: F811
+        """Filters work anonymously on public components."""
+        _make_public(sample_component)
+
+        response = Client().get(
+            _sboms_url(sample_component.id),
+            {"version": "8fae865", "format": "cyclonedx"},
+        )
+
+        assert response.status_code == 200
+        returned_ids = [item["sbom"]["id"] for item in response.json()["items"]]
+        assert returned_ids == [component_sboms["sha_cdx"].id]
+
+    def test_private_component_anonymous_with_filters(self, sample_component, component_sboms):  # noqa: F811
+        """Filters do not bypass authentication on private components."""
+        _make_private(sample_component)
+
+        response = Client().get(_sboms_url(sample_component.id), {"version": "v1.2.3"})
+
+        assert response.status_code == 403
+        assert "Authentication required for private items" in response.json()["detail"]
+
+    def test_private_component_with_auth_and_filters(
+        self,
+        sample_component,  # noqa: F811
+        component_sboms,
+        authenticated_api_client,  # noqa: F811
+    ):
+        """Team members can filter SBOMs on private components."""
+        _make_private(sample_component)
+
+        client, access_token = authenticated_api_client
+        response = client.get(
+            _sboms_url(sample_component.id),
+            {"version": "v1.2.3"},
+            HTTP_AUTHORIZATION=f"Bearer {access_token.encoded_token}",
+        )
+
+        assert response.status_code == 200
+        returned_ids = {item["sbom"]["id"] for item in response.json()["items"]}
+        assert returned_ids == {component_sboms["tagged_cdx"].id, component_sboms["tagged_spdx"].id}


### PR DESCRIPTION
## Summary

`GET /api/v1/components/{component_id}/sboms` now accepts optional `version` and `format` query parameters, exact-matched against `SBOM.version` / `SBOM.format` and applied to the queryset **before** pagination (keeping the existing `bom_type=SBOM` filter and `-created_at` ordering). A filtered miss returns an empty first page in a single request; a hit returns the newest match first.

### Motivation

sbomify-action is gaining git-submodule support: when a parent repo cuts a product release, the action looks up whether a submodule's component already has an SBOM at the pinned version (git tag or short SHA) — attaching it if present, generating/uploading one if not ("backfill"). Without server-side filtering, proving the negative meant paginating the component's entire SBOM history, and trunk-based components accumulate one SBOM per push per format — making the miss case (exactly the case that gates backfill) the most expensive query.

### Notes

- **Matching is exact on purpose** — `v1.2.3` and `1.2.3` are distinct versions; no prefix/fuzzy matching.
- **Response shape, auth semantics, and error handling are unchanged.** Omitted params behave exactly as before; the frontend component page continues to consume the endpoint unfiltered.
- **Plain `None` defaults instead of `Query(None)` sentinels**: the view is also called directly as a Python function by `build_sboms_table_context` (component page SBOMs table); sentinel defaults would have applied bogus filters on that path. Django Ninja still treats them as optional query params (verified in the generated OpenAPI schema).
- **No new index needed**: the existing conditional `UniqueConstraint` on `(component, version, format, qualifiers, bom_type)` is a partial unique index whose `bom_type != 'vex'` predicate is provably satisfied by the endpoint's `bom_type = 'sbom'` filter. Verified with `EXPLAIN ANALYZE` over 5,000 rows: index scan with component, version, and bom_type all in the index condition (0.066 ms).

## Testing

- 10 new tests in `sbomify/apps/core/tests/test_component_sbom_filters.py`: version hit (with ordering), version miss (empty items), exact-match semantics, version+format combined, format alone, no-param behavior unchanged, VEX exclusion at the same version, and the auth matrix (public anonymous ok, private anonymous 403, private with token 200) with filters applied.
- Full backend suite: 6235 passed, 0 failed. `ruff check` / `ruff format` / `mypy` clean. Frontend `bun test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)