### PR TITLE
fix(tea): stop the tea namespace nesting inside itself

### DIFF
--- a/sbomify/apps/tea/tests/test_openapi_surface.py
+++ b/sbomify/apps/tea/tests/test_openapi_surface.py
@@ -1,0 +1,42 @@
+"""The TEA API's own OpenAPI surface.
+
+Both endpoints 500'd on a plain URL-resolution error and nothing noticed,
+because no test ever requested them. They need no fixtures, so there is no
+reason not to assert them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.tea.mappers import TEA_API_VERSION
+
+pytestmark = pytest.mark.django_db
+
+BASE = f"/tea/v{TEA_API_VERSION}/"
+
+
+@pytest.mark.parametrize("path", ["docs", "openapi.json"])
+def test_the_openapi_surface_is_reachable(client: Client, path: str):
+    """Guards the namespace shape. Declaring app_name here as well as
+    urls_namespace on the NinjaAPI nests "tea" inside itself, so every route
+    lands at tea:tea:<name> while django-ninja reverses tea:<name>."""
+    response = client.get(f"{BASE}{path}")
+
+    assert response.status_code == 200
+
+
+def test_the_schema_describes_the_tea_api(client: Client):
+    schema = client.get(f"{BASE}openapi.json").json()
+
+    assert "Transparency Exchange API" in schema["info"]["title"]
+    assert schema["paths"]
+
+
+def test_the_route_names_resolve_without_a_doubled_namespace():
+    """The direct assertion. A doubled namespace still serves the routes, so
+    only reversing catches it."""
+    assert reverse("tea:openapi-json").endswith("openapi.json")
+    assert reverse("tea:api-root") == BASE

--- a/sbomify/apps/tea/urls.py
+++ b/sbomify/apps/tea/urls.py
@@ -16,7 +16,10 @@ from sbomify.logging import getLogger
 
 log = getLogger(__name__)
 
-app_name = "tea"
+# Deliberately no ``app_name``. ``tea_api.urls`` already carries the "tea"
+# namespace from ``urls_namespace``, and declaring one here too nests it inside
+# itself: every route ends up at ``tea:tea:<name>`` while django-ninja reverses
+# ``tea:<name>``, which 500s /docs and /openapi.json with NoReverseMatch.
 
 # Create a dedicated NinjaAPI instance for TEA
 # This allows TEA to have its own OpenAPI docs


### PR DESCRIPTION
Closes #1259.

`/tea/v0.4.0/docs` and `/openapi.json` both 500'd on `NoReverseMatch`. Two namespace layers were declared over the same URLs: `app_name = "tea"` in `apps/tea/urls.py`, which makes `include()` create a `tea` namespace, and `urls_namespace="tea"` on the `NinjaAPI`, whose `.urls` carry their own. Every route therefore lived at `tea:tea:<name>` while django-ninja reverses `tea:<name>`.

Dropped the `app_name`, which is the smaller of the two removals the issue suggested. Checked nothing reversed the outer namespace first: the only `tea:` strings in the tree are cache keys in `test_cache.py`.

```
before                after
/docs         500  →  200
/openapi.json 500  →  200
/discovery    422  →  422   (unchanged, wants params)
```

Verified in the browser as well: the docs page renders the full endpoint list.

Tests do the two things nothing did before — request both endpoints, and reverse the route names directly. The second matters because a doubled namespace still *serves* the routes, so only reversing catches a regression.