### PR TITLE
fix: anonymous artifacts-table 500, token banner copy, KEV badge coverage

### DIFF
--- a/sbomify/apps/plugins/tests/test_kev_badge.py
+++ b/sbomify/apps/plugins/tests/test_kev_badge.py
@@ -1,0 +1,138 @@
+"""The CISA KEV badge, from catalog lookup to rendered markup.
+
+Every piece worked in isolation and the flag defaults to false, so the red badge
+never appeared in any check: no fixture held a CVE that is actually in the
+catalog. Log4Shell stands in here because it is a real KEV entry, and OSV
+reports it as a GHSA id carrying the CVE as an alias, which is the shape the
+alias branch exists for.
+
+The catalog is a frozenset of lower-cased ids, built by ``kev_cve_ids`` from the
+CISA feed. These tests pass one in directly, so nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.template.loader import render_to_string
+
+from sbomify.apps.plugins.apis import _result_with_kev
+from sbomify.apps.vulnerability_scanning.kev import finding_in_kev
+
+LOG4SHELL = "CVE-2021-44228"
+LOG4SHELL_GHSA = "GHSA-jfh8-c2jp-5v3q"
+CATALOG = frozenset({LOG4SHELL.lower()})
+
+
+def _finding(**overrides) -> dict:
+    finding = {
+        "id": LOG4SHELL,
+        "title": "Remote code execution in log4j-core",
+        "severity": "critical",
+    }
+    finding.update(overrides)
+    return finding
+
+
+def _security_run(findings: list[dict], category: str = "security") -> SimpleNamespace:
+    """``_result_with_kev`` reads only ``result`` and ``category``."""
+    return SimpleNamespace(
+        category=category,
+        result={
+            "summary": {
+                "total_findings": len(findings),
+                "by_severity": {"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0},
+            },
+            "findings": findings,
+        },
+    )
+
+
+class TestCatalogMatching:
+    def test_a_listed_id_matches(self):
+        assert finding_in_kev(_finding(), CATALOG) is True
+
+    def test_a_listed_alias_matches(self):
+        """OSV reports the GHSA id, so the CVE only appears under aliases."""
+        finding = _finding(id=LOG4SHELL_GHSA, aliases=[LOG4SHELL])
+
+        assert finding_in_kev(finding, CATALOG) is True
+
+    def test_matching_ignores_case(self):
+        assert finding_in_kev(_finding(id=LOG4SHELL.lower()), CATALOG) is True
+
+    def test_an_unlisted_id_does_not_match(self):
+        assert finding_in_kev(_finding(id="CVE-2026-99999"), CATALOG) is False
+
+    def test_an_empty_catalog_matches_nothing(self):
+        """A failed feed fetch caches an empty set, which must read as "no badge"
+        rather than stamping everything or raising."""
+        assert finding_in_kev(_finding(), frozenset()) is False
+
+
+class TestResponseTimeStamp:
+    def test_only_the_listed_finding_is_stamped(self):
+        run = _security_run([_finding(), _finding(id="CVE-2026-99999", title="Something else")])
+
+        findings = _result_with_kev(run, CATALOG)["findings"]
+
+        assert findings[0]["kev"] is True
+        assert "kev" not in findings[1]
+
+    def test_the_stored_blob_is_left_alone(self):
+        """The flag is response-time data from the cached feed, so the row keeps
+        whatever the plugin wrote."""
+        run = _security_run([_finding()])
+
+        _result_with_kev(run, CATALOG)
+
+        assert "kev" not in run.result["findings"][0]
+
+    def test_a_non_security_run_passes_through(self):
+        run = _security_run([_finding()], category="compliance")
+
+        assert _result_with_kev(run, CATALOG) is run.result
+
+    def test_an_empty_catalog_passes_through(self):
+        run = _security_run([_finding()])
+
+        assert _result_with_kev(run, frozenset()) is run.result
+
+
+class TestBadgeMarkup:
+    """The stamp is only worth anything if the template acts on it."""
+
+    @staticmethod
+    def _render(findings: list[dict]) -> str:
+        run = _security_run(findings)
+        return render_to_string(
+            "plugins/components/_assessment_run_item.html.j2",
+            {
+                "run": {
+                    "id": "run1",
+                    "plugin_name": "osv",
+                    "plugin_display_name": "OSV Vulnerability Scanner",
+                    "plugin_version": "1.0.0",
+                    "category": "security",
+                    "status": "completed",
+                    "run_reason": "on_upload",
+                    "release_names": [],
+                    "completed_at": None,
+                    "result": run.result,
+                },
+                "loop_index": 1,
+            },
+        )
+
+    def test_a_listed_finding_renders_the_badge(self):
+        run = _security_run([_finding()])
+        stamped = _result_with_kev(run, CATALOG)
+
+        html = self._render(stamped["findings"])
+
+        assert "Known Exploited Vulnerabilities catalog" in html
+
+    def test_an_unlisted_finding_renders_no_badge(self):
+        html = self._render([_finding(id="CVE-2026-99999")])
+
+        assert "Known Exploited Vulnerabilities catalog" not in html

--- a/sbomify/apps/sboms/tests/test_views.py
+++ b/sbomify/apps/sboms/tests/test_views.py
@@ -526,3 +526,44 @@ def test_sbom_download_capture_skipped_when_disabled(sample_sbom: SBOM, mocker: 
 
     assert response.status_code == 200
     mock_capture.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestSbomsTableViewAnonymousAccess:
+    """The view serves a public and a private route off the same class.
+
+    A public component passes the component-level check even for an anonymous
+    caller, so the private route used to reach the team lookup with
+    ``AnonymousUser`` and raise. A private component never got that far.
+    """
+
+    def test_private_table_for_a_public_component_does_not_error(self, client, sample_component):  # noqa: F811
+        sample_component.visibility = Component.Visibility.PUBLIC
+        sample_component.save()
+
+        url = reverse("sboms:sboms_table", kwargs={"component_id": sample_component.id})
+        response = client.get(url)
+
+        assert response.status_code == 302
+
+    def test_public_table_stays_open_to_anonymous(self, client, sample_component):  # noqa: F811
+        """The guard must not gate the route that is meant to be anonymous."""
+        sample_component.visibility = Component.Visibility.PUBLIC
+        sample_component.save()
+
+        url = reverse("sboms:sboms_table_public", kwargs={"component_id": sample_component.id})
+        response = client.get(url)
+
+        assert response.status_code == 200
+
+    def test_private_table_still_serves_a_member(self, client, sample_component, sample_user):  # noqa: F811
+        sample_component.visibility = Component.Visibility.PUBLIC
+        sample_component.save()
+        Member.objects.get_or_create(user=sample_user, team=sample_component.team, defaults={"role": "owner"})
+        client.force_login(sample_user)
+        setup_test_session(client, sample_component.team, sample_user)
+
+        url = reverse("sboms:sboms_table", kwargs={"component_id": sample_component.id})
+        response = client.get(url)
+
+        assert response.status_code == 200

--- a/sbomify/apps/sboms/views/sboms_table.py
+++ b/sbomify/apps/sboms/views/sboms_table.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseBase
 from django.shortcuts import render
 from django.views import View
 
@@ -11,6 +11,22 @@ from sbomify.apps.sboms.services.sboms_table import build_sboms_table_context, d
 
 
 class SbomsTableView(View):
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        """Gate the private route only, the way DocumentsTableView does.
+
+        One class serves both routes. A public component clears the
+        component-level check even for an anonymous caller, so without this the
+        private route reached the workspace lookup holding AnonymousUser and
+        raised. A blanket login requirement would wrongly close the public route.
+        """
+        if not kwargs.get("is_public_view", False) and not request.user.is_authenticated:
+            from django.contrib.auth.views import redirect_to_login
+            from django.urls import reverse
+
+            return redirect_to_login(request.get_full_path(), reverse("core:keycloak_login"))
+
+        return super().dispatch(request, *args, **kwargs)
+
     def get(self, request: HttpRequest, component_id: str, is_public_view: bool) -> HttpResponse:
         result = build_sboms_table_context(request, component_id, is_public_view)
         if not result.ok:

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -28,7 +28,7 @@
                 <div class="tw-alert-content">
                     <p class="tw-alert-title">Unscoped tokens detected</p>
                     <p class="text-sm m-0">
-                        You have tokens that are not scoped to any workspace. These tokens grant access to all your workspaces and will be deprecated in a future release. Please create new workspace-scoped tokens and delete the unscoped ones.
+                        These tokens reach every workspace you belong to. They stay valid until you rotate them; there is no forced cutover or auto-expiry. Create a workspace-scoped replacement, move your integration across, then delete the unscoped token.
                     </p>
                 </div>
             </div>

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -209,7 +209,7 @@ class TestTeamTokensView:
         assert "Token B" not in content
 
     def test_unscoped_tokens_shown_with_warning(self, client: Client, sample_team_with_owner_member):
-        """Create unscoped token, verify deprecation warning in response."""
+        """Create unscoped token, verify the banner flags it."""
         team = sample_team_with_owner_member.team
         user = sample_team_with_owner_member.user
         setup_authenticated_client_session(client, team, user)
@@ -224,6 +224,21 @@ class TestTeamTokensView:
         assert "Legacy Token" in content
         assert "Unscoped" in content
         assert "Unscoped tokens detected" in content
+
+    def test_banner_promises_no_cutover(self, client: Client, sample_team_with_owner_member):
+        """docs/access-tokens.md says these stay valid until you rotate them, so
+        the banner must not announce a removal nobody has scheduled."""
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        AccessToken.objects.create(user=user, description="Legacy Token", encoded_token="legacy_token", team=None)
+
+        response = client.get(reverse("teams:team_tokens", kwargs={"team_key": team.key}))
+        content = response.content.decode()
+
+        assert "deprecated" not in content.lower()
+        assert "no forced cutover" in content
 
     def test_legacy_member_role_is_forbidden(self, client: Client, sample_team_with_owner_member):
         """Legacy ``role="member"`` is now rejected by the tokens view.


### PR DESCRIPTION
Closes #1203, #1077, #1134. Three small unrelated issues, one commit each.

## #1203: anonymous request to the private artifacts table 500s

`SbomsTableView` serves the public and the private route off one class. A public component clears `get_component` even for an anonymous caller, so the private route carried on to the workspace lookup and evaluated `Member.objects.filter(user=AnonymousUser)`, which raises `TypeError: Field 'id' expected a number`. Private components never got that far, so only public ones 500d.

`DocumentsTableView` already gates this correctly in `dispatch`, so this copies that rather than inventing a second answer: public route stays open, private route redirects to login. A blanket `LoginRequiredMixin` would have closed the public route.

Verified against a running instance, public component, unauthenticated:

| Route | Before | After |
|---|---|---|
| `/component/<id>/sboms/` | 500 | 302 |
| `/public/component/<id>/sboms/` | 200 | 200 |

One note for whoever reads the test. It sets `visibility`, not `is_public`. `public_access_allowed` reads `visibility`, so an `is_public`-only fixture returns 403 from `get_component` and never reaches the bug. My first attempt did exactly that and passed for the wrong reason.

## #1077: token banner promises a deprecation that is not planned

The banner said unscoped tokens "will be deprecated in a future release". `docs/access-tokens.md` says the opposite: no forced cutover or auto-expiry, because one would break existing CI, so rotate at your convenience. Reworded to match the doc.

No link to the doc. The issue offered it as optional, and I could not verify a published URL for it.

## #1134: KEV badge never exercised

Each piece worked and `kev` defaults to false, so the red badge never rendered in any check: no fixture held a CVE that is actually in CISA's catalog.

Covers the three steps with Log4Shell, a real KEV entry:

- `finding_in_kev` matching by id, by alias, and case-insensitively. The alias case is the one that matters in practice: OSV reports the GHSA id and carries the CVE in `aliases`.
- `_result_with_kev` stamping only the listed finding and leaving the stored blob alone.
- The template rendering the badge for a stamped finding and not for an unstamped one.

The catalog is passed in as a frozenset, so nothing fetches the CISA feed. An empty catalog is covered too, since a failed fetch caches one and it has to read as "no badge" rather than stamping everything.

## Testing

The plugins suite (846) and the teams token tests pass. Ten failures in `sboms/tests` are identical with these commits stashed, so they predate this branch; they also look environmental, since I ran in the dev container rather than the tests container.
