### PR TITLE
chore(release): 26.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sbomify-frontend-components",
   "private": true,
-  "version": "26.7.0",
+  "version": "26.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbomify"
-version = "26.7.0"
+version = "26.7.1"
 description = "sbomify - the security artifact hub"
 authors = [{ name = "sbomify", email = "hello@sbomify.com" }]
 requires-python = ">=3.13,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2714,7 +2714,7 @@ wheels = [
 
 [[package]]
 name = "sbomify"
-version = "26.7.0"
+version = "26.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Bump version to 26.7.1 in `pyproject.toml`, `package.json`, and `uv.lock`

Prep PR for the v26.7.1 release. Tag is cut after this lands on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)