### PR TITLE
chore(deps): ignore TypeScript 7.x in Dependabot bun group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       bun:
         patterns:
           - "*"
+    ignore:
+      # typescript-eslint does not support TypeScript 7 yet
+      # https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
   - package-ecosystem: "uv"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Dependabot's bun group PR (#1139) is failing CI because it bumps `typescript` to 7.0.2, and typescript-eslint does not support TypeScript 7 yet — `@typescript-eslint/eslint-plugin` hard-errors at load time ("typescript-eslint does not support TS 7.0"), which breaks the Bun Lint pre-commit hook.

This adds an `ignore` rule to the bun ecosystem group so Dependabot skips TypeScript `>=7.0.0`. TS 6.x minor/patch updates still come through. The rule can be removed once typescript-eslint/typescript-eslint#10940 lands (TS >= 7.1 support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)