### PR TITLE
fix(sboms): show the latest artifact per format, not just the last

### DIFF
--- a/sbomify/apps/sboms/services/sboms_table.py
+++ b/sbomify/apps/sboms/services/sboms_table.py
@@ -92,8 +92,14 @@ def _attach_vulnerability_counts(sbom_items: list[dict[str, Any]], component_id:
 
 
 def _summary_artifacts(sbom_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """The compact card view: the newest artifact of each bom_type (latest SBOM,
-    latest VEX, latest CBOM, …).
+    """The compact card view: the newest artifact of each (format, bom_type).
+
+    Keyed the same way as ``Component.get_latest_sboms_by_format``, so the card
+    and the release rollup agree on what "latest" means. Both halves of the key
+    earn their place: a component published as CycloneDX and SPDX has two
+    artifacts of bom_type ``sbom``, and a VEX or CBOM shares the cyclonedx
+    format with the SBOM. Dropping either half hides a current artifact behind
+    an unrelated one.
 
     VEX resolution is latest-wins, so the card shows just the newest VEX; the
     superseded ones (and the full SBOM history) live behind the "View all"
@@ -104,12 +110,12 @@ def _summary_artifacts(sbom_items: list[dict[str, Any]]) -> list[dict[str, Any]]
         key=lambda x: x["sbom"]["created_at"].timestamp() if x["sbom"].get("created_at") else 0.0,
         reverse=True,
     )
-    seen: set[str] = set()
+    seen: set[tuple[str, str]] = set()
     summary: list[dict[str, Any]] = []
     for item in by_date:
-        bom_type = item["sbom"].get("bom_type") or "sbom"
-        if bom_type not in seen:
-            seen.add(bom_type)
+        key = (item["sbom"].get("format") or "", item["sbom"].get("bom_type") or "sbom")
+        if key not in seen:
+            seen.add(key)
             summary.append(item)
     return summary
 

--- a/sbomify/apps/sboms/tests/test_sboms_table_service.py
+++ b/sbomify/apps/sboms/tests/test_sboms_table_service.py
@@ -322,7 +322,7 @@ class TestDeleteSbomFromRequest:
         assert result.status_code == 404
 
 
-def _artifact(name: str, fmt: str, bom_type: str, day: int) -> dict:
+def _artifact(name: str, fmt: str, bom_type: str | None, day: int) -> dict:
     from datetime import datetime, timezone
 
     return {
@@ -376,7 +376,14 @@ class TestSummaryArtifacts:
 
         assert {item["sbom"]["bom_type"] for item in summary} == {"sbom", "vex", "cbom"}
 
-    def test_missing_bom_type_defaults_to_sbom(self):
-        summary = _summary_artifacts([_artifact("legacy", "spdx", None, 27)])
+    def test_missing_bom_type_is_treated_as_sbom(self):
+        """A legacy row carrying no bom_type shares the sbom slot rather than
+        opening one of its own, so it cannot show up alongside its successor."""
+        summary = _summary_artifacts(
+            [
+                _artifact("legacy", "spdx", None, 20),
+                _artifact("current", "spdx", "sbom", 27),
+            ]
+        )
 
-        assert len(summary) == 1
+        assert [item["sbom"]["name"] for item in summary] == ["current"]

--- a/sbomify/apps/sboms/tests/test_sboms_table_service.py
+++ b/sbomify/apps/sboms/tests/test_sboms_table_service.py
@@ -11,6 +11,7 @@ from django.test import RequestFactory
 
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.sboms.services.sboms_table import (
+    _summary_artifacts,
     build_sboms_table_context,
     delete_sbom_from_request,
 )
@@ -319,3 +320,63 @@ class TestDeleteSbomFromRequest:
         assert result.ok is False
         assert "not found" in result.error.lower()
         assert result.status_code == 404
+
+
+def _artifact(name: str, fmt: str, bom_type: str, day: int) -> dict:
+    from datetime import datetime, timezone
+
+    return {
+        "sbom": {
+            "id": name,
+            "name": name,
+            "format": fmt,
+            "bom_type": bom_type,
+            "created_at": datetime(2026, 7, day, tzinfo=timezone.utc),
+        }
+    }
+
+
+class TestSummaryArtifacts:
+    """The compact card keeps the newest artifact of each (format, bom_type).
+
+    Same key as ``Component.get_latest_sboms_by_format``, so the card and the
+    release rollup agree on what "latest" means.
+    """
+
+    def test_cyclonedx_and_spdx_sboms_both_survive(self):
+        """Both carry bom_type 'sbom', so keying on bom_type alone showed one."""
+        summary = _summary_artifacts(
+            [
+                _artifact("container-cdx", "cyclonedx", "sbom", 27),
+                _artifact("container-spdx", "spdx", "sbom", 26),
+            ]
+        )
+
+        assert {item["sbom"]["format"] for item in summary} == {"cyclonedx", "spdx"}
+
+    def test_newest_wins_within_one_format(self):
+        summary = _summary_artifacts(
+            [
+                _artifact("old", "cyclonedx", "sbom", 20),
+                _artifact("new", "cyclonedx", "sbom", 27),
+            ]
+        )
+
+        assert [item["sbom"]["name"] for item in summary] == ["new"]
+
+    def test_vex_and_cbom_keep_their_own_slot(self):
+        """They share the cyclonedx format, so format alone would collapse them."""
+        summary = _summary_artifacts(
+            [
+                _artifact("sbom", "cyclonedx", "sbom", 27),
+                _artifact("vex", "cyclonedx", "vex", 26),
+                _artifact("cbom", "cyclonedx", "cbom", 25),
+            ]
+        )
+
+        assert {item["sbom"]["bom_type"] for item in summary} == {"sbom", "vex", "cbom"}
+
+    def test_missing_bom_type_defaults_to_sbom(self):
+        summary = _summary_artifacts([_artifact("legacy", "spdx", None, 27)])
+
+        assert len(summary) == 1


### PR DESCRIPTION
"Latest artifacts & security" collapsed a component's CycloneDX and SPDX SBOMs into one row, so publishing both meant only the newer one appeared and the older one vanished from the card.

`_summary_artifacts` keyed on `bom_type` alone. A CycloneDX SBOM and an SPDX SBOM both carry `bom_type="sbom"`, so the second one displaced the first.

The key is now `(format, bom_type)`, matching `Component.get_latest_sboms_by_format`, which already keys that way and whose docstring spells out the same reasoning. Both halves earn their place: two formats share one `bom_type`, and a VEX or CBOM shares the `cyclonedx` format with the SBOM. Drop either half and a current artifact hides behind an unrelated one.

## Reproduced against a running instance

A component holding a CycloneDX SBOM, a CBOM and a VEX. Uploading an SPDX SBOM to it:

| | Card contents |
|---|---|
| Before | `poetry.lock` (SPDX), CBOM, VEX. `app-vuln-demo` (CycloneDX) gone |
| After | `app-vuln-demo` (CycloneDX), `poetry.lock` (SPDX), CBOM, VEX |

The header counts moved with it, from 3 Critical / 1 High / 6 Medium to 7 Critical / 32 High / 23 Medium, because the row driving them had been swapped out. That is the part worth noting: the collapse silently changed which artifact the component's headline vulnerability posture described.

## Tests

Four cases in `test_sboms_table_service.py`: CycloneDX and SPDX both surviving, newest winning within one format, VEX and CBOM keeping their own slots, and a missing `bom_type` still falling back to `sbom`. The first fails on the old key. 16 pass in the file.
