### PR TITLE
feat(plugins): on-demand assessment re-run

### DIFF
--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -307,6 +307,9 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
         from sbomify.apps.core.authz import can
 
         can_triage = can(request, "artifact:publish_vex", component)
+        # Same tier the rerun endpoint enforces, so the button is only offered
+        # to a caller the API would actually accept.
+        can_rerun = can(request, "component:manage", component)
 
         return render(
             request,
@@ -326,6 +329,7 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 "is_cbom": is_cbom,
                 "is_sbom_backed": is_sbom_backed,
                 "can_triage": can_triage,
+                "can_rerun": can_rerun,
                 "team_key": component.team.key,
             },
         )

--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -7,11 +7,14 @@ from django.db.models import OuterRef, Subquery
 from django.http import HttpRequest
 from ninja import Router
 from ninja.decorators import decorate_view
+from ninja.security import django_auth
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
-from sbomify.apps.access_tokens.auth import optional_auth
+from sbomify.apps.access_tokens.auth import PersonalAccessTokenAuth, optional_auth
+from sbomify.apps.access_tokens.throttling import AccessTokenHeavyRateThrottle, AccessTokenRateThrottle
 from sbomify.apps.core.authz import can
+from sbomify.apps.core.schemas import ErrorCode, ErrorResponse
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member, Team
 from sbomify.logging import getLogger
@@ -23,7 +26,8 @@ from .schemas import (
     AssessmentStatusSummary,
     SBOMAssessmentsResponse,
 )
-from .sdk.enums import RunStatus
+from .sdk.enums import RunReason, RunStatus
+from .tasks import run_assessment_task
 
 logger = getLogger(__name__)
 
@@ -696,3 +700,70 @@ def update_team_plugin_settings(
         "enabled_plugins": settings.enabled_plugins,
         "plugin_configs": settings.plugin_configs,
     }
+
+
+class AssessmentRerunResponse(BaseModel):
+    """Acknowledgement that a re-run was accepted onto the queue."""
+
+    sbom_id: str
+    plugin_name: str
+    status: str
+
+
+@router.post(
+    "/assessments/{sbom_id}/{plugin_name}/rerun",
+    response={
+        202: AssessmentRerunResponse,
+        400: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+    },
+    auth=(PersonalAccessTokenAuth(), django_auth),
+    # A re-run enqueues a scan, so it carries the heavy limit as well as the
+    # global per-token one. Passing a per-op throttle replaces the global,
+    # hence both.
+    throttle=[AccessTokenRateThrottle(), AccessTokenHeavyRateThrottle()],
+)
+def rerun_assessment(request: HttpRequest, sbom_id: str, plugin_name: str) -> tuple[int, Any]:
+    """Queue a fresh run of one plugin against one SBOM.
+
+    The manual path existed on every layer but the top: ``RunReason.MANUAL``,
+    ``AssessmentRun.triggered_by_user`` and the task's ``triggered_by_user_id``
+    were all in place with nothing able to call them, so recovering from a
+    misconfigured plugin or an outage meant re-uploading the SBOM.
+    """
+    sbom = SBOM.objects.select_related("component__team").filter(id=sbom_id).first()
+    if sbom is None:
+        return 404, {"detail": "SBOM not found", "error_code": ErrorCode.NOT_FOUND}
+
+    # Re-running writes a new run against the component, so it needs the same
+    # tier as managing it. A read-only member cannot spend the queue.
+    if not can(request, "component:manage", sbom.component):
+        return 403, {"detail": "Forbidden", "error_code": ErrorCode.FORBIDDEN}
+
+    registered = RegisteredPlugin.objects.filter(name=plugin_name).only("name", "is_enabled").first()
+    if registered is None:
+        return 404, {"detail": f"Plugin '{plugin_name}' is not registered", "error_code": ErrorCode.NOT_FOUND}
+    if not registered.is_enabled:
+        return 400, {"detail": f"Plugin '{plugin_name}' is disabled", "error_code": ErrorCode.BAD_REQUEST}
+
+    # A plugin the workspace turned off must not be reachable by URL: the
+    # orchestrator would happily run it, and the result would appear on a card
+    # the workspace expects to be empty.
+    settings = TeamPluginSettings.objects.filter(team_id=sbom.component.team_id).first()
+    if settings is not None and not settings.is_plugin_enabled(plugin_name):
+        return 400, {
+            "detail": f"Plugin '{plugin_name}' is not enabled for this workspace",
+            "error_code": ErrorCode.BAD_REQUEST,
+        }
+
+    user = getattr(request, "user", None)
+    run_assessment_task.send(
+        sbom_id=sbom.id,
+        plugin_name=plugin_name,
+        run_reason=RunReason.MANUAL.value,
+        triggered_by_user_id=user.id if user is not None and user.is_authenticated else None,
+    )
+
+    logger.info(f"[RERUN] Queued {plugin_name} for SBOM {sbom.id}")
+    return 202, {"sbom_id": sbom.id, "plugin_name": plugin_name, "status": "queued"}

--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -747,11 +747,17 @@ def rerun_assessment(request: HttpRequest, sbom_id: str, plugin_name: str) -> tu
     if not registered.is_enabled:
         return 400, {"detail": f"Plugin '{plugin_name}' is disabled", "error_code": ErrorCode.BAD_REQUEST}
 
-    # A plugin the workspace turned off must not be reachable by URL: the
+    # A plugin the workspace has not enabled must not be reachable by URL: the
     # orchestrator would happily run it, and the result would appear on a card
     # the workspace expects to be empty.
+    #
+    # A missing settings row means "nothing enabled", not "everything allowed".
+    # That is what the rest of the codebase already does: the task layer returns
+    # [] on DoesNotExist ("no plugins to run") and the signal path treats an
+    # empty list as having opted out. Reading it the other way here would let a
+    # re-run start the one thing no other path would.
     settings = TeamPluginSettings.objects.filter(team_id=sbom.component.team_id).first()
-    if settings is not None and not settings.is_plugin_enabled(plugin_name):
+    if settings is None or not settings.is_plugin_enabled(plugin_name):
         return 400, {
             "detail": f"Plugin '{plugin_name}' is not enabled for this workspace",
             "error_code": ErrorCode.BAD_REQUEST,

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -67,6 +67,7 @@
                                         <i class="fas fa-play-circle mr-1"></i>
                                         {{ run.run_reason|format_run_reason }}
                                     </span>
+                                    {% include 'plugins/components/_rerun_button.html.j2' %}
                                     {% if run.completed_at %}
                                         <span>
                                             <i class="fas fa-calendar-check mr-1"></i>
@@ -335,6 +336,7 @@
                                     <i class="fas fa-play-circle mr-1"></i>
                                     {{ run.run_reason|format_run_reason }}
                                 </span>
+                                {% include 'plugins/components/_rerun_button.html.j2' %}
                                 {% if run.completed_at %}
                                     <span>
                                         <i class="fas fa-calendar-check mr-1"></i>

--- a/sbomify/apps/plugins/templates/plugins/components/_rerun_button.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_rerun_button.html.j2
@@ -1,0 +1,14 @@
+{% comment %}Re-run control for one plugin against one SBOM. Included from both branches of _assessment_run_item so the markup lives in one place. Expects run, sbom_id and can_rerun from the surrounding context. Posts to the ninja endpoint directly, the way the triage modal and the danger zones do, because ninja routes carry no Django url name.{% endcomment %}
+{% if can_rerun and sbom_id and run.status != 'running' and run.status != 'pending' %}
+    <span x-data="{ busy: false, done: false, err: '' }" @click.stop>
+        <button type="button"
+                class="tw-badge-secondary hover:text-primary disabled:opacity-50"
+                :disabled="busy || done"
+                :title="err || (done ? 'Queued. Results appear once the run finishes.' : 'Run this plugin again')"
+                @click="busy = true; err = ''; fetch('/api/v1/plugins/assessments/{{ sbom_id|escapejs }}/{{ run.plugin_name|escapejs }}/rerun', { method: 'POST', headers: { 'X-CSRFToken': (document.cookie.match(/csrftoken=([^;]+)/) || [])[1] || '' } }) .then(async r => { if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.detail || ('Request failed (' + r.status + ')')); } done = true; if (window.showToast) window.showToast({ title: 'Re-run queued', type: 'success', message: 'Results appear once the run finishes.' }); }) .catch(e => { err = e.message; if (window.showToast) window.showToast({ title: 'Re-run failed', type: 'error', message: e.message }); }) .finally(() => { busy = false; })">
+            <i class="fas mr-1"
+               :class="busy ? 'fa-spinner fa-spin' : (done ? 'fa-check' : 'fa-rotate-right')"></i>
+            <span x-text="done ? 'Queued' : 'Re-run'"></span>
+        </button>
+    </span>
+{% endif %}

--- a/sbomify/apps/plugins/tests/test_rerun_api.py
+++ b/sbomify/apps/plugins/tests/test_rerun_api.py
@@ -46,8 +46,14 @@ def enabled_plugin():
 
 @pytest.fixture
 def owner_client(sample_sbom, sample_user):  # noqa: F811
-    """A logged-in owner of the SBOM's workspace."""
+    """A logged-in owner of the SBOM's workspace, with the plugin enabled.
+
+    The enablement is part of the contract, not scenery: without a settings row
+    the endpoint refuses, the same way every other path reads a missing row as
+    "nothing enabled".
+    """
     team = sample_sbom.component.team
+    TeamPluginSettings.objects.update_or_create(team=team, defaults={"enabled_plugins": ["osv"]})
     Member.objects.get_or_create(user=sample_user, team=team, defaults={"role": "owner"})
     client = Client()
     client.force_login(sample_user)
@@ -117,6 +123,17 @@ class TestRerunIsGated:
     def test_globally_disabled_plugin_is_rejected(self, owner_client, sample_sbom, enabled_plugin, mocker):  # noqa: F811
         enabled_plugin.is_enabled = False
         enabled_plugin.save()
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url(sample_sbom.id))
+
+        assert response.status_code == 400
+        send.assert_not_called()
+
+    def test_a_workspace_with_no_settings_row_is_rejected(self, owner_client, sample_sbom, enabled_plugin, mocker):  # noqa: F811
+        """A missing row means nothing is enabled, matching the task and signal
+        paths, so it must not read as "everything allowed"."""
+        TeamPluginSettings.objects.filter(team=sample_sbom.component.team).delete()
         send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
 
         response = owner_client.post(_url(sample_sbom.id))

--- a/sbomify/apps/plugins/tests/test_rerun_api.py
+++ b/sbomify/apps/plugins/tests/test_rerun_api.py
@@ -1,0 +1,145 @@
+"""Manual assessment re-run.
+
+Every layer below the API already supported a manual run (``RunReason.MANUAL``,
+``AssessmentRun.triggered_by_user``, the task's ``triggered_by_user_id``) with
+nothing able to call it, so these cover the endpoint that closes the gap and the
+gates it has to hold.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.tests.fixtures import sample_user  # noqa: F401
+from sbomify.apps.plugins.models import RegisteredPlugin, TeamPluginSettings
+from sbomify.apps.sboms.models import SBOM, Component
+from sbomify.apps.sboms.tests.fixtures import (  # noqa: F401
+    sample_component,
+    sample_product,
+    sample_sbom,
+)
+from sbomify.apps.teams.models import Member
+
+pytestmark = pytest.mark.django_db
+
+
+def _url(sbom_id: str, plugin_name: str = "osv") -> str:
+    return f"/api/v1/plugins/assessments/{sbom_id}/{plugin_name}/rerun"
+
+
+@pytest.fixture
+def enabled_plugin():
+    plugin, _ = RegisteredPlugin.objects.update_or_create(
+        name="osv",
+        defaults={
+            "display_name": "OSV Vulnerability Scanner",
+            "category": "security",
+            "version": "1.0.0",
+            "plugin_class_path": "sbomify.apps.plugins.builtins.osv.OSVPlugin",
+            "is_enabled": True,
+        },
+    )
+    return plugin
+
+
+@pytest.fixture
+def owner_client(sample_sbom, sample_user):  # noqa: F811
+    """A logged-in owner of the SBOM's workspace."""
+    team = sample_sbom.component.team
+    Member.objects.get_or_create(user=sample_user, team=team, defaults={"role": "owner"})
+    client = Client()
+    client.force_login(sample_user)
+    session = client.session
+    session["current_team"] = {"id": team.id, "key": team.key, "role": "owner"}
+    session.save()
+    return client
+
+
+class TestRerunSucceeds:
+    def test_owner_queues_a_run(self, owner_client, sample_sbom, enabled_plugin, mocker):  # noqa: F811
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url(sample_sbom.id))
+
+        assert response.status_code == 202
+        assert response.json() == {"sbom_id": sample_sbom.id, "plugin_name": "osv", "status": "queued"}
+        send.assert_called_once()
+
+    def test_the_run_is_attributed_to_the_caller(self, owner_client, sample_sbom, sample_user, enabled_plugin, mocker):  # noqa: F811
+        """Without this the timeline cannot say who asked for the re-run."""
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        owner_client.post(_url(sample_sbom.id))
+
+        kwargs = send.call_args.kwargs
+        assert kwargs["run_reason"] == "manual"
+        assert kwargs["triggered_by_user_id"] == sample_user.id
+
+
+class TestRerunIsGated:
+    def test_anonymous_is_rejected(self, sample_sbom, enabled_plugin, mocker):  # noqa: F811
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = Client().post(_url(sample_sbom.id))
+
+        assert response.status_code in (401, 403)
+        send.assert_not_called()
+
+    def test_a_non_member_cannot_spend_the_queue(self, sample_sbom, enabled_plugin, django_user_model, mocker):  # noqa: F811
+        outsider = django_user_model.objects.create_user(username="outsider", password="x")  # noqa: S106
+        client = Client()
+        client.force_login(outsider)
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = client.post(_url(sample_sbom.id))
+
+        assert response.status_code == 403
+        send.assert_not_called()
+
+    def test_unknown_sbom_is_404(self, owner_client, enabled_plugin, mocker):
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url("does-not-exist"))
+
+        assert response.status_code == 404
+        send.assert_not_called()
+
+    def test_unregistered_plugin_is_404(self, owner_client, sample_sbom, mocker):  # noqa: F811
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url(sample_sbom.id, "no-such-plugin"))
+
+        assert response.status_code == 404
+        send.assert_not_called()
+
+    def test_globally_disabled_plugin_is_rejected(self, owner_client, sample_sbom, enabled_plugin, mocker):  # noqa: F811
+        enabled_plugin.is_enabled = False
+        enabled_plugin.save()
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url(sample_sbom.id))
+
+        assert response.status_code == 400
+        send.assert_not_called()
+
+    def test_a_plugin_the_workspace_turned_off_is_rejected(
+        self, owner_client, sample_sbom, enabled_plugin, mocker
+    ):  # noqa: F811
+        """Otherwise a URL reaches past the workspace's own plugin settings and
+        puts a result on a card it expects to stay empty."""
+        TeamPluginSettings.objects.update_or_create(
+            team=sample_sbom.component.team, defaults={"enabled_plugins": ["ntia-minimum-elements-2021"]}
+        )
+        send = mocker.patch("sbomify.apps.plugins.apis.run_assessment_task.send")
+
+        response = owner_client.post(_url(sample_sbom.id))
+
+        assert response.status_code == 400
+        send.assert_not_called()
+
+
+def test_component_and_sbom_models_are_importable():
+    """Guards the fixture imports above from silently drifting."""
+    assert SBOM is not None and Component is not None and reverse is not None


### PR DESCRIPTION
Closes #1145.

The manual path existed on every layer but the top: `RunReason.MANUAL`, `AssessmentRun.triggered_by_user` and the task's `triggered_by_user_id` were all in place with nothing able to call them. Recovering from a misconfigured plugin or a Dependency Track outage meant re-uploading the SBOM.

`POST /api/v1/plugins/assessments/{sbom_id}/{plugin_name}/rerun` enqueues with `RunReason.MANUAL` and attributes the run to the caller, so the timeline can say who asked. It carries `AccessTokenHeavyRateThrottle` alongside the global one, since a per-op throttle replaces the global rather than adding to it.

## Gates

| Check | Why |
|---|---|
| `can(request, "component:manage")` | re-running writes a run against the component, so a read-only member should not be able to spend the queue |
| plugin registered and globally enabled | mirrors what the orchestrator would refuse anyway, but with a useful status code |
| plugin enabled **for the workspace** | without it a URL reaches past the workspace's own plugin settings and puts a result on a card it expects to stay empty |

## UI

The control lives in the run metadata row through a shared partial, so the markup is not duplicated across the template's security and compliance branches. It is hidden while a run is pending or running, and gated on the same `can()` tier the endpoint enforces, so the button is only offered to a caller the API would accept. It posts to the ninja route directly, which is what the triage modal and the danger zones already do, since ninja routes carry no Django url name.

## Testing

9 tests: the happy path, attribution of `run_reason`/`triggered_by_user_id`, and one per gate (anonymous, non-member, unknown SBOM, unregistered plugin, globally disabled, workspace-disabled). Each rejection asserts the task was never enqueued, not just the status code. 852 plugin tests pass.

Four failures in `test_component_views.py` are identical with this branch stashed.