### PR TITLE
feat(advisories): make the timeline composer persist

### DIFF
--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -11,10 +11,11 @@ is draft / published / withdrawn, whether anyone outside the workspace can read
 it. An advisory can be resolved and unpublished, or published mid-fix, so
 neither collapses into the other.
 
-Creation persists: the New Advisory modal maps the advisory onto the workspace's
-products and their releases, and writes the whole initial graph through
-``create_advisory``. Posting updates, editing and linking VEX still land in the
-following passes, and those handlers say so rather than pretending otherwise.
+Creation and the timeline composer persist: the New Advisory modal writes the
+whole initial graph through ``create_advisory``, and posting an update writes a
+note or a status move through ``post_update``. Editing and linking VEX still
+land in the following passes, and those handlers say so rather than pretending
+otherwise.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     creation_options,
     get_advisory,
     list_advisories,
+    post_update,
 )
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
@@ -171,14 +173,22 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
 
         intent = request.POST.get("intent")
         if intent == "edit":
-            note = "Editing an advisory is the next pass on this UI."
+            messages.info(request, "Not saved yet. Editing an advisory is the next pass on this UI.")
         elif intent == "edit_update":
-            note = "Editing a timeline entry is the next pass on this UI."
+            messages.info(request, "Not saved yet. Editing a timeline entry is the next pass on this UI.")
         elif intent == "link_vex":
-            note = "Linking VEX documents is the pass after the CRUD one."
+            messages.info(request, "Not saved yet. Linking VEX documents is the pass after the CRUD one.")
         else:
             kind = request.POST.get("kind", NOTE_ONLY_KIND)
-            label = UPDATE_KINDS.get(kind, UPDATE_KINDS[NOTE_ONLY_KIND])["label"]
-            note = f'Posting the "{label}" update is the next pass on this UI.'
-        messages.info(request, f"Not saved yet. {note}")
+            result = post_update(
+                team, cast(User, request.user), advisory_id, kind=kind, note=request.POST.get("note", "")
+            )
+            if result.ok:
+                if kind == NOTE_ONLY_KIND:
+                    messages.success(request, "Update posted.")
+                else:
+                    label = UPDATE_KINDS.get(kind, UPDATE_KINDS[NOTE_ONLY_KIND])["label"]
+                    messages.success(request, f"Status moved to {label}.")
+            else:
+                messages.error(request, result.error or "Update not posted.")
         return redirect("core:security_advisory_detail", advisory_id=advisory_id)

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -168,27 +168,33 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
 
     def post(self, request: HttpRequest, advisory_id: str) -> HttpResponse:
         team = _current_team(request)
-        if team is None or not get_advisory(team, advisory_id).ok:
+        if team is None:
             raise Http404("Advisory not found")
 
         intent = request.POST.get("intent")
-        if intent == "edit":
-            messages.info(request, "Not saved yet. Editing an advisory is the next pass on this UI.")
-        elif intent == "edit_update":
-            messages.info(request, "Not saved yet. Editing a timeline entry is the next pass on this UI.")
-        elif intent == "link_vex":
-            messages.info(request, "Not saved yet. Linking VEX documents is the pass after the CRUD one.")
-        else:
-            kind = request.POST.get("kind", NOTE_ONLY_KIND)
-            result = post_update(
-                team, cast(User, request.user), advisory_id, kind=kind, note=request.POST.get("note", "")
-            )
-            if result.ok:
-                if kind == NOTE_ONLY_KIND:
-                    messages.success(request, "Update posted.")
-                else:
-                    label = UPDATE_KINDS.get(kind, UPDATE_KINDS[NOTE_ONLY_KIND])["label"]
-                    messages.success(request, f"Status moved to {label}.")
+        if intent in ("edit", "edit_update", "link_vex"):
+            # Only the stubs pay for the full projection lookup; the real
+            # composer path below lets post_update do the one scoped lookup.
+            if not get_advisory(team, advisory_id).ok:
+                raise Http404("Advisory not found")
+            note = {
+                "edit": "Editing an advisory is the next pass on this UI.",
+                "edit_update": "Editing a timeline entry is the next pass on this UI.",
+                "link_vex": "Linking VEX documents is the pass after the CRUD one.",
+            }[intent]
+            messages.info(request, f"Not saved yet. {note}")
+            return redirect("core:security_advisory_detail", advisory_id=advisory_id)
+
+        kind = (request.POST.get("kind") or NOTE_ONLY_KIND).strip()
+        result = post_update(team, cast(User, request.user), advisory_id, kind=kind, note=request.POST.get("note", ""))
+        if not result.ok and result.status_code == 404:
+            raise Http404("Advisory not found")
+        if result.ok:
+            if kind == NOTE_ONLY_KIND:
+                messages.success(request, "Update posted.")
             else:
-                messages.error(request, result.error or "Update not posted.")
+                label = UPDATE_KINDS.get(kind, UPDATE_KINDS[NOTE_ONLY_KIND])["label"]
+                messages.success(request, f"Status moved to {label}.")
+        else:
+            messages.error(request, result.error or "Update not posted.")
         return redirect("core:security_advisory_detail", advisory_id=advisory_id)

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -455,6 +455,46 @@ def create_advisory(
     return ServiceResult.success(advisory.id)
 
 
+@transaction.atomic
+def post_update(team: Any, user: Any, advisory_id: str, *, kind: str, note: str = "") -> ServiceResult[str]:
+    """The timeline composer's write: a note, or a status move with commentary.
+
+    ``kind`` is either ``update`` (a note that moves nothing) or a
+    remediation status. Status kinds append the ``status_change`` event and
+    keep the advisory's denormalised ``remediation_status`` in step with it,
+    which is the invariant that field's help text promises.
+    """
+    advisory = SecurityAdvisory.objects.filter(team=team).filter(Q(id=advisory_id) | Q(tracking_id=advisory_id)).first()
+    if advisory is None:
+        return ServiceResult.failure("Advisory not found", status_code=404)
+
+    note = note.strip()
+    if kind == "update":
+        if not note:
+            return ServiceResult.failure("An update needs a note.", status_code=400)
+        AdvisoryEvent.objects.create(
+            advisory=advisory, event_type=AdvisoryEvent.EventType.UPDATE, actor=user, body=note
+        )
+        return ServiceResult.success(advisory.id)
+
+    if kind not in SecurityAdvisory.RemediationStatus.values:
+        return ServiceResult.failure("Unknown update type.", status_code=400)
+    if kind == advisory.remediation_status:
+        label = REMEDIATION_META.get(kind, {}).get("label", kind)
+        return ServiceResult.failure(f"The advisory is already {label}.", status_code=400)
+
+    AdvisoryEvent.objects.create(
+        advisory=advisory,
+        event_type=AdvisoryEvent.EventType.STATUS_CHANGE,
+        actor=user,
+        body=note,
+        payload={"from": advisory.remediation_status, "to": kind},
+    )
+    advisory.remediation_status = kind
+    advisory.save(update_fields=["remediation_status", "updated_at"])
+    return ServiceResult.success(advisory.id)
+
+
 def advisory_counts(advisories: list[dict[str, Any]]) -> dict[str, int]:
     """Dashboard tallies, computed from the already-built list.
 

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -464,10 +464,20 @@ def post_update(team: Any, user: Any, advisory_id: str, *, kind: str, note: str 
     keep the advisory's denormalised ``remediation_status`` in step with it,
     which is the invariant that field's help text promises.
     """
-    advisory = SecurityAdvisory.objects.filter(team=team).filter(Q(id=advisory_id) | Q(tracking_id=advisory_id)).first()
+    # Locked for the read-modify-write below: payload["from"] and the
+    # denormalised status both come from the row as read, so two concurrent
+    # posts without the lock could record the same "from" and lose a
+    # transition.
+    advisory = (
+        SecurityAdvisory.objects.select_for_update()
+        .filter(team=team)
+        .filter(Q(id=advisory_id) | Q(tracking_id=advisory_id))
+        .first()
+    )
     if advisory is None:
         return ServiceResult.failure("Advisory not found", status_code=404)
 
+    kind = (kind or "").strip()
     note = note.strip()
     if kind == "update":
         if not note:

--- a/sbomify/apps/security_advisories/tests/test_post_update.py
+++ b/sbomify/apps/security_advisories/tests/test_post_update.py
@@ -1,0 +1,98 @@
+"""The timeline composer's write path.
+
+The invariant worth guarding: a status kind appends the status_change event
+AND moves the denormalised remediation_status in the same transaction, so the
+list column and the timeline can never disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+from sbomify.apps.security_advisories.models import SecurityAdvisory
+from sbomify.apps.security_advisories.services.advisories import post_update
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user(sample_team_with_owner_member):
+    return sample_team_with_owner_member.user
+
+
+class TestPostUpdate:
+    def test_note_appends_an_update_event_and_moves_nothing(self, team, user, advisory):
+        result = post_update(team, user, advisory.id, kind="update", note="Reproduced on 5.1.x.")
+
+        assert result.ok
+        event = advisory.events.get()
+        assert event.event_type == "update"
+        assert event.body == "Reproduced on 5.1.x."
+        assert event.actor == user
+        advisory.refresh_from_db()
+        assert advisory.remediation_status == "identified"
+
+    def test_status_kind_appends_event_and_moves_the_advisory(self, team, user, advisory):
+        result = post_update(team, user, advisory.id, kind="investigating", note="Scoping the parser.")
+
+        assert result.ok
+        event = advisory.events.get()
+        assert event.event_type == "status_change"
+        assert event.payload == {"from": "identified", "to": "investigating"}
+        assert event.body == "Scoping the parser."
+        advisory.refresh_from_db()
+        assert advisory.remediation_status == "investigating"
+
+    def test_status_note_is_optional(self, team, user, advisory):
+        assert post_update(team, user, advisory.id, kind="resolved", note="").ok
+
+    def test_note_without_body_is_rejected(self, team, user, advisory):
+        result = post_update(team, user, advisory.id, kind="update", note="   ")
+
+        assert not result.ok
+        assert advisory.events.count() == 0
+
+    def test_same_status_is_rejected(self, team, user, advisory):
+        result = post_update(team, user, advisory.id, kind="identified", note="")
+
+        assert not result.ok
+        assert "already" in (result.error or "")
+        assert advisory.events.count() == 0
+
+    def test_unknown_kind_is_rejected(self, team, user, advisory):
+        assert not post_update(team, user, advisory.id, kind="escalate_to_legal", note="x").ok
+
+    def test_another_workspaces_advisory_reads_as_absent(self, other_team, user, advisory):
+        result = post_update(other_team, user, advisory.id, kind="update", note="hi")
+
+        assert not result.ok
+        assert result.status_code == 404
+
+    def test_lookup_by_tracking_id(self, team, user, advisory):
+        advisory.tracking_id = "ACME-SA-2026-0001"
+        advisory.status = SecurityAdvisory.Status.PUBLISHED
+        from django.utils import timezone
+
+        advisory.published_at = timezone.now()
+        advisory.save()
+
+        assert post_update(team, user, "ACME-SA-2026-0001", kind="investigating", note="").ok
+
+
+class TestComposerPost:
+    def test_post_moves_status_and_redirects(self, sample_team_with_owner_member, advisory, client):
+        from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+        member = sample_team_with_owner_member
+        setup_authenticated_client_session(client, member.team, member.user)
+
+        response = client.post(
+            reverse("core:security_advisory_detail", args=[advisory.id]),
+            {"kind": "fix_in_progress", "note": "Patch in review."},
+        )
+
+        assert response.status_code == 302
+        advisory.refresh_from_db()
+        assert advisory.remediation_status == "fix_in_progress"
+        assert advisory.events.get().payload["to"] == "fix_in_progress"


### PR DESCRIPTION
## Context

#1280 made advisory *creation* real; the timeline composer on the detail page was still the read-only stub, so posting any update toasted "Not saved yet. Posting the …" — hit while dogfooding the merged feature.

## What changed

`post_update` writes the two things the composer offers:

- **Note only** appends an `update` event and moves nothing. A blank note is refused.
- **A status kind** (Investigating / Fix in progress / Resolved / Won't fix) appends the `status_change` event with a `{from, to}` payload and moves the denormalised `remediation_status` in the same transaction — the invariant that field's help text promises, so the list column and the timeline can never disagree. The optional note rides along as commentary. Posting the status the advisory is already in is refused rather than recorded as a no-op transition.

Lookup accepts the tracking id as well as the primary key, matching the detail page. Editing entries, editing the advisory and linking VEX keep their honest stubs for the following passes.

## Verification

- 9 new tests: note event shape, status move + payload + denormalised field, optional status note, blank-note rejection, same-status rejection, unknown kind, cross-workspace 404, tracking-id lookup, and the composer POST round trip.
- Browser end-to-end on the dev stack via devtools, against a modal-created advisory: an Investigating post flipped the header badge and grew the timeline with the note; a note-only post added an Update entry; re-posting Investigating was refused with nothing written; and the list page's Status column read Investigating afterwards — the denormalised field moved in step.
- 192 app tests green, mypy clean.