### PR TITLE
feat(advisories): map the New Advisory modal onto products and releases

### DIFF
--- a/sbomify/apps/core/templates/core/components/header.html.j2
+++ b/sbomify/apps/core/templates/core/components/header.html.j2
@@ -96,6 +96,21 @@
                                 <i class="fas fa-puzzle-piece w-4 text-center" aria-hidden="true"></i>
                                 Component
                             </button>
+                            {% comment %}A link rather than a dispatch: the advisory modal needs the workspace's products and releases in context, so it lives on the advisories page and ?new=1 opens it on arrival.{% endcomment %}
+                            <a href="{% url 'core:security_advisories_dashboard' %}?new=1"
+                               @click="open = false"
+                               class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-text-muted text-left transition-all duration-150 focus:outline-none focus-visible:bg-primary/10 dropdown-item-hover"
+                               role="menuitem">
+                                <i class="fas fa-shield-halved w-4 text-center" aria-hidden="true"></i>
+                                Advisory
+                            </a>
+                            <a href="{% url 'teams:suppliers' current_team.key %}?new=1"
+                               @click="open = false"
+                               class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-text-muted text-left transition-all duration-150 focus:outline-none focus-visible:bg-primary/10 dropdown-item-hover"
+                               role="menuitem">
+                                <i class="fas fa-truck-field w-4 text-center" aria-hidden="true"></i>
+                                Supplier
+                            </a>
                         </div>
                     </div>
                 {% endif %}

--- a/sbomify/apps/core/templates/core/components/header.html.j2
+++ b/sbomify/apps/core/templates/core/components/header.html.j2
@@ -104,13 +104,6 @@
                                 <i class="fas fa-shield-halved w-4 text-center" aria-hidden="true"></i>
                                 Advisory
                             </a>
-                            <a href="{% url 'teams:suppliers' current_team.key %}?new=1"
-                               @click="open = false"
-                               class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-text-muted text-left transition-all duration-150 focus:outline-none focus-visible:bg-primary/10 dropdown-item-hover"
-                               role="menuitem">
-                                <i class="fas fa-truck-field w-4 text-center" aria-hidden="true"></i>
-                                Supplier
-                            </a>
                         </div>
                     </div>
                 {% endif %}

--- a/sbomify/apps/core/templates/core/components/sidebar.html.j2
+++ b/sbomify/apps/core/templates/core/components/sidebar.html.j2
@@ -217,30 +217,6 @@
                     {% url 'core:security_advisories_dashboard' as advisories_url %}
                     {% include "core/components/sidebar_link.html.j2" with url=advisories_url icon="fa-shield-halved" label="Security Advisories" match="core:security_advisor" %}
                 </li>
-                {# Suppliers — visible to owner/admin only; the list names who we chase for artifacts #}
-                {% if request.session.current_team.role == "owner" or request.session.current_team.role == "admin" %}
-                    <li>
-                        {# Collapsed #}
-                        <a x-show="sidebarCollapsed"
-                           href="{% url 'teams:suppliers' request.session.current_team.key %}"
-                           @click="sidebarMobileOpen = false"
-                           aria-label="Suppliers"
-                           {% if current_view_name == 'teams:suppliers' %}aria-current="page"{% endif %}
-                           class="flex items-center justify-center w-full h-11 rounded-xl transition-all duration-200 {% if current_view_name == 'teams:suppliers' %}bg-primary text-white shadow-sm hover:bg-primary-dark{% else %}text-text sidebar-link-hover-collapsed{% endif %}">
-                            <i class="fas fa-truck-field text-base" aria-hidden="true"></i>
-                        </a>
-                        {# Expanded #}
-                        <a x-show="!sidebarCollapsed"
-                           x-cloak
-                           href="{% url 'teams:suppliers' request.session.current_team.key %}"
-                           @click="sidebarMobileOpen = false"
-                           {% if current_view_name == 'teams:suppliers' %}aria-current="page"{% endif %}
-                           class="flex items-center gap-3 px-4 h-11 rounded-xl transition-all duration-200 {% if current_view_name == 'teams:suppliers' %}bg-primary text-white font-medium shadow-sm hover:bg-primary-dark{% else %}text-text sidebar-link-hover{% endif %}">
-                            <span class="w-5 flex items-center justify-center shrink-0"><i class="fas fa-truck-field text-base" aria-hidden="true"></i></span>
-                            <span>Suppliers</span>
-                        </a>
-                    </li>
-                {% endif %}
                 {# Plugins — visible to owner/admin only #}
                 {% if request.session.current_team.role == "owner" or request.session.current_team.role == "admin" %}
                     <li>

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -14,21 +14,14 @@
                     <p class="text-text-muted text-sm">Publish security advisories for your products</p>
                 </div>
             </div>
-            {% if has_crud_permissions %}
-                <div>
-                    <button type="button"
-                            @click="$dispatch('open-add-advisory-modal')"
-                            class="tw-btn-primary">
-                        <i class="fas fa-plus mr-2"></i>New Advisory
-                    </button>
-                </div>
-            {% endif %}
         </div>
         {# Advisories Table #}
         {% include 'core/security_advisories_table.html.j2' %}
         {# Add Advisory Modal (Alpine.js) #}
         {% if has_crud_permissions %}
+            {# The header's New menu links here with ?new=1; the param is stripped after opening so a refresh does not reopen the modal. #}
             <div x-data="{ open: false, showRef: false, chosenProducts: [] }"
+                 x-init="if (new URLSearchParams(location.search).has('new')) { open = true; history.replaceState(null, '', location.pathname) }"
                  @open-add-advisory-modal.window="open = true; showRef = false">
                 <template x-teleport="body">
                     <div x-show="open"

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -26,9 +26,9 @@
         </div>
         {# Advisories Table #}
         {% include 'core/security_advisories_table.html.j2' %}
-        {# Add Advisory Modal (Alpine.js) — front-end preview, does not persist yet (#1172) #}
+        {# Add Advisory Modal (Alpine.js) #}
         {% if has_crud_permissions %}
-            <div x-data="{ open: false, showRef: false }"
+            <div x-data="{ open: false, showRef: false, chosenProducts: [] }"
                  @open-add-advisory-modal.window="open = true; showRef = false">
                 <template x-teleport="body">
                     <div x-show="open"
@@ -96,6 +96,57 @@
                                                 <option value="medium" selected>Medium</option>
                                                 <option value="low">Low</option>
                                             </select>
+                                        </div>
+                                        {# Affected products, each unfolding its pinnable releases when checked. #}
+                                        <div>
+                                            <label class="tw-form-label">Affected products</label>
+                                            {% if creation_products %}
+                                                <div class="max-h-48 overflow-y-auto rounded-lg border border-border divide-y divide-border/60">
+                                                    {% for product in creation_products %}
+                                                        <div class="px-3 py-2" data-product-block>
+                                                            <label class="flex items-center gap-2.5 text-sm text-text cursor-pointer">
+                                                                <input type="checkbox"
+                                                                       name="products"
+                                                                       value="{{ product.id }}"
+                                                                       x-model="chosenProducts"
+                                                                       @change="if (!$event.target.checked) $event.target.closest('[data-product-block]').querySelectorAll('input[data-release]').forEach(el => el.checked = false)"
+                                                                       class="tw-checkbox" />
+                                                                <i class="fas fa-cube text-xs text-text-muted" aria-hidden="true"></i>
+                                                                {{ product.name }}
+                                                            </label>
+                                                            {% if product.releases %}
+                                                                <div x-show="chosenProducts.includes('{{ product.id|escapejs }}')"
+                                                                     x-cloak
+                                                                     class="mt-2 ml-6 space-y-1.5">
+                                                                    <p class="text-xs text-text-muted">Affected releases (optional)</p>
+                                                                    <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+                                                                        {% for release in product.releases %}
+                                                                            <label class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer">
+                                                                                <input type="checkbox"
+                                                                                       name="affected_releases"
+                                                                                       value="{{ release.id }}"
+                                                                                       data-release
+                                                                                       class="tw-checkbox" />
+                                                                                {{ release.label }}
+                                                                            </label>
+                                                                        {% endfor %}
+                                                                    </div>
+                                                                </div>
+                                                            {% endif %}
+                                                        </div>
+                                                    {% endfor %}
+                                                </div>
+                                                <p class="mt-1.5 text-xs text-text-muted">
+                                                    Optional for a draft; publishing a product advisory requires at least one product.
+                                                </p>
+                                            {% else %}
+                                                <p class="text-sm text-text-muted rounded-lg border border-dashed border-border px-3 py-2.5">
+                                                    No products in this workspace yet.
+                                                    <a href="{% url 'core:products_dashboard' %}"
+                                                       class="text-primary hover:underline">Create one</a>
+                                                    to map advisories to it.
+                                                </p>
+                                            {% endif %}
                                         </div>
                                         {# CVE / reference is optional — hidden until the user chooses to add it. #}
                                         <div>

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -250,6 +250,10 @@
                                 {% else %}
                                     {{ product.name }}
                                 {% endif %}
+                                {% if product.affected_ranges %}
+                                    <span class="ml-1.5 pl-1.5 border-l border-border/60 font-normal opacity-80"
+                                          title="Affected releases">{{ product.affected_ranges|join:", " }}</span>
+                                {% endif %}
                             </span>
                         {% endfor %}
                     </div>

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -11,9 +11,10 @@ is draft / published / withdrawn, whether anyone outside the workspace can read
 it. An advisory can be resolved and unpublished, or published mid-fix, so
 neither collapses into the other.
 
-Writes still do not persist. Creating advisories, posting updates and linking
-VEX land in the following passes, and the handlers below say so rather than
-pretending otherwise.
+Creation persists: the New Advisory modal maps the advisory onto the workspace's
+products and their releases, and writes the whole initial graph through
+``create_advisory``. Posting updates, editing and linking VEX still land in the
+following passes, and those handlers say so rather than pretending otherwise.
 """
 
 from __future__ import annotations
@@ -27,9 +28,12 @@ from django.shortcuts import redirect, render
 from django.views import View
 
 from sbomify.apps.core.models import User
+from sbomify.apps.security_advisories.forms import AdvisoryCreateForm
 from sbomify.apps.security_advisories.services.advisories import (
     REMEDIATION_META,
     advisory_counts,
+    create_advisory,
+    creation_options,
     get_advisory,
     list_advisories,
 )
@@ -87,18 +91,41 @@ def _advisories_context(request: HttpRequest) -> dict[str, Any]:
 
 class SecurityAdvisoriesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
     def get(self, request: HttpRequest) -> HttpResponse:
-        return render(request, "core/security_advisories_dashboard.html.j2", _advisories_context(request))
+        context = _advisories_context(request)
+        team = _current_team(request)
+        context["creation_products"] = (creation_options(team).value or []) if team else []
+        return render(request, "core/security_advisories_dashboard.html.j2", context)
 
     def post(self, request: HttpRequest) -> HttpResponse:
-        # Creation lands with the CRUD pass. In the real flow this writes the
-        # advisory plus its first status_change event, so nobody sets a status
-        # directly.
-        title = request.POST.get("title", "").strip()
-        messages.info(
-            request,
-            f'Not saved yet: "{title or "advisory"}". Creating advisories is the next pass on this UI.',
+        team = _current_team(request)
+        if team is None:
+            raise Http404("Workspace not found")
+
+        form = AdvisoryCreateForm(team, request.POST)
+        if not form.is_valid():
+            # The modal is closed by the redirect, so errors surface as a toast
+            # rather than inline. First error only: one actionable message
+            # beats a wall of them.
+            first_error = next(iter(form.errors.values()))[0]
+            messages.error(request, f"Advisory not created: {first_error}")
+            return redirect("core:security_advisories_dashboard")
+
+        result = create_advisory(
+            team,
+            cast(User, request.user),
+            title=form.cleaned_data["title"],
+            severity=form.cleaned_data.get("severity") or "",
+            description=form.cleaned_data.get("description") or "",
+            identifier=form.cleaned_data.get("vulnerability_id") or "",
+            products=list(form.cleaned_data.get("products") or []),
+            affected_releases=list(form.cleaned_data.get("affected_releases") or []),
         )
-        return redirect("core:security_advisories_dashboard")
+        if not result.ok or result.value is None:
+            messages.error(request, f"Advisory not created: {result.error or 'unknown error'}")
+            return redirect("core:security_advisories_dashboard")
+
+        messages.success(request, f'Advisory "{form.cleaned_data["title"]}" created.')
+        return redirect("core:security_advisory_detail", advisory_id=result.value)
 
 
 class SecurityAdvisoriesTableView(GuestAccessBlockedMixin, LoginRequiredMixin, View):

--- a/sbomify/apps/security_advisories/forms.py
+++ b/sbomify/apps/security_advisories/forms.py
@@ -1,0 +1,59 @@
+"""Validation for the New Advisory modal.
+
+A plain ``Form`` rather than a ``ModelForm``: one submission writes an advisory,
+its products, a vulnerability, per-product statuses and release ranges, so there
+is no single model to bind.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django import forms
+
+from sbomify.apps.core.models import Product, Release
+from sbomify.apps.security_advisories.models import CVE_ID_RE, Severity
+from sbomify.apps.teams.models import Team
+
+
+class AdvisoryCreateForm(forms.Form):
+    """The New Advisory modal's fields, scoped to one workspace.
+
+    ``products`` and ``affected_releases`` querysets are restricted to the team
+    at construction, so another workspace's ids fail validation rather than
+    silently attaching foreign rows.
+    """
+
+    title = forms.CharField(max_length=255)
+    severity = forms.ChoiceField(choices=Severity.choices, required=False)
+    # The modal's single identifier field: a CVE, another database's id
+    # (GHSA-…), or a URL. clean_vulnerability_id sorts out which.
+    vulnerability_id = forms.CharField(max_length=100, required=False)
+    description = forms.CharField(required=False, widget=forms.Textarea)
+    products = forms.ModelMultipleChoiceField(queryset=Product.objects.none(), required=False)
+    affected_releases = forms.ModelMultipleChoiceField(queryset=Release.objects.none(), required=False)
+
+    def __init__(self, team: Team, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["products"].queryset = Product.objects.filter(team=team)  # type: ignore[attr-defined]
+        # ``latest`` is a floating pointer that re-targets as artifacts arrive,
+        # so pinning it as an affected version would change meaning over time.
+        self.fields["affected_releases"].queryset = Release.objects.filter(  # type: ignore[attr-defined]
+            product__team=team, is_latest=False
+        )
+
+    def clean_vulnerability_id(self) -> str:
+        identifier = (self.cleaned_data.get("vulnerability_id") or "").strip()
+        # Normalise the case CVE ids are quoted in; other schemes keep the
+        # user's casing since detect_reference_type matches case-insensitively.
+        if CVE_ID_RE.match(identifier.upper()):
+            return identifier.upper()
+        return identifier
+
+    def clean(self) -> dict[str, Any]:
+        cleaned = super().clean() or {}
+        selected = {product.id for product in cleaned.get("products") or []}
+        stray = [release for release in cleaned.get("affected_releases") or [] if release.product_id not in selected]
+        if stray:
+            self.add_error("affected_releases", "Affected releases must belong to a selected product.")
+        return cleaned

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -424,7 +424,13 @@ def create_advisory(
         status_by_product[product.id] = AdvisoryProductStatus.objects.create(
             vulnerability=vulnerability, advisory_product=advisory_product
         )
+    # Cross-tenant products need no check here: AdvisoryProduct.clean rejects
+    # them, and a foreign release falls out of status_by_product below. The
+    # floating "latest" is the one thing only the form was refusing.
     for release in affected_releases or []:
+        if release.is_latest:
+            transaction.set_rollback(True)
+            return ServiceResult.failure("The floating latest release cannot be pinned as affected.", status_code=400)
         status = status_by_product.get(release.product_id)
         if status is None:
             # A failure result raises nothing, so the atomic block would commit

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -399,8 +399,12 @@ def create_advisory(
         created_by=user,
     )
 
+    # Normalised here as well as in the form, so a caller passing cve-2026-1
+    # directly gets a CVE rather than a misfiled reference.
     identifier = identifier.strip()
-    is_cve = bool(CVE_ID_RE.match(identifier))
+    is_cve = bool(CVE_ID_RE.match(identifier.upper()))
+    if is_cve:
+        identifier = identifier.upper()
     vulnerability = AdvisoryVulnerability.objects.create(
         advisory=advisory,
         cve_id=identifier if is_cve else "",

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -1,24 +1,30 @@
-"""Reading advisories for the workspace UI.
+"""Reading and creating advisories for the workspace UI.
 
 The views render a projection rather than model instances, because the list and
 detail pages want a few derived things the model deliberately does not store:
 the display id, the worst severity across an advisory's vulnerabilities, and a
 timeline that merges messages with status changes.
 
-Everything here is read-only. Writes land with the CRUD pass.
+:func:`create_advisory` is the one write: the New Advisory modal's submission,
+which builds the whole initial graph in a transaction.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from django.db import transaction
 from django.db.models import Prefetch, Q, QuerySet
 
+from sbomify.apps.core.models import Product, Release
 from sbomify.apps.core.services.results import ServiceResult
 from sbomify.apps.security_advisories.models import (
+    CVE_ID_RE,
     AdvisoryEvent,
     AdvisoryProduct,
+    AdvisoryProductStatus,
     AdvisoryReference,
+    AdvisoryVersionRange,
     AdvisoryVulnerability,
     ReferenceType,
     SecurityAdvisory,
@@ -148,6 +154,14 @@ def _vulnerability_projection(vulnerability: AdvisoryVulnerability) -> dict[str,
     }
 
 
+def _range_display(version_range: AdvisoryVersionRange) -> str:
+    """A range the way a chip reads it: the bare version for a single-release
+    pin, interval notation for a real span."""
+    if version_range.introduced and version_range.introduced == version_range.last_affected:
+        return version_range.introduced
+    return str(version_range)
+
+
 def _product_projection(advisory_product: AdvisoryProduct) -> dict[str, Any]:
     """A product chip.
 
@@ -158,6 +172,12 @@ def _product_projection(advisory_product: AdvisoryProduct) -> dict[str, Any]:
     """
     product = advisory_product.product
     name = product.name if product else advisory_product.product_name
+    # Deduplicated but order-preserving: two vulnerabilities citing the same
+    # affected release should not print it twice on the chip.
+    affected: dict[str, None] = {}
+    for status in advisory_product.statuses.all():
+        for version_range in status.version_ranges.all():
+            affected.setdefault(_range_display(version_range))
     return {
         # A stable non-null key for x-for. ``id`` is null for an unlinked
         # product, and Alpine rejects that as a key, so two unlinked products
@@ -165,6 +185,7 @@ def _product_projection(advisory_product: AdvisoryProduct) -> dict[str, Any]:
         "key": advisory_product.id,
         "id": product.id if product else None,
         "name": name,
+        "affected_ranges": list(affected),
     }
 
 
@@ -282,7 +303,10 @@ def _base_queryset(team: Any) -> QuerySet[SecurityAdvisory]:
         SecurityAdvisory.objects.filter(team=team)
         .prefetch_related(
             Prefetch("vulnerabilities", queryset=AdvisoryVulnerability.objects.order_by("cve_id")),
-            Prefetch("products", queryset=AdvisoryProduct.objects.select_related("product")),
+            Prefetch(
+                "products",
+                queryset=AdvisoryProduct.objects.select_related("product").prefetch_related("statuses__version_ranges"),
+            ),
             Prefetch("references", queryset=AdvisoryReference.objects.order_by("reference_type")),
             Prefetch("events", queryset=AdvisoryEvent.objects.select_related("actor").order_by("created_at")),
         )
@@ -316,6 +340,109 @@ def get_advisory(team: Any, advisory_id: str) -> ServiceResult[dict[str, Any]]:
     if advisory is None:
         return ServiceResult.failure("Advisory not found", status_code=404)
     return ServiceResult.success(_advisory_projection(advisory, detail=True))
+
+
+def creation_options(team: Any) -> ServiceResult[list[dict[str, Any]]]:
+    """Products and their pinnable releases, for the New Advisory pickers.
+
+    ``latest`` releases are excluded: that pointer re-targets as artifacts
+    arrive, so "affected: latest" would describe different code next month.
+    """
+    releases_by_product: dict[str, list[dict[str, str]]] = {}
+    release_rows = (
+        Release.objects.filter(product__team=team, is_latest=False)
+        .order_by("-created_at")
+        .values("id", "product_id", "name", "version")
+    )
+    for row in release_rows:
+        label = row["version"] or row["name"]
+        releases_by_product.setdefault(row["product_id"], []).append({"id": row["id"], "label": label})
+
+    products = [
+        {"id": product_id, "name": name, "releases": releases_by_product.get(product_id, [])}
+        for product_id, name in Product.objects.filter(team=team).order_by("name").values_list("id", "name")
+    ]
+    return ServiceResult.success(products)
+
+
+@transaction.atomic
+def create_advisory(
+    team: Any,
+    user: Any,
+    *,
+    title: str,
+    severity: str = "",
+    description: str = "",
+    identifier: str = "",
+    products: list[Product] | None = None,
+    affected_releases: list[Release] | None = None,
+) -> ServiceResult[str]:
+    """The New Advisory modal's write: the whole initial graph, atomically.
+
+    One vulnerability row is always created. A CVE identifier becomes its
+    ``cve_id``; any other identifier is stored as an :class:`AdvisoryReference`
+    (a GHSA cannot live in ``cve_id``, which validates strictly) and the
+    vulnerability keeps the advisory's title as its working name — the model's
+    own vocabulary for a finding with no id yet.
+
+    Every product gets an ``in_triage`` status per the vulnerability from
+    birth, which is the shape :func:`~..models.validate_publishable` will
+    demand at publish time. Each affected release becomes a single-version
+    range pinned to that release, so the advisory keeps naming the version
+    after the release row is ever deleted.
+    """
+    advisory = SecurityAdvisory.objects.create(
+        team=team,
+        title=title.strip(),
+        severity=severity,
+        description=description.strip(),
+        created_by=user,
+    )
+
+    identifier = identifier.strip()
+    is_cve = bool(CVE_ID_RE.match(identifier))
+    vulnerability = AdvisoryVulnerability.objects.create(
+        advisory=advisory,
+        cve_id=identifier if is_cve else "",
+        title="" if is_cve else advisory.title,
+    )
+    if identifier and not is_cve:
+        is_url = identifier.lower().startswith(("http://", "https://"))
+        AdvisoryReference.objects.create(
+            advisory=advisory,
+            external_id="" if is_url else identifier,
+            url=identifier if is_url else "",
+        )
+
+    status_by_product: dict[str, AdvisoryProductStatus] = {}
+    for product in products or []:
+        advisory_product = AdvisoryProduct.objects.create(advisory=advisory, product=product)
+        status_by_product[product.id] = AdvisoryProductStatus.objects.create(
+            vulnerability=vulnerability, advisory_product=advisory_product
+        )
+    for release in affected_releases or []:
+        status = status_by_product.get(release.product_id)
+        if status is None:
+            # A failure result raises nothing, so the atomic block would commit
+            # the half-built advisory without this.
+            transaction.set_rollback(True)
+            return ServiceResult.failure("Affected releases must belong to a selected product.", status_code=400)
+        version = release.version or release.name
+        AdvisoryVersionRange.objects.create(
+            product_status=status,
+            introduced=version,
+            last_affected=version,
+            introduced_release=release,
+            last_affected_release=release,
+        )
+
+    AdvisoryEvent.objects.create(
+        advisory=advisory,
+        event_type=AdvisoryEvent.EventType.STATUS_CHANGE,
+        actor=user,
+        payload={"to": SecurityAdvisory.RemediationStatus.IDENTIFIED.value},
+    )
+    return ServiceResult.success(advisory.id)
 
 
 def advisory_counts(advisories: list[dict[str, Any]]) -> dict[str, int]:

--- a/sbomify/apps/security_advisories/tests/test_create_advisory.py
+++ b/sbomify/apps/security_advisories/tests/test_create_advisory.py
@@ -107,6 +107,23 @@ class TestCreateAdvisory:
         assert not result.ok
         assert SecurityAdvisory.objects.count() == 0
 
+    def test_latest_release_rejected_without_the_form(self, team, user, product):
+        floating = Release.objects.create(product=product, name="latest", is_latest=True)
+        result = create_advisory(team, user, title="Pin latest", products=[product], affected_releases=[floating])
+
+        assert not result.ok
+        assert SecurityAdvisory.objects.count() == 0
+
+    def test_foreign_product_rejected_by_the_model_guard(self, team, other_team, user):
+        # The service leans on AdvisoryProduct.clean for tenancy, so a direct
+        # caller with another workspace's product blows up rather than writing.
+        from django.core.exceptions import ValidationError
+
+        foreign = Product.objects.create(name="Not yours", team=other_team)
+        with pytest.raises(ValidationError, match="Cross-tenant"):
+            create_advisory(team, user, title="x", products=[foreign])
+        assert SecurityAdvisory.objects.count() == 0
+
     def test_release_with_no_version_string_falls_back_to_its_name(self, team, user, product):
         legacy = Release.objects.create(product=product, name="spring-drop", version="")
         result = create_advisory(team, user, title="Legacy", products=[product], affected_releases=[legacy])

--- a/sbomify/apps/security_advisories/tests/test_create_advisory.py
+++ b/sbomify/apps/security_advisories/tests/test_create_advisory.py
@@ -1,0 +1,182 @@
+"""The New Advisory write path: the modal's submission mapped onto the model.
+
+The interesting property is the shape of the initial graph: one vulnerability
+from birth, an in_triage status per product, and affected releases stored as
+pinned single-version ranges — exactly what validate_publishable will demand
+later, so nothing created here needs restructuring before publish.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+from sbomify.apps.core.models import Product, Release
+from sbomify.apps.security_advisories.forms import AdvisoryCreateForm
+from sbomify.apps.security_advisories.models import (
+    AdvisoryProductStatus,
+    AdvisoryReference,
+    SecurityAdvisory,
+)
+from sbomify.apps.security_advisories.services.advisories import create_advisory, creation_options
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def release(product):
+    return Release.objects.create(product=product, name="v1.2.0", version="1.2.0")
+
+
+@pytest.fixture
+def user(sample_team_with_owner_member):
+    return sample_team_with_owner_member.user
+
+
+class TestCreateAdvisory:
+    def test_full_graph_with_cve_product_and_release(self, team, user, product, release):
+        result = create_advisory(
+            team,
+            user,
+            title="Improper authentication in SAML assertion handling",
+            severity="high",
+            description="Signature validation can be bypassed.",
+            identifier="CVE-2026-12345",
+            products=[product],
+            affected_releases=[release],
+        )
+
+        assert result.ok
+        advisory = SecurityAdvisory.objects.get(pk=result.value)
+        assert advisory.team == team
+        assert advisory.created_by == user
+        assert advisory.severity == "high"
+
+        vulnerability = advisory.vulnerabilities.get()
+        assert vulnerability.cve_id == "CVE-2026-12345"
+
+        advisory_product = advisory.products.get()
+        assert advisory_product.product == product
+        assert advisory_product.product_name == product.name
+
+        status = vulnerability.product_statuses.get()
+        assert status.advisory_product == advisory_product
+        assert status.status == AdvisoryProductStatus.Status.IN_TRIAGE
+
+        version_range = status.version_ranges.get()
+        assert version_range.introduced == "1.2.0"
+        assert version_range.last_affected == "1.2.0"
+        assert version_range.introduced_release == release
+        assert version_range.last_affected_release == release
+
+        event = advisory.events.get()
+        assert event.event_type == "status_change"
+        assert event.payload == {"to": "identified"}
+        assert event.actor == user
+
+    def test_non_cve_identifier_becomes_a_reference(self, team, user):
+        result = create_advisory(team, user, title="Prototype pollution", identifier="GHSA-abcd-1234-wxyz")
+
+        advisory = SecurityAdvisory.objects.get(pk=result.value)
+        # A GHSA cannot live in cve_id, which validates strictly, so the
+        # vulnerability keeps the advisory title as its working name.
+        vulnerability = advisory.vulnerabilities.get()
+        assert vulnerability.cve_id == ""
+        assert vulnerability.title == "Prototype pollution"
+
+        reference = advisory.references.get()
+        assert reference.external_id == "GHSA-abcd-1234-wxyz"
+        assert reference.reference_type == "ghsa"
+
+    def test_url_identifier_lands_in_the_url_field(self, team, user):
+        result = create_advisory(team, user, title="Vendor bulletin", identifier="https://example.com/vsa-1")
+
+        reference = AdvisoryReference.objects.get(advisory_id=result.value)
+        assert reference.url == "https://example.com/vsa-1"
+        assert reference.external_id == ""
+
+    def test_release_of_unselected_product_rolls_everything_back(self, team, user, product, release):
+        result = create_advisory(team, user, title="Bad mapping", products=[], affected_releases=[release])
+
+        assert not result.ok
+        assert SecurityAdvisory.objects.count() == 0
+
+    def test_release_with_no_version_string_falls_back_to_its_name(self, team, user, product):
+        legacy = Release.objects.create(product=product, name="spring-drop", version="")
+        result = create_advisory(team, user, title="Legacy", products=[product], affected_releases=[legacy])
+
+        version_range = SecurityAdvisory.objects.get(pk=result.value).vulnerabilities.get().product_statuses.get().version_ranges.get()
+        assert version_range.introduced == "spring-drop"
+
+
+class TestAdvisoryCreateForm:
+    def test_rejects_a_release_whose_product_is_not_selected(self, team, product, release):
+        other = Product.objects.create(name="Acme Router", team=team)
+        form = AdvisoryCreateForm(team, {"title": "x", "products": [other.id], "affected_releases": [release.id]})
+
+        assert not form.is_valid()
+        assert "affected_releases" in form.errors
+
+    def test_rejects_another_workspaces_product(self, team, other_team):
+        foreign = Product.objects.create(name="Not yours", team=other_team)
+        form = AdvisoryCreateForm(team, {"title": "x", "products": [foreign.id]})
+
+        assert not form.is_valid()
+        assert "products" in form.errors
+
+    def test_normalises_cve_case(self, team):
+        form = AdvisoryCreateForm(team, {"title": "x", "vulnerability_id": "cve-2026-0001"})
+
+        assert form.is_valid()
+        assert form.cleaned_data["vulnerability_id"] == "CVE-2026-0001"
+
+    def test_latest_release_is_not_offered_or_accepted(self, team, product):
+        floating = Release.objects.create(product=product, name="latest", is_latest=True)
+        form = AdvisoryCreateForm(team, {"title": "x", "products": [product.id], "affected_releases": [floating.id]})
+
+        assert not form.is_valid()
+        assert all(r["id"] != floating.id for p in creation_options(team).value for r in p["releases"])
+
+
+class TestDashboardCreatePost:
+    def test_post_creates_and_redirects_to_detail(self, sample_team_with_owner_member, product, release, client):
+        from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+        member = sample_team_with_owner_member
+        setup_authenticated_client_session(client, member.team, member.user)
+
+        response = client.post(
+            reverse("core:security_advisories_dashboard"),
+            {
+                "title": "Improper authentication",
+                "severity": "critical",
+                "vulnerability_id": "CVE-2026-99999",
+                "products": [product.id],
+                "affected_releases": [release.id],
+            },
+        )
+
+        advisory = SecurityAdvisory.objects.get()
+        assert response.status_code == 302
+        assert response.url == reverse("core:security_advisory_detail", args=[advisory.id])
+        assert advisory.products.get().product == product
+
+    def test_invalid_post_creates_nothing(self, sample_team_with_owner_member, client):
+        from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+        member = sample_team_with_owner_member
+        setup_authenticated_client_session(client, member.team, member.user)
+
+        response = client.post(reverse("core:security_advisories_dashboard"), {"title": ""})
+
+        assert response.status_code == 302
+        assert response.url == reverse("core:security_advisories_dashboard")
+        assert SecurityAdvisory.objects.count() == 0
+
+    def test_detail_chip_shows_affected_releases(self, team, user, product, release):
+        from sbomify.apps.security_advisories.services.advisories import get_advisory
+
+        result = create_advisory(team, user, title="Chip", products=[product], affected_releases=[release])
+        detail = get_advisory(team, result.value).value
+
+        assert detail["products"][0]["affected_ranges"] == ["1.2.0"]

--- a/sbomify/apps/security_advisories/tests/test_create_advisory.py
+++ b/sbomify/apps/security_advisories/tests/test_create_advisory.py
@@ -74,6 +74,12 @@ class TestCreateAdvisory:
         assert event.payload == {"to": "identified"}
         assert event.actor == user
 
+    def test_lowercase_cve_is_normalised_without_the_form(self, team, user):
+        result = create_advisory(team, user, title="Direct call", identifier="cve-2026-0001")
+
+        vulnerability = SecurityAdvisory.objects.get(pk=result.value).vulnerabilities.get()
+        assert vulnerability.cve_id == "CVE-2026-0001"
+
     def test_non_cve_identifier_becomes_a_reference(self, team, user):
         result = create_advisory(team, user, title="Prototype pollution", identifier="GHSA-abcd-1234-wxyz")
 

--- a/sbomify/apps/teams/templates/teams/components/supplier_rows.html.j2
+++ b/sbomify/apps/teams/templates/teams/components/supplier_rows.html.j2
@@ -84,6 +84,9 @@
         {% else %}
             <p class="text-text font-medium m-0">No suppliers yet</p>
             <p class="text-text-muted text-sm m-0 mt-1">Add the vendors you collect SBOMs and documents from.</p>
+            <button type="button" class="tw-btn-primary mt-4" @click="add()">
+                <i class="fas fa-plus mr-2" aria-hidden="true"></i>Add your first supplier
+            </button>
         {% endif %}
     </div>
 {% endif %}

--- a/sbomify/apps/teams/templates/teams/suppliers.html.j2
+++ b/sbomify/apps/teams/templates/teams/suppliers.html.j2
@@ -16,6 +16,10 @@
                     <p class="text-text-muted text-sm m-0">The vendors you collect SBOMs and documents from</p>
                 </div>
             </div>
+            {# The page's own entry point: suppliers are reachable by URL only while the feature matures, so there is no New-menu entry to lean on. #}
+            <button type="button" class="tw-btn-primary" @click="add()">
+                <i class="fas fa-plus mr-2" aria-hidden="true"></i>Add supplier
+            </button>
         </div>
         {# List #}
         <div class="tw-card">

--- a/sbomify/apps/teams/templates/teams/suppliers.html.j2
+++ b/sbomify/apps/teams/templates/teams/suppliers.html.j2
@@ -3,6 +3,7 @@
 {% block content %}
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
          x-data="{ open: false, form: { supplierId: '', name: '', contactName: '', contactEmail: '', website: '', notes: '' }, add() { this.form = { supplierId: '', name: '', contactName: '', contactEmail: '', website: '', notes: '' }; this.open = true; }, edit(data) { this.form = { supplierId: data.supplierId, name: data.supplierName, contactName: data.supplierContactName, contactEmail: data.supplierContactEmail, website: data.supplierWebsite, notes: data.supplierNotes, }; this.open = true; }, }"
+         x-init="if (new URLSearchParams(location.search).has('new')) { add(); history.replaceState(null, '', location.pathname) }"
          @refresh-suppliers.window="open = false">
         {# Page header #}
         <div class="flex items-start justify-between gap-4 flex-wrap mb-8">
@@ -15,9 +16,6 @@
                     <p class="text-text-muted text-sm m-0">The vendors you collect SBOMs and documents from</p>
                 </div>
             </div>
-            <button type="button" class="tw-btn-primary" @click="add()">
-                <i class="fas fa-plus mr-2" aria-hidden="true"></i>Add supplier
-            </button>
         </div>
         {# List #}
         <div class="tw-card">


### PR DESCRIPTION
## Context

The New Advisory modal collected a title, a severity and a CVE and then threw them away: the POST handler was a stub from the read-only pass (#1254). The data model was already ahead of it — `AdvisoryProduct`, per-product VEX statuses, release-pinned version ranges — and `validate_publishable` demands the product mapping at publish time. This aligns the modal with that model.

## What changed

**Modal.** An *Affected products* picker lists the workspace's products; checking one unfolds its releases as *Affected releases* checkboxes. The floating `latest` release is excluded: it re-targets as artifacts arrive, so pinning it as an affected version would change meaning over time. Unchecking a product clears its release selections, so a stray release can't ride along. With no products in the workspace, the picker gives way to a link to create one.

**Persistence.** Creation now writes the whole initial graph in one transaction through `create_advisory`:

- One vulnerability row from birth. A CVE lands in `cve_id` (case-normalised); a GHSA or URL becomes a typed `AdvisoryReference` and the vulnerability keeps the advisory title as its working name — the model's own vocabulary for a finding with no id yet.
- An `in_triage` status per product per vulnerability — the exact shape `validate_publishable` demands, so nothing created here needs restructuring before publish.
- Each affected release stored as a single-version range pinned to the release (`introduced == last_affected`), so the advisory keeps naming the version if the release row is ever deleted.
- The first timeline event: `status_change` to *identified*, which is what the modal's info box has promised all along.

**Validation.** A Django Form scoped to the workspace: foreign product or release ids fail loudly, and a release whose product is not selected is a form error rather than a silent drop. A mid-service violation of that rule marks the transaction for rollback so no half-built advisory commits.

**Detail page.** Product chips now show the mapped releases (`Lithium · 0.99-wiz-test`), so the mapping is visible where the advisory is read.

## Verification

- 9 new tests (service graph shape, GHSA/URL identifier routing, rollback on stray release, version-less legacy release fallback, form scoping, `latest` exclusion, view POST round trip, detail projection).
- Browser drill via devtools against the dev stack, on a workspace with 26 products / 52 releases: picker renders, releases unfold per product, auto-uncheck works, and a real submission created the full graph — verified in the DB (`in_triage` statuses, pinned ranges, identified event, zero `validate_publishable` blockers) and on the rendered detail page. No console errors.