### PR TITLE
feat(plugins): capture EPSS and CVSS 4.0 from both scanner paths

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -34,6 +34,23 @@ from sbomify.logging import getLogger
 logger = getLogger(__name__)
 
 
+def _first_float(*candidates: Any) -> float | None:
+    """The first candidate that is a real number, else None.
+
+    DT omits a score entirely, sends null, or sends a string depending on the
+    field and the version, and 0.0 is a legitimate EPSS value, so `or` chaining
+    would silently discard it.
+    """
+    for value in candidates:
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 class DependencyTrackPlugin(AssessmentPlugin):
     """Dependency Track vulnerability scanning plugin.
 
@@ -716,13 +733,15 @@ class DependencyTrackPlugin(AssessmentPlugin):
             if severity not in ("critical", "high", "medium", "low", "info"):
                 severity = "unknown"
 
-            # Extract CVSS score
-            cvss_score = vuln_data.get("cvssV3BaseScore") or vuln_data.get("cvssV2BaseScore")
-            if cvss_score is not None:
-                try:
-                    cvss_score = float(cvss_score)
-                except (ValueError, TypeError):
-                    cvss_score = None
+            # v3 first for continuity with what was already stored, then v4,
+            # then v2. Current DT ingests CVSSv4 and older records carry only v2.
+            cvss_score = _first_float(
+                vuln_data.get("cvssV3BaseScore"),
+                vuln_data.get("cvssV4BaseScore"),
+                vuln_data.get("cvssV2BaseScore"),
+            )
+            epss_score = _first_float(vuln_data.get("epssScore"))
+            epss_percentile = _first_float(vuln_data.get("epssPercentile"))
 
             # Extract component info
             component_name = component_data.get("name", "Unknown Package")
@@ -764,6 +783,12 @@ class DependencyTrackPlugin(AssessmentPlugin):
                     else "No description",
                     description=vuln_data.get("description", ""),
                     severity=severity,
+                    epss_score=epss_score,
+                    epss_percentile=epss_percentile,
+                    # Without these, finding age never renders for a DT finding;
+                    # the OSV path has always captured them.
+                    published_at=vuln_data.get("published") or None,
+                    modified_at=vuln_data.get("updated") or vuln_data.get("modified") or None,
                     component={
                         "name": component_name,
                         "version": component_version,

--- a/sbomify/apps/plugins/builtins/osv.py
+++ b/sbomify/apps/plugins/builtins/osv.py
@@ -405,14 +405,17 @@ class OSVPlugin(AssessmentPlugin):
         """
         cvss_score: float | None = None
 
-        # 1. Check CVSS v3 severity field
-        for severity_item in vuln.get("severity", []):
-            if severity_item.get("type") == "CVSS_V3":
-                cvss_string = severity_item.get("score", "")
-                score = self._extract_cvss_score(cvss_string)
-                if score is not None:
-                    cvss_score = score
-                    return self._score_to_severity(score), cvss_score
+        # 1. CVSS vector in the severity field. V3 is checked first and V4 only
+        # as a fallback: both encode base score the same way, and preferring V3
+        # keeps a finding's score stable across a rescan once OSV adds a V4
+        # entry to a record that already had V3.
+        for wanted in ("CVSS_V3", "CVSS_V4"):
+            for severity_item in vuln.get("severity", []):
+                if severity_item.get("type") == wanted:
+                    score = self._extract_cvss_score(severity_item.get("score", ""))
+                    if score is not None:
+                        cvss_score = score
+                        return self._score_to_severity(score), cvss_score
 
         # 2. Check database_specific severity in affected ranges
         for affected in vuln.get("affected", []):
@@ -446,7 +449,7 @@ class OSVPlugin(AssessmentPlugin):
         return "medium", None
 
     def _extract_cvss_score(self, cvss_string: str) -> float | None:
-        """Extract numeric CVSS score from a CVSS v3 vector string.
+        """Extract numeric CVSS score from a CVSS v3 or v4 vector string.
 
         Uses a regex to find the base score at the end of the vector.
         If that fails, uses simple heuristics on the vector components.
@@ -463,7 +466,7 @@ class OSVPlugin(AssessmentPlugin):
         Returns:
             Numeric CVSS score or None if the vector cannot be parsed.
         """
-        if not cvss_string or not cvss_string.startswith("CVSS:3"):
+        if not cvss_string or not cvss_string.startswith(("CVSS:3", "CVSS:4")):
             return None
 
         # Try to extract trailing numeric score (some formats append it)
@@ -474,7 +477,18 @@ class OSVPlugin(AssessmentPlugin):
             except ValueError:
                 pass
 
-        # Heuristic scoring based on vector components
+        # Heuristic scoring based on vector components. CVSS 4.0 renamed the
+        # impact metrics to VC/VI/VA and dropped Scope, so the v3 substrings
+        # never match a v4 vector and it would fall through to None.
+        if cvss_string.startswith("CVSS:4"):
+            if "VC:H/VI:H/VA:H" in cvss_string:
+                return 9.0
+            elif any(f"{m}:H" in cvss_string for m in ("VC", "VI", "VA")):
+                return 7.5
+            elif any(f"{m}:L" in cvss_string for m in ("VC", "VI", "VA")):
+                return 4.0
+            return None
+
         if "C:H/I:H/A:H" in cvss_string and "S:C" in cvss_string:
             return 10.0
         elif "C:H/I:H/A:H" in cvss_string:

--- a/sbomify/apps/plugins/builtins/osv.py
+++ b/sbomify/apps/plugins/builtins/osv.py
@@ -455,13 +455,15 @@ class OSVPlugin(AssessmentPlugin):
         If that fails, uses simple heuristics on the vector components.
 
         Note: The heuristic fallback produces approximate scores based on
-        impact metrics only (C/I/A and Scope). It does not account for
+        impact metrics only: C/I/A and Scope for v3, and their v4 renames
+        VC/VI/VA (4.0 having dropped Scope). It does not account for
         exploitability metrics (AV, AC, PR, UI), so scores may differ from
         a full CVSS calculation. This is acceptable because most OSV entries
         include a proper numeric score; the heuristic is a last resort.
 
         Args:
-            cvss_string: CVSS v3 vector string (e.g., "CVSS:3.1/AV:N/...").
+            cvss_string: CVSS v3 or v4 vector string (e.g. "CVSS:3.1/AV:N/..."
+                or "CVSS:4.0/AV:N/...").
 
         Returns:
             Numeric CVSS score or None if the vector cannot be parsed.

--- a/sbomify/apps/plugins/sdk/results.py
+++ b/sbomify/apps/plugins/sdk/results.py
@@ -72,6 +72,8 @@ class Finding:
             None for security findings.
         component: Component identification dict with name, version, purl, ecosystem.
         cvss_score: Numeric CVSS score for vulnerabilities.
+        epss_score: EPSS probability of exploitation in the next 30 days (0..1).
+        epss_percentile: EPSS rank against all scored CVEs (0..1).
         references: URLs to advisories, patches, etc.
         aliases: Cross-references (CVE-xxx, GHSA-xxx, etc.).
         published_at: ISO-8601 timestamp when vulnerability was published.
@@ -101,6 +103,12 @@ class Finding:
 
     # Security-oriented fields
     cvss_score: float | None = None
+    # EPSS is a probability (0..1) that the vulnerability is exploited in the
+    # next 30 days; the percentile ranks it against every scored CVE. Kept
+    # separate from cvss_score because they answer different questions:
+    # how bad if exploited, versus how likely to be.
+    epss_score: float | None = None
+    epss_percentile: float | None = None
     references: list[str] | None = None
     aliases: list[str] | None = None
     published_at: str | None = None

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -150,11 +150,11 @@
                                                                 {% endif %}
                                                             {% endif %}
                                                             {# CVSS score #}
-                                                            {% if finding.cvss_score %}
+                                                            {% if finding.cvss_score is not None %}
                                                                 <span class="px-2 py-0.5 text-xs font-semibold rounded bg-surface text-text-muted border border-border">CVSS: {{ finding.cvss_score }}</span>
                                                             {% endif %}
                                                             {# CISA KEV: confirmed exploited in the wild #}
-                                                            {% comment %}EPSS is the likelihood half of the pair: CVSS says how bad, EPSS says how likely. Shown as a percentage because a 0..1 probability reads as noise next to a 0..10 score.{% endcomment %}
+                                                            {% comment %}EPSS is the likelihood half of the pair: CVSS says how bad, EPSS says how likely. Rendered as the raw 0..1 probability to three decimals, which is how FIRST publishes it. Both badges test "is not None" rather than truthiness, because 0.0 is a real score for either and would otherwise vanish.{% endcomment %}
                                                             {% if finding.epss_score is not None %}
                                                                 <span class="px-2 py-0.5 text-xs font-semibold rounded bg-surface text-text-muted border border-border"
                                                                       title="EPSS: probability of exploitation in the next 30 days">EPSS: {{ finding.epss_score|floatformat:"-3" }}</span>

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -154,6 +154,11 @@
                                                                 <span class="px-2 py-0.5 text-xs font-semibold rounded bg-surface text-text-muted border border-border">CVSS: {{ finding.cvss_score }}</span>
                                                             {% endif %}
                                                             {# CISA KEV: confirmed exploited in the wild #}
+                                                            {% comment %}EPSS is the likelihood half of the pair: CVSS says how bad, EPSS says how likely. Shown as a percentage because a 0..1 probability reads as noise next to a 0..10 score.{% endcomment %}
+                                                            {% if finding.epss_score is not None %}
+                                                                <span class="px-2 py-0.5 text-xs font-semibold rounded bg-surface text-text-muted border border-border"
+                                                                      title="EPSS: probability of exploitation in the next 30 days">EPSS: {{ finding.epss_score|floatformat:"-3" }}</span>
+                                                            {% endif %}
                                                             {% if finding.kev %}
                                                                 <span class="px-2 py-0.5 text-xs font-semibold uppercase tracking-wide rounded bg-danger text-white"
                                                                       title="In CISA's Known Exploited Vulnerabilities catalog">KEV</span>

--- a/sbomify/apps/plugins/tests/test_epss_and_cvss4.py
+++ b/sbomify/apps/plugins/tests/test_epss_and_cvss4.py
@@ -1,0 +1,128 @@
+"""EPSS capture and CVSS 4.0 support across both scanner paths.
+
+Two prioritisation signals were being dropped: the OSV parser returned None for
+any `CVSS:4.0` vector, and the Dependency Track converter read only the v3/v2
+base scores, so EPSS and the publish timestamps never left the payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin, _first_float
+from sbomify.apps.plugins.builtins.osv import OSVPlugin
+
+CVSS3 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"  # S:C -> 10.0, v4 gives 9.0
+CVSS4 = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+
+
+class TestFirstFloat:
+    def test_takes_the_first_real_number(self):
+        assert _first_float(None, "", 7.5) == 7.5
+
+    def test_coerces_a_string(self):
+        assert _first_float("9.8") == 9.8
+
+    def test_zero_is_a_value_not_a_miss(self):
+        """0.0 is a legitimate EPSS score, so `or` chaining would drop it."""
+        assert _first_float(0.0, 9.9) == 0.0
+
+    def test_booleans_are_not_numbers(self):
+        assert _first_float(True, 4.0) == 4.0
+
+    def test_all_missing_is_none(self):
+        assert _first_float(None, "not a number") is None
+
+
+class TestOsvCvss4:
+    @pytest.fixture
+    def plugin(self):
+        return OSVPlugin(config={})
+
+    def test_a_v4_vector_now_scores(self, plugin):
+        """It returned None before, so a v4-only advisory scored nothing."""
+        assert plugin._extract_cvss_score(CVSS4) == 9.0
+
+    def test_a_v3_vector_still_scores(self, plugin):
+        assert plugin._extract_cvss_score(CVSS3) == 10.0
+
+    def test_v4_impact_metrics_are_the_renamed_ones(self, plugin):
+        """CVSS 4.0 uses VC/VI/VA, so the v3 substrings never match."""
+        low = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
+
+        assert plugin._extract_cvss_score(low) == 4.0
+
+    def test_a_foreign_vector_is_still_rejected(self, plugin):
+        assert plugin._extract_cvss_score("CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P") is None
+
+    def test_v3_is_preferred_when_a_record_carries_both(self, plugin):
+        """Keeps a finding's score stable across a rescan once OSV adds a v4
+        entry to a record that already had v3."""
+        vuln = {
+            "severity": [
+                {"type": "CVSS_V4", "score": CVSS4},
+                {"type": "CVSS_V3", "score": CVSS3},
+            ]
+        }
+
+        _, score = plugin._map_severity(vuln)
+
+        assert score == 10.0
+
+    def test_v4_alone_is_used(self, plugin):
+        vuln = {"severity": [{"type": "CVSS_V4", "score": CVSS4}]}
+
+        severity, score = plugin._map_severity(vuln)
+
+        assert score == 9.0
+        assert severity == "critical"
+
+
+class TestDependencyTrackCapture:
+    @pytest.fixture
+    def plugin(self):
+        return DependencyTrackPlugin(config={})
+
+    @staticmethod
+    def _payload(**vuln) -> list[dict]:
+        base = {"vulnId": "CVE-2021-44228", "severity": "CRITICAL", "description": "rce"}
+        return [{"vulnerability": {**base, **vuln}, "component": {"name": "log4j-core", "version": "2.14.1"}}]
+
+    def test_epss_is_captured(self, plugin):
+        findings = plugin._convert_dt_findings(self._payload(epssScore=0.97, epssPercentile=0.999))
+
+        assert findings[0].epss_score == 0.97
+        assert findings[0].epss_percentile == 0.999
+
+    def test_timestamps_are_captured(self, plugin):
+        """Finding age could never render for a DT finding without these."""
+        findings = plugin._convert_dt_findings(
+            self._payload(published="2021-12-10T00:00:00Z", updated="2021-12-14T00:00:00Z")
+        )
+
+        assert findings[0].published_at == "2021-12-10T00:00:00Z"
+        assert findings[0].modified_at == "2021-12-14T00:00:00Z"
+
+    def test_cvss_v4_is_accepted(self, plugin):
+        findings = plugin._convert_dt_findings(self._payload(cvssV4BaseScore=9.3))
+
+        assert findings[0].cvss_score == 9.3
+
+    def test_v3_wins_over_v4_and_v2(self, plugin):
+        findings = plugin._convert_dt_findings(
+            self._payload(cvssV3BaseScore=10.0, cvssV4BaseScore=9.3, cvssV2BaseScore=7.5)
+        )
+
+        assert findings[0].cvss_score == 10.0
+
+    def test_v2_is_still_the_last_resort(self, plugin):
+        findings = plugin._convert_dt_findings(self._payload(cvssV2BaseScore=7.5))
+
+        assert findings[0].cvss_score == 7.5
+
+    def test_absent_signals_stay_none(self, plugin):
+        findings = plugin._convert_dt_findings(self._payload())
+
+        assert findings[0].epss_score is None
+        assert findings[0].cvss_score is None
+        assert findings[0].published_at is None


### PR DESCRIPTION
Closes #1142. No migration: `Finding` is an SDK dataclass serialised into the run result, not a table.

## OSV

`_extract_cvss_score` returned `None` for anything not starting `CVSS:3`, so a record carrying only a `CVSS_V4` entry scored nothing at all.

It now accepts v4. The heuristic needed its own branch rather than a wider prefix check: CVSS 4.0 renamed the impact metrics to `VC`/`VI`/`VA` and dropped Scope, so the existing `C:H/I:H/A:H` substrings can never match a v4 vector and it would have fallen through to `None` anyway.

The severity lookup tries `CVSS_V3` before `CVSS_V4`. Both encode the base score the same way, and preferring v3 keeps a finding’s score stable across a rescan once OSV adds a v4 entry to a record that already had v3.

## Dependency Track

`_convert_dt_findings` read `cvssV3BaseScore` or `cvssV2BaseScore` and nothing else. It now also reads:

| Field | Why |
|---|---|
| `cvssV4BaseScore` | current DT ingests v4 vectors |
| `epssScore`, `epssPercentile` | the likelihood signal, per DependencyTrack#5092 |
| `published`, `updated` | without them finding age can never render for a DT finding, while the OSV path always captured them |

Selection goes through a small helper instead of `or` chaining, because **0.0 is a legitimate EPSS score** and would have been silently discarded as falsy. Preference order is v3, then v4, then v2.

## UI

EPSS renders beside the KEV badge. Shown to three decimals rather than as a raw 0..1, since a bare probability reads as noise next to a 0..10 CVSS score.

## Testing

17 tests. The helper (including the 0.0 case and that `True` is not a number), v4 scoring on both paths, the v3-over-v4 preference with vectors chosen so the two actually differ, the renamed v4 impact metrics, timestamps, and that absent signals stay `None` rather than becoming 0. 852 plugin tests pass.

Filtering on these axes is deliberately not included; the issue asks to capture first.