### PR TITLE
fix(api): enforce workspace-scoped token binding across the workspaces API

### DIFF
--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -1265,11 +1265,14 @@ def list_teams(request: HttpRequest) -> tuple[int, Any]:
 
     # Route token-authenticated listings through can() so a narrow
     # action-scoped token (e.g. publish-only) can't enumerate workspaces its
-    # scopes don't grant it to read. Sessions carry no token and skip this.
-    if getattr(request, "access_token_record", None) is not None:
-        memberships = [m for m in memberships if can(request, "workspace:read", m.team)]
-        if not memberships:
-            return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+    # scopes don't grant it to read. One check covers the whole listing: the
+    # token's action-scope gate is team-independent, workspace binding was
+    # already applied to the queryset above, and workspace:read's role tier
+    # admits every remaining membership. Sessions carry no token and skip this.
+    if getattr(request, "access_token_record", None) is not None and not can(
+        request, "workspace:read", memberships[0].team
+    ):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     return 200, [_build_team_response(request, membership.team) for membership in memberships]
 

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -1257,11 +1257,19 @@ def list_teams(request: HttpRequest) -> tuple[int, Any]:
     if not all_memberships.exists():
         return 200, []
 
-    memberships = (
-        all_memberships.exclude(role="guest").select_related("team").order_by("team__created_at", "team__id").all()
+    memberships = list(
+        all_memberships.exclude(role="guest").select_related("team").order_by("team__created_at", "team__id")
     )
     if not memberships:
         return 403, {"detail": "Guest members can only access public pages"}
+
+    # Route token-authenticated listings through can() so a narrow
+    # action-scoped token (e.g. publish-only) can't enumerate workspaces its
+    # scopes don't grant it to read. Sessions carry no token and skip this.
+    if getattr(request, "access_token_record", None) is not None:
+        memberships = [m for m in memberships if can(request, "workspace:read", m.team)]
+        if not memberships:
+            return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     return 200, [_build_team_response(request, membership.team) for membership in memberships]
 

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -196,6 +196,9 @@ def update_team_branding_field(
         logger.warning(f"User {user.username} is not owner of team {team_key}")
         return 403, {"detail": "Only allowed for owners"}
 
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     branding_data = _normalize_branding_payload(team.branding_info)
     current_branding = BrandingInfo(**branding_data)
     update_data = current_branding.model_dump()
@@ -271,6 +274,9 @@ def update_team_branding(
         logger.warning(f"User {user.username} is not owner of team {team_key}")
         return 403, {"detail": "Only allowed for owners"}
 
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     # TODO: has to be a separate model
     branding_data = _normalize_branding_payload(team.branding_info)
     branding_info = BrandingInfo(**branding_data).model_dump()
@@ -343,6 +349,9 @@ def upload_branding_file(
 
     if not Member.objects.filter(user=user, team=team, role="owner").exists():
         return 403, {"detail": "Only allowed for owners"}
+
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     branding_data = _normalize_branding_payload(team.branding_info)
     current_branding = BrandingInfo(**branding_data)
@@ -741,6 +750,10 @@ def get_contact_profile(
     if error:
         return error
 
+    assert team is not None  # guaranteed when error is None
+    if not can(request, "workspace:read", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     # Allow all team members to view contact profiles (for use in component metadata)
     try:
         profile = ContactProfile.objects.prefetch_related("entities", "entities__contacts").get(
@@ -767,6 +780,10 @@ def create_contact_profile(request: HttpRequest, team_key: str, payload: Contact
         return 403, {"detail": "Only owners and admins can manage contact profiles"}
 
     assert team is not None  # guaranteed when error is None
+    # can() also enforces token workspace/action scope — the membership role
+    # check above alone would let a token scoped to another workspace write here.
+    if not can(request, "workspace:manage", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     try:
         with transaction.atomic():
@@ -861,6 +878,8 @@ def update_contact_profile(
         return 403, {"detail": "Only owners and admins can manage contact profiles"}
 
     assert team is not None  # guaranteed when error is None
+    if not can(request, "workspace:manage", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     try:
         profile = ContactProfile.objects.prefetch_related("entities", "entities__contacts").get(
@@ -973,6 +992,10 @@ def delete_contact_profile(request: HttpRequest, team_key: str, profile_id: str)
     if not _user_can_manage_profiles(role):
         return 403, {"detail": "Only owners and admins can manage contact profiles"}
 
+    assert team is not None  # guaranteed when error is None
+    if not can(request, "workspace:manage", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     try:
         profile = ContactProfile.objects.get(team=team, pk=profile_id)
     except ContactProfile.DoesNotExist:
@@ -1006,6 +1029,9 @@ def update_team(request: HttpRequest, team_key: str, payload: TeamUpdateSchema) 
     # Check if user is owner
     if not Member.objects.filter(user=user, team=team, role="owner").exists():
         return 403, {"detail": "Only owners can update team information"}
+
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     try:
         with transaction.atomic():
@@ -1052,6 +1078,9 @@ def patch_team(request: HttpRequest, team_key: str, payload: TeamPatchSchema) ->
     # Check if user is owner
     if not Member.objects.filter(user=user, team=team, role="owner").exists():
         return 403, {"detail": "Only owners can update team information"}
+
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     try:
         with transaction.atomic():
@@ -1109,6 +1138,9 @@ def update_team_domain(request: HttpRequest, team_key: str, payload: TeamDomainS
     # Check if user is owner
     if not Member.objects.filter(user=user, team=team, role="owner").exists():
         return 403, {"detail": "Only owners can update team domain"}
+
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
 
     # Feature gating: Check billing plan
     from sbomify.apps.billing.models import BillingPlan
@@ -1188,6 +1220,9 @@ def delete_team_domain(request: HttpRequest, team_key: str) -> tuple[int, Any]:
     if not Member.objects.filter(user=user, team=team, role="owner").exists():
         return 403, {"detail": "Only owners can update team domain"}
 
+    if not can(request, "workspace:administer", team):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
     # Store domain for cache invalidation
     old_domain = team.custom_domain
 
@@ -1210,6 +1245,15 @@ def list_teams(request: HttpRequest) -> tuple[int, Any]:
     user = cast(User, request.user)
 
     all_memberships = Member.objects.filter(user=user)
+
+    # A workspace-scoped token must only see its bound workspace. Every other
+    # endpoint resolves to the token's team (via can()/_get_user_team_id), so
+    # listing all of the user's workspaces here lets scoped-token clients bind
+    # to a workspace the token can't actually act on.
+    token_team = getattr(request, "token_team", None)
+    if token_team is not None:
+        all_memberships = all_memberships.filter(team=token_team)
+
     if not all_memberships.exists():
         return 200, []
 

--- a/sbomify/apps/teams/tests/test_token_workspace_scoping.py
+++ b/sbomify/apps/teams/tests/test_token_workspace_scoping.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
 
 from sbomify.apps.access_tokens.models import AccessToken
@@ -88,6 +89,31 @@ class TestWorkspaceListingScope:
         assert response.status_code == 200
         keys = {ws["key"] for ws in response.json()}
         assert keys == {bound.key, other.key}
+
+    def test_publish_only_token_cannot_list_workspaces(self, owner_of_two_workspaces):
+        user, bound, _ = owner_of_two_workspaces
+        token = AccessToken.objects.create(
+            user=user,
+            encoded_token=create_personal_access_token(user),
+            team=bound,
+            scopes=["artifact:publish"],
+            description="Publish-only token",
+        )
+        response = Client().get(WORKSPACES_URL, **_headers(token))
+        assert response.status_code == 403
+
+    def test_read_scoped_token_lists_bound_workspace(self, owner_of_two_workspaces):
+        user, bound, _ = owner_of_two_workspaces
+        token = AccessToken.objects.create(
+            user=user,
+            encoded_token=create_personal_access_token(user),
+            team=bound,
+            scopes=["workspace:read"],
+            description="Read-scoped token",
+        )
+        response = Client().get(WORKSPACES_URL, **_headers(token))
+        assert response.status_code == 200
+        assert [ws["key"] for ws in response.json()] == [bound.key]
 
 
 @pytest.mark.django_db
@@ -172,6 +198,31 @@ class TestWorkspaceSettingsScope:
             Client(), f"{WORKSPACES_URL}{other.key}/branding/brand_color", {"value": "#123456"}, scoped_token
         )
         assert response.status_code == 403
+
+    def test_scoped_token_cannot_put_branding_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = Client().put(
+            f"{WORKSPACES_URL}{other.key}/branding",
+            json.dumps({"brand_color": "#123456"}),
+            content_type="application/json",
+            **_headers(scoped_token),
+        )
+        assert response.status_code == 403
+        other.refresh_from_db()
+        assert not other.branding_info.get("brand_color")
+
+    def test_scoped_token_cannot_upload_branding_file_in_non_bound_workspace(
+        self, owner_of_two_workspaces, scoped_token
+    ):
+        _, _, other = owner_of_two_workspaces
+        response = Client().post(
+            f"{WORKSPACES_URL}{other.key}/branding/upload/icon",
+            {"file": SimpleUploadedFile("icon.png", b"not-a-real-png", content_type="image/png")},
+            **_headers(scoped_token),
+        )
+        assert response.status_code == 403
+        other.refresh_from_db()
+        assert not other.branding_info.get("icon")
 
     def test_scoped_token_can_patch_bound_workspace(self, owner_of_two_workspaces, scoped_token):
         _, bound, _ = owner_of_two_workspaces

--- a/sbomify/apps/teams/tests/test_token_workspace_scoping.py
+++ b/sbomify/apps/teams/tests/test_token_workspace_scoping.py
@@ -1,0 +1,181 @@
+"""Regression tests: a workspace-scoped access token must only see and act on
+its bound workspace, even when the user is owner/admin of other workspaces.
+
+Covers the production incident where a token scoped to workspace A could list
+every workspace the user belongs to (which made the sbomify-action wizard bind
+to the wrong workspace) and could create contact profiles in workspace B.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.test import Client
+
+from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.access_tokens.utils import create_personal_access_token
+from sbomify.apps.core.utils import number_to_random_token
+from sbomify.apps.teams.models import ContactProfile, Member, Team
+
+WORKSPACES_URL = "/api/v1/workspaces/"
+
+
+@pytest.fixture
+def owner_of_two_workspaces(db, django_user_model):
+    """A user who is owner of two workspaces: the token-bound one and another."""
+    user = django_user_model.objects.create_user(username="multiws", email="multiws@example.com", password="pw")
+    bound = Team.objects.create(name="Bound WS")
+    bound.key = number_to_random_token(bound.pk)
+    bound.save()
+    other = Team.objects.create(name="Other WS")
+    other.key = number_to_random_token(other.pk)
+    other.save()
+    Member.objects.create(user=user, team=bound, role="owner", is_default_team=False)
+    Member.objects.create(user=user, team=other, role="owner", is_default_team=True)
+    return user, bound, other
+
+
+@pytest.fixture
+def scoped_token(owner_of_two_workspaces):
+    user, bound, _ = owner_of_two_workspaces
+    return AccessToken.objects.create(
+        user=user, encoded_token=create_personal_access_token(user), team=bound, description="Scoped token"
+    )
+
+
+@pytest.fixture
+def unscoped_token(owner_of_two_workspaces):
+    user, _, _ = owner_of_two_workspaces
+    return AccessToken.objects.create(
+        user=user, encoded_token=create_personal_access_token(user), description="Unscoped token"
+    )
+
+
+def _headers(token: AccessToken) -> dict[str, str]:
+    return {"HTTP_AUTHORIZATION": f"Bearer {token.encoded_token}"}
+
+
+def _post_json(client: Client, url: str, payload: dict, token: AccessToken):
+    return client.post(url, json.dumps(payload), content_type="application/json", **_headers(token))
+
+
+def _patch_json(client: Client, url: str, payload: dict, token: AccessToken):
+    return client.patch(url, json.dumps(payload), content_type="application/json", **_headers(token))
+
+
+@pytest.mark.django_db
+class TestWorkspaceListingScope:
+    def test_scoped_token_lists_only_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, bound, _ = owner_of_two_workspaces
+        response = Client().get(WORKSPACES_URL, **_headers(scoped_token))
+        assert response.status_code == 200
+        keys = [ws["key"] for ws in response.json()]
+        assert keys == [bound.key]
+
+    def test_unscoped_token_lists_all_workspaces(self, owner_of_two_workspaces, unscoped_token):
+        _, bound, other = owner_of_two_workspaces
+        response = Client().get(WORKSPACES_URL, **_headers(unscoped_token))
+        assert response.status_code == 200
+        keys = {ws["key"] for ws in response.json()}
+        assert keys == {bound.key, other.key}
+
+    def test_session_lists_all_workspaces(self, owner_of_two_workspaces):
+        user, bound, other = owner_of_two_workspaces
+        client = Client()
+        client.force_login(user)
+        response = client.get(WORKSPACES_URL)
+        assert response.status_code == 200
+        keys = {ws["key"] for ws in response.json()}
+        assert keys == {bound.key, other.key}
+
+
+@pytest.mark.django_db
+class TestContactProfileScope:
+    def test_scoped_token_cannot_list_profiles_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = Client().get(f"{WORKSPACES_URL}{other.key}/contact-profiles", **_headers(scoped_token))
+        assert response.status_code == 403
+
+    def test_scoped_token_cannot_get_profile_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        profile = ContactProfile.objects.create(team=other, name="Existing")
+        response = Client().get(f"{WORKSPACES_URL}{other.key}/contact-profiles/{profile.id}", **_headers(scoped_token))
+        assert response.status_code == 403
+
+    def test_scoped_token_cannot_create_profile_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = _post_json(
+            Client(), f"{WORKSPACES_URL}{other.key}/contact-profiles", {"name": "Sneaky"}, scoped_token
+        )
+        assert response.status_code == 403
+        assert not ContactProfile.objects.filter(team=other, name="Sneaky").exists()
+
+    def test_scoped_token_cannot_update_profile_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        profile = ContactProfile.objects.create(team=other, name="Existing")
+        response = _patch_json(
+            Client(),
+            f"{WORKSPACES_URL}{other.key}/contact-profiles/{profile.id}",
+            {"name": "Renamed"},
+            scoped_token,
+        )
+        assert response.status_code == 403
+        profile.refresh_from_db()
+        assert profile.name == "Existing"
+
+    def test_scoped_token_cannot_delete_profile_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        profile = ContactProfile.objects.create(team=other, name="Existing")
+        response = Client().delete(
+            f"{WORKSPACES_URL}{other.key}/contact-profiles/{profile.id}", **_headers(scoped_token)
+        )
+        assert response.status_code == 403
+        assert ContactProfile.objects.filter(pk=profile.pk).exists()
+
+    def test_scoped_token_can_manage_profiles_in_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, bound, _ = owner_of_two_workspaces
+        client = Client()
+        base_url = f"{WORKSPACES_URL}{bound.key}/contact-profiles"
+
+        response = _post_json(client, base_url, {"name": "In scope"}, scoped_token)
+        assert response.status_code == 201
+        profile_id = response.json()["id"]
+
+        response = _patch_json(client, f"{base_url}/{profile_id}", {"name": "Still in scope"}, scoped_token)
+        assert response.status_code == 200
+
+        response = client.delete(f"{base_url}/{profile_id}", **_headers(scoped_token))
+        assert response.status_code == 204
+
+    def test_unscoped_token_can_manage_profiles_in_any_workspace(self, owner_of_two_workspaces, unscoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = _post_json(
+            Client(), f"{WORKSPACES_URL}{other.key}/contact-profiles", {"name": "Unscoped"}, unscoped_token
+        )
+        assert response.status_code == 201
+        assert ContactProfile.objects.filter(team=other, name="Unscoped").exists()
+
+
+@pytest.mark.django_db
+class TestWorkspaceSettingsScope:
+    def test_scoped_token_cannot_patch_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = _patch_json(Client(), f"{WORKSPACES_URL}{other.key}", {"name": "Hijacked"}, scoped_token)
+        assert response.status_code == 403
+        other.refresh_from_db()
+        assert other.name == "Other WS"
+
+    def test_scoped_token_cannot_update_branding_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        response = _patch_json(
+            Client(), f"{WORKSPACES_URL}{other.key}/branding/brand_color", {"value": "#123456"}, scoped_token
+        )
+        assert response.status_code == 403
+
+    def test_scoped_token_can_patch_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, bound, _ = owner_of_two_workspaces
+        response = _patch_json(Client(), f"{WORKSPACES_URL}{bound.key}", {"name": "Renamed WS"}, scoped_token)
+        assert response.status_code == 200
+        bound.refresh_from_db()
+        assert bound.name == "Renamed WS"

--- a/sbomify/apps/teams/tests/test_token_workspace_scoping.py
+++ b/sbomify/apps/teams/tests/test_token_workspace_scoping.py
@@ -224,6 +224,29 @@ class TestWorkspaceSettingsScope:
         other.refresh_from_db()
         assert not other.branding_info.get("icon")
 
+    def test_scoped_token_cannot_set_domain_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        for method in ("put", "patch"):
+            response = getattr(Client(), method)(
+                f"{WORKSPACES_URL}{other.key}/domain",
+                json.dumps({"domain": "hijacked.example.com"}),
+                content_type="application/json",
+                **_headers(scoped_token),
+            )
+            assert response.status_code == 403
+        other.refresh_from_db()
+        assert not other.custom_domain
+
+    def test_scoped_token_cannot_delete_domain_in_non_bound_workspace(self, owner_of_two_workspaces, scoped_token):
+        _, _, other = owner_of_two_workspaces
+        other.custom_domain = "trust.other.example"
+        other.custom_domain_validated = True
+        other.save(update_fields=["custom_domain", "custom_domain_validated"])
+        response = Client().delete(f"{WORKSPACES_URL}{other.key}/domain", **_headers(scoped_token))
+        assert response.status_code == 403
+        other.refresh_from_db()
+        assert other.custom_domain == "trust.other.example"
+
     def test_scoped_token_can_patch_bound_workspace(self, owner_of_two_workspaces, scoped_token):
         _, bound, _ = owner_of_two_workspaces
         response = _patch_json(Client(), f"{WORKSPACES_URL}{bound.key}", {"name": "Renamed WS"}, scoped_token)


### PR DESCRIPTION
## Summary

A workspace-scoped access token could see and mutate workspaces outside its scope (both bugs reproduced against production on 2026-07-23 with a PAT scoped to one workspace, user belonging to 12).

The root cause is a split enforcement path: `can()` → `verify_item_access` enforces the token's bound workspace (`request.token_team`) and its action scopes, but any route that only checked `Member` role rows never consulted the token at all.

### Fixes

1. **`GET /api/v1/workspaces/` ignored token scope.** It returned every workspace the authenticated user belongs to, which is what made the sbomify-action wizard bind to the wrong workspace (it derived a team key from this listing while every other endpoint resolves to the token's bound team). `list_teams` now filters by `request.token_team`; unscoped tokens and sessions keep the full listing.

2. **Contact-profile routes skipped the token-scope check that the list route enforces.** `create/update/delete_contact_profile` only checked the membership role, so a token scoped to workspace A could create profiles in workspace B whenever the user is owner/admin of B (confirmed in production). They now gate on `can(request, "workspace:manage", team)`; the single-profile GET gains the same `can(request, "workspace:read", team)` gate the list route already had.

3. **Audit: same hole in every other write route in the file.** Branding (PATCH field / PUT / upload), team update (PUT/PATCH), and custom domain (PUT/PATCH/DELETE) used raw owner `Member` checks. They now also gate on `can(request, "workspace:administer", team)` — owner-only tier, so behaviour-identical for sessions; it only adds token workspace/action-scope enforcement.

### Regression tests

`sbomify/apps/teams/tests/test_token_workspace_scoping.py` (13 tests):
- Scoped token → `GET /workspaces/` returns exactly the bound workspace.
- Scoped token → 403 on list/get/create/update/delete of contact profiles, workspace PATCH, and branding writes in a non-bound workspace (with DB assertions that nothing was written), even though the user is owner there.
- Scoped token still fully works inside its bound workspace; unscoped PAT and session behaviour unchanged.

### Test results

`teams/`, `access_tokens/`, `core/test_authz.py`, `core/test_crud_apis.py`: **664 passed, 0 failed**. Ruff + mypy clean.

### Note on the products-count discrepancy (secondary check from the incident)

`list_products` and `get_team_asset_count` run the identical query (`Product.objects.filter(team_id=...)`, no soft-delete/visibility filter) with the team resolved the same way, so they cannot disagree for the same request identity. The observed "0 items listed vs. billing says 1 product" is most plausibly the two observations resolving different workspaces — a side effect of bug 1, which this PR removes at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)