### PR TITLE
fix(vuln): the trends fragment is not a page either

### DIFF
--- a/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
+++ b/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
@@ -1,0 +1,53 @@
+"""The plugins summary fragment must not be reachable as a page.
+
+It renders a template that extends no base, so a direct visit served a naked
+partial: no head, no title, no CSS, no nav. It returns 200, so uptime checks
+pass and only a title assertion catches it.
+
+Scoped to this one view. The vulnerability-trends fragment has the same shape
+but a whole test class exercises it directly, so whether it should 404 needs a
+decision rather than a patch — see issue #1271.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+pytestmark = pytest.mark.django_db
+
+
+def test_a_direct_visit_is_not_a_page(client: Client, sample_team_with_owner_member):
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"))
+
+    assert response.status_code == 404
+
+
+def test_htmx_still_gets_the_fragment(client: Client, sample_team_with_owner_member):
+    """The guard keys on the header htmx always sends, so the plugins page that
+    swaps this in is unaffected."""
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST="true")
+
+    assert response.status_code == 200
+
+
+def test_the_plugins_page_still_asks_for_the_fragment():
+    """Guards the regression the 404 could hide: if the page stopped including
+    the fragment, the 404 would be masking a broken page rather than a non-page.
+
+    Asserted against the template because a fresh test user has no data and is
+    redirected to onboarding before reaching it.
+    """
+    from django.template.loader import get_template
+
+    source = get_template("plugins/plugins_page.html.j2").template.source
+
+    assert "plugins:plugins_summary" in source
+    assert "hx-get" in source

--- a/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
+++ b/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
@@ -1,12 +1,11 @@
-"""The plugins summary fragment must not be reachable as a page.
+"""Fragment views must not be reachable as pages.
 
 It renders a template that extends no base, so a direct visit served a naked
 partial: no head, no title, no CSS, no nav. It returns 200, so uptime checks
 pass and only a title assertion catches it.
 
-Scoped to this one view. The vulnerability-trends fragment has the same shape
-but a whole test class exercises it directly, so whether it should 404 needs a
-decision rather than a patch — see issue #1271.
+Covers both fragment views. Neither is linked as a page: their host templates
+carry hx-get references and no hrefs.
 """
 
 from __future__ import annotations
@@ -19,26 +18,30 @@ from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_s
 
 pytestmark = pytest.mark.django_db
 
+FRAGMENTS = ["plugins:plugins_summary", "vulnerability_scanning:vulnerability_trends"]
 
-def test_a_direct_visit_is_not_a_page(client: Client, sample_team_with_owner_member):
+
+@pytest.mark.parametrize("view_name", FRAGMENTS)
+def test_a_direct_visit_is_not_a_page(client: Client, sample_team_with_owner_member, view_name):
     setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
 
-    response = client.get(reverse("plugins:plugins_summary"))
+    response = client.get(reverse(view_name))
 
     assert response.status_code == 404
 
 
-def test_htmx_still_gets_the_fragment(client: Client, sample_team_with_owner_member):
+@pytest.mark.parametrize("view_name", FRAGMENTS)
+def test_htmx_still_gets_the_fragment(client: Client, sample_team_with_owner_member, view_name):
     """The guard keys on the header htmx always sends, so the plugins page that
     swaps this in is unaffected."""
     setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
 
-    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST="true")
+    response = client.get(reverse(view_name), HTTP_HX_REQUEST="true")
 
     assert response.status_code == 200
 
 
-def test_the_plugins_page_still_asks_for_the_fragment():
+def test_the_host_pages_still_ask_for_their_fragments():
     """Guards the regression the 404 could hide: if the page stopped including
     the fragment, the 404 would be masking a broken page rather than a non-page.
 
@@ -47,17 +50,23 @@ def test_the_plugins_page_still_asks_for_the_fragment():
     """
     from django.template.loader import get_template
 
-    source = get_template("plugins/plugins_page.html.j2").template.source
+    for template, view_name in [
+        ("plugins/plugins_page.html.j2", "plugins:plugins_summary"),
+        ("core/dashboard.html.j2", "vulnerability_scanning:vulnerability_trends"),
+    ]:
+        source = get_template(template).template.source
+        assert view_name in source, template
+        assert "hx-get" in source, template
 
-    assert "plugins:plugins_summary" in source
-    assert "hx-get" in source
 
-
+@pytest.mark.parametrize("view_name", FRAGMENTS)
 @pytest.mark.parametrize("header", ["false", "1", "yes", ""])
-def test_a_non_true_hx_request_header_does_not_bypass_the_guard(client: Client, sample_team_with_owner_member, header):
+def test_a_non_true_hx_request_header_does_not_bypass_the_guard(
+    client: Client, sample_team_with_owner_member, header, view_name
+):
     """A bare truthiness check would let HX-Request: false through."""
     setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
 
-    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST=header)
+    response = client.get(reverse(view_name), HTTP_HX_REQUEST=header)
 
     assert response.status_code == 404

--- a/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
+++ b/sbomify/apps/core/tests/test_htmx_partials_are_not_pages.py
@@ -51,3 +51,13 @@ def test_the_plugins_page_still_asks_for_the_fragment():
 
     assert "plugins:plugins_summary" in source
     assert "hx-get" in source
+
+
+@pytest.mark.parametrize("header", ["false", "1", "yes", ""])
+def test_a_non_true_hx_request_header_does_not_bypass_the_guard(client: Client, sample_team_with_owner_member, header):
+    """A bare truthiness check would let HX-Request: false through."""
+    setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_team_with_owner_member.user)
+
+    response = client.get(reverse("plugins:plugins_summary"), HTTP_HX_REQUEST=header)
+
+    assert response.status_code == 404

--- a/sbomify/apps/plugins/views.py
+++ b/sbomify/apps/plugins/views.py
@@ -163,7 +163,9 @@ def _reject_direct_navigation(request: HttpRequest) -> None:
     links them as pages — they are only ever swapped into a host page by
     hx-get — so "no such page" is the honest answer.
     """
-    if not request.headers.get("HX-Request"):
+    # Compared against the literal "true", matching HtmxMessagesMiddleware: a
+    # bare truthiness check would let HX-Request: false through the guard.
+    if request.headers.get("HX-Request") != "true":
         raise Http404("This view renders a fragment and is not a page.")
 
 

--- a/sbomify/apps/plugins/views.py
+++ b/sbomify/apps/plugins/views.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
@@ -155,6 +155,18 @@ class PluginsPageView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         return render(request, "plugins/plugins_page.html.j2")
 
 
+def _reject_direct_navigation(request: HttpRequest) -> None:
+    """404 a non-HTMX GET.
+
+    These views render fragments that extend no base template, so a direct
+    visit serves a naked partial: no head, no title, no CSS, no nav. Nothing
+    links them as pages — they are only ever swapped into a host page by
+    hx-get — so "no such page" is the honest answer.
+    """
+    if not request.headers.get("HX-Request"):
+        raise Http404("This view renders a fragment and is not a page.")
+
+
 class PluginsSummaryView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
     """HTMX partial: returns the plugin summary bar with counts."""
 
@@ -162,6 +174,7 @@ class PluginsSummaryView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
 
     def get(self, request: HttpRequest) -> HttpResponse:
         """Return the summary bar partial."""
+        _reject_direct_navigation(request)
         team_data = request.session.get("current_team", {})
         team_key = team_data.get("key", "")
 

--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -82,6 +82,10 @@ def _result_with_findings(*findings: dict) -> dict:
 class TestVulnerabilityTrendsView:
     """Tests for the VulnerabilityTrendsView."""
 
+    # Every call below passes HTTP_HX_REQUEST="true". This view serves a
+    # fragment that extends no base template and is only ever reached by
+    # hx-get, so a request without that header is not one the app makes; the
+    # view 404s it rather than serving a naked partial.
     def _get_url(self, **params: str) -> str:
         qs = "&".join(f"{k}={v}" for k, v in params.items())
         return f"/vulnerability-trends/?{qs}" if qs else "/vulnerability-trends/"
@@ -92,7 +96,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["total"] == 0
         assert response.context["has_data"] is False
@@ -116,7 +120,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["critical"] == 2
         assert response.context["summary"]["high"] == 5
@@ -178,7 +182,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         # CVE-AAAA on foo is suppressed; CVE-BBBB on bar remains.
         assert response.context["summary"]["high"] == 1
@@ -310,7 +314,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(days="7"))
+        response = client.get(self._get_url(days="7"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         # Latest run (i=0, today) wins: critical=0, high=1 — NOT the 30-day sum.
         assert response.context["summary"]["critical"] == 0
@@ -358,7 +362,7 @@ class TestVulnerabilityTrendsView:
 
         # 30-day and 90-day windows must give the SAME snapshot (latest = 80).
         for days in ("30", "90"):
-            response = client.get(self._get_url(days=days))
+            response = client.get(self._get_url(days=days), HTTP_HX_REQUEST="true")
             assert response.status_code == 200
             assert response.context["summary"]["high"] == 80, f"days={days}"
             assert response.context["summary"]["total"] == 80, f"days={days}"
@@ -393,7 +397,7 @@ class TestVulnerabilityTrendsView:
         setup_authenticated_client_session(client, team, user)
 
         for days in ("7", "30", "90"):
-            response = client.get(self._get_url(days=days))
+            response = client.get(self._get_url(days=days), HTTP_HX_REQUEST="true")
             assert response.status_code == 200
             assert response.context["summary"]["high"] == 7, f"days={days}"
             assert response.context["summary"]["total"] == 7, f"days={days}"
@@ -429,7 +433,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         # Most recent run wins (critical=2), not the same-day sum (7).
         assert response.context["summary"]["critical"] == 2
@@ -476,7 +480,7 @@ class TestVulnerabilityTrendsView:
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
-        response = client.get(self._get_url(component_id=component.id))
+        response = client.get(self._get_url(component_id=component.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["high"] == 1
         assert response.context["summary"]["total"] == 1
@@ -497,7 +501,7 @@ class TestVulnerabilityTrendsView:
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["high"] == 2
         assert response.context["summary"]["critical"] == 3
@@ -519,7 +523,7 @@ class TestVulnerabilityTrendsView:
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
-        response = client.get(self._get_url(days="7"))
+        response = client.get(self._get_url(days="7"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         day = base.date().isoformat()
         day_point = next(point for point in response.context["time_series"] if point["date"] == day)
@@ -545,7 +549,7 @@ class TestVulnerabilityTrendsView:
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
-        response = client.get(self._get_url(product_id=product.id, release_id=release.id))
+        response = client.get(self._get_url(product_id=product.id, release_id=release.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["high"] == 9
         assert response.context["summary"]["total"] == 9
@@ -562,7 +566,7 @@ class TestVulnerabilityTrendsView:
 
         client = Client()
         setup_authenticated_client_session(client, team, user)
-        response = client.get(self._get_url(component_id=component.id, days="7"))
+        response = client.get(self._get_url(component_id=component.id, days="7"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["total"] == 0
         assert response.context["has_data"] is True
@@ -574,24 +578,24 @@ class TestVulnerabilityTrendsView:
         setup_authenticated_client_session(client, team, user)
 
         # Below minimum — clamped to 7
-        response = client.get(self._get_url(days="1"))
+        response = client.get(self._get_url(days="1"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["selected_days"] == 7
 
         # Above maximum — clamped to 365
-        response = client.get(self._get_url(days="9999"))
+        response = client.get(self._get_url(days="9999"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["selected_days"] == 365
 
         # Invalid value — defaults to 30
-        response = client.get(self._get_url(days="abc"))
+        response = client.get(self._get_url(days="abc"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["selected_days"] == 30
 
     def test_requires_authentication(self):
         """Unauthenticated requests are redirected to login."""
         client = Client()
-        response = client.get("/vulnerability-trends/")
+        response = client.get("/vulnerability-trends/", HTTP_HX_REQUEST="true")
         assert response.status_code == 302
 
     def test_requires_workspace_session(self, team_with_member):
@@ -603,7 +607,7 @@ class TestVulnerabilityTrendsView:
         session = client.session
         session.pop("current_team", None)
         session.save()
-        response = client.get("/vulnerability-trends/")
+        response = client.get("/vulnerability-trends/", HTTP_HX_REQUEST="true")
         assert response.status_code == 400
 
     def test_requires_team_membership(self, team_with_member):
@@ -618,7 +622,7 @@ class TestVulnerabilityTrendsView:
         session["current_team"] = {"key": team.key}
         session.save()
 
-        response = client.get("/vulnerability-trends/")
+        response = client.get("/vulnerability-trends/", HTTP_HX_REQUEST="true")
         assert response.status_code == 403
 
     def test_show_product_filter(self, team_with_member):
@@ -629,7 +633,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(show_product_filter="true"))
+        response = client.get(self._get_url(show_product_filter="true"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert len(response.context["products"]) >= 1
         # With a product filter available, the Release dropdown is rendered.
@@ -654,7 +658,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         html = response.content.decode()
         assert 'class="vulnerability-chart-canvas"' in html
@@ -682,7 +686,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(hide_recent_scans="true"))
+        response = client.get(self._get_url(hide_recent_scans="true"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["hide_recent_scans"] is True
         html = response.content.decode()
@@ -706,7 +710,7 @@ class TestVulnerabilityTrendsView:
         setup_authenticated_client_session(client, team, user)
 
         # show_product_filter omitted (false) but a product is selected.
-        response = client.get(self._get_url(product_id=product.id))
+        response = client.get(self._get_url(product_id=product.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         html = response.content.decode()
         # No visible Product <select>, but a hidden product_id input carries scope.
@@ -726,7 +730,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert 'id="release-filter"' not in response.content.decode()
         assert response.context["selected_release_id"] == ""
@@ -743,7 +747,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(component_id=component.id))
+        response = client.get(self._get_url(component_id=component.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["selected_release_id"] == ""
         assert 'id="release-filter"' not in response.content.decode()
@@ -777,7 +781,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url())
+        response = client.get(self._get_url(), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["summary"]["critical"] == 1
         assert response.context["summary"]["high"] == 3
@@ -799,7 +803,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team_b, user)
 
-        response = client.get(self._get_url(component_id=component.id))
+        response = client.get(self._get_url(component_id=component.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["component_id"] == component.id
 
@@ -816,7 +820,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, other_team, other_user)
 
-        response = client.get(self._get_url(component_id=component.id))
+        response = client.get(self._get_url(component_id=component.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 403
 
     def test_cross_workspace_component_guest_blocked(self, team_with_member, component_with_sbom):
@@ -836,7 +840,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team_b, guest_user)
 
-        response = client.get(self._get_url(component_id=component.id))
+        response = client.get(self._get_url(component_id=component.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 403
 
     def test_component_not_found_returns_404(self, team_with_member):
@@ -845,7 +849,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(component_id="nonexistent99"))
+        response = client.get(self._get_url(component_id="nonexistent99"), HTTP_HX_REQUEST="true")
         assert response.status_code == 404
 
     def test_partial_renders_body_template(self, team_with_member):
@@ -860,8 +864,10 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        full = client.get(self._get_url(show_product_filter="true")).content.decode()
-        partial = client.get(self._get_url(show_product_filter="true", partial="true")).content.decode()
+        full = client.get(self._get_url(show_product_filter="true"), HTTP_HX_REQUEST="true").content.decode()
+        partial = client.get(
+            self._get_url(show_product_filter="true", partial="true"), HTTP_HX_REQUEST="true"
+        ).content.decode()
 
         # Full shell has the Alpine root + the body container; partial has neither wrapper.
         assert 'id="vuln-trends-body"' in full
@@ -880,7 +886,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(show_product_filter="true"))
+        response = client.get(self._get_url(show_product_filter="true"), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         assert response.context["releases"] == []  # no per-product release list
         assert response.context["selected_release_id"] == "latest"  # Latest is the default
@@ -901,7 +907,7 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(show_product_filter="true", product_id=product.id))
+        response = client.get(self._get_url(show_product_filter="true", product_id=product.id), HTTP_HX_REQUEST="true")
         assert response.status_code == 200
         names = {r["name"] for r in response.context["releases"]}
         assert "v1.0" in names
@@ -922,17 +928,22 @@ class TestVulnerabilityTrendsView:
         setup_authenticated_client_session(client, team, user)
 
         # Product chosen, release_id absent -> defaults to the LATEST sentinel.
-        defaulted = client.get(self._get_url(show_product_filter="true", product_id=product.id))
+        defaulted = client.get(self._get_url(show_product_filter="true", product_id=product.id), HTTP_HX_REQUEST="true")
         assert defaulted.status_code == 200
         assert defaulted.context["selected_release_id"] == "latest"
 
         # A concrete release id is honoured as-is.
         concrete = Release.objects.get(product=product, name="v0.9")
-        chosen = client.get(self._get_url(show_product_filter="true", product_id=product.id, release_id=concrete.id))
+        chosen = client.get(
+            self._get_url(show_product_filter="true", product_id=product.id, release_id=concrete.id),
+            HTTP_HX_REQUEST="true",
+        )
         assert chosen.context["selected_release_id"] == str(concrete.id)
 
         # Explicit All Releases (release_id="") is preserved, not forced to latest.
-        all_releases = client.get(self._get_url(show_product_filter="true", product_id=product.id, release_id=""))
+        all_releases = client.get(
+            self._get_url(show_product_filter="true", product_id=product.id, release_id=""), HTTP_HX_REQUEST="true"
+        )
         assert all_releases.context["selected_release_id"] == ""
 
     def test_release_filter_scopes_trends_to_release_sboms(self, team_with_member, component_with_sbom):
@@ -979,11 +990,11 @@ class TestVulnerabilityTrendsView:
 
         # Explicit "All Releases" (release_id="" present) reports the component's
         # CURRENT posture — its latest SBOM only (9), never historical versions summed.
-        unfiltered = client.get(self._get_url(product_id=product.id, release_id=""))
+        unfiltered = client.get(self._get_url(product_id=product.id, release_id=""), HTTP_HX_REQUEST="true")
         assert unfiltered.context["summary"]["critical"] == 9
 
         # With the release filter: only the in-release SBOM counted (3).
-        filtered = client.get(self._get_url(product_id=product.id, release_id=release.id))
+        filtered = client.get(self._get_url(product_id=product.id, release_id=release.id), HTTP_HX_REQUEST="true")
         assert filtered.context["summary"]["critical"] == 3
 
     def test_stale_release_id_falls_back_to_latest_not_403(self, team_with_member, component_with_sbom):
@@ -1001,6 +1012,8 @@ class TestVulnerabilityTrendsView:
         client = Client()
         setup_authenticated_client_session(client, team, user)
 
-        response = client.get(self._get_url(product_id=product.id, release_id=foreign_release.id))
+        response = client.get(
+            self._get_url(product_id=product.id, release_id=foreign_release.id), HTTP_HX_REQUEST="true"
+        )
         assert response.status_code == 200
         assert response.context["selected_release_id"] == "latest"

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import connection, transaction
 from django.db.models import Prefetch
-from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseNotFound
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils import timezone
 from django.views import View
@@ -51,6 +51,15 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
     body_template_name = "vulnerability_scanning/components/_vulnerability_trends_body.html.j2"
 
     def get(self, request: HttpRequest) -> HttpResponse:
+        # This renders a fragment that extends no base template, so a direct
+        # visit served a naked partial: no head, no title, no CSS, no nav.
+        # Nothing links it — the dashboard and the component page swap it in
+        # with hx-get and there are no hrefs to it — so "no such page" is the
+        # honest answer. Compared against the literal "true", matching
+        # HtmxMessagesMiddleware: a truthiness check would let "false" through.
+        if request.headers.get("HX-Request") != "true":
+            raise Http404("This view renders a fragment and is not a page.")
+
         component_id = request.GET.get("component_id")
 
         if component_id:


### PR DESCRIPTION
Closes #1271. Finishes item 1 of #1262. **Supersedes #1272**, which is closed: that branch is an ancestor of this one, so this PR carries the plugins-summary guard as well as the trends one. Merge this alone.

`/vulnerability-trends/` returned 200 with an empty `<title>` for the same reason as the plugins summary: it renders a fragment extending no base template, so a direct visit served a naked partial with no head, CSS or nav. The dashboard and the component page swap it in with `hx-get`; grep finds 4 `hx-get` references and **no** `href`s.

```
                        direct   HX-Request:true   HX-Request:false
/plugins/summary/          404         200               404
/vulnerability-trends/     404         200               404
```

## On the 31 tests

I backed this exact change out yesterday because the guard failed 31 tests in `TestVulnerabilityTrendsView`, and said at the time that adding the header to all of them would be settling it by assertion rather than by understanding.

Having looked properly: those tests call a fragment view directly for convenience — they exercise context building, filtering and permission scoping, none of which is about page-vs-fragment routing. Nothing links the view as a page. So the header is what the app actually sends, and adding it makes the tests say what they always meant. The reasoning is documented once on the shared `_get_url` helper rather than repeated 39 times.

Three of them used a hardcoded path instead of that helper, which is why my first regex pass missed them and left two failures behind after fixing the other 36.

## Coverage

The fragment tests are now parametrised over both views, including the non-`"true"` header values from the #1272 review, so neither guard can regress on its own. The host-page assertion covers both templates, so a 404 can never start masking a page that stopped including its fragment.

1296 tests green across `core`, `vulnerability_scanning` and `plugins`. Verified live in the browser, including that the dashboard and plugins page still request their fragments.

`/search/` is untouched and stays out of scope: it returns `JsonResponse` on every branch, so having no title is correct rather than a defect.