### PR TITLE
fix(sentry): guard against WebSocket connections being sampled as transactions (currently a no-op)

### DIFF
--- a/sbomify/apps/core/tests/test_sentry_traces_sampler.py
+++ b/sbomify/apps/core/tests/test_sentry_traces_sampler.py
@@ -1,0 +1,52 @@
+"""Sampling policy for Sentry transactions.
+
+The WebSocket case is the one with teeth: a socket lives as long as the tab
+stays open, so sampling it as a transaction records the connection lifetime as
+a duration. One tab left open overnight reports as a 12-hour request and drags
+every latency percentile with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.settings import _sentry_traces_sampler as sample
+
+
+class TestWebSockets:
+    def test_a_websocket_is_never_sampled(self):
+        """Dropped rather than rate-limited: a long-lived socket is the healthy
+        case, and there is no duration here worth measuring."""
+        assert sample({"asgi_scope": {"type": "websocket", "path": "/ws/workspace/abc/"}}) == 0.0
+
+    def test_an_asgi_http_request_is_still_sampled(self):
+        """The guard keys on the scope type, so it must not swallow ordinary
+        ASGI traffic on the same server."""
+        assert sample({"asgi_scope": {"type": "http", "path": "/dashboard"}}) > 0
+
+    def test_a_lifespan_scope_is_still_sampled(self):
+        """Only websocket is special-cased; anything else falls through."""
+        assert sample({"asgi_scope": {"type": "lifespan"}}) > 0
+
+
+class TestTheExistingRoutesAreUndisturbed:
+    @pytest.mark.parametrize(
+        "context",
+        [
+            {"wsgi_environ": {"PATH_INFO": "/api/v1/releases"}},
+            {"wsgi_environ": {"PATH_INFO": "/x", "HTTP_HX_REQUEST": "true"}},
+            {"wsgi_environ": {"PATH_INFO": "/dashboard"}},
+            {"transaction_context": {"op": "dramatiq"}},
+            {},
+        ],
+    )
+    def test_everything_else_keeps_a_non_zero_rate(self, context):
+        assert sample(context) > 0
+
+
+def test_a_zero_base_rate_still_wins(monkeypatch):
+    """Turning sampling off globally must not be re-enabled by any branch."""
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0")
+
+    assert sample({"asgi_scope": {"type": "http"}}) == 0.0
+    assert sample({"asgi_scope": {"type": "websocket"}}) == 0.0

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -780,6 +780,16 @@ def _sentry_traces_sampler(sampling_context: dict[str, Any]) -> float:
     except (ValueError, TypeError):
         job_rate = base_rate
 
+    # A WebSocket lives for as long as the tab stays open, so sampling it as a
+    # transaction records the connection lifetime as a duration: one socket held
+    # overnight reports as a 12-hour "request" and drags every latency
+    # percentile with it. Drop them rather than rate-limit them, since a
+    # long-lived socket is the healthy case and there is no duration here worth
+    # measuring.
+    asgi_scope = sampling_context.get("asgi_scope") or {}
+    if asgi_scope.get("type") == "websocket":
+        return 0.0
+
     wsgi_environ = sampling_context.get("wsgi_environ")
     if wsgi_environ:
         path = wsgi_environ.get("PATH_INFO", "")


### PR DESCRIPTION
A WebSocket lives as long as the tab stays open, so sampling it as a transaction records the connection lifetime as a duration. A socket held overnight reports as a 12-hour request and drags every latency percentile with it. The better the connection, the worse it looks.

`_sentry_traces_sampler` read `wsgi_environ` for HTTP and the transaction op for jobs. ASGI WebSocket scopes match neither, so they fell through to the base rate.

```
websocket    0.0   <- was 0.1
asgi http    0.1
wsgi api     0.1
wsgi htmx    0.1
dramatiq     0.1
empty        0.1
```

Dropped outright rather than rate-limited, because a long-lived socket is the healthy case and there is no duration here worth measuring. Keyed on `asgi_scope["type"]` so ordinary ASGI HTTP on the same server is untouched; tests cover that and the `lifespan` scope, plus that a zero base rate still wins.

## This does not fix the panel that prompted it

Worth being explicit. The slowest-endpoints panel showing `/ws/workspace/<key>/` at 45,060,224 ms is built from **access logs, not Sentry** — its columns (`http_host`, `http_uri`, `http_status`, `http_client_ip`) are the proxy log fields. Nothing in this PR changes it.

That panel needs status `101` excluded from its query. Filtering on the status beats filtering `/ws/*`, since it covers any socket route added later. The legend already tracks `101` alongside 200/201/403, which is the direct evidence the handshakes are in the dataset.

So: this PR fixes the same distortion where it lives in our code, and the dashboard change is separate and not mine to make.