### PR TITLE
feat(vuln): surface malicious packages as their own class

### DIFF
--- a/sbomify/apps/core/tests/test_release_public_posture.py
+++ b/sbomify/apps/core/tests/test_release_public_posture.py
@@ -66,7 +66,7 @@ def test_public_release_page_shows_vuln_posture(sample_team_with_owner_member):
     match = re.search(r'<script id="vuln-posture-data"[^>]*>(.*?)</script>', html, re.DOTALL)
     assert match is not None
     posture = json.loads(match.group(1))
-    assert posture["counts"] == {"critical": 0, "high": 1, "medium": 0, "low": 0, "unknown": 0, "total": 1}
+    assert posture["counts"] == {"critical": 0, "high": 1, "medium": 0, "low": 0, "unknown": 0, "total": 1, "malicious": 0}
     assert posture["suppressed_count"] == 1
     by_id = {f["id"]: f for f in posture["findings"]}
     assert by_id["CVE-2026-1"]["suppressed"] is False

--- a/sbomify/apps/plugins/apis.py
+++ b/sbomify/apps/plugins/apis.py
@@ -122,29 +122,46 @@ def _get_plugin_display_names_map(plugin_names: set[str]) -> dict[str, str]:
 
 
 def _result_with_kev(run: AssessmentRun, kev_ids: frozenset[str] | None) -> Any:
-    """A copy of the run's result with per-finding KEV flags stamped in.
+    """A copy of the run's result with the read-time finding flags stamped in.
 
-    The stored blob is never mutated; the flag is response-time data from the
-    cached CISA feed. Non-security runs and empty catalogs pass through as-is.
+    Two flags, both derived rather than stored: ``kev`` from the cached CISA
+    feed, and ``malicious`` from evidence already inside the finding. Deriving
+    them here means every run ever recorded carries them without a rescan.
+
+    The stored blob is never mutated. Non-security runs pass through as-is.
     """
     result = run.result
-    if not kev_ids or run.category != "security" or not isinstance(result, dict):
+    if run.category != "security" or not isinstance(result, dict):
         return result
     findings = result.get("findings")
     if not isinstance(findings, list):
         return result
-    from sbomify.apps.vulnerability_scanning.kev import finding_in_kev
 
-    # Build a new findings list only once a KEV match is actually found — the
-    # common case (no matches) returns the original result with no allocation.
+    from sbomify.apps.vulnerability_scanning.kev import finding_in_kev
+    from sbomify.apps.vulnerability_scanning.malicious import stamp_malicious
+
+    # Build a new findings list only once a match is actually found — the common
+    # case (no matches) returns the original result with no allocation.
     stamped: list[Any] | None = None
-    for i, finding in enumerate(findings):
-        if isinstance(finding, dict) and finding_in_kev(finding, kev_ids):
-            if stamped is None:
-                stamped = list(findings)
-            stamped[i] = {**finding, "kev": True}
+    if kev_ids:
+        for i, finding in enumerate(findings):
+            if isinstance(finding, dict) and finding_in_kev(finding, kev_ids):
+                if stamped is None:
+                    stamped = list(findings)
+                stamped[i] = {**finding, "kev": True}
+
+    findings_out, malicious_count = stamp_malicious(stamped if stamped is not None else findings)
+    if findings_out is not (stamped if stamped is not None else findings):
+        stamped = findings_out
+
     if stamped is None:
         return result
+
+    # Surfaced on the summary so dashboards and posture cards can split the
+    # class out without walking every finding again.
+    summary = result.get("summary")
+    if malicious_count and isinstance(summary, dict):
+        return {**result, "findings": stamped, "summary": {**summary, "malicious_count": malicious_count}}
     return {**result, "findings": stamped}
 
 

--- a/sbomify/apps/plugins/schemas.py
+++ b/sbomify/apps/plugins/schemas.py
@@ -31,6 +31,10 @@ class FindingSchema(BaseModel):
     # In CISA's Known Exploited Vulnerabilities catalog; stamped at serialization
     # time from the cached KEV feed, never stored.
     kev: bool = False
+    # Stamped read-time beside kev. Without it declared here django-ninja
+    # serialises against the schema and drops the field, so the badge would
+    # never render however correct the classification was.
+    malicious: bool = False
 
     @field_validator("aliases", mode="before")
     @classmethod
@@ -63,6 +67,9 @@ class AssessmentSummarySchema(BaseModel):
     error_count: int = 0
     by_severity: dict[str, int] | None = None
     suppressed_count: int = 0
+    # Counted beside the severity buckets, not inside them: a malicious package
+    # is a different decision class rather than a slice of the same axis.
+    malicious_count: int = 0
 
 
 class AssessmentResultSchema(BaseModel):

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -164,6 +164,13 @@
                                                             {% if finding.cvss_score %}
                                                                 <span class="px-2 py-0.5 text-xs font-semibold rounded bg-surface text-text-muted border border-border">CVSS: {{ finding.cvss_score }}</span>
                                                             {% endif %}
+                                                            {% comment %}A malicious package is a different decision from a vulnerable one: rip it out now rather than schedule a patch. Shown ahead of severity because the severity is not the point, and the OpenSSF records carry none at all.{% endcomment %}
+                                                            {% if finding.malicious %}
+                                                                <span class="px-2 py-0.5 text-xs font-semibold uppercase tracking-wide rounded bg-danger text-white"
+                                                                      title="Malicious package: remove it rather than upgrade">
+                                                                    <i class="fas fa-skull-crossbones mr-1"></i>Malicious
+                                                                </span>
+                                                            {% endif %}
                                                             {# CISA KEV: confirmed exploited in the wild #}
                                                             {% if finding.kev %}
                                                                 <span class="px-2 py-0.5 text-xs font-semibold uppercase tracking-wide rounded bg-danger text-white"

--- a/sbomify/apps/vulnerability_scanning/malicious.py
+++ b/sbomify/apps/vulnerability_scanning/malicious.py
@@ -1,0 +1,86 @@
+"""Recognising a malicious-package advisory among ordinary vulnerabilities.
+
+A compromised package is a different decision class from a CVE: you rip it out
+now, you do not schedule a patch. Today both arrive through the same scanner and
+render identically, and the OpenSSF ones arrive *worse* than unclassified —
+carrying no severity at all, they fall through ``OSVPlugin._map_severity`` to its
+``"medium"`` default, so a supply-chain compromise reads as a considered
+middling judgement rather than as a gap.
+
+Detection is derived at read time rather than stored, the same way the CISA KEV
+flag is. The evidence is already inside the finding, so every run ever recorded
+classifies correctly with no rescan, no backfill and no migration.
+
+The signals, verified against the live OSV API rather than assumed:
+
+* ``MAL-`` id prefix. OpenSSF's malicious-packages corpus, structural and exact.
+* ``database_specific["malicious-packages-origins"]``, which those records carry
+  and which survives an entry being surfaced under a different id.
+* an alias pointing at a ``MAL-`` id.
+* failing all of those, the formulaic summary line. GitHub's malware advisories
+  (e.g. GHSA-hxxf-q3w9-4xgw, "Malicious Package in eslint-scope") carry **no**
+  structured marker in OSV at all: `database_specific` holds only cwe_ids,
+  github_reviewed and severity. Title matching is the sole remaining signal for
+  them, so it is deliberately narrow, anchored on the two wordings both
+  databases actually emit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Both databases open with a fixed phrase: OpenSSF writes "Malicious code in
+# <pkg> (<ecosystem>)", GitHub writes "Malicious Package in <pkg>". Anchoring on
+# these rather than a bare "malicious" keeps an advisory that merely *describes*
+# malicious behaviour ("allows a malicious actor to ...") out of the class.
+_TITLE_MARKERS = ("malicious code in", "malicious package in")
+
+_ORIGINS_KEY = "malicious-packages-origins"
+
+
+def _has_mal_id(value: Any) -> bool:
+    return isinstance(value, str) and value.strip().upper().startswith("MAL-")
+
+
+def is_malicious_finding(finding: dict[str, Any]) -> bool:
+    """Whether this finding reports a malicious package rather than a vulnerability."""
+    if not isinstance(finding, dict):
+        return False
+
+    if _has_mal_id(finding.get("id")):
+        return True
+
+    aliases = finding.get("aliases")
+    if isinstance(aliases, list) and any(_has_mal_id(alias) for alias in aliases):
+        return True
+
+    metadata = finding.get("metadata")
+    if isinstance(metadata, dict):
+        database_specific = metadata.get("database_specific")
+        if isinstance(database_specific, dict) and _ORIGINS_KEY in database_specific:
+            return True
+
+    haystack = " ".join(str(finding.get(field) or "") for field in ("title", "description")).lower()
+    return any(marker in haystack for marker in _TITLE_MARKERS)
+
+
+def stamp_malicious(findings: list[Any] | None) -> tuple[list[Any], int]:
+    """Copy ``findings`` with ``malicious`` set where it applies, plus a count.
+
+    Returns the original list untouched when nothing matches, so the common case
+    allocates nothing.
+    """
+    if not isinstance(findings, list):
+        return [], 0
+
+    stamped: list[Any] | None = None
+    count = 0
+    for i, finding in enumerate(findings):
+        if not is_malicious_finding(finding):
+            continue
+        count += 1
+        if stamped is None:
+            stamped = list(findings)
+        stamped[i] = {**finding, "malicious": True}
+
+    return (stamped if stamped is not None else findings), count

--- a/sbomify/apps/vulnerability_scanning/malicious.py
+++ b/sbomify/apps/vulnerability_scanning/malicious.py
@@ -42,7 +42,7 @@ def _has_mal_id(value: Any) -> bool:
     return isinstance(value, str) and value.strip().upper().startswith("MAL-")
 
 
-def is_malicious_finding(finding: dict[str, Any]) -> bool:
+def is_malicious_finding(finding: Any) -> bool:
     """Whether this finding reports a malicious package rather than a vulnerability."""
     if not isinstance(finding, dict):
         return False
@@ -60,8 +60,13 @@ def is_malicious_finding(finding: dict[str, Any]) -> bool:
         if isinstance(database_specific, dict) and _ORIGINS_KEY in database_specific:
             return True
 
-    haystack = " ".join(str(finding.get(field) or "") for field in ("title", "description")).lower()
-    return any(marker in haystack for marker in _TITLE_MARKERS)
+    # Anchored at the start of the title, falling back to the description only
+    # when there is no title. Both databases lead with the phrase ("Malicious
+    # code in <pkg>", "Malicious Package in <pkg>"), whereas an ordinary
+    # advisory that happens to contain it does so mid-sentence. Searching
+    # anywhere in title+description would sweep those in.
+    heading = str(finding.get("title") or finding.get("description") or "").strip().lower()
+    return heading.startswith(_TITLE_MARKERS)
 
 
 def stamp_malicious(findings: list[Any] | None) -> tuple[list[Any], int]:

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
+
 # CycloneDX analysis states that suppress a finding (mirrors vex._SUPPRESSING_STATES).
 _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
 _SEVERITIES = ("critical", "high", "medium", "low", "unknown")
@@ -40,7 +42,10 @@ def _is_suppressed(finding: dict[str, Any]) -> bool:
 
 
 def _empty_counts() -> dict[str, int]:
-    return {sev: 0 for sev in _SEVERITIES} | {"total": 0}
+    # "malicious" sits alongside the severity buckets rather than inside them:
+    # it is a different decision class, and the OpenSSF records carry no
+    # severity at all, so it is not a slice of the same axis.
+    return {sev: 0 for sev in _SEVERITIES} | {"total": 0, "malicious": 0}
 
 
 def build_release_vuln_posture(release: Any) -> dict[str, Any]:
@@ -181,15 +186,19 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
         suppressed = _is_suppressed(finding)
         # The Trust Center shows the VEX-applied posture: suppressed findings
         # drop out of the counts (they still appear in the list, marked).
+        malicious = is_malicious_finding(finding)
         if suppressed:
             suppressed_count += 1
         else:
             counts[sev] += 1
             counts["total"] += 1
+            if malicious:
+                counts["malicious"] += 1
         findings.append(
             {
                 "id": finding.get("id"),
                 "severity": sev,
+                "malicious": malicious,
                 "component": component.get("name") or "",
                 "component_version": component.get("version") or "",
                 "suppressed": suppressed,

--- a/sbomify/apps/vulnerability_scanning/tests/test_malicious.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_malicious.py
@@ -46,6 +46,13 @@ class TestTitleFallback:
 
         assert is_malicious_finding(finding) is True
 
+    def test_the_marker_must_lead_the_title(self):
+        """An advisory that mentions the phrase mid-sentence is not a malicious
+        package; both databases lead with it."""
+        finding = {"id": "CVE-2021-1", "title": "Flaw permits a Malicious Package in the cache"}
+
+        assert is_malicious_finding(finding) is False
+
     def test_a_bare_mention_of_malicious_does_not_match(self):
         """Plenty of ordinary CVEs describe what an attacker can do. Matching on
         the word alone would sweep them into a remove-it-now class."""
@@ -72,7 +79,7 @@ class TestOrdinaryFindings:
         assert is_malicious_finding(finding) is False
 
     def test_a_non_dict_is_not_malicious(self):
-        assert is_malicious_finding("MAL-2024-9506") is False  # type: ignore[arg-type]
+        assert is_malicious_finding("MAL-2024-9506") is False
 
 
 class TestStamping:

--- a/sbomify/apps/vulnerability_scanning/tests/test_malicious.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_malicious.py
@@ -1,0 +1,157 @@
+"""Malicious-package classification.
+
+Shapes taken from the live OSV API rather than invented, because the two
+databases present very differently and the difference is the whole problem:
+
+* ``MAL-2024-9506`` (OpenSSF) carries **no** severity field, so it falls through
+  ``OSVPlugin._map_severity`` to its ``"medium"`` default. A supply-chain
+  compromise therefore reads as a considered middling judgement.
+* ``GHSA-hxxf-q3w9-4xgw`` (GitHub, "Malicious Package in eslint-scope") carries a
+  real CVSS_V3 vector and **no** structured malware marker at all: its
+  ``database_specific`` holds only cwe_ids, github_reviewed and severity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding, stamp_malicious
+
+
+class TestStructuralSignals:
+    def test_a_mal_id_is_malicious(self):
+        assert is_malicious_finding({"id": "MAL-2024-9506"}) is True
+
+    def test_case_and_padding_do_not_matter(self):
+        assert is_malicious_finding({"id": "  mal-2024-9506 "}) is True
+
+    def test_a_mal_alias_is_enough(self):
+        """The entry can surface under another id while aliasing the MAL record."""
+        assert is_malicious_finding({"id": "GHSA-aaaa-bbbb-cccc", "aliases": ["MAL-2024-9506"]}) is True
+
+    def test_the_openssf_origins_marker_is_enough(self):
+        finding = {"id": "SOMETHING-ELSE", "metadata": {"database_specific": {"malicious-packages-origins": [{}]}}}
+
+        assert is_malicious_finding(finding) is True
+
+
+class TestTitleFallback:
+    """The only signal GitHub's malware advisories leave in OSV."""
+
+    def test_the_github_wording_matches(self):
+        assert is_malicious_finding({"id": "GHSA-hxxf-q3w9-4xgw", "title": "Malicious Package in eslint-scope"}) is True
+
+    def test_the_openssf_wording_matches(self):
+        finding = {"id": "GHSA-x", "title": "Malicious code in assetiq-kudu-node (npm)"}
+
+        assert is_malicious_finding(finding) is True
+
+    def test_a_bare_mention_of_malicious_does_not_match(self):
+        """Plenty of ordinary CVEs describe what an attacker can do. Matching on
+        the word alone would sweep them into a remove-it-now class."""
+        finding = {
+            "id": "CVE-2021-44228",
+            "title": "Remote code execution in log4j",
+            "description": "Allows a malicious actor to execute arbitrary code.",
+        }
+
+        assert is_malicious_finding(finding) is False
+
+
+class TestOrdinaryFindings:
+    @pytest.mark.parametrize(
+        "finding",
+        [
+            {"id": "CVE-2021-44228", "title": "RCE in log4j"},
+            {"id": "GHSA-jfh8-c2jp-5v3q"},
+            {"id": ""},
+            {},
+        ],
+    )
+    def test_not_malicious(self, finding):
+        assert is_malicious_finding(finding) is False
+
+    def test_a_non_dict_is_not_malicious(self):
+        assert is_malicious_finding("MAL-2024-9506") is False  # type: ignore[arg-type]
+
+
+class TestStamping:
+    def test_only_the_malicious_finding_is_stamped(self):
+        findings = [{"id": "CVE-2021-44228"}, {"id": "MAL-2024-9506"}]
+
+        stamped, count = stamp_malicious(findings)
+
+        assert count == 1
+        assert "malicious" not in stamped[0]
+        assert stamped[1]["malicious"] is True
+
+    def test_the_original_list_is_left_alone(self):
+        """The stored run blob must not be mutated; the flag is read-time data."""
+        findings = [{"id": "MAL-2024-9506"}]
+
+        stamp_malicious(findings)
+
+        assert "malicious" not in findings[0]
+
+    def test_no_matches_allocates_nothing(self):
+        findings = [{"id": "CVE-2021-44228"}]
+
+        stamped, count = stamp_malicious(findings)
+
+        assert count == 0
+        assert stamped is findings
+
+    def test_a_missing_findings_list_is_handled(self):
+        assert stamp_malicious(None) == ([], 0)
+
+
+class TestSurfaces:
+    """The classification only matters if the display and count paths act on it."""
+
+    @staticmethod
+    def _result(findings):
+        return {"summary": {"total_findings": len(findings)}, "findings": findings}
+
+    def test_display_rows_put_malicious_first(self):
+        """The OpenSSF records carry no severity, so severity ordering alone
+        buries a remove-now finding among the mediums."""
+        from sbomify.apps.vulnerability_scanning.utils import extract_finding_rows
+
+        rows = extract_finding_rows(
+            self._result(
+                [
+                    {"id": "CVE-2021-44228", "severity": "critical", "component": {"name": "log4j"}},
+                    {"id": "MAL-2024-9506", "severity": "medium", "component": {"name": "assetiq-kudu-node"}},
+                ]
+            ),
+            [],
+        )
+
+        assert rows[0]["id"] == "MAL-2024-9506"
+        assert rows[0]["malicious"] is True
+        assert rows[1]["malicious"] is False
+
+    def test_posture_counts_split_the_class_out(self):
+        from sbomify.apps.vulnerability_scanning.posture import _empty_counts
+
+        assert "malicious" in _empty_counts()
+
+    def test_the_run_stamp_reaches_stored_history(self, mocker):
+        """Derived at read time, so runs recorded before this shipped classify
+        without a rescan or a backfill."""
+        from types import SimpleNamespace
+
+        from sbomify.apps.plugins.apis import _result_with_kev
+
+        run = SimpleNamespace(
+            category="security",
+            result=self._result([{"id": "MAL-2024-9506"}, {"id": "CVE-2021-44228"}]),
+        )
+
+        out = _result_with_kev(run, frozenset())
+
+        assert out["findings"][0]["malicious"] is True
+        assert "malicious" not in out["findings"][1]
+        assert out["summary"]["malicious_count"] == 1
+        # the stored blob is untouched
+        assert "malicious" not in run.result["findings"][0]

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -78,7 +78,7 @@ def test_posture_splits_raw_vs_vex_applied(release):
     assert p["has_data"] is True
     # VEX applied: only CVE-1 survives (CVE-2 not_affected, CVE-3 false_positive dropped);
     # the operational finding is excluded entirely.
-    assert p["counts"] == {"critical": 1, "high": 0, "medium": 0, "low": 0, "unknown": 0, "total": 1}
+    assert p["counts"] == {"critical": 1, "high": 0, "medium": 0, "low": 0, "unknown": 0, "total": 1, "malicious": 0}
     assert p["suppressed_count"] == 2
     supp = {f["id"]: f for f in p["findings"]}
     assert supp["CVE-2"]["suppressed"] is True

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from django.db.models import F
 
+from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
+
 _ZERO_COUNTS = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 
 
@@ -221,11 +223,15 @@ def extract_finding_rows(
                 "vex_justification": vex_justification,
                 "vex_suppressed": vex_state in _SUPPRESSING_VEX_STATES,
                 "vex_manual": vex_manual,
+                "malicious": is_malicious_finding(vuln),
                 "source": vuln.get("source") or "",
             }
         )
 
-    rows.sort(key=lambda r: (_SEVERITY_RANK.get(r["severity"], 5), -(r["cvss_score"] or 0)))
+    # Malicious packages first, ahead of severity: they are a remove-now decision
+    # and the OpenSSF records carry no severity to rank them by, so severity
+    # ordering alone buries them among the mediums.
+    rows.sort(key=lambda r: (not r["malicious"], _SEVERITY_RANK.get(r["severity"], 5), -(r["cvss_score"] or 0)))
     return rows
 
 


### PR DESCRIPTION
Closes #1186.

A compromised package is a different decision from a vulnerable one: remove it now, rather than schedule a patch. Both arrived through the same scanner and rendered identically.

## Step 1, the verification the issue asks for

Checked against the live OSV API rather than assumed. The two databases present very differently:

| | signal | severity in OSV |
|---|---|---|
| `MAL-2024-9506` (OpenSSF) | `MAL-` id + `database_specific.malicious-packages-origins` | **none at all** |
| `GHSA-hxxf-q3w9-4xgw` (GitHub) | **no structured marker whatsoever** — `database_specific` holds only `cwe_ids`, `github_reviewed`, `severity` | real CVSS_V3 |

One correction to the issue: it predicts these render with *unknown* severity. They render as **medium**, because `_map_severity` falls through to a `"medium"` default when nothing matches. That is worse than unknown, since a supply-chain compromise then reads as a considered middling judgement rather than as a gap.

## Derived, not stored

Classification happens at read time, mirroring the KEV flag, because the evidence is already inside the stored finding. Every run ever recorded classifies correctly with no rescan, no backfill and no migration. The stored blob is never mutated, and a test pins that.

## Detection order

1. `MAL-` id prefix, structural and exact
2. `database_specific["malicious-packages-origins"]`, which survives an entry surfacing under a different id
3. an alias pointing at a `MAL-` id
4. only then, the summary line

That last one earns its place: GitHub's malware advisories leave nothing structured in OSV, so the title is the only signal available. It is anchored on the two wordings both databases actually emit (`Malicious code in …`, `Malicious Package in …`) rather than a bare "malicious" keyword, so an ordinary CVE describing what an attacker can do is not swept in. There is a test for exactly that case.

## Surfaces

- red badge with its own icon, distinct from KEV
- sorted **ahead of** severity, since the OpenSSF records carry no severity to rank by and severity ordering alone buries them among the mediums
- counted **beside** the severity buckets rather than inside them, because it is a different axis and not a slice of the same one

## Testing

19 tests: each structural signal, the title fallback and its false-positive guard, ordinary findings, non-dict input, stamping (including that the stored list is untouched and that a no-match run allocates nothing), and the three surfaces.

14 failures in `vulnerability_scanning/tests` are identical with this branch stashed. Verified by comparing the failing sets, not just the counts, after a first attempt where untracked files skewed the baseline.

## Not in this PR

The third acceptance box, "alerting treats the class as immediate", depends on #1143, which is not built.
