### PR TITLE
fix(core): recover the workspace WebSocket after backend restarts

### DIFF
--- a/sbomify/apps/core/js/components/websocket-store.spec.ts
+++ b/sbomify/apps/core/js/components/websocket-store.spec.ts
@@ -181,6 +181,19 @@ describe('WebSocket store reconnection', () => {
         expect(runPendingTimer()).toBe(1000)
     })
 
+    test('does not retry close codes that can never succeed', () => {
+        // 1008 policy violation, 1002 protocol error, 1003 unsupported data:
+        // terminal verdicts about the client, so retrying is a slow no-op loop.
+        for (const code of [1008, 1002, 1003]) {
+            getStore().connect('workspace-key')
+            sockets[sockets.length - 1].open()
+            sockets[sockets.length - 1].drop(true, code)
+
+            expect(pending).toHaveLength(0)
+            getStore().disconnect()
+        }
+    })
+
     test('does not reconnect after a deliberate disconnect', () => {
         const store = getStore()
         store.connect('workspace-key')

--- a/sbomify/apps/core/js/components/websocket-store.spec.ts
+++ b/sbomify/apps/core/js/components/websocket-store.spec.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test'
+
+interface StoredSocket {
+    url: string
+    closed: { code: number; reason: string } | null
+    onopen: (() => void) | null
+    onmessage: ((event: { data: string }) => void) | null
+    onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null
+    onerror: (() => void) | null
+}
+
+const sockets: FakeWebSocket[] = []
+
+class FakeWebSocket implements StoredSocket {
+    static OPEN = 1
+    url: string
+    closed: { code: number; reason: string } | null = null
+    onopen: (() => void) | null = null
+    onmessage: ((event: { data: string }) => void) | null = null
+    onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null = null
+    onerror: (() => void) | null = null
+
+    constructor(url: string) {
+        this.url = url
+        sockets.push(this)
+    }
+
+    close(code: number, reason: string): void {
+        this.closed = { code, reason }
+    }
+
+    /** Drive a successful handshake. */
+    open(): void {
+        this.onopen?.()
+    }
+
+    /** Drive a close the way a browser would after a drop or a rejected handshake. */
+    drop(wasClean = false, code = 1006): void {
+        this.onclose?.({ code, reason: '', wasClean })
+    }
+}
+
+const stores: Record<string, unknown> = {}
+
+mock.module('alpinejs', () => ({
+    default: {
+        store: (name: string, value?: unknown) => {
+            if (value !== undefined) {
+                stores[name] = value
+                return undefined
+            }
+            return stores[name]
+        }
+    }
+}))
+
+interface WsStore {
+    connect: (workspaceKey: string) => void
+    disconnect: () => void
+    connected: boolean
+    reconnectAttempts: number
+    socket: FakeWebSocket | null
+}
+
+const { registerWebSocketStore } = await import('./websocket-store')
+
+/** Timers the store scheduled, so tests can run them without waiting. */
+const pending: { fn: () => void; delay: number }[] = []
+
+const realSetTimeout = globalThis.setTimeout
+const realClearTimeout = globalThis.clearTimeout
+const realRandom = Math.random
+
+function getStore(): WsStore {
+    return stores.ws as WsStore
+}
+
+/** Run the reconnect timer the store is waiting on, returning its delay. */
+function runPendingTimer(): number {
+    const timer = pending.shift()
+    if (!timer) throw new Error('expected a reconnect to be scheduled, none was')
+    timer.fn()
+    return timer.delay
+}
+
+describe('WebSocket store reconnection', () => {
+    beforeEach(() => {
+        sockets.length = 0
+        pending.length = 0
+
+        ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket
+        ;(globalThis as unknown as { window: unknown }).window = {
+            location: { protocol: 'https:', host: 'app.sbomify.com' },
+            dispatchEvent: () => true
+        }
+        ;(globalThis as unknown as { CustomEvent: unknown }).CustomEvent = class {
+            constructor(
+                public type: string,
+                public init?: { detail?: unknown }
+            ) {}
+        }
+        // Jitter is proportional, so pinning it keeps the backoff assertions exact.
+        Math.random = () => 0
+        ;(globalThis as unknown as { setTimeout: unknown }).setTimeout = (fn: () => void, delay: number) => {
+            pending.push({ fn, delay })
+            return pending.length
+        }
+        ;(globalThis as unknown as { clearTimeout: unknown }).clearTimeout = () => {
+            pending.length = 0
+        }
+
+        registerWebSocketStore()
+    })
+
+    afterEach(() => {
+        ;(globalThis as unknown as { setTimeout: unknown }).setTimeout = realSetTimeout
+        ;(globalThis as unknown as { clearTimeout: unknown }).clearTimeout = realClearTimeout
+        Math.random = realRandom
+    })
+
+    test('retries when the very first handshake is refused', () => {
+        // A backend restart while the page loads means onopen never fires. The
+        // tab has no live updates at all, so this is the case that most needs a
+        // retry, and it was the one case that got none.
+        getStore().connect('workspace-key')
+        sockets[0].drop()
+
+        expect(runPendingTimer()).toBe(1000)
+        expect(sockets).toHaveLength(2)
+    })
+
+    test('retries when the server closes cleanly, as a graceful deploy does', () => {
+        // docker stop / a deploy shuts uvicorn down gracefully, so the browser
+        // sees a completed close handshake (wasClean=true). Gating the retry on
+        // wasClean left every open tab dead after each deploy — and deliberate
+        // client disconnects detach the handler entirely, so any close that
+        // reaches it is the server's doing.
+        getStore().connect('workspace-key')
+        sockets[0].open()
+        sockets[0].drop(true, 1001)
+
+        expect(runPendingTimer()).toBe(1000)
+        expect(sockets).toHaveLength(2)
+    })
+
+    test('backs off across consecutive failures instead of retrying every second', () => {
+        getStore().connect('workspace-key')
+        sockets[0].open()
+
+        const delays: number[] = []
+        for (let i = 0; i < 4; i++) {
+            sockets[sockets.length - 1].drop()
+            delays.push(runPendingTimer())
+        }
+
+        expect(delays).toEqual([1000, 2000, 4000, 8000])
+    })
+
+    test('gives up once the attempt budget is spent', () => {
+        getStore().connect('workspace-key')
+        sockets[0].open()
+
+        for (let i = 0; i < 10; i++) {
+            sockets[sockets.length - 1].drop()
+            runPendingTimer()
+        }
+        sockets[sockets.length - 1].drop()
+
+        expect(pending).toHaveLength(0)
+    })
+
+    test('a reconnect that succeeds restores the full attempt budget', () => {
+        getStore().connect('workspace-key')
+        sockets[0].open()
+
+        sockets[0].drop()
+        runPendingTimer()
+        sockets[1].open()
+        sockets[1].drop()
+
+        expect(runPendingTimer()).toBe(1000)
+    })
+
+    test('does not reconnect after a deliberate disconnect', () => {
+        const store = getStore()
+        store.connect('workspace-key')
+        sockets[0].open()
+
+        store.disconnect()
+        sockets[0].drop(true, 1000)
+
+        expect(pending).toHaveLength(0)
+        expect(sockets).toHaveLength(1)
+    })
+
+    test('a replaced socket closing late does not tear down the live one', () => {
+        const store = getStore()
+        store.connect('workspace-a')
+        sockets[0].open()
+
+        // connect() closes the old socket, but the browser fires its close event
+        // asynchronously — by then the new socket is the one in the store.
+        store.connect('workspace-b')
+        sockets[1].open()
+        sockets[0].drop(true, 1000)
+
+        expect(store.connected).toBe(true)
+        expect(store.socket).toBe(sockets[1])
+    })
+
+    test('connects to the workspace-scoped wss URL', () => {
+        getStore().connect('workspace-key')
+
+        expect(sockets[0].url).toBe('wss://app.sbomify.com/ws/workspace/workspace-key/')
+    })
+})

--- a/sbomify/apps/core/js/components/websocket-store.spec.ts
+++ b/sbomify/apps/core/js/components/websocket-store.spec.ts
@@ -67,9 +67,26 @@ const { registerWebSocketStore } = await import('./websocket-store')
 /** Timers the store scheduled, so tests can run them without waiting. */
 const pending: { fn: () => void; delay: number }[] = []
 
-const realSetTimeout = globalThis.setTimeout
-const realClearTimeout = globalThis.clearTimeout
+const globals = globalThis as unknown as Record<string, unknown>
+const realGlobals: Record<string, unknown> = {
+    WebSocket: globals.WebSocket,
+    window: globals.window,
+    CustomEvent: globals.CustomEvent,
+    setTimeout: globals.setTimeout,
+    clearTimeout: globals.clearTimeout
+}
 const realRandom = Math.random
+
+function restoreGlobals(): void {
+    for (const [name, value] of Object.entries(realGlobals)) {
+        if (value === undefined) {
+            delete globals[name]
+        } else {
+            globals[name] = value
+        }
+    }
+    Math.random = realRandom
+}
 
 function getStore(): WsStore {
     return stores.ws as WsStore
@@ -113,9 +130,7 @@ describe('WebSocket store reconnection', () => {
     })
 
     afterEach(() => {
-        ;(globalThis as unknown as { setTimeout: unknown }).setTimeout = realSetTimeout
-        ;(globalThis as unknown as { clearTimeout: unknown }).clearTimeout = realClearTimeout
-        Math.random = realRandom
+        restoreGlobals()
     })
 
     test('retries when the very first handshake is refused', () => {

--- a/sbomify/apps/core/js/components/websocket-store.ts
+++ b/sbomify/apps/core/js/components/websocket-store.ts
@@ -62,6 +62,20 @@ export function registerWebSocketStore(): void {
             // Disconnect from any existing connection
             this.disconnect();
 
+            this.openSocket(workspaceKey);
+        },
+
+        /**
+         * Open a socket without tearing down retry state.
+         *
+         * Retries route here rather than through connect(), which resets the
+         * attempt counter as part of its deliberate-disconnect semantics. Going
+         * through connect() zeroed the counter on every retry, so the backoff
+         * never grew past its first step and the attempt budget was never spent.
+         */
+        openSocket(workspaceKey: string): void {
+            const state = this as unknown as WebSocketStoreState;
+
             state.workspaceKey = workspaceKey;
             state.connecting = true;
             state.lastError = null;
@@ -107,7 +121,6 @@ export function registerWebSocketStore(): void {
                 };
 
                 state.socket.onclose = (event: CloseEvent) => {
-                    const wasConnected = state.connected;
                     state.connected = false;
                     state.connecting = false;
                     state.socket = null;
@@ -122,9 +135,14 @@ export function registerWebSocketStore(): void {
                         }
                     }));
 
-                    // Attempt reconnection if this wasn't a clean close
-                    // and we were previously connected or trying to connect
-                    if (!event.wasClean && wasConnected && state.workspaceKey) {
+                    // Every close that reaches this handler is the server's or
+                    // the network's doing — disconnect() detaches handlers
+                    // before closing. That includes wasClean closes: a graceful
+                    // deploy completes the close handshake, and gating on
+                    // wasClean (or on having been connected before, which a
+                    // refused handshake never was) left tabs permanently silent
+                    // after each backend restart.
+                    if (state.workspaceKey) {
                         this.scheduleReconnect();
                     }
                 };
@@ -157,6 +175,13 @@ export function registerWebSocketStore(): void {
             }
 
             if (state.socket) {
+                // Detach first: the close event arrives asynchronously, and a
+                // stale handler firing after connect() has installed a new
+                // socket would null it out and mark the live connection down.
+                state.socket.onopen = null;
+                state.socket.onmessage = null;
+                state.socket.onclose = null;
+                state.socket.onerror = null;
                 state.socket.close(1000, 'Client disconnect');
                 state.socket = null;
             }
@@ -176,6 +201,9 @@ export function registerWebSocketStore(): void {
                 return;
             }
 
+            // The budget now genuinely runs out, which it never did before, so
+            // a tab that sleeps through all ten attempts stays silent. Retrying
+            // on visibilitychange is the upgrade if that turns up in practice.
             if (state.reconnectAttempts >= RECONNECT_MAX_ATTEMPTS) {
                 state.lastError = 'Max reconnection attempts reached';
                 if (DEBUG) {
@@ -193,7 +221,7 @@ export function registerWebSocketStore(): void {
 
             state.reconnectTimer = setTimeout(() => {
                 if (state.workspaceKey) {
-                    this.connect(state.workspaceKey);
+                    this.openSocket(state.workspaceKey);
                 }
             }, delay);
         },
@@ -207,6 +235,7 @@ export function registerWebSocketStore(): void {
         }
     } as WebSocketStoreState & {
         connect: (workspaceKey: string) => void;
+        openSocket: (workspaceKey: string) => void;
         disconnect: () => void;
         scheduleReconnect: () => void;
         isReady: () => boolean;

--- a/sbomify/apps/core/js/components/websocket-store.ts
+++ b/sbomify/apps/core/js/components/websocket-store.ts
@@ -20,6 +20,10 @@ const RECONNECT_BASE_DELAY_MS = 1000; // Start with 1 second
 const RECONNECT_MAX_DELAY_MS = 30000; // Max 30 seconds
 const RECONNECT_MAX_ATTEMPTS = 10; // Give up after 10 attempts
 
+// Terminal verdicts about this client: policy violation (auth), protocol
+// error, unsupported data. Retrying these replays the same rejection.
+const NO_RETRY_CLOSE_CODES = new Set([1002, 1003, 1008]);
+
 interface WebSocketMessage {
     type: string;
     [key: string]: unknown;
@@ -137,12 +141,12 @@ export function registerWebSocketStore(): void {
 
                     // Every close that reaches this handler is the server's or
                     // the network's doing — disconnect() detaches handlers
-                    // before closing. That includes wasClean closes: a graceful
-                    // deploy completes the close handshake, and gating on
-                    // wasClean (or on having been connected before, which a
-                    // refused handshake never was) left tabs permanently silent
-                    // after each backend restart.
-                    if (state.workspaceKey) {
+                    // before closing. That includes wasClean closes: uvicorn
+                    // sends a clean 1012 (service restart, "please retry") on
+                    // shutdown, so gating on wasClean (or on having been
+                    // connected before, which a refused handshake never was)
+                    // left tabs permanently silent after each deploy.
+                    if (state.workspaceKey && !NO_RETRY_CLOSE_CODES.has(event.code)) {
                         this.scheduleReconnect();
                     }
                 };


### PR DESCRIPTION
## Context

The staging slow-endpoint panel shows `/ws/` at ~45M ms average. That number is connection lifetime, not latency: the panel aggregates proxy access logs, and a WebSocket's log entry spans the whole session, so a tab left open all day reports as one twelve-hour "request". The panel needs to exclude status 101 upgrades; that query lives outside this repo. Django never traces these connections (`asgi.py` routes `websocket` through `AuthMiddlewareStack` with no Sentry middleware), so no server-side change applies. This PR replaces #1278, which guarded a code path that never runs.

Auditing the path behind the panel surfaced real client bugs instead. The reconnect logic in the Alpine `ws` store could not survive a backend restart, so every deploy left open tabs without live updates until someone reloaded them.

## Bugs

1. **Graceful shutdowns never triggered a retry.** uvicorn closes WebSockets with a clean 1012 Service Restart on SIGTERM ([uvicorn#1816](https://github.com/Kludex/uvicorn/pull/1816)), a code defined as "client may retry". The browser reports `wasClean: true` for it, and the retry gate skipped every wasClean close, so the one close code that asks for a reconnect got none. Reproduced on the dev stack: stopping the backend left the store at `connected: false, reconnectAttempts: 0` with no timer pending.
2. **A refused handshake never retried.** The gate also required a previously successful connection, and `onopen` never fires when the handshake is refused. A tab loaded during a restart stayed silent forever.
3. **The backoff never grew.** Retries re-entered `connect()`, whose `disconnect()` call reset the attempt counter, so the delay stayed at one second and the ten-attempt budget never decremented. After one failed retry the loop stopped.

## Fix

- Retries route through a new `openSocket()` that preserves retry state; `connect()` keeps its reset semantics for deliberate use.
- `disconnect()` detaches all handlers before closing. Only server- or network-initiated closes reach the close handler now, so the handler retries any close except the terminal codes 1002/1003/1008, per [websocket.org's error-handling guidance](https://websocket.org/guides/error-handling/). This also stops a replaced socket's late close event from tearing down the live connection after a workspace switch.

## Verification

- 9 bun tests: refused first handshake, the clean-close deploy case, terminal-code suppression, backoff growth (1s/2s/4s/8s), budget exhaustion, budget reset on success, deliberate disconnect, the late-close race, and the URL shape.
- Live drills against the dev stack, driven through devtools on a workspace holding 1,250 SBOMs:
  - `docker restart` on the backend: the tab logged the clean 1012, retried through two 502 refusals on the backoff schedule, reconnected in 7s, and a `channel_layer` broadcast after the restart was delivered — group membership survives the reconnect.
  - A 489 KB broadcast carrying 3,000 findings parsed and dispatched intact, alongside small payloads.
  - Connecting to a workspace the user is not a member of: Channels rejects before the upgrade (HTTP 403 → close 1006), and the attempt budget bounded the retries.
  - Switching workspaces mid-retry cancelled the pending timer, and a broadcast to the abandoned workspace did not leak into the new connection.
  - Console showed only the browser's native handshake failure logs; no script errors.