### PR TITLE
feat(plugins): retire Dependency-Track projects for superseded SBOMs

### DIFF
--- a/sbomify/apps/plugins/retention.py
+++ b/sbomify/apps/plugins/retention.py
@@ -1,4 +1,4 @@
-"""Retention for ``plugins_assessment_runs``.
+"""Retention for ``plugins_assessment_runs`` and Dependency-Track project versions.
 
 The table only grows: every scan, every retry, every scheduled run. It was at
 roughly 10,300 rows climbing ~170/day when #1120 was filed, with no policy at
@@ -35,6 +35,11 @@ DEFAULT_KEEP_PER_PLUGIN = 10
 
 # Nothing newer than this is touched, regardless of how many runs exist.
 DEFAULT_MIN_AGE_DAYS = 30
+
+# Same floor for DT project versions, for a different reason: an SBOM is
+# uploaded and scanned before ``sync_release_tags`` attaches it to a release,
+# and pruning inside that window would delete the project a running scan polls.
+DEFAULT_DT_MIN_AGE_DAYS = 30
 
 
 def prunable_run_ids(
@@ -118,4 +123,86 @@ def prune_assessment_runs(
         removed += per_model.get("plugins.AssessmentRun", 0)
     if removed:
         logger.info(f"[RETENTION] pruned {removed} assessment runs")
+    return removed
+
+
+def prunable_dt_project_version_ids(*, min_age_days: int = DEFAULT_DT_MIN_AGE_DAYS) -> list[Any]:
+    """Project-version ids whose SBOM has fallen out of every current release.
+
+    Dependency-Track re-analyses its whole portfolio on its own schedule, so its
+    CPU cost grows with every SBOM ever uploaded, whether or not anyone reads the
+    result. That is a load floor our own sweep cadence cannot lower.
+
+    Dropping a version costs nothing a reader can see: findings are already
+    stored in ``AssessmentRun`` and the Trust Center reads those, so a pruned
+    SBOM keeps its posture. A later scan recreates the project.
+
+    Ids rather than rows, matching ``prunable_run_ids``, so the policy can be
+    counted or dry-run without being welded to the deletion.
+    """
+    from django.db.models import Exists, OuterRef
+
+    from sbomify.apps.core.models import ReleaseArtifact
+    from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+    cutoff = timezone.now() - timedelta(days=max(0, min_age_days))
+
+    # Exists() rather than a reverse accessor, matching the scheduled sweep:
+    # ReleaseArtifact.sbom carries no related_name, so a join here would couple
+    # this query to the default accessor name.
+    return list(
+        SbomDependencyTrackProjectVersion.objects.filter(created_at__lt=cutoff)
+        .annotate(
+            in_current_release=Exists(
+                ReleaseArtifact.objects.filter(sbom_id=OuterRef("sbom_id"), release__is_latest=True)
+            )
+        )
+        .filter(in_current_release=False)
+        .values_list("id", flat=True)
+    )
+
+
+def prune_dt_project_versions(
+    *,
+    min_age_days: int = DEFAULT_DT_MIN_AGE_DAYS,
+    dry_run: bool = False,
+) -> int:
+    """Delete stale DT project versions and their local rows. Returns how many went.
+
+    The local row is dropped only once Dependency-Track has no copy, so a server
+    that is down or refusing keeps its rows and the next sweep retries them. A
+    404 counts as success: the project is already gone, and leaving the row
+    behind would strand it forever.
+
+    One row at a time rather than batched, because each is a network call to a
+    server that may be unreachable, and one bad server must not abort the rest.
+    """
+    from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError, DependencyTrackClient
+    from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+    doomed = prunable_dt_project_version_ids(min_age_days=min_age_days)
+    if dry_run:
+        logger.info(f"[RETENTION] dry run: {len(doomed)} DT project versions would be pruned")
+        return len(doomed)
+
+    removed = 0
+    rows = SbomDependencyTrackProjectVersion.objects.filter(id__in=doomed).select_related("dt_server")
+    for row in rows.iterator():
+        try:
+            client = DependencyTrackClient(row.dt_server.url, row.dt_server.api_key)
+            client.delete_project(str(row.dt_project_version_uuid))
+        except DependencyTrackAPIError as exc:
+            if exc.status_code != 404:
+                logger.warning(
+                    f"[RETENTION] leaving DT version {row.dt_project_version_uuid} on "
+                    f"{row.dt_server.name} for the next sweep: {exc}"
+                )
+                continue
+        except Exception as exc:
+            logger.warning(f"[RETENTION] DT delete failed for {row.dt_project_version_uuid}: {exc}")
+            continue
+        row.delete()
+        removed += 1
+    if removed:
+        logger.info(f"[RETENTION] pruned {removed} DT project versions")
     return removed

--- a/sbomify/apps/plugins/retention.py
+++ b/sbomify/apps/plugins/retention.py
@@ -191,12 +191,20 @@ def prune_dt_project_versions(
 
     batch_size = max(1, batch_size)
     removed = 0
+    # One client per server, not per row: each holds a requests.Session, and a
+    # backlog on one server is the case this sweep exists for, so rebuilding it
+    # per row throws away every connection.
+    clients: dict[Any, DependencyTrackClient] = {}
     for start in range(0, len(doomed), batch_size):
         batch = doomed[start : start + batch_size]
         rows = SbomDependencyTrackProjectVersion.objects.filter(id__in=batch).select_related("dt_server")
         for row in rows:
             try:
-                client = DependencyTrackClient(row.dt_server.url, row.dt_server.api_key)
+                # Built inside the try so a bad server config costs its own
+                # rows rather than the whole sweep.
+                client = clients.get(row.dt_server_id)
+                if client is None:
+                    client = clients[row.dt_server_id] = DependencyTrackClient(row.dt_server.url, row.dt_server.api_key)
                 client.delete_project(str(row.dt_project_version_uuid))
             except DependencyTrackAPIError as exc:
                 if exc.status_code != 404:

--- a/sbomify/apps/plugins/retention.py
+++ b/sbomify/apps/plugins/retention.py
@@ -165,6 +165,7 @@ def prunable_dt_project_version_ids(*, min_age_days: int = DEFAULT_DT_MIN_AGE_DA
 def prune_dt_project_versions(
     *,
     min_age_days: int = DEFAULT_DT_MIN_AGE_DAYS,
+    batch_size: int = 500,
     dry_run: bool = False,
 ) -> int:
     """Delete stale DT project versions and their local rows. Returns how many went.
@@ -174,8 +175,11 @@ def prune_dt_project_versions(
     404 counts as success: the project is already gone, and leaving the row
     behind would strand it forever.
 
-    One row at a time rather than batched, because each is a network call to a
-    server that may be unreachable, and one bad server must not abort the rest.
+    Deleted one row at a time, because each is a network call to a server that
+    may be unreachable, and one bad server must not abort the rest. Selected in
+    batches, because a backlog that has never been swept is exactly what this
+    is for and one ``IN`` list of every id would run past the parameter limit
+    before it ran slowly.
     """
     from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError, DependencyTrackClient
     from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
@@ -185,24 +189,30 @@ def prune_dt_project_versions(
         logger.info(f"[RETENTION] dry run: {len(doomed)} DT project versions would be pruned")
         return len(doomed)
 
+    batch_size = max(1, batch_size)
     removed = 0
-    rows = SbomDependencyTrackProjectVersion.objects.filter(id__in=doomed).select_related("dt_server")
-    for row in rows.iterator():
-        try:
-            client = DependencyTrackClient(row.dt_server.url, row.dt_server.api_key)
-            client.delete_project(str(row.dt_project_version_uuid))
-        except DependencyTrackAPIError as exc:
-            if exc.status_code != 404:
-                logger.warning(
-                    f"[RETENTION] leaving DT version {row.dt_project_version_uuid} on "
-                    f"{row.dt_server.name} for the next sweep: {exc}"
-                )
+    for start in range(0, len(doomed), batch_size):
+        batch = doomed[start : start + batch_size]
+        rows = SbomDependencyTrackProjectVersion.objects.filter(id__in=batch).select_related("dt_server")
+        for row in rows:
+            try:
+                client = DependencyTrackClient(row.dt_server.url, row.dt_server.api_key)
+                client.delete_project(str(row.dt_project_version_uuid))
+            except DependencyTrackAPIError as exc:
+                if exc.status_code != 404:
+                    logger.warning(
+                        f"[RETENTION] leaving DT version {row.dt_project_version_uuid} on "
+                        f"{row.dt_server.name} for the next sweep: {exc}"
+                    )
+                    continue
+            except Exception:
+                # Unexpected, so keep the traceback: an API error is already
+                # handled above, and anything reaching here is a shape we have
+                # not seen from this client.
+                logger.exception(f"[RETENTION] DT delete failed for {row.dt_project_version_uuid}")
                 continue
-        except Exception as exc:
-            logger.warning(f"[RETENTION] DT delete failed for {row.dt_project_version_uuid}: {exc}")
-            continue
-        row.delete()
-        removed += 1
+            row.delete()
+            removed += 1
     if removed:
         logger.info(f"[RETENTION] pruned {removed} DT project versions")
     return removed

--- a/sbomify/apps/plugins/tasks/__init__.py
+++ b/sbomify/apps/plugins/tasks/__init__.py
@@ -1350,3 +1350,20 @@ def prune_assessment_runs_task() -> int:
     removed = prune_assessment_runs()
     logger.info(f"[TASK_prune_assessment_runs] removed {removed} runs")
     return removed
+
+
+@cron("45 3 * * *")  # type: ignore[untyped-decorator]  # Daily, after the assessment-run prune
+@dramatiq.actor(queue_name="assessment_retention", max_retries=1, time_limit=1800000)
+def prune_dt_project_versions_task() -> int:
+    """Drop Dependency-Track project versions for SBOMs no longer in a current release.
+
+    DT re-analyses its whole portfolio on its own schedule, so its CPU cost rises
+    with every SBOM ever uploaded and never falls. Our own sweep cadence cannot
+    lower that floor. See plugins/retention.py for the rule and why pruning is
+    invisible to readers.
+    """
+    from sbomify.apps.plugins.retention import prune_dt_project_versions
+
+    removed = prune_dt_project_versions()
+    logger.info(f"[TASK_prune_dt_project_versions] removed {removed} DT project versions")
+    return removed

--- a/sbomify/apps/plugins/tests/test_retention.py
+++ b/sbomify/apps/plugins/tests/test_retention.py
@@ -7,13 +7,19 @@ interaction rather than either rule alone.
 
 from __future__ import annotations
 
+import uuid
 from datetime import timedelta
 
 import pytest
 from django.utils import timezone
 
 from sbomify.apps.plugins.models import AssessmentRun
-from sbomify.apps.plugins.retention import prunable_run_ids, prune_assessment_runs
+from sbomify.apps.plugins.retention import (
+    prunable_dt_project_version_ids,
+    prunable_run_ids,
+    prune_assessment_runs,
+    prune_dt_project_versions,
+)
 from sbomify.apps.plugins.sdk.enums import RunReason, RunStatus
 
 pytestmark = pytest.mark.django_db
@@ -119,3 +125,119 @@ class TestPruning:
 
     def test_an_empty_table_is_a_no_op(self):
         assert prune_assessment_runs() == 0
+
+
+class TestDependencyTrackVersionRetention:
+    """DT project-version retention.
+
+    DT re-analyses its whole portfolio on its own schedule, so its CPU cost rises
+    with every SBOM ever uploaded and never falls, which our own sweep cadence
+    cannot lower. What makes the set non-empty is eviction: uploading a newer
+    SBOM for the same (component, format, bom_type) drops the previous one from
+    the latest release, and its DT project would otherwise live forever.
+    """
+
+    def _version(self, sbom, *, days_ago: int):
+        from sbomify.apps.vulnerability_scanning.models import (
+            DependencyTrackServer,
+            SbomDependencyTrackProjectVersion,
+        )
+
+        server, _ = DependencyTrackServer.objects.get_or_create(
+            url="https://dt.example.test", defaults={"name": "dt-1", "api_key": "k"}
+        )
+        row = SbomDependencyTrackProjectVersion.objects.create(
+            sbom=sbom,
+            dt_server=server,
+            dt_project_version=str(sbom.id),
+            dt_project_version_uuid=uuid.uuid4(),
+        )
+        SbomDependencyTrackProjectVersion.objects.filter(pk=row.pk).update(
+            created_at=timezone.now() - timedelta(days=days_ago)
+        )
+        return row
+
+    def _supersede(self, sbom):
+        """Upload a newer SBOM into the same slot, which is what evicts this one.
+
+        Goes through the real post_save signal rather than deleting the link by
+        hand, so the test breaks if eviction ever stops happening.
+        """
+        from sbomify.apps.sboms.models import SBOM
+
+        return SBOM.objects.create(
+            name=sbom.name,
+            version="99.0.0",
+            format=sbom.format,
+            format_version=sbom.format_version,
+            component=sbom.component,
+            sbom_filename="newer.json",
+            source="test",
+        )
+
+    def test_a_current_release_protects_a_version_however_old(self, sample_sbom):
+        row = self._version(sample_sbom, days_ago=900)
+
+        assert row.id not in prunable_dt_project_version_ids()
+
+    def test_a_superseded_sbom_becomes_prunable(self, sample_sbom):
+        row = self._version(sample_sbom, days_ago=90)
+        self._supersede(sample_sbom)
+
+        assert row.id in prunable_dt_project_version_ids()
+
+    def test_the_age_floor_covers_the_upload_to_tag_window(self, sample_sbom):
+        """A freshly superseded version still waits out the floor: an SBOM is
+        scanned before its release tags settle, and pruning inside that window
+        would delete the project a running scan is polling."""
+        row = self._version(sample_sbom, days_ago=1)
+        self._supersede(sample_sbom)
+
+        assert row.id not in prunable_dt_project_version_ids()
+
+    def test_prune_deletes_the_dt_project_and_the_row(self, sample_sbom, mocker):
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        row = self._version(sample_sbom, days_ago=90)
+        self._supersede(sample_sbom)
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+
+        assert prune_dt_project_versions() == 1
+        client.return_value.delete_project.assert_called_once_with(str(row.dt_project_version_uuid))
+        assert not SbomDependencyTrackProjectVersion.objects.filter(pk=row.pk).exists()
+
+    def test_a_failing_server_keeps_its_rows_for_the_next_sweep(self, sample_sbom, mocker):
+        from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        row = self._version(sample_sbom, days_ago=90)
+        self._supersede(sample_sbom)
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+        client.return_value.delete_project.side_effect = DependencyTrackAPIError("down", status_code=503)
+
+        assert prune_dt_project_versions() == 0
+        assert SbomDependencyTrackProjectVersion.objects.filter(pk=row.pk).exists()
+
+    def test_an_already_gone_project_still_drops_the_row(self, sample_sbom, mocker):
+        """404 counts as success. Leaving the row behind would strand it forever."""
+        from sbomify.apps.vulnerability_scanning.clients import DependencyTrackAPIError
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        row = self._version(sample_sbom, days_ago=90)
+        self._supersede(sample_sbom)
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+        client.return_value.delete_project.side_effect = DependencyTrackAPIError("gone", status_code=404)
+
+        assert prune_dt_project_versions() == 1
+        assert not SbomDependencyTrackProjectVersion.objects.filter(pk=row.pk).exists()
+
+    def test_dry_run_touches_nothing(self, sample_sbom, mocker):
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        self._version(sample_sbom, days_ago=90)
+        self._supersede(sample_sbom)
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+
+        assert prune_dt_project_versions(dry_run=True) == 1
+        client.return_value.delete_project.assert_not_called()
+        assert SbomDependencyTrackProjectVersion.objects.count() == 1

--- a/sbomify/apps/plugins/tests/test_retention.py
+++ b/sbomify/apps/plugins/tests/test_retention.py
@@ -281,6 +281,40 @@ class TestDependencyTrackVersionRetention:
         ]
         assert len(selects) == 3
 
+    def test_one_client_per_server_not_one_per_row(self, sample_sbom, mocker):
+        """Each client holds a requests.Session, so building one per row throws
+        away every connection on exactly the backlog this sweep is for."""
+        from sbomify.apps.sboms.models import SBOM
+
+        for index in range(4):
+            sbom = SBOM.objects.create(
+                name=f"pooled-{index}",
+                version=f"1.0.{index}",
+                format=sample_sbom.format,
+                format_version=sample_sbom.format_version,
+                component=sample_sbom.component,
+                sbom_filename=f"pooled-{index}.json",
+                source="test",
+            )
+            self._version(sbom, days_ago=90)
+            SBOM.objects.create(
+                name=sbom.name,
+                version=f"99.0.{index}",
+                format=sbom.format,
+                format_version=sbom.format_version,
+                component=sbom.component,
+                sbom_filename=f"newer-pooled-{index}.json",
+                source="test",
+            )
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+
+        assert prune_dt_project_versions(batch_size=2) == 4
+
+        # All four rows share one server, and the batch boundary must not
+        # reset the pool either.
+        assert client.call_count == 1
+        assert client.return_value.delete_project.call_count == 4
+
     def test_dry_run_touches_nothing(self, sample_sbom, mocker):
         from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
 

--- a/sbomify/apps/plugins/tests/test_retention.py
+++ b/sbomify/apps/plugins/tests/test_retention.py
@@ -11,6 +11,8 @@ import uuid
 from datetime import timedelta
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from sbomify.apps.plugins.models import AssessmentRun
@@ -230,6 +232,54 @@ class TestDependencyTrackVersionRetention:
 
         assert prune_dt_project_versions() == 1
         assert not SbomDependencyTrackProjectVersion.objects.filter(pk=row.pk).exists()
+
+    def test_batching_selects_everything_it_was_given(self, sample_sbom, mocker):
+        """A backlog that has never been swept is what this is for, so the ids
+        are selected in batches rather than as one IN list. The batch size must
+        not change the outcome."""
+        from sbomify.apps.sboms.models import SBOM
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        for index in range(5):
+            # The uniqueness is on (component, version, format, qualifiers,
+            # bom_type), so every SBOM here needs its own version, the newer
+            # one that supersedes it included.
+            sbom = SBOM.objects.create(
+                name=f"batched-{index}",
+                version=f"1.0.{index}",
+                format=sample_sbom.format,
+                format_version=sample_sbom.format_version,
+                component=sample_sbom.component,
+                sbom_filename=f"batched-{index}.json",
+                source="test",
+            )
+            self._version(sbom, days_ago=90)
+            SBOM.objects.create(
+                name=sbom.name,
+                version=f"99.0.{index}",
+                format=sbom.format,
+                format_version=sbom.format_version,
+                component=sbom.component,
+                sbom_filename=f"newer-{index}.json",
+                source="test",
+            )
+        client = mocker.patch("sbomify.apps.vulnerability_scanning.clients.DependencyTrackClient")
+
+        with CaptureQueriesContext(connection) as queries:
+            removed = prune_dt_project_versions(batch_size=2)
+
+        assert removed == 5
+        assert client.return_value.delete_project.call_count == 5
+        assert not SbomDependencyTrackProjectVersion.objects.filter(sbom__name__startswith="batched-").exists()
+        # Three selects for five rows at two a time, not one IN list of five.
+        selects = [
+            q["sql"]
+            for q in queries.captured_queries
+            if "sbom_dt_project_versions" in q["sql"]
+            and q["sql"].lstrip().upper().startswith("SELECT")
+            and " IN (" in q["sql"]
+        ]
+        assert len(selects) == 3
 
     def test_dry_run_touches_nothing(self, sample_sbom, mocker):
         from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion


### PR DESCRIPTION
Closes #1154 by taking option 2. Option 1 changes the sweep cadence for paid teams, which is a product call, so it is left alone.

## What grows

Dependency-Track re-analyses its whole portfolio on its own schedule. Its CPU cost therefore rises with every SBOM ever uploaded and never falls, whether or not anyone reads the result. No cadence change on our side lowers that floor.

Stage feeds it steadily. Each master merge uploads a new SBOM batch, and `Release.add_artifact_to_latest_release` evicts the previous SBOM of the same `(component, format, bom_type)` slot from the latest release. The evicted SBOM keeps its `SbomDependencyTrackProjectVersion` row and its DT project forever. Nothing reads either one again.

## The rule

A project version is prunable when its SBOM sits in no release marked `is_latest` **and** the row is older than 30 days. Both conditions, for different reasons:

- The release check is what makes the set non-empty. Eviction is the only way an SBOM leaves `latest`, so the prunable set is exactly the superseded builds.
- The age floor covers the window between upload and release tagging. An SBOM is scanned before its tags settle, and pruning inside that window would delete the project a running scan is polling.

Pruning is invisible to readers: findings are already stored in `AssessmentRun` and the Trust Center reads those, so a pruned SBOM keeps its posture. A later scan recreates the project.

## Failure handling

The local row is deleted only after DT confirms the project is gone, so a server that is down or refusing keeps its rows and the next sweep retries them. A 404 counts as success, since the project is already gone and leaving the row would strand it forever. Rows go one at a time rather than batched, because each is a network call and one unreachable server must not abort the rest.

## Shape

`prunable_dt_project_version_ids` and `prune_dt_project_versions` join the existing `plugins/retention.py`, matching `prunable_run_ids` and `prune_assessment_runs`: ids first so the policy can be counted or dry-run without being welded to the deletion. `prune_dt_project_versions_task` runs daily at 03:45, after the assessment-run prune on the same queue.

The eligibility query uses `Exists()` on `ReleaseArtifact` rather than a reverse accessor, matching `_run_scheduled_security_scans`, because the FK carries no `related_name`.

## Tests

Seven new, all through the real eviction path: they create a newer SBOM and let the `post_save` signal evict the old one, so the suite breaks if eviction ever stops happening. Covered: a current release protects a version at 900 days, a superseded one becomes prunable, the age floor holds a freshly superseded one, prune deletes both the DT project and the row, a 503 keeps the row, a 404 drops it, and a dry run touches nothing.

`960 passed` across `sbomify/apps/plugins/tests/`.

## Not in scope

Option 1, scoping the hourly DT sweep to current releases, caps our own enqueue cost and composes with this. It needs a product decision on cadence for paid teams.
