### PR TITLE
fix(tests): the UX fixture reuses the auto-created latest release

### DIFF
--- a/sbomify/apps/core/tests/e2e/fixtures.py
+++ b/sbomify/apps/core/tests/e2e/fixtures.py
@@ -5,7 +5,7 @@ from typing import Generator
 import pytest
 from django.utils import timezone
 
-from sbomify.apps.core.models import Component, Product, Release
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Component, Product, Release
 from sbomify.apps.core.tests.e2e.factories import *  # noqa: F403
 from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
 
@@ -197,3 +197,113 @@ def document_component_details(component_factory, product_factory, document_fact
     document_factory(component, name="simple-document.pdf", version="1.0.0")
 
     return component
+
+
+@pytest.fixture
+def trust_center_product(product_factory, component_factory, sbom_factory, document_factory, team_with_business_plan):
+    """Realistic trust-center product: SBOM + doc + identifiers + links + releases."""
+    team_with_business_plan.is_public = True
+    team_with_business_plan.save()
+
+    name = "UX Review Product"
+    _id = hashlib.md5(name.encode()).hexdigest()[:12]
+    product = product_factory(name=name, _id=_id, is_public=True)
+
+    bom = component_factory(
+        "Backend API",
+        Component.ComponentType.BOM,
+        product=product,
+        visibility=Component.Visibility.PUBLIC,
+    )
+    sbom_factory(bom, name="backend-api-sbom.json", version="2.4.1")
+
+    doc = component_factory(
+        "Compliance Pack",
+        Component.ComponentType.DOCUMENT,
+        product=product,
+        visibility=Component.Visibility.PUBLIC,
+    )
+    document_factory(doc, name="soc2-report.pdf", version="2025")
+
+    ProductIdentifier.objects.bulk_create(
+        [
+            ProductIdentifier(
+                product=product,
+                identifier_type=ProductIdentifier.IdentifierType.SKU,
+                value="SKU-UX-001",
+                team=product.team,
+            ),
+            ProductIdentifier(
+                product=product,
+                identifier_type=ProductIdentifier.IdentifierType.GTIN_13,
+                value="0123456789012",
+                team=product.team,
+            ),
+            ProductIdentifier(
+                product=product,
+                identifier_type=ProductIdentifier.IdentifierType.CPE,
+                value="cpe:2.3:a:test:product:1.0.0:*:*:*:*:*:*:*",
+                team=product.team,
+            ),
+        ]
+    )
+
+    ProductLink.objects.bulk_create(
+        [
+            ProductLink(
+                product=product,
+                link_type=ProductLink.LinkType.WEBSITE,
+                title="Product Website",
+                url="https://example.com",
+                team=product.team,
+            ),
+            ProductLink(
+                product=product,
+                link_type=ProductLink.LinkType.REPOSITORY,
+                title="GitHub Repository",
+                url="https://github.com/example/product",
+                team=product.team,
+            ),
+            ProductLink(
+                product=product,
+                link_type=ProductLink.LinkType.DOCUMENTATION,
+                title="Documentation",
+                url="https://docs.example.com",
+                team=product.team,
+            ),
+        ]
+    )
+
+    # Versioned releases: is_latest=False. The model reserves is_latest for
+    # the auto-managed `latest` synthetic release; `.create()` (not bulk) so
+    # save-time validations and signals run.
+    for name_, description, is_prerelease in [
+        ("v1.0.0", "Initial GA release", False),
+        ("v1.1.0", "Maintenance release", False),
+        ("v2.0.0", "Major update — new dashboard, faster scans", False),
+        ("v2.1.0-beta", "Beta — preview of release-channel feature", True),
+    ]:
+        Release.objects.create(
+            product=product,
+            name=name_,
+            description=description,
+            is_latest=False,
+            is_prerelease=is_prerelease,
+        )
+
+    # The synthetic auto-managed `latest` release already exists: adding the
+    # SBOM and the document above fires the signals that create it. Creating a
+    # second one trips the "A product can only have one latest release" guard,
+    # which is what broke every case built on this fixture. get_or_create so the
+    # fixture still works if it is ever used without artifacts.
+    #
+    # The public views filter it out of release lists; the UX-review pages
+    # exercise both the filtered list rendering and the synthetic-release
+    # download CTA.
+    Release.objects.get_or_create(
+        product=product,
+        name=LATEST_RELEASE_NAME,
+        defaults={"is_latest": True, "is_prerelease": False},
+    )
+
+    yield product

--- a/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
+++ b/sbomify/apps/core/tests/e2e/test_ux_review_trust_center.py
@@ -15,9 +15,8 @@ from pathlib import Path
 import pytest
 from playwright.sync_api import Page
 
-from sbomify.apps.core.models import LATEST_RELEASE_NAME, Component, Release
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Component
 from sbomify.apps.core.tests.e2e.fixtures import *  # noqa: F403
-from sbomify.apps.sboms.models import ProductIdentifier, ProductLink
 
 OUT_DIR = Path("/tmp/ux-review")
 
@@ -41,109 +40,6 @@ def _full_page_screenshot(page: Page, label: str, width: int) -> Path:
     out = OUT_DIR / f"{label}__{width}.jpg"
     page.screenshot(path=out.as_posix(), type="jpeg", full_page=True, quality=80)
     return out
-
-
-@pytest.fixture
-def trust_center_product(product_factory, component_factory, sbom_factory, document_factory, team_with_business_plan):
-    """Realistic trust-center product: SBOM + doc + identifiers + links + releases."""
-    team_with_business_plan.is_public = True
-    team_with_business_plan.save()
-
-    name = "UX Review Product"
-    _id = hashlib.md5(name.encode()).hexdigest()[:12]
-    product = product_factory(name=name, _id=_id, is_public=True)
-
-    bom = component_factory(
-        "Backend API",
-        Component.ComponentType.BOM,
-        product=product,
-        visibility=Component.Visibility.PUBLIC,
-    )
-    sbom_factory(bom, name="backend-api-sbom.json", version="2.4.1")
-
-    doc = component_factory(
-        "Compliance Pack",
-        Component.ComponentType.DOCUMENT,
-        product=product,
-        visibility=Component.Visibility.PUBLIC,
-    )
-    document_factory(doc, name="soc2-report.pdf", version="2025")
-
-    ProductIdentifier.objects.bulk_create([
-        ProductIdentifier(
-            product=product,
-            identifier_type=ProductIdentifier.IdentifierType.SKU,
-            value="SKU-UX-001",
-            team=product.team,
-        ),
-        ProductIdentifier(
-            product=product,
-            identifier_type=ProductIdentifier.IdentifierType.GTIN_13,
-            value="0123456789012",
-            team=product.team,
-        ),
-        ProductIdentifier(
-            product=product,
-            identifier_type=ProductIdentifier.IdentifierType.CPE,
-            value="cpe:2.3:a:test:product:1.0.0:*:*:*:*:*:*:*",
-            team=product.team,
-        ),
-    ])
-
-    ProductLink.objects.bulk_create([
-        ProductLink(
-            product=product,
-            link_type=ProductLink.LinkType.WEBSITE,
-            title="Product Website",
-            url="https://example.com",
-            team=product.team,
-        ),
-        ProductLink(
-            product=product,
-            link_type=ProductLink.LinkType.REPOSITORY,
-            title="GitHub Repository",
-            url="https://github.com/example/product",
-            team=product.team,
-        ),
-        ProductLink(
-            product=product,
-            link_type=ProductLink.LinkType.DOCUMENTATION,
-            title="Documentation",
-            url="https://docs.example.com",
-            team=product.team,
-        ),
-    ])
-
-    # Versioned releases: is_latest=False. The model reserves is_latest for
-    # the auto-managed `latest` synthetic release; `.create()` (not bulk) so
-    # save-time validations and signals run.
-    for name_, description, is_prerelease in [
-        ("v1.0.0", "Initial GA release", False),
-        ("v1.1.0", "Maintenance release", False),
-        ("v2.0.0", "Major update — new dashboard, faster scans", False),
-        ("v2.1.0-beta", "Beta — preview of release-channel feature", True),
-    ]:
-        Release.objects.create(
-            product=product,
-            name=name_,
-            description=description,
-            is_latest=False,
-            is_prerelease=is_prerelease,
-        )
-
-    # Synthetic auto-managed `latest` release — created the way the
-    # production code does (via the reserved name + is_latest=True). The
-    # public views filter this out of release lists; the UX-review pages
-    # exercise both the filtered list rendering and the synthetic-release
-    # download CTA.
-    Release.objects.create(
-        product=product,
-        name=LATEST_RELEASE_NAME,
-        is_latest=True,
-        is_prerelease=False,
-    )
-
-    yield product
 
 
 @pytest.fixture

--- a/sbomify/apps/core/tests/test_ux_review_fixture_builds.py
+++ b/sbomify/apps/core/tests/test_ux_review_fixture_builds.py
@@ -1,0 +1,40 @@
+"""The trust-center UX fixture, checked outside the screenshot generator.
+
+The generator is gated behind RUN_UX_REVIEW=1 and skipped in CI, which is
+right for a screenshot tool but meant it rotted silently: 28 of its 32 cases
+had been erroring at fixture setup and nothing reported it.
+
+This builds the same fixture with no browser and no screenshots, so the
+generator's setup is covered by an ordinary CI run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.core.models import LATEST_RELEASE_NAME, Release
+from sbomify.apps.core.tests.e2e.fixtures import *  # noqa: F403
+
+pytestmark = pytest.mark.django_db
+
+
+def test_the_trust_center_fixture_builds(trust_center_product):
+    """Guards the collision between the fixture's own latest release and the
+    one the SBOM/document signals create. Adding both used to raise
+    "A product can only have one latest release"."""
+    assert trust_center_product.pk is not None
+
+
+def test_the_product_ends_up_with_exactly_one_latest_release(trust_center_product):
+    latest = Release.objects.filter(product=trust_center_product, is_latest=True)
+
+    assert latest.count() == 1
+    assert latest.get().name == LATEST_RELEASE_NAME
+
+
+def test_the_versioned_releases_are_all_present(trust_center_product):
+    """The screenshots are of a populated product; an empty release list would
+    still pass the checks above."""
+    names = set(Release.objects.filter(product=trust_center_product, is_latest=False).values_list("name", flat=True))
+
+    assert {"v1.0.0", "v1.1.0", "v2.0.0", "v2.1.0-beta"} <= names


### PR DESCRIPTION
Closes #1261.

The fixture created its own release with `is_latest=True`, but adding the SBOM and the document fires the signals that already create one, so the second tripped the one-latest-release guard in `models.py:296`. `get_or_create` on the reserved name, so it still works if the fixture is ever used without artifacts.

```
RUN_UX_REVIEW=1 pytest .../test_ux_review_trust_center.py
before:  4 passed, 28 errors   →  4 of 32 images
after:  32 passed              →  32 of 32 images
```

The issue also asked for a non-gated test, since the module is skipped in CI and that is why this rotted unseen. Moved `trust_center_product` into `e2e/fixtures.py`, where every other factory already lives, and added `test_ux_review_fixture_builds.py`: it builds the fixture with no browser and asserts exactly one latest release plus the versioned ones. That runs in an ordinary CI pass, so the next collision fails loudly instead of silently halving the output.