### PR TITLE
feat(security): per-IP rate limit for anonymous and public endpoints

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -142,7 +142,7 @@ jobs:
           - name: "Licensing Tests"
             path: "sbomify/apps/licensing/tests/"
           - name: "Access Token Tests"
-            path: "sbomify/apps/access_tokens/tests.py"
+            path: "sbomify/apps/access_tokens/"
           - name: "Notification Tests"
             path: "sbomify/apps/notifications/tests.py"
           - name: "Onboarding Tests"

--- a/bin/check_ci_test_matrix.py
+++ b/bin/check_ci_test_matrix.py
@@ -43,11 +43,17 @@ def main() -> int:
     covered = {group["path"] for group in groups}
     apps = _apps_with_tests()
 
-    problems = [
-        f"  {app}: has tests that no shard runs"
-        for app in apps
-        if not any(path.startswith(f"sbomify/apps/{app}/") for path in covered)
-    ]
+    # Checking the app prefix alone is not enough: an app with both tests.py and
+    # a tests/ directory would pass on a shard covering only one of them, and the
+    # other would never run. Each location has to be reachable from some path.
+    problems = []
+    for app in apps:
+        for location in TEST_LOCATIONS:
+            relative = f"sbomify/apps/{app}/{location}"
+            if not (APPS_DIR / app / location).exists():
+                continue
+            if not any(relative.startswith(path.rstrip("/")) for path in covered):
+                problems.append(f"  {app}: {location} is not run by any shard")
     # A stale path silently collects nothing; a stale ignore silently stops
     # excluding, which is how e2e tests would leak into the Core shard.
     problems += [

--- a/sbomify/apis.py
+++ b/sbomify/apis.py
@@ -9,7 +9,7 @@ from ninja import NinjaAPI
 from ninja.errors import Throttled
 from ninja.renderers import JSONRenderer
 
-from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle, AnonymousIPRateThrottle
 
 try:
     __version__ = version("sbomify")
@@ -38,9 +38,14 @@ api = NinjaAPI(
     # usable for programmatic clients (which carry no CSRF cookie and cannot be a CSRF
     # vector). See sbomify/apps/core/middleware.py.
     csrf=True,
-    # Per-token API rate limit (#1060): every router inherits this global throttle,
-    # keyed on the AccessToken pk. Session/anonymous requests are exempt.
-    throttle=AccessTokenRateThrottle(),
+    # Two complementary global throttles, because each returns no cache key for
+    # the other's population: the token one keys on the AccessToken pk and skips
+    # anonymous callers, the anonymous one keys on client IP and skips requests
+    # that resolved a token. Together they cover every route, including the
+    # auth=None public ones, without decorating each endpoint. A per-operation
+    # throttle replaces these rather than adding to them, so the heavy-upload
+    # routes pass both of theirs explicitly.
+    throttle=[AccessTokenRateThrottle(), AnonymousIPRateThrottle()],
     renderer=UTCZRenderer(),
     title="sbomify API",
     version=__version__,

--- a/sbomify/apis.py
+++ b/sbomify/apis.py
@@ -42,9 +42,13 @@ api = NinjaAPI(
     # the other's population: the token one keys on the AccessToken pk and skips
     # anonymous callers, the anonymous one keys on client IP and skips requests
     # that resolved a token. Together they cover every route, including the
-    # auth=None public ones, without decorating each endpoint. A per-operation
-    # throttle replaces these rather than adding to them, so the heavy-upload
-    # routes pass both of theirs explicitly.
+    # auth=None public ones, without decorating each endpoint.
+    #
+    # A per-operation throttle replaces this whole list rather than adding to
+    # it, so any endpoint declaring its own must re-list every global throttle
+    # it still wants. The artifact-upload routes are the example: they pass
+    # AccessTokenRateThrottle alongside AccessTokenHeavyRateThrottle for that
+    # reason, and being PAT-only they have no need of the anonymous one.
     throttle=[AccessTokenRateThrottle(), AnonymousIPRateThrottle()],
     renderer=UTCZRenderer(),
     title="sbomify API",

--- a/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
+++ b/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
@@ -56,6 +56,29 @@ class TestKeying:
         assert AnonymousIPRateThrottle.cache_key_prefix != AccessTokenRateThrottle.cache_key_prefix
 
 
+class TestFailureModes:
+    def test_an_unidentifiable_caller_is_still_throttled(self):
+        """A security control that switches itself off when the environment is
+        misconfigured is worse than one that occasionally over-throttles."""
+        throttle = AnonymousIPRateThrottle()
+        request = RequestFactory().get("/api/v1/anything")
+        request.META.pop("REMOTE_ADDR", None)
+
+        assert throttle.get_cache_key(request) is not None
+
+    def test_unidentifiable_callers_share_one_bucket(self):
+        throttle = AnonymousIPRateThrottle(rate="2/min")
+
+        def anonymous():
+            request = RequestFactory().get("/api/v1/anything")
+            request.META.pop("REMOTE_ADDR", None)
+            return request
+
+        allowed = [throttle.allow_request(anonymous()) for _ in range(3)]
+
+        assert allowed == [True, True, False]
+
+
 class TestSpoofing:
     def test_x_real_ip_from_an_untrusted_peer_is_ignored(self):
         """Honouring it unconditionally would let a caller rotate the header to

--- a/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
+++ b/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
@@ -1,0 +1,106 @@
+"""Per-IP throttling for the surfaces the token throttle cannot reach.
+
+``AccessTokenRateThrottle`` keys on the resolved token row, so every public
+route (Trust Center, the ``auth=None`` ninja endpoints, the document
+access-request POST, the OIDC exchange) had no limit of any kind.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.cache import cache
+from django.test import RequestFactory, override_settings
+
+from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle, AnonymousIPRateThrottle
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _request(remote_addr: str = "203.0.113.7", **meta):
+    request = RequestFactory().get("/api/v1/anything")
+    request.META["REMOTE_ADDR"] = remote_addr
+    request.META.update(meta)
+    return request
+
+
+class TestKeying:
+    def test_an_anonymous_request_gets_a_key(self):
+        assert AnonymousIPRateThrottle().get_cache_key(_request()) is not None
+
+    def test_two_ips_get_separate_budgets(self):
+        throttle = AnonymousIPRateThrottle()
+
+        assert throttle.get_cache_key(_request("203.0.113.7")) != throttle.get_cache_key(_request("203.0.113.8"))
+
+    def test_a_token_request_is_left_to_the_token_throttle(self):
+        """Otherwise one authenticated call is charged to two budgets."""
+        request = _request()
+        request.access_token_record = object()
+
+        assert AnonymousIPRateThrottle().get_cache_key(request) is None
+
+    def test_the_two_throttles_never_key_the_same_request(self):
+        anon, token = AnonymousIPRateThrottle(), AccessTokenRateThrottle()
+        anonymous_request = _request()
+
+        assert anon.get_cache_key(anonymous_request) is not None
+        assert token.get_cache_key(anonymous_request) is None
+
+    def test_its_window_is_separate_from_the_token_throttle(self):
+        """A shared prefix would make the two read and write one counter."""
+        assert AnonymousIPRateThrottle.cache_key_prefix != AccessTokenRateThrottle.cache_key_prefix
+
+
+class TestSpoofing:
+    def test_x_real_ip_from_an_untrusted_peer_is_ignored(self):
+        """Honouring it unconditionally would let a caller rotate the header to
+        mint a fresh budget per request."""
+        throttle = AnonymousIPRateThrottle()
+        spoofed = throttle.get_cache_key(_request("203.0.113.7", HTTP_X_REAL_IP="198.51.100.1"))
+        plain = throttle.get_cache_key(_request("203.0.113.7"))
+
+        assert spoofed == plain
+
+    @override_settings(TRUSTED_PROXIES=["203.0.113.7"])
+    def test_a_trusted_proxy_is_honoured(self):
+        """Behind Caddy the peer is the proxy for everyone, so without this the
+        whole internet would share a single budget."""
+        throttle = AnonymousIPRateThrottle()
+        forwarded = throttle.get_cache_key(_request("203.0.113.7", HTTP_X_REAL_IP="198.51.100.1"))
+        direct = throttle.get_cache_key(_request("203.0.113.7"))
+
+        assert forwarded != direct
+
+
+class TestEnforcement:
+    def test_the_budget_runs_out(self):
+        throttle = AnonymousIPRateThrottle(rate="3/min")
+        request = _request()
+
+        allowed = [throttle.allow_request(request) for _ in range(4)]
+
+        assert allowed == [True, True, True, False]
+
+    def test_one_ip_running_out_does_not_block_another(self):
+        throttle = AnonymousIPRateThrottle(rate="2/min")
+        for _ in range(3):
+            throttle.allow_request(_request("203.0.113.7"))
+
+        assert throttle.allow_request(_request("203.0.113.9")) is True
+
+    def test_it_reports_a_budget_for_the_headers(self):
+        """RateLimitHeadersMiddleware reads this to emit X-RateLimit-*, which
+        previously only ever described token calls."""
+        throttle = AnonymousIPRateThrottle(rate="5/min")
+        request = _request()
+
+        throttle.allow_request(request)
+
+        limit, remaining, reset = request._access_token_ratelimit
+        assert (limit, remaining) == (5, 4)
+        assert reset > 0

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -102,9 +102,13 @@ class AnonymousIPRateThrottle(AccessTokenRateThrottle):
             return None
         from sbomify.apps.core.utils import get_client_ip
 
-        client_ip = get_client_ip(request)
-        if not client_ip:
-            return None
+        # No usable address (REMOTE_ADDR absent under a misconfigured proxy or
+        # ASGI server) must not mean "unlimited". Returning None here would skip
+        # the throttle entirely, so a control meant to bound abuse would switch
+        # itself off exactly when the environment is wrong. Everything
+        # unidentifiable shares one bucket instead: worst case a few callers
+        # contend, which is a far better failure than none being limited.
+        client_ip = get_client_ip(request) or "unknown"
         return f"{self.cache_key_prefix}_{client_ip}"
 
 

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -74,6 +74,40 @@ class AccessTokenHeavyRateThrottle(AccessTokenRateThrottle):
         super().__init__(rate or settings.API_TOKEN_HEAVY_RATE_LIMIT)
 
 
+class AnonymousIPRateThrottle(AccessTokenRateThrottle):
+    """Per-IP limit for the surfaces no token throttle can reach.
+
+    ``AccessTokenRateThrottle`` keys on the resolved token row, so session and
+    anonymous callers get no budget at all. That leaves the public surfaces
+    (Trust Center pages, the ``auth=None`` ninja routes, the document
+    access-request POST, the OIDC exchange) with no limit of any kind.
+
+    Keying on :func:`get_client_ip` rather than ``REMOTE_ADDR`` matters: the app
+    sits behind Caddy, so the peer address is the proxy for every caller and a
+    single shared budget would be trivially exhausted. That helper only honours
+    ``X-Real-IP`` from a trusted proxy, so the key cannot be spoofed to escape
+    the limit either.
+
+    A request that already carries a token is left to the token throttle, so an
+    authenticated integration is not charged twice for one call.
+    """
+
+    cache_key_prefix = "throttle_anon_ip"
+
+    def __init__(self, rate: str | None = None) -> None:
+        super().__init__(rate or settings.API_ANONYMOUS_RATE_LIMIT)
+
+    def get_cache_key(self, request: HttpRequest) -> str | None:
+        if getattr(request, "access_token_record", None) is not None:
+            return None
+        from sbomify.apps.core.utils import get_client_ip
+
+        client_ip = get_client_ip(request)
+        if not client_ip:
+            return None
+        return f"{self.cache_key_prefix}_{client_ip}"
+
+
 class RateLimitHeadersMiddleware:
     """Surface the per-token throttle budget as X-RateLimit-* response headers (#1076).
 

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -852,6 +852,11 @@ API_TOKEN_RATE_LIMIT = os.environ.get("API_TOKEN_RATE_LIMIT", "1000/min")
 # S3 write, downstream scan/assessment enqueue).
 API_TOKEN_HEAVY_RATE_LIMIT = os.environ.get("API_TOKEN_HEAVY_RATE_LIMIT", "100/min")
 
+# Anonymous/session callers carry no token, so the per-token limits above never
+# apply to them. Keyed per client IP. Generous enough that a human browsing the
+# Trust Center never notices, low enough to blunt scripted enumeration.
+API_ANONYMOUS_RATE_LIMIT = os.environ.get("API_ANONYMOUS_RATE_LIMIT", "120/min")
+
 # OIDC Trusted Publishing — see sbomify.apps.oidc.
 # Action workflows request an ID token with this audience; the backend
 # enforces the ``aud`` claim against it during verification.


### PR DESCRIPTION
Closes #1144.

`AccessTokenRateThrottle` keys on the resolved token row, so session and anonymous callers got no budget at all. Every public surface was unlimited: Trust Center pages, the `auth=None` ninja routes, the document access-request POST, and the OIDC exchange.

## Keying

`AnonymousIPRateThrottle` keys on `get_client_ip`, not `REMOTE_ADDR`. Behind Caddy the peer address is the proxy for every caller, so `REMOTE_ADDR` would have put the entire internet into one shared bucket. That helper also refuses to honour `X-Real-IP` unless the peer is a trusted proxy, so the key cannot be rotated to mint a fresh budget per request. Both properties are covered by tests.

## Applied globally, not per endpoint

There are twenty-odd `auth=None` endpoints. Rather than decorate each, this adds a second global throttle, which is safe because the two are complementary:

| Caller | token throttle | anon throttle |
|---|---|---|
| PAT request | keys on token pk | returns `None` |
| session / anonymous | returns `None` | keys on client IP |

So each request is charged to exactly one budget. The heavy-upload routes already pass both of their throttles explicitly, which they must, since a per-operation throttle replaces the global rather than adding to it.

Subclassing the token throttle also means `RateLimitHeadersMiddleware` now emits `X-RateLimit-*` for anonymous calls, which it previously could only do for token calls.

Default `120/min` per IP via `API_ANONYMOUS_RATE_LIMIT`: generous enough that a human browsing the Trust Center never notices, low enough to blunt scripted enumeration.

## One thing this turned up

The new tests live in `access_tokens/tests/`, beside the app’s existing `tests.py`. The CI shard pointed only at `tests.py`, so they would not have run.

The guard I added in #1227 did not catch it: it only checked that *some* path under the app was in the matrix, so an app with both `tests.py` and `tests/` passed while one of them was never executed. Widened the shard, and taught the guard to require every test location of an app to be reachable. Verified by reverting the shard and watching it fail with `access_tokens: tests is not run by any shard`.

## Testing

10 throttle tests: keying, per-IP isolation, that a token request is left alone, that the two throttles never key the same request, separate cache prefixes, spoofed vs trusted `X-Real-IP`, budget exhaustion, and the header budget. 71 access_tokens tests pass.