### PR TITLE
fix(plugins): serialise lifecycle folds per component

### DIFF
--- a/sbomify/apps/plugins/lifecycle.py
+++ b/sbomify/apps/plugins/lifecycle.py
@@ -94,6 +94,18 @@ def record_run(run: Any) -> dict[str, int]:
     if component_id is None:
         return {"opened": 0, "seen": 0, "resolved": 0}
 
+    # One gate lock on the component row before touching its lifecycle rows.
+    # Two concurrent folds for the same component deadlocked on stage: the
+    # per-row FOR UPDATE below locks in whatever order the planner scans, so
+    # two identical scans can interleave into an AB/BA wait — and two runs
+    # inserting the same new advisory would race the unique constraint. The
+    # caller swallows failures to protect the stored run, so a lost fold left
+    # no trace beyond a warning. Folds are order-dependent by nature; making
+    # them queue here is the semantics, not a cost.
+    from sbomify.apps.core.models import Component
+
+    Component.objects.select_for_update().filter(pk=component_id).first()
+
     now = timezone.now()
     present = _advisories(run.result)
 


### PR DESCRIPTION
## The deadlock

Stage, 2026-08-03 02:10 UTC:

```
ERROR:  deadlock detected
DETAIL:  Process 541940 waits for ShareLock on transaction 19330552; blocked by process 541895.
         Process 541895 waits for ShareLock on transaction 19330543; blocked by process 541940.
Process 541940: SELECT ... FROM plugins_vulnerability_lifecycle WHERE component_id = 'FoKftlVn4uyq' FOR UPDATE
Process 541895: SELECT ... FROM plugins_vulnerability_lifecycle WHERE component_id = 'FoKftlVn4uyq' FOR UPDATE
```

Two workers folded runs for the same component at once (a bulk rescan finishing two of its SBOMs together). `record_run` opens with `select_for_update()` over all of the component's lifecycle rows, and `FOR UPDATE` without a deterministic order locks rows in whatever order the plan scans them — two identical statements can take different paths (two candidate indexes, generic vs custom plans) and interleave into an AB/BA wait.

## Why it mattered more than log noise

The orchestrator deliberately swallows lifecycle failures so a failed fold cannot lose the stored scan result. The deadlock victim's fold therefore vanished with nothing but a warning: `last_seen_at` never bumped, opens and resolves from that run missed until the next scan — quietly skewing exactly the numbers this table exists to make honest (age of open criticals, MTTR).

## Fix

One `select_for_update` on the **component row** before touching its lifecycle rows. Concurrent folds for the same component now queue at a single gate, which:

- removes the row-ordering hazard entirely (one lock, no scan-order dependence), and
- closes the quieter race the same concurrency implies: two runs inserting the same new advisory for a component tripping the `(component, advisory)` unique constraint, which the same swallow-path would also have eaten.

Folds into one component are order-dependent by nature — the function's own docstring is about which run's evidence wins — so serialising them is the semantics, not an added cost. Folds for different components are untouched and still run fully in parallel.

## Verification

All 17 lifecycle tests pass; ruff and mypy clean. The race itself is a two-connection plan-divergence scenario that a unit test cannot reproduce deterministically, so the correctness argument is by construction: a single gate row admits one fold per component at a time.