### PR TITLE
fix(oidc): name the cause when a bot cannot create a release

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -2872,8 +2872,28 @@ def create_release(request: HttpRequest, payload: ReleaseCreateSchema) -> Any:
 
     if request_is_oidc_authed(request):
         bound_component_id = bound_component_id_for_request(request)
-        if bound_component_id is None or not product.components.filter(id=bound_component_id).exists():
-            return 403, {"detail": "You do not have permission to create releases", "error_code": ErrorCode.FORBIDDEN}
+        # Distinct wording per cause. These two share both a status and a call site with the
+        # role denial above, so one shared message leaves a CI log no way to tell which check
+        # rejected it, and the two have opposite remedies. Naming the component and the product
+        # leaks nothing: the caller supplied the product id and holds the binding for the
+        # component.
+        if bound_component_id is None:
+            return 403, {
+                "detail": (
+                    "This OIDC token has no component binding, so it cannot create releases. "
+                    "Re-create the trusted-publishing binding for the component."
+                ),
+                "error_code": ErrorCode.FORBIDDEN,
+            }
+        if not product.components.filter(id=bound_component_id).exists():
+            return 403, {
+                "detail": (
+                    f"Component {bound_component_id} is not part of product {product.id}, so this "
+                    "OIDC token cannot create releases for it. Add the component to the product, "
+                    "then retry."
+                ),
+                "error_code": ErrorCode.FORBIDDEN,
+            }
 
     # Prevent creating releases with name "latest" manually
     if payload.name.lower() == LATEST_RELEASE_NAME.lower():

--- a/sbomify/apps/oidc/tests/test_permissions.py
+++ b/sbomify/apps/oidc/tests/test_permissions.py
@@ -811,9 +811,7 @@ class TestBotReleaseConfinement:
         from sbomify.apps.sboms.models import SBOM
 
         _product, release = self._release_in(team_with_business_plan, bound_component)
-        other_sbom = SBOM.objects.create(
-            name="o", component=other_component, format="cyclonedx", format_version="1.6"
-        )
+        other_sbom = SBOM.objects.create(name="o", component=other_component, format="cyclonedx", format_version="1.6")
 
         resp = Client().post(
             f"/api/v1/releases/{release.id}/artifacts",
@@ -855,6 +853,35 @@ class TestBotReleaseConfinement:
             HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
         )
         assert resp.status_code == 403
+        # The message has to name the cause. This denial, the missing-binding one below and the
+        # workspace-role one all return 403 from the same endpoint, and they have different
+        # remedies, so a CI log showing the shared wording cannot be acted on.
+        detail = resp.json()["detail"]
+        assert bound_component.id in detail
+        assert product.id in detail
+        assert detail != "You do not have permission to create releases"
+
+    def test_bot_without_a_binding_says_so(self, oidc_sbomify_token, bound_component, team_with_business_plan, mocker):
+        """An orphan bot is denied for a different reason than an unattached component.
+
+        Patched rather than deleting the binding row: ``cleanup_bot_user_on_binding_delete``
+        reaps the bot User on delete, so the request would fail earlier and never reach the
+        branch under test.
+        """
+        from sbomify.apps.core.models import Product
+
+        product = Product.objects.create(name="prod-orphan", team=team_with_business_plan)
+        product.components.add(bound_component)
+        mocker.patch("sbomify.apps.oidc.permissions.bound_component_id_for_request", return_value=None)
+
+        resp = Client().post(
+            "/api/v1/releases",
+            data=json.dumps({"product_id": product.id, "name": "v9"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {oidc_sbomify_token}",
+        )
+        assert resp.status_code == 403
+        assert "no component binding" in resp.json()["detail"]
 
     def test_bot_can_tag_its_bound_component(self, oidc_sbomify_token, bound_component, team_with_business_plan):
         """Control: the bot IS allowed to tag its bound component — proving the deny cases above
@@ -862,9 +889,7 @@ class TestBotReleaseConfinement:
         from sbomify.apps.sboms.models import SBOM
 
         _product, release = self._release_in(team_with_business_plan, bound_component)
-        bound_sbom = SBOM.objects.create(
-            name="b", component=bound_component, format="cyclonedx", format_version="1.6"
-        )
+        bound_sbom = SBOM.objects.create(name="b", component=bound_component, format="cyclonedx", format_version="1.6")
 
         resp = Client().post(
             f"/api/v1/releases/{release.id}/artifacts",


### PR DESCRIPTION
Refs #1260. Does not close it: the CI failure is stage data, not code.

## What the log could not tell you

`create_release` returns 403 from three places with one body:

- `can(request, "release:create", product)` fails, so the caller lacks the workspace role
- the OIDC bot has no binding
- the OIDC bot's bound component is not in the product

All three sent `You do not have permission to create releases`. The remedies differ: grant a role, re-create the binding, attach the component. Working out which one fired on stage meant reading the endpoint source.

This splits the two confinement branches and names the cause in each. The role denial keeps its wording. Naming the component and the product leaks nothing, since the caller supplied the product id and holds the binding for the component.

## Root cause of #1260 itself

The stage product `xJ6NJlgTK37Y` does not list component `odzUCI8r2any`. Its public page shows `FoKftlVn4uyq`, `Kpj3ZylyBDkb` and `XNsX40tonzvv`. Public pages list only public components, so treat that as evidence rather than proof, but it matches the 403 and it matches which matrix leg fails: whichever leg has to create the release gets it, and the two legs swap between runs. On run 30518561624 `container-spdx` failed; on 30554732679 `container-cyclonedx` failed and `container-spdx` passed.

Attaching the component to the product on stage is what turns CI green. This PR only makes the next occurrence self-diagnosing.

The race raised in the issue is already handled. `create_release` catches the name collision and returns the existing release, so the losing leg gets a 200 rather than an error.

## Tests

Two in `TestBotReleaseConfinement`:

- the existing unattached-component test now asserts the message names both ids and differs from the role wording
- a new test covers the missing-binding branch, patched rather than deleting the row, because `cleanup_bot_user_on_binding_delete` reaps the bot user on delete and the request would fail before reaching the branch

`5 passed` in `sbomify/apps/oidc/tests/test_permissions.py::TestBotReleaseConfinement`.
