### PR TITLE
feat(plugins): OpenChain Telco SBOM Guide v1.1 conformance plugin

### DIFF
--- a/sbomify/apps/plugins/apps.py
+++ b/sbomify/apps/plugins/apps.py
@@ -90,6 +90,28 @@ class PluginsConfig(AppConfig):
             },
         )
 
+        # OpenChain Telco SBOM Guide v1.1 Plugin
+        _register(
+            "openchain-telco-1.1",
+            {
+                "display_name": "OpenChain Telco SBOM Guide v1.1",
+                "description": (
+                    "Checks SBOMs against the OpenChain Telco SBOM Guide v1.1, which telco "
+                    "and regulated buyers ask for by name. The Guide mandates SPDX 2.2 or 2.3, "
+                    "so a CycloneDX document cannot conform. Covers the required document and "
+                    "package elements, the recommended package hash and PURL, the DESCRIBES and "
+                    "CONTAINS relationships, and the build information including the CISA SBOM Type."
+                ),
+                "category": "compliance",
+                "version": "1.0.0",
+                "plugin_class_path": "sbomify.apps.plugins.builtins.openchain_telco.OpenChainTelcoPlugin",
+                "is_enabled": True,
+                "is_beta": True,
+                "is_builtin": True,
+                "default_config": {},
+            },
+        )
+
         # FDA Medical Device Cybersecurity 2025 Plugin
         _register(
             "fda-medical-device-2025",

--- a/sbomify/apps/plugins/builtins/openchain_telco.py
+++ b/sbomify/apps/plugins/builtins/openchain_telco.py
@@ -1,0 +1,388 @@
+"""OpenChain Telco SBOM Guide v1.1 conformance.
+
+Checks an SBOM against the requirement clauses of the OpenChain Telco SBOM
+Guide v1.1, which telco and regulated buyers ask for by name.
+
+One thing worth knowing before reading the checks: **the Guide mandates SPDX**.
+Section 3.1 states a conformant document "SHALL adhere to the version 2.2 of the
+SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3",
+and §3.3.2 explains the choice over CycloneDX explicitly. A CycloneDX SBOM
+cannot be conformant at all, so it fails 3.1 rather than being assessed
+field-by-field against a profile it can never satisfy.
+
+Clause coverage, with the ones that are not machine-checkable from the document
+alone called out:
+
+* 3.1  Data Format — SPDX 2.2 or 2.3
+* 3.2  Required document-creation and package elements, plus the RECOMMENDED
+       checksum/verification code and PURL, and the DESCRIBES/CONTAINS
+       relationships
+* 3.3  Machine-readable format — JSON is what reaches us; Tag:Value cannot be
+       assessed here because ingestion normalises to JSON
+* 3.5  Build information — Created, CreatorComment, and the Creator field's
+       Organization and Tool lines, plus the CISA SBOM Type keyword
+* 3.6-3.13 concern delivery, scope, confidentiality and process. They are
+       properties of how an SBOM is supplied rather than of its content, so no
+       finding is emitted for them.
+
+Source: https://github.com/OpenChain-Project/Telco-WG/blob/main/OpenChain-Telco-SBOM-Guide_EN.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sbomify.apps.plugins.sdk.base import AssessmentPlugin, SBOMContext
+from sbomify.apps.plugins.sdk.enums import AssessmentCategory
+from sbomify.apps.plugins.sdk.results import (
+    AssessmentResult,
+    AssessmentSummary,
+    Finding,
+    PluginMetadata,
+)
+from sbomify.logging import getLogger
+
+logger = getLogger(__name__)
+
+# §3.5: the six CISA SBOM types, expected in CreatorComment as "SBOM Type: xxx".
+_CISA_SBOM_TYPES = ("design", "source", "build", "analyzed", "deployed", "runtime")
+
+_SUPPORTED_SPDX_VERSIONS = ("SPDX-2.2", "SPDX-2.3")
+
+
+class OpenChainTelcoPlugin(AssessmentPlugin):
+    """OpenChain Telco SBOM Guide v1.1 conformance checks."""
+
+    VERSION = "1.0.0"
+    STANDARD_NAME = "OpenChain Telco SBOM Guide"
+    STANDARD_VERSION = "1.1"
+    STANDARD_URL = "https://github.com/OpenChain-Project/Telco-WG/blob/main/OpenChain-Telco-SBOM-Guide_EN.md"
+
+    def get_metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="openchain-telco-1.1",
+            version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE,
+            supported_bom_types=["sbom"],
+        )
+
+    def assess(
+        self,
+        sbom_id: str,
+        sbom_path: Path,
+        dependency_status: dict[str, Any] | None = None,
+        context: SBOMContext | None = None,
+    ) -> AssessmentResult:
+        logger.info(f"[OPENCHAIN-TELCO] Starting conformance check for SBOM {sbom_id}")
+
+        try:
+            sbom_data = json.loads(sbom_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            return self._create_error_result(f"Invalid JSON format: {e}")
+        except Exception as e:
+            return self._create_error_result(f"Failed to read SBOM: {e}")
+
+        findings = self._check(sbom_data)
+
+        summary = AssessmentSummary(
+            total_findings=len(findings),
+            pass_count=sum(1 for f in findings if f.status == "pass"),
+            fail_count=sum(1 for f in findings if f.status == "fail"),
+            warning_count=sum(1 for f in findings if f.status == "warning"),
+            error_count=0,
+        )
+        logger.info(
+            f"[OPENCHAIN-TELCO] Completed for SBOM {sbom_id}: "
+            f"{summary.pass_count} pass, {summary.fail_count} fail, {summary.warning_count} warn"
+        )
+
+        return AssessmentResult(
+            plugin_name="openchain-telco-1.1",
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=summary,
+            findings=findings,
+            metadata={
+                "standard_name": self.STANDARD_NAME,
+                "standard_version": self.STANDARD_VERSION,
+                "standard_url": self.STANDARD_URL,
+            },
+        )
+
+    # ---- clause checks -------------------------------------------------
+
+    def _check(self, sbom: dict[str, Any]) -> list[Finding]:
+        spdx_version = sbom.get("spdxVersion") or ""
+        findings = [self._data_format(spdx_version)]
+
+        # Everything below reads SPDX field names. Against a non-SPDX document
+        # they would all fail for the same single reason, which buries the one
+        # finding that matters, so the run stops at 3.1.
+        if not str(spdx_version).startswith("SPDX-"):
+            return findings
+
+        findings.extend(self._document_creation(sbom))
+        findings.extend(self._packages(sbom))
+        findings.append(self._relationships(sbom))
+        findings.extend(self._build_information(sbom))
+        return findings
+
+    def _finding(self, clause: str, slug: str, title: str, status: str, description: str, fix: str = "") -> Finding:
+        return Finding(
+            id=f"openchain-telco-1.1:{slug}",
+            title=f"{clause} {title}",
+            description=description,
+            status=status,
+            severity="info",
+            remediation=fix or None,
+        )
+
+    def _data_format(self, spdx_version: Any) -> Finding:
+        version = str(spdx_version or "")
+        if version in _SUPPORTED_SPDX_VERSIONS:
+            return self._finding("3.1", "data-format", "Data Format", "pass", f"Document declares {version}.")
+        if version.startswith("SPDX-"):
+            return self._finding(
+                "3.1",
+                "data-format",
+                "Data Format",
+                "fail",
+                f"The Guide requires SPDX 2.2 or 2.3; this document declares {version}.",
+                "Produce the SBOM as SPDX 2.2 or 2.3.",
+            )
+        return self._finding(
+            "3.1",
+            "data-format",
+            "Data Format",
+            "fail",
+            "The Guide requires SPDX 2.2 or 2.3 (§3.1). This document is not SPDX, so it cannot conform.",
+            "Produce an SPDX 2.2 or 2.3 document. CycloneDX cannot satisfy this Guide.",
+        )
+
+    def _document_creation(self, sbom: dict[str, Any]) -> list[Finding]:
+        creation_info = sbom.get("creationInfo") or {}
+        required = {
+            "spdx-version": ("SPDXVersion", sbom.get("spdxVersion")),
+            "data-license": ("DataLicense", sbom.get("dataLicense")),
+            "spdx-id": ("SPDXID", sbom.get("SPDXID")),
+            "document-name": ("DocumentName", sbom.get("name")),
+            "document-namespace": ("DocumentNamespace", sbom.get("documentNamespace")),
+            "creator": ("Creator", creation_info.get("creators")),
+            "created": ("Created", creation_info.get("created")),
+        }
+        findings = []
+        for slug, (field, value) in required.items():
+            present = bool(value)
+            findings.append(
+                self._finding(
+                    "3.2",
+                    slug,
+                    field,
+                    "pass" if present else "fail",
+                    f"{field} is present." if present else f"{field} is required by §3.2 and is missing.",
+                    "" if present else f"Populate {field} in the document creation information.",
+                )
+            )
+        return findings
+
+    def _packages(self, sbom: dict[str, Any]) -> list[Finding]:
+        packages = [p for p in (sbom.get("packages") or []) if isinstance(p, dict)]
+        if not packages:
+            return [
+                self._finding(
+                    "3.2",
+                    "packages",
+                    "Package information",
+                    "fail",
+                    "The document contains no packages, so none of the required package elements can be present.",
+                    "Include the packages the SBOM describes.",
+                )
+            ]
+
+        required = {
+            "package-name": ("PackageName", "name"),
+            "package-spdx-id": ("SPDXID", "SPDXID"),
+            "package-version": ("PackageVersion", "versionInfo"),
+            "package-supplier": ("PackageSupplier", "supplier"),
+            "package-download-location": ("PackageDownloadLocation", "downloadLocation"),
+            "package-license-concluded": ("PackageLicenseConcluded", "licenseConcluded"),
+            "package-license-declared": ("PackageLicenseDeclared", "licenseDeclared"),
+            "package-copyright": ("PackageCopyrightText", "copyrightText"),
+        }
+        findings = []
+        for slug, (field, key) in required.items():
+            missing = [p.get("name") or p.get("SPDXID") or "?" for p in packages if not p.get(key)]
+            findings.append(self._coverage_finding("3.2", slug, field, packages, missing, status_when_missing="fail"))
+
+        # §3.2: one of PackageChecksum or PackageVerificationCode is RECOMMENDED.
+        no_hash = [
+            p.get("name") or "?" for p in packages if not (p.get("checksums") or p.get("packageVerificationCode"))
+        ]
+        findings.append(
+            self._coverage_finding(
+                "3.2",
+                "package-hash",
+                "PackageChecksum or PackageVerificationCode",
+                packages,
+                no_hash,
+                status_when_missing="warning",
+                recommended=True,
+            )
+        )
+
+        # §3.2: a package SHOULD be identified by a PURL, carried in ExternalRef.
+        no_purl = [p.get("name") or "?" for p in packages if not self._has_purl(p)]
+        findings.append(
+            self._coverage_finding(
+                "3.2",
+                "package-purl",
+                "Package URL (PURL)",
+                packages,
+                no_purl,
+                status_when_missing="warning",
+                recommended=True,
+            )
+        )
+        return findings
+
+    @staticmethod
+    def _has_purl(package: dict[str, Any]) -> bool:
+        for ref in package.get("externalRefs") or []:
+            if isinstance(ref, dict) and str(ref.get("referenceType", "")).lower() == "purl":
+                return True
+        return False
+
+    def _coverage_finding(
+        self,
+        clause: str,
+        slug: str,
+        field: str,
+        packages: list[dict[str, Any]],
+        missing: list[str],
+        *,
+        status_when_missing: str,
+        recommended: bool = False,
+    ) -> Finding:
+        total = len(packages)
+        if not missing:
+            return self._finding(clause, slug, field, "pass", f"All {total} packages carry {field}.")
+        # Name a handful rather than every package: the list is for orienting the
+        # reader, and a thousand-package SBOM would otherwise produce a wall.
+        sample = ", ".join(missing[:5]) + (f" and {len(missing) - 5} more" if len(missing) > 5 else "")
+        word = "RECOMMENDED" if recommended else "REQUIRED"
+        return self._finding(
+            clause,
+            slug,
+            field,
+            status_when_missing,
+            f"{len(missing)} of {total} packages are missing {field}, which §{clause} marks {word}: {sample}.",
+            f"Populate {field} for every package.",
+        )
+
+    def _relationships(self, sbom: dict[str, Any]) -> Finding:
+        kinds = {
+            str(r.get("relationshipType", "")).upper() for r in (sbom.get("relationships") or []) if isinstance(r, dict)
+        }
+        missing = [k for k in ("DESCRIBES", "CONTAINS") if k not in kinds]
+        if not missing:
+            return self._finding("3.2", "relationships", "Relationships", "pass", "DESCRIBES and CONTAINS present.")
+        return self._finding(
+            "3.2",
+            "relationships",
+            "Relationships",
+            "fail",
+            f"§3.2 requires at least DESCRIBES and CONTAINS relationships; missing: {', '.join(missing)}.",
+            "Emit the relationships describing the document and its contained packages.",
+        )
+
+    def _build_information(self, sbom: dict[str, Any]) -> list[Finding]:
+        creation_info = sbom.get("creationInfo") or {}
+        creators = [str(c) for c in (creation_info.get("creators") or [])]
+        comment = str(creation_info.get("creatorComment") or "")
+        findings = []
+
+        has_org = any(c.strip().lower().startswith("organization:") for c in creators)
+        findings.append(
+            self._finding(
+                "3.5",
+                "creator-organization",
+                "Creator Organization",
+                "pass" if has_org else "fail",
+                "Creator includes an Organization line."
+                if has_org
+                else "§3.5 requires the Creator field to include a line with the Organization keyword.",
+                "" if has_org else "Add an 'Organization: <name>' creator entry.",
+            )
+        )
+
+        tool_lines = [c for c in creators if c.strip().lower().startswith("tool:")]
+        # §3.5: the Tool line must carry name and version. The Guide says they
+        # SHOULD be hyphen-separated, so a missing version is the failure and
+        # the separator is not policed.
+        tool_versioned = any(re.search(r"\d", line.split(":", 1)[1]) for line in tool_lines if ":" in line)
+        findings.append(
+            self._finding(
+                "3.5",
+                "creator-tool",
+                "Creator Tool and version",
+                "pass" if tool_versioned else "fail",
+                "Creator includes a Tool line carrying a version."
+                if tool_versioned
+                else "§3.5 requires a Tool line naming the tool and its version.",
+                "" if tool_versioned else "Add a 'Tool: <name>-<version>' creator entry.",
+            )
+        )
+
+        findings.append(
+            self._finding(
+                "3.5",
+                "creator-comment",
+                "CreatorComment",
+                "pass" if comment else "fail",
+                "CreatorComment is present."
+                if comment
+                else "§3.2 and §3.5 require CreatorComment, which carries the SBOM build information.",
+                "" if comment else "Populate CreatorComment.",
+            )
+        )
+
+        has_type = any(t in comment.lower() for t in _CISA_SBOM_TYPES)
+        findings.append(
+            self._finding(
+                "3.5",
+                "sbom-type",
+                "SBOM Type",
+                "pass" if has_type else "fail",
+                "CreatorComment names a CISA SBOM Type."
+                if has_type
+                else "§3.5 requires the CISA SBOM Type in CreatorComment "
+                "(Design, Source, Build, Analyzed, Deployed or Runtime).",
+                "" if has_type else "Add 'SBOM Type: Build' (or the applicable type) to CreatorComment.",
+            )
+        )
+        return findings
+
+    def _create_error_result(self, error_message: str) -> AssessmentResult:
+        """An unreadable document cannot be judged conformant or not."""
+        return AssessmentResult(
+            plugin_name="openchain-telco-1.1",
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.COMPLIANCE.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=AssessmentSummary(total_findings=1, pass_count=0, fail_count=0, warning_count=0, error_count=1),
+            findings=[
+                Finding(
+                    id="openchain-telco-1.1:error",
+                    title="Assessment Error",
+                    description=error_message,
+                    status="error",
+                    severity="high",
+                )
+            ],
+            metadata={"standard_name": self.STANDARD_NAME, "standard_version": self.STANDARD_VERSION},
+        )

--- a/sbomify/apps/plugins/builtins/openchain_telco.py
+++ b/sbomify/apps/plugins/builtins/openchain_telco.py
@@ -54,6 +54,18 @@ _CISA_SBOM_TYPES = ("design", "source", "build", "analyzed", "deployed", "runtim
 _SUPPORTED_SPDX_VERSIONS = ("SPDX-2.2", "SPDX-2.3")
 
 
+# Most of §3.2's required document elements are top-level SPDX keys; only
+# Creator and Created live under creationInfo. Saying "in the document creation
+# information" for all of them sends the reader to the wrong place.
+_CREATION_INFO_FIELDS = {"creator", "created"}
+
+
+def _where_to_fix(slug: str, field: str) -> str:
+    if slug in _CREATION_INFO_FIELDS:
+        return f"Populate {field} in the document creation information."
+    return f"Populate the top-level {field} key."
+
+
 class OpenChainTelcoPlugin(AssessmentPlugin):
     """OpenChain Telco SBOM Guide v1.1 conformance checks."""
 
@@ -165,7 +177,11 @@ class OpenChainTelcoPlugin(AssessmentPlugin):
         )
 
     def _document_creation(self, sbom: dict[str, Any]) -> list[Finding]:
-        creation_info = sbom.get("creationInfo") or {}
+        # A malformed document can carry any JSON type here. Calling .get on a
+        # non-dict would raise and lose the assessment entirely, when the point
+        # of the check is to report the document as non-conformant.
+        raw_creation_info = sbom.get("creationInfo")
+        creation_info = raw_creation_info if isinstance(raw_creation_info, dict) else {}
         required = {
             "spdx-version": ("SPDXVersion", sbom.get("spdxVersion")),
             "data-license": ("DataLicense", sbom.get("dataLicense")),
@@ -185,7 +201,7 @@ class OpenChainTelcoPlugin(AssessmentPlugin):
                     field,
                     "pass" if present else "fail",
                     f"{field} is present." if present else f"{field} is required by §3.2 and is missing.",
-                    "" if present else f"Populate {field} in the document creation information.",
+                    "" if present else _where_to_fix(slug, field),
                 )
             )
         return findings
@@ -301,7 +317,11 @@ class OpenChainTelcoPlugin(AssessmentPlugin):
         )
 
     def _build_information(self, sbom: dict[str, Any]) -> list[Finding]:
-        creation_info = sbom.get("creationInfo") or {}
+        # A malformed document can carry any JSON type here. Calling .get on a
+        # non-dict would raise and lose the assessment entirely, when the point
+        # of the check is to report the document as non-conformant.
+        raw_creation_info = sbom.get("creationInfo")
+        creation_info = raw_creation_info if isinstance(raw_creation_info, dict) else {}
         creators = [str(c) for c in (creation_info.get("creators") or [])]
         comment = str(creation_info.get("creatorComment") or "")
         findings = []

--- a/sbomify/apps/plugins/builtins/openchain_telco.py
+++ b/sbomify/apps/plugins/builtins/openchain_telco.py
@@ -371,6 +371,11 @@ class OpenChainTelcoPlugin(AssessmentPlugin):
             )
         )
 
+        # A bare substring match, deliberately. "SBOM Type: Build" is only the
+        # recommended syntax; the Guide then says it requires no particular
+        # format, "only ... that at least one of the words 'Design', 'Source',
+        # 'Build', 'Analyzed', 'Deployed', 'Runtime' is present, regardless of
+        # the case". Demanding the label would fail documents the Guide accepts.
         has_type = any(t in comment.lower() for t in _CISA_SBOM_TYPES)
         findings.append(
             self._finding(

--- a/sbomify/apps/plugins/tests/test_builtin_reconciliation.py
+++ b/sbomify/apps/plugins/tests/test_builtin_reconciliation.py
@@ -68,6 +68,7 @@ class TestBuiltinReconciliation:
         builtins = RegisteredPlugin.objects.filter(is_builtin=True)
         expected_names = {
             "ntia-minimum-elements-2021",
+            "openchain-telco-1.1",
             "fda-medical-device-2025",
             "bsi-tr03183-v2.1-compliance",
             "sbom-verification",

--- a/sbomify/apps/plugins/tests/test_openchain_telco.py
+++ b/sbomify/apps/plugins/tests/test_openchain_telco.py
@@ -255,3 +255,44 @@ def test_metadata_matches_the_registered_name():
 
     assert metadata.name == "openchain-telco-1.1"
     assert metadata.category.value == "compliance"
+
+
+class TestMalformedInput:
+    """A non-conformant document must be reported, not crash the assessment."""
+
+    def test_a_non_dict_creation_info_does_not_crash(self, plugin, tmp_path):
+        document = _conformant() | {"creationInfo": "not an object"}
+
+        result = _run(plugin, document, tmp_path)
+
+        statuses = _by_slug(result)
+        assert statuses["creator"] == "fail"
+        assert statuses["created"] == "fail"
+        assert result.summary.error_count == 0
+
+    def test_a_null_creation_info_does_not_crash(self, plugin, tmp_path):
+        document = _conformant() | {"creationInfo": None}
+
+        assert _by_slug(_run(plugin, document, tmp_path))["creator"] == "fail"
+
+
+class TestRemediationPointsAtTheRightPlace:
+    def test_top_level_fields_are_named_as_top_level(self, plugin, tmp_path):
+        """Most §3.2 document elements are top-level keys; only Creator and
+        Created live under creationInfo."""
+        document = _conformant()
+        del document["dataLicense"]
+
+        result = _run(plugin, document, tmp_path)
+        finding = next(f for f in result.findings if f.id.endswith("data-license"))
+
+        assert "top-level" in finding.remediation
+
+    def test_creation_info_fields_are_named_as_such(self, plugin, tmp_path):
+        document = _conformant()
+        document["creationInfo"]["creators"] = []
+
+        result = _run(plugin, document, tmp_path)
+        finding = next(f for f in result.findings if f.id.endswith(":creator"))
+
+        assert "document creation information" in finding.remediation

--- a/sbomify/apps/plugins/tests/test_openchain_telco.py
+++ b/sbomify/apps/plugins/tests/test_openchain_telco.py
@@ -1,0 +1,257 @@
+"""OpenChain Telco SBOM Guide v1.1 conformance checks.
+
+The clause numbers and wording come from the published Guide, not from the
+issue, which describes it as "a field-presence profile over CycloneDX". §3.1
+says the opposite: a conformant document SHALL be SPDX 2.2 or 2.3, and §3.3.2
+explains the choice over CycloneDX. That is pinned first, since it is the
+difference between assessing a document and assessing one that can never pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sbomify.apps.plugins.builtins.openchain_telco import OpenChainTelcoPlugin
+
+
+@pytest.fixture
+def plugin():
+    return OpenChainTelcoPlugin()
+
+
+def _conformant() -> dict:
+    """A document that satisfies every machine-checkable clause."""
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "acme-gateway",
+        "documentNamespace": "https://acme.test/spdx/acme-gateway-1.0",
+        "creationInfo": {
+            "created": "2026-07-29T00:00:00Z",
+            "creators": ["Organization: Acme Corp", "Tool: syft-1.18.1"],
+            "creatorComment": "SBOM Type: Build",
+        },
+        "packages": [
+            {
+                "name": "django",
+                "SPDXID": "SPDXRef-Package-django",
+                "versionInfo": "5.1.4",
+                "supplier": "Organization: Django Software Foundation",
+                "downloadLocation": "https://pypi.org/project/Django/",
+                "licenseConcluded": "BSD-3-Clause",
+                "licenseDeclared": "BSD-3-Clause",
+                "copyrightText": "Copyright (c) Django Software Foundation",
+                "checksums": [{"algorithm": "SHA256", "checksumValue": "abc123"}],
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": "pkg:pypi/django@5.1.4",
+                    }
+                ],
+            }
+        ],
+        "relationships": [
+            {"relationshipType": "DESCRIBES"},
+            {"relationshipType": "CONTAINS"},
+        ],
+    }
+
+
+def _run(plugin, document, tmp_path: Path):
+    path = tmp_path / "sbom.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return plugin.assess("sbom-1", path)
+
+
+def _by_slug(result) -> dict[str, str]:
+    return {f.id.split(":", 1)[1]: f.status for f in result.findings}
+
+
+class TestDataFormat:
+    def test_a_conformant_spdx_document_passes_everything(self, plugin, tmp_path):
+        result = _run(plugin, _conformant(), tmp_path)
+
+        assert result.summary.fail_count == 0
+        assert result.summary.warning_count == 0
+
+    @pytest.mark.parametrize("version", ["SPDX-2.2", "SPDX-2.3"])
+    def test_both_accepted_spdx_versions(self, plugin, tmp_path, version):
+        document = _conformant() | {"spdxVersion": version}
+
+        assert _by_slug(_run(plugin, document, tmp_path))["data-format"] == "pass"
+
+    def test_an_older_spdx_version_fails(self, plugin, tmp_path):
+        document = _conformant() | {"spdxVersion": "SPDX-2.1"}
+
+        assert _by_slug(_run(plugin, document, tmp_path))["data-format"] == "fail"
+
+    def test_cyclonedx_cannot_conform(self, plugin, tmp_path):
+        """§3.1 mandates SPDX, so a CycloneDX document fails outright rather
+        than being judged field by field against a profile it cannot satisfy."""
+        result = _run(plugin, {"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}, tmp_path)
+
+        statuses = _by_slug(result)
+        assert statuses["data-format"] == "fail"
+        # and nothing else is reported, so the one real reason is not buried
+        assert list(statuses) == ["data-format"]
+
+
+class TestDocumentElements:
+    @pytest.mark.parametrize(
+        ("field", "slug"),
+        [
+            ("dataLicense", "data-license"),
+            ("SPDXID", "spdx-id"),
+            ("name", "document-name"),
+            ("documentNamespace", "document-namespace"),
+        ],
+    )
+    def test_a_missing_required_document_field_fails(self, plugin, tmp_path, field, slug):
+        document = _conformant()
+        del document[field]
+
+        assert _by_slug(_run(plugin, document, tmp_path))[slug] == "fail"
+
+    def test_missing_creator_fails(self, plugin, tmp_path):
+        document = _conformant()
+        document["creationInfo"]["creators"] = []
+
+        assert _by_slug(_run(plugin, document, tmp_path))["creator"] == "fail"
+
+
+class TestPackageElements:
+    @pytest.mark.parametrize(
+        ("field", "slug"),
+        [
+            ("versionInfo", "package-version"),
+            ("supplier", "package-supplier"),
+            ("downloadLocation", "package-download-location"),
+            ("licenseConcluded", "package-license-concluded"),
+            ("licenseDeclared", "package-license-declared"),
+            ("copyrightText", "package-copyright"),
+        ],
+    )
+    def test_a_missing_required_package_field_fails(self, plugin, tmp_path, field, slug):
+        document = _conformant()
+        del document["packages"][0][field]
+
+        assert _by_slug(_run(plugin, document, tmp_path))[slug] == "fail"
+
+    def test_a_missing_hash_is_only_a_warning(self, plugin, tmp_path):
+        """§3.2 marks checksum/verification code RECOMMENDED, not required."""
+        document = _conformant()
+        del document["packages"][0]["checksums"]
+
+        assert _by_slug(_run(plugin, document, tmp_path))["package-hash"] == "warning"
+
+    def test_a_verification_code_satisfies_the_hash_requirement(self, plugin, tmp_path):
+        """The Guide accepts either, so one must not be reported as missing
+        because the other is absent."""
+        document = _conformant()
+        del document["packages"][0]["checksums"]
+        document["packages"][0]["packageVerificationCode"] = {"packageVerificationCodeValue": "d6a7"}
+
+        assert _by_slug(_run(plugin, document, tmp_path))["package-hash"] == "pass"
+
+    def test_a_missing_purl_is_only_a_warning(self, plugin, tmp_path):
+        """§3.2 says a package SHOULD be identified by a PURL."""
+        document = _conformant()
+        del document["packages"][0]["externalRefs"]
+
+        assert _by_slug(_run(plugin, document, tmp_path))["package-purl"] == "warning"
+
+    def test_a_non_purl_external_ref_does_not_count(self, plugin, tmp_path):
+        document = _conformant()
+        document["packages"][0]["externalRefs"] = [{"referenceType": "cpe23Type", "referenceLocator": "cpe:2.3:a:x"}]
+
+        assert _by_slug(_run(plugin, document, tmp_path))["package-purl"] == "warning"
+
+    def test_a_document_with_no_packages_fails(self, plugin, tmp_path):
+        document = _conformant() | {"packages": []}
+
+        assert _by_slug(_run(plugin, document, tmp_path))["packages"] == "fail"
+
+    def test_the_message_names_only_a_sample_of_offenders(self, plugin, tmp_path):
+        """A thousand-package SBOM must not produce a wall of package names."""
+        document = _conformant()
+        document["packages"] = [{"name": f"pkg-{i}", "SPDXID": f"SPDXRef-{i}"} for i in range(20)]
+
+        result = _run(plugin, document, tmp_path)
+        finding = next(f for f in result.findings if f.id.endswith("package-version"))
+
+        assert "and 15 more" in finding.description
+
+
+class TestRelationships:
+    def test_both_required_relationships_present_passes(self, plugin, tmp_path):
+        assert _by_slug(_run(plugin, _conformant(), tmp_path))["relationships"] == "pass"
+
+    def test_a_missing_contains_fails(self, plugin, tmp_path):
+        document = _conformant()
+        document["relationships"] = [{"relationshipType": "DESCRIBES"}]
+
+        result = _run(plugin, document, tmp_path)
+        finding = next(f for f in result.findings if f.id.endswith("relationships"))
+
+        assert finding.status == "fail"
+        assert "CONTAINS" in finding.description
+
+
+class TestBuildInformation:
+    def test_a_creator_without_an_organization_fails(self, plugin, tmp_path):
+        document = _conformant()
+        document["creationInfo"]["creators"] = ["Tool: syft-1.18.1"]
+
+        assert _by_slug(_run(plugin, document, tmp_path))["creator-organization"] == "fail"
+
+    def test_a_tool_without_a_version_fails(self, plugin, tmp_path):
+        """§3.5 requires the Tool line to carry name and version."""
+        document = _conformant()
+        document["creationInfo"]["creators"] = ["Organization: Acme Corp", "Tool: syft"]
+
+        assert _by_slug(_run(plugin, document, tmp_path))["creator-tool"] == "fail"
+
+    def test_a_missing_creator_comment_fails(self, plugin, tmp_path):
+        document = _conformant()
+        document["creationInfo"]["creatorComment"] = ""
+
+        assert _by_slug(_run(plugin, document, tmp_path))["creator-comment"] == "fail"
+
+    @pytest.mark.parametrize("sbom_type", ["Design", "Source", "Build", "Analyzed", "Deployed", "Runtime"])
+    def test_each_cisa_sbom_type_is_recognised(self, plugin, tmp_path, sbom_type):
+        document = _conformant()
+        document["creationInfo"]["creatorComment"] = f"SBOM Type: {sbom_type}"
+
+        assert _by_slug(_run(plugin, document, tmp_path))["sbom-type"] == "pass"
+
+    def test_a_comment_without_an_sbom_type_fails(self, plugin, tmp_path):
+        document = _conformant()
+        document["creationInfo"]["creatorComment"] = "Generated nightly."
+
+        assert _by_slug(_run(plugin, document, tmp_path))["sbom-type"] == "fail"
+
+
+class TestUnreadableInput:
+    def test_invalid_json_is_an_error_not_a_verdict(self, plugin, tmp_path):
+        """An unreadable document cannot be judged conformant or not."""
+        path = tmp_path / "sbom.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        result = plugin.assess("sbom-1", path)
+
+        assert result.summary.error_count == 1
+        assert result.summary.fail_count == 0
+
+
+def test_metadata_matches_the_registered_name():
+    """The registry entry and the plugin must agree, or the orchestrator
+    cannot load it."""
+    metadata = OpenChainTelcoPlugin().get_metadata()
+
+    assert metadata.name == "openchain-telco-1.1"
+    assert metadata.category.value == "compliance"


### PR DESCRIPTION
Closes #1191. One more builtin following `ntia.py`, no new infrastructure.

## A correction worth reading first

The issue calls the Guide "a field-presence profile over **CycloneDX**". The published Guide says the opposite. §3.1:

> An OpenChain Telco SBOM Guide compatible document SHALL adhere to the version 2.2 of the SPDX Data Format as standardized in ISO/IEC 5962:2021, or to the version 2.3

and §3.3.2 sets out the reasoning for choosing SPDX over CycloneDX explicitly. **A CycloneDX SBOM cannot conform at all.**

So a CycloneDX document fails 3.1 and the run stops there, rather than emitting a dozen "missing SPDXVersion / missing DataLicense / missing PackageCopyrightText" findings that would bury the one reason that actually matters. There is a test asserting exactly one finding comes back in that case.

I pulled the Guide text rather than working from the issue summary, because shipping a compliance plugin against half-remembered requirements is worse than not shipping one.

## Clause coverage

| Clause | Checked |
|---|---|
| 3.1 Data Format | SPDX 2.2 or 2.3 |
| 3.2 Document creation | SPDXVersion, DataLicense, SPDXID, DocumentName, DocumentNamespace, Creator, Created |
| 3.2 Package | PackageName, SPDXID, PackageVersion, PackageSupplier, PackageDownloadLocation, PackageLicenseConcluded, PackageLicenseDeclared, PackageCopyrightText |
| 3.2 Recommended | PackageChecksum **or** PackageVerificationCode, and PURL in ExternalRef, both as warnings |
| 3.2 Relationships | at least DESCRIBES and CONTAINS |
| 3.5 Build information | Creator Organization line, Creator Tool line carrying a version, CreatorComment, and the CISA SBOM Type keyword |

The RECOMMENDED items are warnings rather than failures, because the Guide marks them RECOMMENDED and SHOULD, not SHALL. Either hash form satisfies the clause, since the Guide accepts both, and a test covers the verification-code path so one is not reported missing because the other is absent.

## Deliberately not checked

- **3.3 Tag:Value** cannot be assessed here: ingestion normalises to JSON, so the Tag:Value alternative never reaches the plugin.
- **3.6 to 3.13** govern timing, method of delivery, scope, SaaS, containers, verification, merger and confidentiality. Those are properties of how an SBOM is supplied, not of the document, so no finding is emitted.

Both are documented in the module rather than silently skipped, so the next reader does not have to work out whether they were missed.

## Testing

36 tests, all passing on the first run: both accepted SPDX versions, an older one, the CycloneDX case, each required document and package field, both recommended items including the either/or hash, the relationships, every one of the six CISA SBOM types, unreadable JSON reported as an error rather than a verdict, and that the plugin metadata matches its registry name. Registered in the reconciliation test that pins builtin names. 884 plugin tests pass.