### PR TITLE
fix(plugins): a skipped assessment reads as skipped, not as warnings

### DIFF
--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -4,7 +4,7 @@
 {% with run_id=run.id|default:loop_index result=run.result|default_if_none:"" summary=run.result.summary|default_if_none:"" fail_count=run.result.summary.fail_count|default:0 error_count=run.result.summary.error_count|default:0 pass_count=run.result.summary.pass_count|default:0 %}
     {% comment %}has_issues is the explicit-failure signal (fail+error). A run with only warnings (pass_count==0) is shown as "Warnings Only" rather than "Passed" so the per-card badge matches the dashboard summary and BSI's dependency gate (see _is_run_failing and orchestrator._is_passing).
     skipped mirrors _is_run_skipped in plugins/apis.py. A plugin that could not run (Dependency Track handed an SPDX SBOM, PQC handed a document with no crypto assets) reports one info/warning finding and metadata.skipped, which the counters above cannot tell apart from a real warnings-only verdict. Without this the card claims the plugin ran and disagreed with the scanners beside it.{% endcomment %}
-    {% with has_issues=fail_count|add:error_count is_security=run.category|is_security_category skipped=run.result.metadata.skipped %}
+    {% with has_issues=fail_count|add:error_count is_security=run.category|is_security_category skipped=result.metadata.skipped %}
         {# Compute security total from by_severity #}
         {% if is_security and run.result.summary.by_severity %}
             {% with sev=run.result.summary.by_severity security_total=run.result.summary.total_findings|default:0 %}

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -2,8 +2,9 @@
 {% load plugins_extras %}
 {# Safely compute has_issues - run.result may be None for pending/running assessments #}
 {% with run_id=run.id|default:loop_index result=run.result|default_if_none:"" summary=run.result.summary|default_if_none:"" fail_count=run.result.summary.fail_count|default:0 error_count=run.result.summary.error_count|default:0 pass_count=run.result.summary.pass_count|default:0 %}
-    {% comment %}has_issues is the explicit-failure signal (fail+error). A run with only warnings (pass_count==0) is shown as "Warnings Only" rather than "Passed" so the per-card badge matches the dashboard summary and BSI's dependency gate (see _is_run_failing and orchestrator._is_passing).{% endcomment %}
-    {% with has_issues=fail_count|add:error_count is_security=run.category|is_security_category %}
+    {% comment %}has_issues is the explicit-failure signal (fail+error). A run with only warnings (pass_count==0) is shown as "Warnings Only" rather than "Passed" so the per-card badge matches the dashboard summary and BSI's dependency gate (see _is_run_failing and orchestrator._is_passing).
+    skipped mirrors _is_run_skipped in plugins/apis.py. A plugin that could not run (Dependency Track handed an SPDX SBOM, PQC handed a document with no crypto assets) reports one info/warning finding and metadata.skipped, which the counters above cannot tell apart from a real warnings-only verdict. Without this the card claims the plugin ran and disagreed with the scanners beside it.{% endcomment %}
+    {% with has_issues=fail_count|add:error_count is_security=run.category|is_security_category skipped=run.result.metadata.skipped %}
         {# Compute security total from by_severity #}
         {% if is_security and run.result.summary.by_severity %}
             {% with sev=run.result.summary.by_severity security_total=run.result.summary.total_findings|default:0 %}
@@ -270,7 +271,8 @@
             {% endwith %}
         {% else %}
             {# Compliance / non-security rendering #}
-            <div class="tw-collapsible-card {% if error_count %}tw-collapsible-card--danger{% elif fail_count %}tw-collapsible-card--warning{% elif run.status == 'completed' and pass_count == 0 %}tw-collapsible-card--warning{% elif run.status == 'completed' %}tw-collapsible-card--success{% endif %}"
+            {% comment %}A skipped run keeps the neutral base border: it produced no verdict, so it is neither a warning nor a pass.{% endcomment %}
+            <div class="tw-collapsible-card {% if skipped %}{% elif error_count %}tw-collapsible-card--danger{% elif fail_count %}tw-collapsible-card--warning{% elif run.status == 'completed' and pass_count == 0 %}tw-collapsible-card--warning{% elif run.status == 'completed' %}tw-collapsible-card--success{% endif %}"
                  id="plugin-{{ run.plugin_name }}"
                  x-data="{ expanded: false }">
                 <div class="tw-collapsible-header" @click="expanded = !expanded">
@@ -288,7 +290,12 @@
                             </span>
                         {% endif %}
                         {% if run.status == 'completed' %}
-                            {% if has_issues %}
+                            {% if skipped %}
+                                <span class="tw-badge-secondary"
+                                      title="This plugin did not run, so it reported no verdict.">
+                                    <i class="fas fa-ban mr-1"></i>Skipped
+                                </span>
+                            {% elif has_issues %}
                                 <span class="tw-badge-secondary">
                                     <i class="fas fa-exclamation-triangle mr-1"></i>{{ has_issues }} Issue{{ has_issues|pluralize }}
                                 </span>
@@ -315,7 +322,10 @@
                                 <i class="fas fa-clock mr-1"></i>Pending
                             </span>
                         {% endif %}
-                        {% if run.result.summary %}
+                        {% comment %}A skipped run's finding count is always 1 and means nothing; the reader wants the reason, which otherwise stays hidden until the card is expanded.{% endcomment %}
+                        {% if skipped %}
+                            <span class="text-text-muted text-sm truncate">{{ run.result.findings.0.title }}</span>
+                        {% elif run.result.summary %}
                             <span class="text-text-muted text-sm hidden md:inline">{{ run.result.summary.total_findings|default:0 }} findings</span>
                         {% endif %}
                     </div>

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -8,7 +8,8 @@
         {# Compute security total from by_severity #}
         {% if is_security and run.result.summary.by_severity %}
             {% with sev=run.result.summary.by_severity security_total=run.result.summary.total_findings|default:0 %}
-                <div class="tw-collapsible-card {% if security_total %}tw-collapsible-card--warning{% elif run.status == 'completed' %}tw-collapsible-card--success{% endif %}"
+                {% comment %}A skipped run keeps the neutral base border: it produced no verdict, so it is neither a warning nor a clean scan.{% endcomment %}
+                <div class="tw-collapsible-card {% if skipped %}{% elif security_total %}tw-collapsible-card--warning{% elif run.status == 'completed' %}tw-collapsible-card--success{% endif %}"
                      id="plugin-{{ run.plugin_name }}"
                      x-data="{ expanded: false }">
                     <div class="tw-collapsible-header" @click="expanded = !expanded">
@@ -26,7 +27,13 @@
                                 </span>
                             {% endif %}
                             {% if run.status == 'completed' %}
-                                {% if security_total %}
+                                {% comment %}A skipped scanner counts its own stand-down notice as one info finding, so security_total is 1 and the card would otherwise claim a vulnerability the scanner never reported.{% endcomment %}
+                                {% if skipped %}
+                                    <span class="tw-badge-secondary"
+                                          title="This plugin did not scan, so it reported no verdict.">
+                                        <i class="fas fa-ban mr-1"></i>Skipped
+                                    </span>
+                                {% elif security_total %}
                                     <span class="tw-badge-secondary">
                                         <i class="fas fa-shield-alt mr-1"></i>{{ security_total }} Vulnerabilit{{ security_total|pluralize:"y,ies" }}
                                     </span>
@@ -48,7 +55,10 @@
                                     <i class="fas fa-clock mr-1"></i>Pending
                                 </span>
                             {% endif %}
-                            {% if run.result.summary %}
+                            {% comment %}A skipped run's finding count is always 1 and means nothing; the reader wants the reason, which otherwise stays hidden until the card is expanded.{% endcomment %}
+                            {% if skipped %}
+                                <span class="text-text-muted text-sm truncate">{{ run.result.findings.0.title }}</span>
+                            {% elif run.result.summary %}
                                 <span class="text-text-muted text-sm hidden md:inline">{{ run.result.summary.total_findings|default:0 }} findings</span>
                             {% endif %}
                         </div>

--- a/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
+++ b/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
@@ -158,3 +158,86 @@ class TestSkippedRunBadge:
 
         assert "2 Issues" in html
         assert "Skipped" not in html
+
+
+def _security_run(**overrides) -> dict:
+    """A security run as the plugins actually emit it, with ``by_severity``.
+
+    ``_run`` omits it, which sends every case above through the compliance
+    branch. Dependency Track fills it in even when it skips (one ``info``), so
+    the card renders through the security branch instead, and that is the path
+    that called the skip "1 Vulnerability".
+    """
+    run = _run(**overrides)
+    run["result"]["summary"]["by_severity"] = {
+        "critical": 0,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "info": 1,
+        "unknown": 0,
+    }
+    return run
+
+
+class TestSkippedSecurityRunBadge:
+    """Same rule, security branch: DT handed an SPDX SBOM scanned nothing."""
+
+    def test_skipped_run_reads_as_skipped_not_as_a_vulnerability(self):
+        run = _security_run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        header = _header(run)
+
+        assert "Skipped" in header
+        assert "Vulnerabilit" not in header
+
+    def test_skipped_run_names_the_reason_without_expanding(self):
+        run = _security_run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        header = _header(run)
+
+        assert "Format Not Supported" in header
+        assert "1 findings" not in header
+
+    def test_skipped_run_is_not_coloured_as_a_warning(self):
+        run = _security_run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        assert "tw-collapsible-card--warning" not in _render(run)
+
+    def test_a_real_scan_is_untouched(self):
+        """The case beside it on the same page: OSV reporting real findings."""
+        run = _security_run(plugin_name="osv", plugin_display_name="OSV Vulnerability Scanner")
+        run["result"]["summary"]["total_findings"] = 117
+        run["result"]["summary"]["by_severity"] = {
+            "critical": 7,
+            "high": 32,
+            "medium": 23,
+            "low": 55,
+            "info": 0,
+            "unknown": 0,
+        }
+
+        header = _header(run)
+
+        assert "117 Vulnerabilities" in header
+        assert "Skipped" not in header
+
+    def test_a_clean_scan_is_untouched(self):
+        run = _security_run()
+        run["result"]["summary"]["total_findings"] = 0
+        run["result"]["summary"]["by_severity"] = {
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+            "info": 0,
+            "unknown": 0,
+        }
+
+        header = _header(run)
+
+        assert "No Vulnerabilities" in header
+        assert "Skipped" not in header

--- a/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
+++ b/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
@@ -1,0 +1,152 @@
+"""The per-run assessment card badge.
+
+A plugin that could not run returns ``metadata={"skipped": True}``. The API
+layer honours that through ``_is_run_skipped``; these tests hold the template to
+the same reading, because a skipped run rendered as "Warnings Only" reads as a
+scanner that ran and disagreed with the others.
+"""
+
+from __future__ import annotations
+
+from django.template.loader import render_to_string
+
+
+def _run(**overrides) -> dict:
+    run = {
+        "id": "run1",
+        "plugin_name": "dependency-track",
+        "plugin_display_name": "Dependency Track",
+        "plugin_version": "1.0.0",
+        "category": "security",
+        "status": "completed",
+        "run_reason": "on_upload",
+        "release_names": [],
+        "completed_at": None,
+        "result": {
+            "summary": {
+                "total_findings": 1,
+                "pass_count": 0,
+                "fail_count": 0,
+                "warning_count": 1,
+                "error_count": 0,
+            },
+            "findings": [
+                {
+                    "id": "dependency-track:unsupported-format",
+                    "title": "Format Not Supported",
+                    "description": "Dependency Track only supports CycloneDX format.",
+                    "status": "warning",
+                    "severity": "info",
+                }
+            ],
+            "metadata": {},
+        },
+    }
+    run.update(overrides)
+    return run
+
+
+def _render(run: dict) -> str:
+    return render_to_string("plugins/components/_assessment_run_item.html.j2", {"run": run, "loop_index": 1})
+
+
+def _header(run: dict) -> str:
+    """What a reader sees before expanding the card.
+
+    The findings list lives inside ``x-show="expanded"``, so asserting against
+    the whole render would pass on text nobody can see.
+    """
+    return _render(run).split('x-show="expanded"')[0]
+
+
+class TestSkippedRunBadge:
+    def test_skipped_run_reads_as_skipped(self):
+        """DT on an SPDX SBOM: it never scanned, so "Warnings Only" is a lie."""
+        run = _run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        html = _render(run)
+
+        assert "Skipped" in html
+        assert "Warnings Only" not in html
+
+    def test_skipped_run_names_the_reason_without_expanding(self):
+        """"1 findings" says nothing about why the plugin stood down, and the
+        finding that explains it is hidden until the card is expanded."""
+        run = _run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        header = _header(run)
+
+        assert "Format Not Supported" in header
+        assert "1 findings" not in header
+
+    def test_skipped_run_is_not_coloured_as_a_warning(self):
+        run = _run()
+        run["result"]["metadata"] = {"skipped": True}
+
+        html = _render(run)
+
+        assert "tw-collapsible-card--warning" not in html
+
+    def test_a_skipped_compliance_run_reads_the_same(self):
+        """PQC skips a document with no crypto assets. Different category, same
+        rendering branch, so it was mislabelled the same way."""
+        run = _run(
+            plugin_name="pqc",
+            plugin_display_name="Post-Quantum Readiness",
+            category="compliance",
+        )
+        run["result"]["metadata"] = {"skipped": True}
+        run["result"]["findings"] = [
+            {
+                "id": "pqc:no-assets",
+                "title": "No cryptographic assets found",
+                "description": "This document declares no crypto-asset components; nothing to assess.",
+                "status": "info",
+                "severity": "info",
+            }
+        ]
+
+        header = _header(run)
+
+        assert "Skipped" in header
+        assert "Warnings Only" not in header
+        assert "No cryptographic assets found" in header
+
+    def test_a_real_warnings_only_run_is_untouched(self):
+        """A plugin that ran and produced only warnings still reads that way."""
+        html = _render(_run())
+
+        assert "Warnings Only" in html
+        assert "Skipped" not in html
+
+    def test_a_passing_run_is_untouched(self):
+        run = _run()
+        run["result"]["summary"] = {
+            "total_findings": 3,
+            "pass_count": 3,
+            "fail_count": 0,
+            "warning_count": 0,
+            "error_count": 0,
+        }
+
+        html = _render(run)
+
+        assert "Passed" in html
+        assert "Skipped" not in html
+
+    def test_a_failing_run_is_untouched(self):
+        run = _run()
+        run["result"]["summary"] = {
+            "total_findings": 2,
+            "pass_count": 0,
+            "fail_count": 2,
+            "warning_count": 0,
+            "error_count": 0,
+        }
+
+        html = _render(run)
+
+        assert "2 Issues" in html
+        assert "Skipped" not in html

--- a/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
+++ b/sbomify/apps/plugins/tests/test_assessment_run_item_badge.py
@@ -71,8 +71,8 @@ class TestSkippedRunBadge:
         assert "Warnings Only" not in html
 
     def test_skipped_run_names_the_reason_without_expanding(self):
-        """"1 findings" says nothing about why the plugin stood down, and the
-        finding that explains it is hidden until the card is expanded."""
+        """A finding count says nothing about why the plugin stood down, and the
+        finding that explains it stays hidden until the card is expanded."""
         run = _run()
         run["result"]["metadata"] = {"skipped": True}
 
@@ -119,6 +119,14 @@ class TestSkippedRunBadge:
         html = _render(_run())
 
         assert "Warnings Only" in html
+        assert "Skipped" not in html
+
+    def test_a_run_with_no_result_still_renders(self):
+        """Pending and running rows carry result=None, which is why the template
+        aliases it before the skipped lookup."""
+        html = _render(_run(status="running", result=None))
+
+        assert "Running" in html
         assert "Skipped" not in html
 
     def test_a_passing_run_is_untouched(self):


### PR DESCRIPTION
A plugin that could not run returns `metadata={"skipped": True}`. `_is_run_skipped` in `plugins/apis.py` honours that, but the assessment card did not: it read the finding counters, which cannot tell a stand-down apart from a real verdict, and labelled it as though the plugin had run and disagreed with the scanners beside it.

Three commits, the last one added after testing the first two against a live upload.

## What the card showed

Dependency Track cannot read SPDX (its own plugin registry entry says so), so on an SPDX SBOM it returns a skipped result carrying one finding, `dependency-track:unsupported-format` / "Format Not Supported", `status="warning"`, `severity="info"`. Zero vulnerabilities.

| | Badge |
|---|---|
| Before | `1 Vulnerability` · `1 findings`, warning border |
| After | `Skipped` · `Format Not Supported`, neutral border |

Beside it on the same page, OSV reported 117 real findings from the same SBOM. "1 Vulnerability" is a count Dependency Track never produced, which is what makes two scanners look like they disagree when one of them never scanned.

## Why the third commit exists

The first two fixed only the compliance branch. Dependency Track is `category="security"` and fills in `by_severity` (one `info`) even when it stands down, so its card takes:

```
{% if is_security and run.result.summary.by_severity %}
```

the security branch, where `skipped` was computed and never read. The security path now honours it in the same three places: badge, header text, border.

The existing fixture is what hid this. It set `category` to `security` but left out `by_severity`, so all ten original tests rendered through the compliance branch and the security path had no coverage at all. `_security_run` adds the shape the plugins actually emit, taken from a real stored run rather than guessed.

## Testing

848 plugin tests pass. The three new security-branch assertions fail before the template change and pass after. Verified live: uploading an SPDX SBOM produced the "Skipped" card while every other plugin on the page rendered unchanged.

## Not in this PR

The expanded card still shows a severity grid reading `Total 1` for a skipped run, repeating the same count one layer down. The compliance branch has the identical wart, so both should move together rather than diverge here.
