### PR TITLE
fix: staging QA follow-up (VEX detail perf, misleading triage text, Trust Center double-count)

### DIFF
--- a/sbomify/apps/core/tests/test_component_views.py
+++ b/sbomify/apps/core/tests/test_component_views.py
@@ -208,9 +208,7 @@ class TestComponentCbomIssuesTable:
         team = sample_team_with_owner_member.team
         component, _ = self._cbom_with_run(
             team,
-            findings=[
-                {"title": "ML-KEM-768: Quantum-safe", "status": "pass", "severity": "info", "description": "ok"}
-            ],
+            findings=[{"title": "ML-KEM-768: Quantum-safe", "status": "pass", "severity": "info", "description": "ok"}],
         )
 
         response = self._component_page(team, sample_user, component)
@@ -232,3 +230,165 @@ class TestComponentCbomIssuesTable:
 
         assert response.status_code == 200
         assert response.context["latest_cbom_issues"] == []
+
+
+@pytest.mark.django_db
+class TestComponentItemVexAliasEnrichment:
+    """The VEX detail page enriches a suppression's display id/aliases from the
+    component's latest scan (Dependency-Track's CVE vs. OSV's GHSA for the same
+    vulnerability). Regression coverage for the two-phase winner-id query (#1218)
+    that replaced a direct DISTINCT-ON `result` projection — same behavior, cheaper
+    query shape."""
+
+    def setup_method(self):
+        self.client = Client()
+
+    def test_suppression_resolves_alias_from_latest_scan(self, sample_team_with_owner_member, sample_user, mocker):
+        import json
+
+        from sbomify.apps.plugins.models import AssessmentRun
+        from sbomify.apps.sboms.models import SBOM
+
+        team = sample_team_with_owner_member.team
+        component = Component.objects.create(
+            name="Aliased Component",
+            team=team,
+            component_type=Component.ComponentType.BOM,
+            visibility=Component.Visibility.PRIVATE,
+        )
+        sbom = SBOM.objects.create(
+            name="app",
+            version="1.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="app.json",
+            bom_type=SBOM.BomType.SBOM,
+        )
+        # Scanner reports the vuln under a GHSA id, with the CVE as an alias.
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            category="security",
+            status="completed",
+            result={
+                "findings": [
+                    {
+                        "id": "GHSA-xxxx",
+                        "aliases": ["CVE-2021-1"],
+                        "severity": "high",
+                        "component": {"name": "foo", "version": "1.0.0"},
+                    }
+                ]
+            },
+        )
+        vex = SBOM.objects.create(
+            name="app-vex",
+            version="1.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="vex.json",
+            bom_type=SBOM.BomType.VEX,
+            source="manual_upload",
+        )
+        # The hand-authored VEX names only the CVE — the alias-enrichment must
+        # pull "GHSA-xxxx" in from the scanner's finding.
+        vex_doc = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "components": [
+                {
+                    "type": "library",
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "purl": "pkg:npm/foo@1.0.0",
+                    "bom-ref": "pkg:npm/foo@1.0.0",
+                }
+            ],
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2021-1",
+                    "analysis": {"state": "not_affected", "justification": "code_not_reachable"},
+                    "affects": [{"ref": "pkg:npm/foo@1.0.0"}],
+                }
+            ],
+        }
+        mocker.patch("sbomify.apps.core.object_store.S3Client").return_value.get_sbom_data.return_value = json.dumps(
+            vex_doc
+        ).encode()
+
+        self.client.login(username=sample_user.username, password="test")
+        setup_test_session(self.client, team, sample_user)
+        url = reverse(
+            "core:component_item", kwargs={"component_id": component.id, "item_type": "vex", "item_id": vex.id}
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        suppressions = response.context["vex_suppressions"]
+        assert len(suppressions) == 1
+        assert suppressions[0]["id"] == "CVE-2021-1"
+        assert suppressions[0]["aliases"] == ["GHSA-xxxx"]
+
+    def test_sbom_page_merges_provider_counts_by_alias(self, sample_team_with_owner_member, sample_user):
+        """The SBOM detail page's vulnerability summary (Block B's own two-phase
+        winner-id query) merges two providers' findings for the same vulnerability
+        into one count, matching the component page badge."""
+        from sbomify.apps.plugins.models import AssessmentRun
+        from sbomify.apps.sboms.models import SBOM
+
+        team = sample_team_with_owner_member.team
+        component = Component.objects.create(
+            name="Dual Scanned Component",
+            team=team,
+            component_type=Component.ComponentType.BOM,
+            visibility=Component.Visibility.PRIVATE,
+        )
+        sbom = SBOM.objects.create(
+            name="app",
+            version="1.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="app.json",
+            bom_type=SBOM.BomType.SBOM,
+        )
+        pkg = {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"}
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="dependency-track",
+            category="security",
+            status="completed",
+            result={"findings": [{"id": "CVE-2021-23337", "severity": "high", "component": pkg}]},
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            category="security",
+            status="completed",
+            result={
+                "findings": [
+                    {
+                        "id": "GHSA-35jh-r3h4-6jhm",
+                        "severity": "critical",
+                        "aliases": ["CVE-2021-23337"],
+                        "component": pkg,
+                    }
+                ]
+            },
+        )
+
+        self.client.login(username=sample_user.username, password="test")
+        setup_test_session(self.client, team, sample_user)
+        url = reverse(
+            "core:component_item", kwargs={"component_id": component.id, "item_type": "sboms", "item_id": sbom.id}
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        summary = response.context["vulnerability_summary"]
+        assert summary["total"] == 1
+        assert summary["critical"] == 1
+        assert summary["high"] == 0

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -183,13 +183,23 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     )
                     alias_map: dict[str, list[str]] = {}
                     if latest_sbom_id:
-                        provider_results = list(
+                        # Two-phase DISTINCT ON: picking the winning run ids first
+                        # touches no JSON; only then is `result` fetched for just
+                        # those winners. Projecting `result` directly on the
+                        # DISTINCT ON query forces Postgres to de-TOAST every
+                        # historical rescan's blob before picking a winner — the
+                        # same class of bug #1121 fixed for the SBOM list and
+                        # trends endpoints, still live here (#1218).
+                        winner_ids = list(
                             AssessmentRun.objects.filter(
                                 sbom_id=latest_sbom_id, category="security", status="completed"
                             )
                             .order_by("plugin_name", "-created_at")
                             .distinct("plugin_name")
-                            .values_list("result", flat=True)
+                            .values_list("id", flat=True)
+                        )
+                        provider_results = list(
+                            AssessmentRun.objects.filter(id__in=winner_ids).values_list("result", flat=True)
                         )
                         for finding in merge_findings_by_alias(provider_results)["findings"]:
                             id_set = [i for i in [finding.get("id"), *(finding.get("aliases") or [])] if i]
@@ -231,11 +241,17 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 )
                 from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
 
-                provider_runs = list(
+                # Two-phase DISTINCT ON — see the VEX alias-enrichment block above
+                # for why: picking winner ids first avoids de-TOASTing every
+                # historical rescan's `result` blob just to discard the losers.
+                winner_ids = list(
                     AssessmentRun.objects.filter(sbom_id=item_id, category="security", status="completed")
                     .order_by("plugin_name", "-created_at")
                     .distinct("plugin_name")
-                    .values_list("plugin_name", "result")
+                    .values_list("id", flat=True)
+                )
+                provider_runs = list(
+                    AssessmentRun.objects.filter(id__in=winner_ids).values_list("plugin_name", "result")
                 )
                 merged = merge_findings_by_alias([result for _, result in provider_runs])
                 rows = extract_finding_rows(merged, load_vex_suppressions(component_id_from_item))

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -62,6 +62,8 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     from sbomify.apps.plugins.models import AssessmentRun
     from sbomify.apps.plugins.sdk.enums import AssessmentCategory, RunStatus
     from sbomify.apps.sboms.models import SBOM
+    from sbomify.apps.vulnerability_scanning.utils import _fold_finding
+    from sbomify.apps.vulnerability_scanning.vex import _finding_ids
 
     sbom_ids = list(
         release.artifacts.filter(sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM).values_list("sbom_id", flat=True)
@@ -84,22 +86,15 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     if not runs:
         return {"has_data": False}
 
-    counts = _empty_counts()
-    findings: list[dict[str, Any]] = []
-    suppressed_count = 0
-    # Dedupe the same vuln on the same package identity (purl, or name+version) across
-    # providers; a shared package name at different versions stays distinct so a release
-    # shipping two versions of a vulnerable dep isn't undercounted.
-    seen: set[tuple[str, str]] = set()
+    # Pass 1: collect every real finding across every run, each tagged with its
+    # package identity (purl, or name+version, or sbom-scoped name, or None —
+    # unchanged from before). meaningful_runs tracks per-run whether the scanner
+    # actually analyzed the SBOM (vs. only operational error markers).
     meaningful_runs = 0
-
+    candidates: list[tuple[dict[str, Any], str | None]] = []
     for run in runs:
         run_findings = (run.result or {}).get("findings", []) or []
         real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
-        # A run that produced findings but none are real vulnerabilities (only
-        # operational error / no-product markers) did not actually analyze the SBOM,
-        # so it must not let the release advertise a clean posture. A run with no
-        # findings at all is a genuine clean scan and does count.
         if not run_findings or real_findings:
             meaningful_runs += 1
         for finding in real_findings:
@@ -110,8 +105,9 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             purl = (component.get("purl") or "").lower()
             name = (component.get("name") or "").lower()
             version = (component.get("version") or "").lower()
-            # Dedupe only when a package identity is actually known, and fail open
-            # otherwise so instances aren't wrongly collapsed:
+            # Identity is known only when there's a package to anchor it to, and
+            # fails open (never deduped) otherwise so instances aren't wrongly
+            # collapsed:
             #  - purl, or name+version -> a stable identity, deduped release-wide;
             #  - name only -> scoped to this SBOM, so two providers of one SBOM
             #    collapse but the same name in another component (maybe a different
@@ -125,38 +121,66 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
                 identity = f"sbom:{run.sbom_id}:{name}"
             else:
                 identity = None
-            if identity is not None:
-                dedupe_key = ((finding.get("id") or "").lower(), identity)
-                if dedupe_key in seen:
-                    continue
-                seen.add(dedupe_key)
-
-            sev = _severity_bucket(finding)
-            suppressed = _is_suppressed(finding)
-            # The Trust Center shows the VEX-applied posture: suppressed findings
-            # drop out of the counts (they still appear in the list, marked).
-            if suppressed:
-                suppressed_count += 1
-            else:
-                counts[sev] += 1
-                counts["total"] += 1
-            findings.append(
-                {
-                    "id": finding.get("id"),
-                    "severity": sev,
-                    "component": component.get("name") or "",
-                    "component_version": component.get("version") or "",
-                    "suppressed": suppressed,
-                    "state": finding.get("analysis_state") or "",
-                    "justification": finding.get("analysis_justification") or "",
-                    "title": finding.get("title") or finding.get("description") or "",
-                }
-            )
+            candidates.append((finding, identity))
 
     # Every run that ran only produced operational error markers — the release was
     # not actually analyzed, so don't let the Trust Center claim it is clean.
     if meaningful_runs == 0:
         return {"has_data": False}
+
+    # Pass 2: within one package identity, providers report the same vulnerability
+    # under different ids (Dependency-Track's CVE, OSV's GHSA) — an id/alias
+    # overlap there is the same finding and must fold to one row (worst severity
+    # wins), or the count doubles and the same CVE/GHSA pair appears twice at
+    # inconsistent severities (#1220, measured live: 66 findings vs. the correct
+    # 31 for one dual-scanned component). A candidate with no identity is never
+    # folded — we can't confirm two identity-less findings are the same package.
+    deduped: list[dict[str, Any]] = []
+    alias_index: dict[str, dict[str, int]] = {}
+    for finding, identity in candidates:
+        if identity is None:
+            deduped.append(finding)
+            continue
+        bucket = alias_index.setdefault(identity, {})
+        fid_set = _finding_ids(finding)
+        existing_idx = next((bucket[fid] for fid in fid_set if fid in bucket), None)
+        if existing_idx is not None:
+            _fold_finding(deduped[existing_idx], finding)
+        else:
+            existing_idx = len(deduped)
+            deduped.append(finding)
+        for fid in fid_set:
+            bucket[fid] = existing_idx
+
+    # Pass 3: bucket the deduped findings into the severity/suppression counts
+    # and the display rows.
+    counts = _empty_counts()
+    findings: list[dict[str, Any]] = []
+    suppressed_count = 0
+    for finding in deduped:
+        raw_component = finding.get("component")
+        component = raw_component if isinstance(raw_component, dict) else {}
+        sev = _severity_bucket(finding)
+        suppressed = _is_suppressed(finding)
+        # The Trust Center shows the VEX-applied posture: suppressed findings
+        # drop out of the counts (they still appear in the list, marked).
+        if suppressed:
+            suppressed_count += 1
+        else:
+            counts[sev] += 1
+            counts["total"] += 1
+        findings.append(
+            {
+                "id": finding.get("id"),
+                "severity": sev,
+                "component": component.get("name") or "",
+                "component_version": component.get("version") or "",
+                "suppressed": suppressed,
+                "state": finding.get("analysis_state") or "",
+                "justification": finding.get("analysis_justification") or "",
+                "title": finding.get("title") or finding.get("description") or "",
+            }
+        )
 
     # Most severe first, suppressed sink to the bottom within each severity.
     order = {sev: i for i, sev in enumerate(_SEVERITIES)}

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -143,14 +143,31 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             continue
         bucket = alias_index.setdefault(identity, {})
         fid_set = _finding_ids(finding)
-        existing_idx = next((bucket[fid] for fid in fid_set if fid in bucket), None)
-        if existing_idx is not None:
-            _fold_finding(deduped[existing_idx], finding)
-        else:
+        # A finding can bridge two entries that were distinct so far (its alias
+        # set intersects both) — fold every match into the first so the union
+        # stays transitive instead of leaving a duplicate behind, mirroring
+        # merge_findings_by_alias (Copilot review of #1220).
+        match_idxs: list[int] = []
+        for fid in fid_set:
+            idx = bucket.get(fid)
+            if idx is not None and idx not in match_idxs:
+                match_idxs.append(idx)
+        if not match_idxs:
             existing_idx = len(deduped)
             deduped.append(finding)
+        else:
+            existing_idx = match_idxs[0]
+            _fold_finding(deduped[existing_idx], finding)
+            for extra_idx in match_idxs[1:]:
+                _fold_finding(deduped[existing_idx], deduped[extra_idx])
+                deduped[extra_idx]["_dead"] = True
+                for fid, idx in bucket.items():
+                    if idx == extra_idx:
+                        bucket[fid] = existing_idx
         for fid in fid_set:
             bucket[fid] = existing_idx
+
+    deduped = [finding for finding in deduped if not finding.pop("_dead", False)]
 
     # Pass 3: bucket the deduped findings into the severity/suppression counts
     # and the display rows.

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -114,6 +114,32 @@ def test_posture_dedupes_same_vuln_across_providers(release):
 
 
 @pytest.mark.django_db
+def test_posture_dedupes_cve_ghsa_alias_pair_across_providers(release):
+    """Dependency-Track reporting a CVE and OSV reporting the equivalent GHSA for
+    the same package must fold to one finding, not two (#1220 — measured live as a
+    2x-inflated public Trust Center count with the pair listed at two severities)."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    pkg = {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"}
+    _run(
+        sbom,
+        [{"id": "CVE-2021-23337", "severity": "high", "component": pkg}],
+        plugin="dependency-track",
+    )
+    _run(
+        sbom,
+        [{"id": "GHSA-35jh-r3h4-6jhm", "severity": "critical", "aliases": ["CVE-2021-23337"], "component": pkg}],
+        plugin="osv",
+    )
+
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 1
+    assert p["counts"]["critical"] == 1  # worst of the two providers' severities wins
+    assert len(p["findings"]) == 1
+
+
+@pytest.mark.django_db
 def test_posture_keeps_same_cve_different_versions(release):
     """Two components shipping the same package at different versions, both hit by
     one CVE, are counted separately — not collapsed by the cross-provider dedup."""

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -140,6 +140,30 @@ def test_posture_dedupes_cve_ghsa_alias_pair_across_providers(release):
 
 
 @pytest.mark.django_db
+def test_posture_folds_three_way_alias_bridge(release):
+    """A third provider's finding can bridge two entries that looked distinct so
+    far (its alias set intersects both) — all three must fold to one row, not
+    two, matching merge_findings_by_alias's transitive fold (Copilot review of
+    #1220)."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    pkg = {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"}
+    _run(sbom, [{"id": "CVE-1", "severity": "low", "component": pkg}], plugin="providerA")
+    _run(sbom, [{"id": "CVE-2", "severity": "medium", "component": pkg}], plugin="providerB")
+    _run(
+        sbom,
+        [{"id": "CVE-3", "severity": "critical", "aliases": ["CVE-1", "CVE-2"], "component": pkg}],
+        plugin="providerC",
+    )
+
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 1
+    assert p["counts"]["critical"] == 1
+    assert len(p["findings"]) == 1
+
+
+@pytest.mark.django_db
 def test_posture_keeps_same_cve_different_versions(release):
     """Two components shipping the same package at different versions, both hit by
     one CVE, are counted separately — not collapsed by the cross-provider dedup."""

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex.py
@@ -239,6 +239,40 @@ def test_reapply_false_positive_suppresses_and_records_state() -> None:
     assert out["findings"][0]["analysis_state"] == "false_positive"
 
 
+def test_reapply_no_detail_defaults_to_uploaded_vex_message() -> None:
+    """A suppressing statement with no detail text of its own falls back to a
+    message naming the source — an uploaded document, not a triage decision."""
+    result = _result(
+        {
+            "id": "CVE-1",
+            "severity": "high",
+            "component": {"name": "foo", "version": "1.0.0", "purl": "pkg:npm/foo@1.0.0"},
+        },
+    )
+    statements = vex.derive_vex_suppressions(_vex_doc(_stmt("CVE-1", "pkg:npm/foo@1.0.0")))
+    statements[0]["detail"] = None
+    statements[0]["source"] = "manual_upload"
+    out = vex.reapply_vex_to_stored_result(result, statements)
+    assert out["findings"][0]["analysis_detail"] == "Suppressed by uploaded VEX"
+
+
+def test_reapply_no_detail_triage_source_defaults_to_manual_message() -> None:
+    """The same fallback, sourced from an in-app triage decision, must not claim
+    a VEX document was uploaded — that misattributes a human decision (#1219)."""
+    result = _result(
+        {
+            "id": "CVE-1",
+            "severity": "high",
+            "component": {"name": "foo", "version": "1.0.0", "purl": "pkg:npm/foo@1.0.0"},
+        },
+    )
+    statements = vex.derive_vex_suppressions(_vex_doc(_stmt("CVE-1", "pkg:npm/foo@1.0.0")))
+    statements[0]["detail"] = None
+    statements[0]["source"] = vex.TRIAGE_SOURCE
+    out = vex.reapply_vex_to_stored_result(result, statements)
+    assert out["findings"][0]["analysis_detail"] == "Suppressed via manual triage"
+
+
 def test_reapply_osv_alias_suppressed_no_overmatch() -> None:
     result = _result(
         {"id": "GHSA-x", "severity": "high", "aliases": ["CVE-1"], "component": {"name": "foo", "version": "1.0.0"}},
@@ -388,6 +422,18 @@ def test_annotate_carries_justification_from_statement() -> None:
 
     assert f.analysis_state == "not_affected"
     assert f.analysis_justification == "code_not_reachable"  # from the VEX statement
+
+
+def test_annotate_no_detail_triage_source_defaults_to_manual_message() -> None:
+    f = _sdk_finding("CVE-1", "foo", "1.0.0", purl="pkg:npm/foo@1.0.0")
+    result = _sdk_result(f)
+    statements = vex.derive_vex_suppressions(_vex_doc(_stmt("CVE-1", "pkg:npm/foo@1.0.0")))
+    statements[0]["detail"] = None
+    statements[0]["source"] = vex.TRIAGE_SOURCE
+
+    vex.annotate_findings_with_vex(result, statements)
+
+    assert f.analysis_detail == "Suppressed via manual triage"
 
 
 def test_annotate_noop_without_statements() -> None:

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex.py
@@ -273,6 +273,23 @@ def test_reapply_no_detail_triage_source_defaults_to_manual_message() -> None:
     assert out["findings"][0]["analysis_detail"] == "Suppressed via manual triage"
 
 
+def test_reapply_no_detail_dependency_track_source_is_not_called_uploaded() -> None:
+    """A Dependency-Track-synced VEX is imported from the scanner, not uploaded
+    by a user — the fallback text must not conflate the two (Copilot review of #1219)."""
+    result = _result(
+        {
+            "id": "CVE-1",
+            "severity": "high",
+            "component": {"name": "foo", "version": "1.0.0", "purl": "pkg:npm/foo@1.0.0"},
+        },
+    )
+    statements = vex.derive_vex_suppressions(_vex_doc(_stmt("CVE-1", "pkg:npm/foo@1.0.0")))
+    statements[0]["detail"] = None
+    statements[0]["source"] = vex.DEPENDENCY_TRACK_SOURCE
+    out = vex.reapply_vex_to_stored_result(result, statements)
+    assert out["findings"][0]["analysis_detail"] == "Suppressed by synced Dependency-Track VEX"
+
+
 def test_reapply_osv_alias_suppressed_no_overmatch() -> None:
     result = _result(
         {"id": "GHSA-x", "severity": "high", "aliases": ["CVE-1"], "component": {"name": "foo", "version": "1.0.0"}},

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -86,6 +86,11 @@ def strict_vex_reads() -> Iterator[None]:
 # analyst's in-app decisions alongside, not instead of, an imported VEX.
 TRIAGE_SOURCE = "sbomify-triage"
 
+# Source tag the Dependency-Track plugin stamps on a synced triage-decision VEX
+# (see plugins/builtins/dependency_track.py). Distinct from a hand-uploaded
+# document — it's imported from the scanner, not something the user uploaded.
+DEPENDENCY_TRACK_SOURCE = "dependency-track"
+
 # CycloneDX vulnerability property names sbomify-triage writes to anchor a
 # product-scoped (component-wide) decision to the package version it was
 # asserted against, so a later scan on a different version can flag it stale.
@@ -108,8 +113,11 @@ def _default_suppression_detail(statement: dict[str, Any]) -> str:
     vs "· VEX") — an analyst's in-app decision must never read back as a document
     upload that never happened.
     """
-    if statement.get("source") == TRIAGE_SOURCE:
+    source = statement.get("source")
+    if source == TRIAGE_SOURCE:
         return "Suppressed via manual triage"
+    if source == DEPENDENCY_TRACK_SOURCE:
+        return "Suppressed by synced Dependency-Track VEX"
     return "Suppressed by uploaded VEX"
 
 

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -101,6 +101,18 @@ TRIAGE_DECIDED_AT_PROP = "sbomify:triage:decidedAt"
 _SEVERITIES = ("critical", "high", "medium", "low", "info", "unknown")
 
 
+def _default_suppression_detail(statement: dict[str, Any]) -> str:
+    """Fallback detail text when a suppressing statement carries none itself.
+
+    Matches the provenance the state badge already shows elsewhere ("· manually"
+    vs "· VEX") — an analyst's in-app decision must never read back as a document
+    upload that never happened.
+    """
+    if statement.get("source") == TRIAGE_SOURCE:
+        return "Suppressed via manual triage"
+    return "Suppressed by uploaded VEX"
+
+
 def _statement_ids(vuln: dict[str, Any]) -> set[str]:
     ids: set[str] = set()
     primary = _norm_id(vuln.get("id"))
@@ -417,7 +429,9 @@ def annotate_findings_with_vex(result: Any, statements: list[dict[str, Any]]) ->
             statement = matches[0]
             finding.analysis_state = statement.get("state") or "not_affected"
             finding.analysis_justification = statement.get("justification") or finding.analysis_justification
-            finding.analysis_detail = statement.get("detail") or finding.analysis_detail or "Suppressed by uploaded VEX"
+            finding.analysis_detail = (
+                statement.get("detail") or finding.analysis_detail or _default_suppression_detail(statement)
+            )
             # Stale if ANY matching statement is stale, not just the first — a
             # competing product-scoped imported statement must not shadow an
             # anchored triage statement's version drift. None (not False) when
@@ -467,7 +481,7 @@ def reapply_vex_to_stored_result(
             finding["analysis_state"] = statement.get("state") or "not_affected"
             if statement.get("justification"):
                 finding["analysis_justification"] = statement["justification"]
-            finding["analysis_detail"] = statement.get("detail") or "Suppressed by uploaded VEX"
+            finding["analysis_detail"] = statement.get("detail") or _default_suppression_detail(statement)
             # Stale if ANY matching statement is stale (see annotate_findings_with_vex).
             finding_pkg = _finding_package(finding)
             if any(_statement_is_stale_for(s, finding_pkg) for s in matches):


### PR DESCRIPTION
## Summary

Fixes 3 defects found during a full staging QA pass over the 26 PRs merged 2026-07-13→26 (#1218, #1219, #1220).

### #1219 — manual triage decisions displayed as "Suppressed by uploaded VEX"

A suppressing statement with no detail text of its own fell back to a hardcoded message naming an uploaded document, regardless of the statement's actual source. An in-app triage decision with no notes read back as a VEX upload that never happened. That undoes the triage-vs-upload distinction the state badge already gets right ("· manually" vs "· VEX"). The fallback now branches on `statement.get("source")`.

### #1220 — Trust Center release posture double-counted cross-provider findings

`build_release_vuln_posture` deduped on an exact finding-id string match. Two providers reporting the same vulnerability under different ids (Dependency-Track's CVE, OSV's GHSA) both survived and counted separately. Measured live: a release with one dual-scanned component showed 66 total findings on the public Trust Center vs. the correct 31 on the component page, with the same GHSA listed twice at two different severities.

Findings within one already-resolved package identity now fold when their id/alias sets overlap, keeping the worse severity. The identity computation itself (purl, name+version, or SBOM-scoped name) is untouched. A candidate with no identity is still never folded, and two components shipping the same package at different versions still count separately.

### #1218 — VEX detail page loads 5-30s+, one reproducible 504

`ComponentItemView` had two queries picking the latest `AssessmentRun` per plugin via `DISTINCT ON` while projecting the full `result` JSONB directly on the same query. That's the exact anti-pattern #1121 already fixed for the SBOM list and vulnerability trends endpoints, at two call sites that never got the same treatment. Postgres de-TOASTs every historical run's blob before the sort/unique step can discard the losers, so a component whose SBOM is rescanned repeatedly (an hourly scanner cron, in the case that surfaced this) pays for its entire scan history on every VEX or SBOM detail page load.

Both call sites now pick winning run ids touching no JSON first, then fetch `result` only for those winners. Same behavior, cheaper query shape.

## Testing

- New regression tests for all three: source-aware detail-text fallback (both `annotate_findings_with_vex` and `reapply_vex_to_stored_result`), a posture test replicating the exact CVE/GHSA double-count scenario, and two `ComponentItemView` tests (VEX alias-map resolution, SBOM vulnerability-summary merge) proving the two-phase query preserves behavior.
- Full suite for `core`, `vulnerability_scanning`, `plugins`, `sboms`: 4125 passed, 7 skipped. (4 unrelated failures in newsletter-export tests, caused by a stale test-container image missing an already-declared dependency, not touched by this PR.)
- ruff, mypy, tsc, bandit all clean.
