### PR TITLE
fix(plugins): the summary fragment is not a page

### DIFF
--- a/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
+++ b/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
@@ -1,0 +1,53 @@
+"""The plugins summary fragment must not be reachable as a page.
+
+It renders a template that extends no base, so a direct visit served a naked
+partial: no head, no title, no CSS, no nav. It returns 200, so uptime checks
+pass and only a title assertion catches it.
+
+Scoped to this one view. The vulnerability-trends fragment has the same shape
+but a whole test class exercises it directly, so whether it should 404 needs a
+decision rather than a patch — see issue #1271.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+pytestmark = pytest.mark.django_db
+
+
+def test_a_direct_visit_is_not_a_page(client: Client, sample_team_with_owner_member):
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"))
+
+    assert response.status_code == 404
+
+
+def test_htmx_still_gets_the_fragment(client: Client, sample_team_with_owner_member):
+    """The guard keys on the header htmx always sends, so the plugins page that
+    swaps this in is unaffected."""
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST="true")
+
+    assert response.status_code == 200
+
+
+def test_the_plugins_page_still_asks_for_the_fragment():
+    """Guards the regression the 404 could hide: if the page stopped including
+    the fragment, the 404 would be masking a broken page rather than a non-page.
+
+    Asserted against the template because a fresh test user has no data and is
+    redirected to onboarding before reaching it.
+    """
+    from django.template.loader import get_template
+
+    source = get_template("plugins/plugins_page.html.j2").template.source
+
+    assert "plugins:plugins_summary" in source
+    assert "hx-get" in source

--- a/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
+++ b/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
@@ -51,3 +51,13 @@ def test_the_plugins_page_still_asks_for_the_fragment():
 
     assert "plugins:plugins_summary" in source
     assert "hx-get" in source
+
+
+@pytest.mark.parametrize("header", ["false", "1", "yes", ""])
+def test_a_non_true_hx_request_header_does_not_bypass_the_guard(client: Client, sample_team_with_owner_member, header):
+    """A bare truthiness check would let HX-Request: false through."""
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST=header)
+
+    assert response.status_code == 404

--- a/sbomify/apps/plugins/views.py
+++ b/sbomify/apps/plugins/views.py
@@ -163,7 +163,9 @@ def _reject_direct_navigation(request: HttpRequest) -> None:
     links them as pages — they are only ever swapped into a host page by
     hx-get — so "no such page" is the honest answer.
     """
-    if not request.headers.get("HX-Request"):
+    # Compared against the literal "true", matching HtmxMessagesMiddleware: a
+    # bare truthiness check would let HX-Request: false through the guard.
+    if request.headers.get("HX-Request") != "true":
         raise Http404("This view renders a fragment and is not a page.")
 
 

--- a/sbomify/apps/plugins/views.py
+++ b/sbomify/apps/plugins/views.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
@@ -155,6 +155,18 @@ class PluginsPageView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         return render(request, "plugins/plugins_page.html.j2")
 
 
+def _reject_direct_navigation(request: HttpRequest) -> None:
+    """404 a non-HTMX GET.
+
+    These views render fragments that extend no base template, so a direct
+    visit serves a naked partial: no head, no title, no CSS, no nav. Nothing
+    links them as pages — they are only ever swapped into a host page by
+    hx-get — so "no such page" is the honest answer.
+    """
+    if not request.headers.get("HX-Request"):
+        raise Http404("This view renders a fragment and is not a page.")
+
+
 class PluginsSummaryView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
     """HTMX partial: returns the plugin summary bar with counts."""
 
@@ -162,6 +174,7 @@ class PluginsSummaryView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
 
     def get(self, request: HttpRequest) -> HttpResponse:
         """Return the summary bar partial."""
+        _reject_direct_navigation(request)
         team_data = request.session.get("current_team", {})
         team_key = team_data.get("key", "")
 


### PR DESCRIPTION
Refs #1271 — the half of it that can be fixed without a wider decision.

`/plugins/summary/` returned 200 with an empty `<title>` because it renders a fragment extending no base template, so a direct visit served a naked partial: no head, no CSS, no nav. Nothing links it — the plugins page swaps it in with `hx-get`, and there are no `href`s to it anywhere — so "no such page" is the honest answer. The empty title was the symptom; being routable as a page was the defect.

Keyed on the header htmx always sends, so the swap is untouched:

```
/plugins/summary/      direct=404  viaHtmx=200
/vulnerability-trends/ direct=200  viaHtmx=200   (unchanged)
```

**Deliberately scoped to this one view.** `/vulnerability-trends/` has the same shape, but I tried the same guard there and it failed 31 existing tests in `TestVulnerabilityTrendsView`, which exercise it directly with no `HX-Request` header. That is evidence worth respecting rather than silencing: either those tests are calling it directly for convenience, or the view has a page-ish role I have not found. Either way it needs a decision, not a patch, so it is untouched here and #1271 stays open for it.

Three tests: the direct visit 404s, htmx still gets the fragment, and the plugins page still asks for it — that last one so the 404 cannot quietly start masking a broken page instead of a non-page. It asserts against the template rather than a response because a fresh test user is redirected to onboarding before reaching the page.

946 plugin tests green.