### PR TITLE
feat(advisories): version selection and range-picking in the New Advisory modal

### DIFF
--- a/sbomify/apps/core/js/alpine-components.ts
+++ b/sbomify/apps/core/js/alpine-components.ts
@@ -31,6 +31,7 @@ import { registerComponentMetaInfoEditor } from './component-meta-info-editor';
 import { registerComponentMetaInfo } from './component-meta-info';
 import { registerAccountDangerZone } from './components/account-danger-zone';
 import { registerDatePicker } from './components/date-picker';
+import { advisoryProductPicker } from './components/advisory-product-picker';
 
 // ============================================
 // COMPONENT IMPORTS - SBOM Module
@@ -197,6 +198,7 @@ export function registerCommonComponents(): void {
     registerAlpineComponent('collapsible', collapsible);
     registerAlpineComponent('formState', formState);
     registerAlpineComponent('chartSelector', chartSelector);
+    registerAlpineComponent('advisoryProductPicker', advisoryProductPicker);
 }
 
 /**

--- a/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
@@ -127,3 +127,32 @@ describe('expanding rows', () => {
         expect(picker.isExpanded('p1')).toBe(false)
     })
 })
+
+describe('the half-ticked parent box', () => {
+    test('an unselected product is never partial', () => {
+        expect(picker.isPartiallySelected(picker.products[0])).toBe(false)
+    })
+
+    test('a product selected with no versions picked is fully ticked, not partial', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.isProductSelected('p1')).toBe(true)
+        // No versions picked means the whole product is covered.
+        expect(picker.isPartiallySelected(picker.products[0])).toBe(false)
+    })
+
+    test('some but not all versions picked shows partial', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        expect(picker.isPartiallySelected(picker.products[0])).toBe(true)
+    })
+
+    test('every version picked is the whole product again, so not partial', () => {
+        picker.toggleAllVersions(picker.products[0])
+        expect(picker.allVersionsSelected(picker.products[0])).toBe(true)
+        expect(picker.isPartiallySelected(picker.products[0])).toBe(false)
+    })
+
+    test('a product with no versions can never be partial', () => {
+        picker.toggleProduct(2, plain)
+        expect(picker.isPartiallySelected(picker.products[2])).toBe(false)
+    })
+})

--- a/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { advisoryProductPicker, type PickerProduct } from './advisory-product-picker'
+
+const PRODUCTS: PickerProduct[] = [
+    { id: 'p1', name: 'Gateway', releases: [{ id: 'r1', label: '1.0' }, { id: 'r2', label: '1.1' }, { id: 'r3', label: '1.2' }] },
+    { id: 'p2', name: 'Vault', releases: [{ id: 'r4', label: '2.0' }] },
+    { id: 'p3', name: 'Edge', releases: [] },
+    { id: 'p4', name: 'Console', releases: [] },
+]
+
+const shift = { shiftKey: true } as MouseEvent
+const plain = { shiftKey: false } as MouseEvent
+
+let picker: ReturnType<typeof advisoryProductPicker>
+
+beforeEach(() => {
+    picker = advisoryProductPicker(structuredClone(PRODUCTS))
+})
+
+describe('selecting products', () => {
+    test('a plain click toggles one product', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.selectedProducts).toEqual(['p1'])
+
+        picker.toggleProduct(0, plain)
+        expect(picker.selectedProducts).toEqual([])
+    })
+
+    test('shift-click fills the range between the anchor and the click', () => {
+        picker.toggleProduct(0, plain)
+        picker.toggleProduct(2, shift)
+        expect(picker.selectedProducts).toEqual(['p1', 'p2', 'p3'])
+    })
+
+    test('a shift range works backwards too', () => {
+        picker.toggleProduct(3, plain)
+        picker.toggleProduct(1, shift)
+        expect(picker.selectedProducts.sort()).toEqual(['p2', 'p3', 'p4'])
+    })
+
+    test('shift-clicking a selected row clears the range rather than inverting each one', () => {
+        picker.selectAll()
+        picker.toggleProduct(0, plain)   // p1 off; anchor here
+        picker.toggleProduct(2, shift)   // clears p1..p3, leaves p4
+        expect(picker.selectedProducts).toEqual(['p4'])
+    })
+
+    test('shift with no anchor behaves like a plain click', () => {
+        picker.toggleProduct(2, shift)
+        expect(picker.selectedProducts).toEqual(['p3'])
+    })
+
+    test('select all and clear all', () => {
+        picker.selectAll()
+        expect(picker.allSelected).toBe(true)
+        expect(picker.selectedProducts).toHaveLength(4)
+
+        picker.clearAll()
+        expect(picker.allSelected).toBe(false)
+        expect(picker.anySelected).toBe(false)
+    })
+})
+
+describe('selecting versions', () => {
+    test('ticking a version implies its product', () => {
+        picker.toggleRelease(picker.products[0], 1, plain)
+        expect(picker.selectedReleases).toEqual(['r2'])
+        expect(picker.isProductSelected('p1')).toBe(true)
+    })
+
+    test('shift-click fills a range of versions within one product', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        picker.toggleRelease(picker.products[0], 2, shift)
+        expect(picker.selectedReleases).toEqual(['r1', 'r2', 'r3'])
+    })
+
+    test('deselecting a product drops the versions selected under it', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        picker.toggleRelease(picker.products[1], 0, plain)
+        expect(picker.selectedReleases.sort()).toEqual(['r1', 'r4'])
+
+        picker.toggleProduct(0, plain)   // Gateway off
+        expect(picker.selectedReleases).toEqual(['r4'])
+        expect(picker.isProductSelected('p1')).toBe(false)
+    })
+
+    test('the all-versions toggle selects then clears every version', () => {
+        const gateway = picker.products[0]
+        picker.toggleAllVersions(gateway)
+        expect(picker.allVersionsSelected(gateway)).toBe(true)
+        expect(picker.isProductSelected('p1')).toBe(true)
+
+        picker.toggleAllVersions(gateway)
+        expect(picker.allVersionsSelected(gateway)).toBe(false)
+        expect(picker.selectedReleases).toEqual([])
+    })
+
+    test('a version range anchors per product, not globally', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)   // anchor in Gateway
+        picker.toggleRelease(picker.products[1], 0, shift)   // Vault has its own anchor
+        expect(picker.selectedReleases.sort()).toEqual(['r1', 'r4'])
+    })
+})
+
+describe('the collapsed row summary', () => {
+    test('no versions picked means the whole product is affected', () => {
+        expect(picker.versionSummary(picker.products[0])).toBe('All versions')
+    })
+
+    test('some versions picked shows the count', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        expect(picker.versionSummary(picker.products[0])).toBe('1 of 3 versions')
+    })
+
+    test('a product with no releases says nothing about versions', () => {
+        expect(picker.versionSummary(picker.products[2])).toBe('')
+    })
+})
+
+describe('expanding rows', () => {
+    test('expansion is independent of selection', () => {
+        picker.toggleExpanded('p1')
+        expect(picker.isExpanded('p1')).toBe(true)
+        expect(picker.isProductSelected('p1')).toBe(false)
+
+        picker.toggleExpanded('p1')
+        expect(picker.isExpanded('p1')).toBe(false)
+    })
+})

--- a/sbomify/apps/core/js/components/advisory-product-picker.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.ts
@@ -156,6 +156,21 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             return product.releases.length > 0 && this.selectedReleasesFor(product).length === product.releases.length;
         },
 
+        /**
+         * Whether the product's box should render half-ticked.
+         *
+         * Picking no versions means the advisory covers the product whole, so a
+         * full tick is right. Picking every version is the same claim by a
+         * longer route, so that is a full tick too. Anything between is a
+         * partial claim, and the box should say so rather than implying the
+         * whole product is affected.
+         */
+        isPartiallySelected(product: PickerProduct): boolean {
+            if (!this.isProductSelected(product.id)) return false;
+            const picked = this.selectedReleasesFor(product).length;
+            return picked > 0 && picked < product.releases.length;
+        },
+
         toggleAllVersions(product: PickerProduct): void {
             const selectAll = !this.allVersionsSelected(product);
             product.releases.forEach((release) => this.setRelease(release, selectAll));

--- a/sbomify/apps/core/js/components/advisory-product-picker.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.ts
@@ -1,0 +1,180 @@
+export interface PickerRelease {
+    id: string;
+    label: string;
+}
+
+export interface PickerProduct {
+    id: string;
+    name: string;
+    releases: PickerRelease[];
+}
+
+/**
+ * Product and version picker for the New Advisory modal.
+ *
+ * An advisory routinely covers a whole product line — several products, or a
+ * run of consecutive versions — so ticking one box at a time is the wrong unit
+ * of work. This adds the selection idioms a file manager has: shift-click for a
+ * range, select-all for the lot, and an all-versions toggle per product.
+ *
+ * Selection is held here rather than in the checkboxes themselves. Shift-click
+ * has to set a range of boxes from one event, which a `x-model` binding cannot
+ * express, so the boxes render `:checked` from this state and the form submits
+ * from hidden inputs instead. That keeps one source of truth and means a
+ * range-select and a plain click go through exactly the same path.
+ */
+export function advisoryProductPicker(products: PickerProduct[] = []) {
+    return {
+        products,
+        selectedProducts: [] as string[],
+        selectedReleases: [] as string[],
+        expanded: [] as string[],
+
+        /** Index of the last product row clicked, for shift-click ranges. */
+        anchor: null as number | null,
+        /** Last release row clicked, keyed by product, for ranges within one product. */
+        releaseAnchor: {} as Record<string, number>,
+
+        isProductSelected(id: string): boolean {
+            return this.selectedProducts.includes(id);
+        },
+
+        isReleaseSelected(id: string): boolean {
+            return this.selectedReleases.includes(id);
+        },
+
+        isExpanded(id: string): boolean {
+            return this.expanded.includes(id);
+        },
+
+        toggleExpanded(id: string): void {
+            this.expanded = this.isExpanded(id)
+                ? this.expanded.filter((value) => value !== id)
+                : [...this.expanded, id];
+        },
+
+        get allSelected(): boolean {
+            return this.products.length > 0 && this.selectedProducts.length === this.products.length;
+        },
+
+        get anySelected(): boolean {
+            return this.selectedProducts.length > 0;
+        },
+
+        /**
+         * Select or deselect one product, or a range of them when shift is held.
+         *
+         * The range takes the state the clicked row ends up in, which is how
+         * every file manager behaves: shift-clicking an unticked row after
+         * ticking one fills the span in rather than inverting each row.
+         */
+        toggleProduct(index: number, event?: MouseEvent): void {
+            const product = this.products[index];
+            if (!product) return;
+
+            const shouldSelect = !this.isProductSelected(product.id);
+            const from = event?.shiftKey && this.anchor !== null ? this.anchor : index;
+            const [start, end] = from <= index ? [from, index] : [index, from];
+
+            for (let i = start; i <= end; i++) {
+                this.setProduct(this.products[i], shouldSelect);
+            }
+            this.anchor = index;
+        },
+
+        setProduct(product: PickerProduct | undefined, selected: boolean): void {
+            if (!product) return;
+
+            if (selected) {
+                if (!this.isProductSelected(product.id)) {
+                    this.selectedProducts = [...this.selectedProducts, product.id];
+                }
+                return;
+            }
+
+            this.selectedProducts = this.selectedProducts.filter((id) => id !== product.id);
+            // A version cannot be affected by an advisory that no longer names
+            // its product, so dropping the product drops its versions with it.
+            const releaseIds = new Set(product.releases.map((release) => release.id));
+            this.selectedReleases = this.selectedReleases.filter((id) => !releaseIds.has(id));
+        },
+
+        selectAll(): void {
+            this.selectedProducts = this.products.map((product) => product.id);
+            this.anchor = null;
+        },
+
+        clearAll(): void {
+            this.selectedProducts = [];
+            this.selectedReleases = [];
+            this.anchor = null;
+        },
+
+        /**
+         * Select or deselect one version, or a range within the same product.
+         *
+         * Ticking a version implies its product: naming an affected version of
+         * something you have not marked affected is not a state worth being
+         * able to reach.
+         */
+        toggleRelease(product: PickerProduct, index: number, event?: MouseEvent): void {
+            const release = product.releases[index];
+            if (!release) return;
+
+            const shouldSelect = !this.isReleaseSelected(release.id);
+            const previous = this.releaseAnchor[product.id];
+            const from = event?.shiftKey && previous !== undefined ? previous : index;
+            const [start, end] = from <= index ? [from, index] : [index, from];
+
+            for (let i = start; i <= end; i++) {
+                this.setRelease(product.releases[i], shouldSelect);
+            }
+            this.releaseAnchor[product.id] = index;
+
+            if (this.selectedReleasesFor(product).length > 0) {
+                this.setProduct(product, true);
+            }
+        },
+
+        setRelease(release: PickerRelease | undefined, selected: boolean): void {
+            if (!release) return;
+
+            if (selected) {
+                if (!this.isReleaseSelected(release.id)) {
+                    this.selectedReleases = [...this.selectedReleases, release.id];
+                }
+                return;
+            }
+            this.selectedReleases = this.selectedReleases.filter((id) => id !== release.id);
+        },
+
+        selectedReleasesFor(product: PickerProduct): string[] {
+            return product.releases.filter((release) => this.isReleaseSelected(release.id)).map((r) => r.id);
+        },
+
+        allVersionsSelected(product: PickerProduct): boolean {
+            return product.releases.length > 0 && this.selectedReleasesFor(product).length === product.releases.length;
+        },
+
+        toggleAllVersions(product: PickerProduct): void {
+            const selectAll = !this.allVersionsSelected(product);
+            product.releases.forEach((release) => this.setRelease(release, selectAll));
+            if (selectAll) this.setProduct(product, true);
+            this.releaseAnchor[product.id] = 0;
+        },
+
+        /**
+         * What the collapsed product row says about its versions.
+         *
+         * No selection means the advisory covers the product as a whole, which
+         * is the common case and reads better as "All versions" than as an
+         * empty count.
+         */
+        versionSummary(product: PickerProduct): string {
+            if (product.releases.length === 0) return '';
+            const count = this.selectedReleasesFor(product).length;
+            if (count === 0) return 'All versions';
+            return `${count} of ${product.releases.length} versions`;
+        },
+    };
+}

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -119,25 +119,37 @@
                                                         </button>
                                                     </div>
                                                 </div>
-                                                <div class="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border/60">
+                                                <div class="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border/60 select-none">
                                                     <template x-for="(product, index) in products" :key="product.id">
                                                         <div>
                                                             <div class="flex items-center gap-2 px-3 py-2">
                                                                 {% comment %}
-                                                                The handler sits on the label, not the input: a click on
-                                                                either lands here exactly once, and prevent-default stops
-                                                                the browser toggling a box whose state we own. Space on a
-                                                                focused box bubbles here too, so keyboard still works.
+                                                                The row is the control, not a label wrapping a checkbox.
+                                                                A real click on label text makes the browser forward a
+                                                                second click to the nested input, which fired this
+                                                                handler twice and moved the selection to the wrong
+                                                                version. There is no label here to forward, so a click
+                                                                lands exactly once. The box is painted from state and
+                                                                takes no pointer or tab stop of its own; the row carries
+                                                                the role, the checked state and the keyboard handling.
                                                                 {% endcomment %}
-                                                                <label class="flex items-center gap-2.5 text-sm text-text cursor-pointer flex-1 min-w-0"
-                                                                       @click.prevent="toggleProduct(index, $event)">
+                                                                <div class="flex items-center gap-2.5 text-sm text-text cursor-pointer flex-1 min-w-0 select-none"
+                                                                     role="checkbox"
+                                                                     tabindex="0"
+                                                                     :aria-checked="isPartiallySelected(product) ? 'mixed' : (isProductSelected(product.id) ? 'true' : 'false')"
+                                                                     @click="toggleProduct(index, $event)"
+                                                                     @keydown.space.prevent="toggleProduct(index)"
+                                                                     @keydown.enter.prevent="toggleProduct(index)">
                                                                     <input type="checkbox"
-                                                                           class="tw-checkbox shrink-0"
-                                                                           :checked="isProductSelected(product.id)" />
+                                                                           class="tw-checkbox shrink-0 pointer-events-none"
+                                                                           tabindex="-1"
+                                                                           aria-hidden="true"
+                                                                           :checked="isProductSelected(product.id)"
+                                                                           x-effect="$el.indeterminate = isPartiallySelected(product)" />
                                                                     <i class="fas fa-cube text-xs text-text-muted shrink-0"
                                                                        aria-hidden="true"></i>
                                                                     <span class="truncate" x-text="product.name"></span>
-                                                                </label>
+                                                                </div>
                                                                 <button type="button"
                                                                         x-show="product.releases.length"
                                                                         @click="toggleExpanded(product.id)"
@@ -149,9 +161,11 @@
                                                                        aria-hidden="true"></i>
                                                                 </button>
                                                             </div>
-                                                            {# Guarded on releases as well as expansion: a product with no
-                                                               versions has nothing to show, and its toggle is hidden, so
-                                                               this would only ever render an empty panel. #}
+                                                            {% comment %}
+                                                            Guarded on releases as well as expansion: a product with no
+                                                            versions has nothing to show, and its toggle is hidden, so
+                                                            this would only ever render an empty panel.
+                                                            {% endcomment %}
                                                             <div x-show="isExpanded(product.id) && product.releases.length"
                                                                  x-cloak
                                                                  class="px-3 pb-2.5 ml-6">
@@ -162,13 +176,20 @@
                                                                 </button>
                                                                 <div class="flex flex-wrap gap-x-4 gap-y-1.5">
                                                                     <template x-for="(release, rIndex) in product.releases" :key="release.id">
-                                                                        <label class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer"
-                                                                               @click.prevent="toggleRelease(product, rIndex, $event)">
+                                                                        <div class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer select-none"
+                                                                             role="checkbox"
+                                                                             tabindex="0"
+                                                                             :aria-checked="isReleaseSelected(release.id) ? 'true' : 'false'"
+                                                                             @click="toggleRelease(product, rIndex, $event)"
+                                                                             @keydown.space.prevent="toggleRelease(product, rIndex)"
+                                                                             @keydown.enter.prevent="toggleRelease(product, rIndex)">
                                                                             <input type="checkbox"
-                                                                                   class="tw-checkbox"
+                                                                                   class="tw-checkbox pointer-events-none"
+                                                                                   tabindex="-1"
+                                                                                   aria-hidden="true"
                                                                                    :checked="isReleaseSelected(release.id)" />
                                                                             <span x-text="release.label"></span>
-                                                                        </label>
+                                                                        </div>
                                                                     </template>
                                                                 </div>
                                                             </div>
@@ -235,7 +256,7 @@
                                         which gave a one-sentence aside the weight of a field. It says the
                                         same thing here, next to the button that does it.
                                         {% endcomment %}
-                                        <p class="text-xs text-text-muted m-0 hidden sm:block">
+                                        <p class="text-xs text-text-muted m-0 hidden sm:block min-w-0 flex-1">
                                             Opens as a draft with its first update, <span class="text-text">Vulnerability identified</span>.
                                         </p>
                                         <div class="flex items-center gap-2">

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -20,9 +20,9 @@
         {# Add Advisory Modal (Alpine.js) #}
         {% if has_crud_permissions %}
             {# The header's New menu links here with ?new=1; the param is stripped after opening so a refresh does not reopen the modal. #}
-            <div x-data="{ open: false, showRef: false, chosenProducts: [] }"
+            <div x-data="{ open: false }"
                  x-init="if (new URLSearchParams(location.search).has('new')) { open = true; history.replaceState(null, '', location.pathname) }"
-                 @open-add-advisory-modal.window="open = true; showRef = false">
+                 @open-add-advisory-modal.window="open = true">
                 <template x-teleport="body">
                     <div x-show="open"
                          x-cloak
@@ -69,7 +69,7 @@
                                       method="post"
                                       action="{% url 'core:security_advisories_dashboard' %}">
                                     {% csrf_token %}
-                                    <div class="tw-modal-body space-y-4">
+                                    <div class="tw-modal-body space-y-5">
                                         <div>
                                             <label class="tw-form-label" for="advisoryTitle">
                                                 Title <span class="text-danger">*</span>
@@ -81,7 +81,7 @@
                                                    placeholder="e.g. Improper authentication in SAML assertion handling"
                                                    required />
                                         </div>
-                                        <div>
+                                        <div class="max-w-[12rem]">
                                             <label class="tw-form-label" for="advisorySeverity">Severity</label>
                                             <select id="advisorySeverity" name="severity" class="tw-form-input">
                                                 <option value="critical">Critical</option>
@@ -90,106 +90,160 @@
                                                 <option value="low">Low</option>
                                             </select>
                                         </div>
-                                        {# Affected products, each unfolding its pinnable releases when checked. #}
-                                        <div>
-                                            <label class="tw-form-label">Affected products</label>
-                                            {% if creation_products %}
-                                                <div class="max-h-48 overflow-y-auto rounded-lg border border-border divide-y divide-border/60">
-                                                    {% for product in creation_products %}
-                                                        <div class="px-3 py-2" data-product-block>
-                                                            <label class="flex items-center gap-2.5 text-sm text-text cursor-pointer">
-                                                                <input type="checkbox"
-                                                                       name="products"
-                                                                       value="{{ product.id }}"
-                                                                       x-model="chosenProducts"
-                                                                       @change="if (!$event.target.checked) $event.target.closest('[data-product-block]').querySelectorAll('input[data-release]').forEach(el => el.checked = false)"
-                                                                       class="tw-checkbox" />
-                                                                <i class="fas fa-cube text-xs text-text-muted" aria-hidden="true"></i>
-                                                                {{ product.name }}
-                                                            </label>
-                                                            {% if product.releases %}
-                                                                <div x-show="chosenProducts.includes('{{ product.id|escapejs }}')"
-                                                                     x-cloak
-                                                                     class="mt-2 ml-6 space-y-1.5">
-                                                                    <p class="text-xs text-text-muted">Affected releases (optional)</p>
-                                                                    <div class="flex flex-wrap gap-x-4 gap-y-1.5">
-                                                                        {% for release in product.releases %}
-                                                                            <label class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer">
-                                                                                <input type="checkbox"
-                                                                                       name="affected_releases"
-                                                                                       value="{{ release.id }}"
-                                                                                       data-release
-                                                                                       class="tw-checkbox" />
-                                                                                {{ release.label }}
-                                                                            </label>
-                                                                        {% endfor %}
-                                                                    </div>
-                                                                </div>
-                                                            {% endif %}
-                                                        </div>
-                                                    {% endfor %}
+                                        {% comment %}
+                                        Affected products and versions.
+
+                                        Selection state lives in the Alpine component rather than in the
+                                        checkboxes, because shift-click sets a whole range from one event.
+                                        The boxes render from that state and the form submits from the
+                                        hidden inputs at the end of the block.
+                                        {% endcomment %}
+                                        {% if creation_products %}
+                                            {{ creation_products|json_script:"advisoryProductsData" }}
+                                            <div x-data="advisoryProductPicker(window.parseJsonScript('advisoryProductsData'))">
+                                                <div class="flex items-end justify-between gap-3 mb-1.5">
+                                                    <label class="tw-form-label !mb-0">Affected products</label>
+                                                    <div class="flex items-center gap-2 text-xs">
+                                                        <button type="button"
+                                                                @click="selectAll()"
+                                                                :disabled="allSelected"
+                                                                class="text-primary hover:underline disabled:opacity-40 disabled:no-underline disabled:cursor-default">
+                                                            Select all
+                                                        </button>
+                                                        <span class="text-border" aria-hidden="true">|</span>
+                                                        <button type="button"
+                                                                @click="clearAll()"
+                                                                :disabled="!anySelected"
+                                                                class="text-text-muted hover:text-text disabled:opacity-40 disabled:cursor-default">
+                                                            Clear
+                                                        </button>
+                                                    </div>
                                                 </div>
+                                                <div class="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border/60">
+                                                    <template x-for="(product, index) in products" :key="product.id">
+                                                        <div>
+                                                            <div class="flex items-center gap-2 px-3 py-2">
+                                                                {% comment %}
+                                                                The handler sits on the label, not the input: a click on
+                                                                either lands here exactly once, and prevent-default stops
+                                                                the browser toggling a box whose state we own. Space on a
+                                                                focused box bubbles here too, so keyboard still works.
+                                                                {% endcomment %}
+                                                                <label class="flex items-center gap-2.5 text-sm text-text cursor-pointer flex-1 min-w-0"
+                                                                       @click.prevent="toggleProduct(index, $event)">
+                                                                    <input type="checkbox"
+                                                                           class="tw-checkbox shrink-0"
+                                                                           :checked="isProductSelected(product.id)" />
+                                                                    <i class="fas fa-cube text-xs text-text-muted shrink-0"
+                                                                       aria-hidden="true"></i>
+                                                                    <span class="truncate" x-text="product.name"></span>
+                                                                </label>
+                                                                <button type="button"
+                                                                        x-show="product.releases.length"
+                                                                        @click="toggleExpanded(product.id)"
+                                                                        :aria-expanded="isExpanded(product.id) ? 'true' : 'false'"
+                                                                        class="flex items-center gap-1.5 text-xs text-text-muted hover:text-text shrink-0">
+                                                                    <span x-text="versionSummary(product)"></span>
+                                                                    <i class="fas fa-chevron-down text-[0.625rem] transition-transform"
+                                                                       :class="isExpanded(product.id) ? 'rotate-180' : ''"
+                                                                       aria-hidden="true"></i>
+                                                                </button>
+                                                            </div>
+                                                            {# Guarded on releases as well as expansion: a product with no
+                                                               versions has nothing to show, and its toggle is hidden, so
+                                                               this would only ever render an empty panel. #}
+                                                            <div x-show="isExpanded(product.id) && product.releases.length"
+                                                                 x-cloak
+                                                                 class="px-3 pb-2.5 ml-6">
+                                                                <button type="button"
+                                                                        @click="toggleAllVersions(product)"
+                                                                        class="text-xs text-primary hover:underline mb-1.5">
+                                                                    <span x-text="allVersionsSelected(product) ? 'Clear versions' : 'Select every version'"></span>
+                                                                </button>
+                                                                <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+                                                                    <template x-for="(release, rIndex) in product.releases" :key="release.id">
+                                                                        <label class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer"
+                                                                               @click.prevent="toggleRelease(product, rIndex, $event)">
+                                                                            <input type="checkbox"
+                                                                                   class="tw-checkbox"
+                                                                                   :checked="isReleaseSelected(release.id)" />
+                                                                            <span x-text="release.label"></span>
+                                                                        </label>
+                                                                    </template>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                                <template x-for="id in selectedProducts" :key="id">
+                                                    <input type="hidden" name="products" :value="id" />
+                                                </template>
+                                                <template x-for="id in selectedReleases" :key="id">
+                                                    <input type="hidden" name="affected_releases" :value="id" />
+                                                </template>
                                                 <p class="mt-1.5 text-xs text-text-muted">
-                                                    Optional for a draft; publishing a product advisory requires at least one product.
+                                                    Shift-click to select a range. Leave versions unpicked to cover the whole product.
                                                 </p>
-                                            {% else %}
+                                            </div>
+                                        {% else %}
+                                            <div>
+                                                <label class="tw-form-label">Affected products</label>
                                                 <p class="text-sm text-text-muted rounded-lg border border-dashed border-border px-3 py-2.5">
                                                     No products in this workspace yet.
                                                     <a href="{% url 'core:products_dashboard' %}"
                                                        class="text-primary hover:underline">Create one</a>
                                                     to map advisories to it.
                                                 </p>
-                                            {% endif %}
-                                        </div>
-                                        {# CVE / reference is optional — hidden until the user chooses to add it. #}
-                                        <div>
+                                            </div>
+                                        {% endif %}
+                                        {% comment %}
+                                        Everything optional folds behind one link. The modal had grown to
+                                        six always-visible blocks, which read as a form demanding all of
+                                        them; a draft only genuinely needs a title.
+                                        {% endcomment %}
+                                        <div x-data="{ showDetails: false }">
                                             <button type="button"
-                                                    x-show="!showRef"
-                                                    @click="showRef = true; $nextTick(() => $refs.vulnId.focus())"
+                                                    x-show="!showDetails"
+                                                    @click="showDetails = true"
                                                     class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-dark transition-colors">
-                                                <i class="fas fa-plus text-xs"></i>Link a CVE or reference
+                                                <i class="fas fa-plus text-xs" aria-hidden="true"></i>Add a CVE or description
                                             </button>
-                                            <div x-show="showRef" x-cloak class="space-y-1.5">
-                                                <div class="flex items-center justify-between">
-                                                    <label class="tw-form-label !mb-0" for="advisoryVulnId">CVE or reference</label>
-                                                    <button type="button"
-                                                            @click="showRef = false; $refs.vulnId.value = ''"
-                                                            class="text-xs text-text-muted hover:text-text transition-colors">
-                                                        Remove
-                                                    </button>
+                                            <div x-show="showDetails" x-cloak class="space-y-4">
+                                                <div>
+                                                    <label class="tw-form-label" for="advisoryVulnId">CVE or reference</label>
+                                                    <input type="hidden" name="type" value="cve" />
+                                                    <input id="advisoryVulnId"
+                                                           name="vulnerability_id"
+                                                           type="text"
+                                                           class="tw-form-input"
+                                                           placeholder="CVE-2026-0000" />
                                                 </div>
-                                                <input type="hidden" name="type" value="cve" />
-                                                <input id="advisoryVulnId"
-                                                       name="vulnerability_id"
-                                                       x-ref="vulnId"
-                                                       type="text"
-                                                       class="tw-form-input"
-                                                       placeholder="CVE-2026-0000" />
-                                                <p class="text-xs text-text-muted">Optional. Link the CVE or a vendor advisory reference.</p>
+                                                <div>
+                                                    <label class="tw-form-label" for="advisoryDescription">Description</label>
+                                                    <textarea id="advisoryDescription"
+                                                              name="description"
+                                                              class="tw-form-input"
+                                                              rows="3"
+                                                              placeholder="Describe the vulnerability..."></textarea>
+                                                </div>
                                             </div>
                                         </div>
-                                        <div>
-                                            <label class="tw-form-label" for="advisoryDescription">Description</label>
-                                            <textarea id="advisoryDescription"
-                                                      name="description"
-                                                      class="tw-form-input"
-                                                      rows="3"
-                                                      placeholder="Describe the vulnerability..."></textarea>
-                                            <p class="mt-1.5 text-xs text-text-muted">Optional. A brief description of the issue.</p>
-                                        </div>
-                                        {# Reinforce the timeline model: creating the advisory posts its first update. #}
-                                        <div class="flex items-start gap-2.5 rounded-lg bg-info/5 border border-info/20 px-3 py-2.5">
-                                            <i class="fas fa-timeline text-info text-sm mt-0.5"></i>
-                                            <p class="text-xs text-text-muted">
-                                                This opens the advisory with its first update, <span class="font-medium text-text">Vulnerability identified</span>. Post further updates to move it through Investigating, Fix in progress and Resolved.
-                                            </p>
-                                        </div>
                                     </div>
-                                    <div class="tw-modal-footer">
-                                        <button type="button" class="tw-btn-ghost" @click="open = false">Cancel</button>
-                                        <button type="submit" class="tw-btn-primary">
-                                            <i class="fas fa-plus mr-2"></i>Create Advisory
-                                        </button>
+                                    <div class="tw-modal-footer !justify-between">
+                                        {% comment %}
+                                        The timeline note used to be a bordered info panel in the body,
+                                        which gave a one-sentence aside the weight of a field. It says the
+                                        same thing here, next to the button that does it.
+                                        {% endcomment %}
+                                        <p class="text-xs text-text-muted m-0 hidden sm:block">
+                                            Opens as a draft with its first update, <span class="text-text">Vulnerability identified</span>.
+                                        </p>
+                                        <div class="flex items-center gap-2">
+                                            <button type="button" class="tw-btn-ghost" @click="open = false">Cancel</button>
+                                            <button type="submit" class="tw-btn-primary">
+                                                <i class="fas fa-plus mr-2"></i>Create Advisory
+                                            </button>
+                                        </div>
                                     </div>
                                 </form>
                             </div>
@@ -200,4 +254,5 @@
         {% endif %}
     </div>
 {% endblock %}
-{% block scripts %}{% endblock %}
+{% block scripts %}
+{% endblock %}

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -858,6 +858,12 @@ html.no-transitions * {
   position: relative;
   overflow: hidden;
   border: none;
+  /* A button label is a single action, so it never wraps, and the button never
+     gives up width to whatever shares its flex row. Without these, a footer
+     holding both helper text and buttons squeezes the buttons until the label
+     breaks over two lines. */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tw-btn:focus-visible,
@@ -1254,6 +1260,18 @@ html.no-transitions * {
   background-color: var(--color-primary);
   border-color: var(--color-primary);
   background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-size: 100% 100%;
+}
+
+/* Half-ticked: "some of what this box covers", e.g. a product where only some
+   versions are affected. The control is appearance:none, so the browser's own
+   indeterminate mark never renders and the state has to be drawn here. Declared
+   after :checked deliberately — an indeterminate box is usually checked too, and
+   at equal specificity the dash has to win over the tick. */
+.tw-checkbox:indeterminate {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M4.5 8h7' stroke='white' stroke-width='2' stroke-linecap='round'/%3e%3c/svg%3e");
   background-size: 100% 100%;
 }
 


### PR DESCRIPTION
Reworks the product picker in the New Advisory modal: more capable where the work actually is, and considerably less to read on open.

## Less to answer

The modal had grown to six always-visible blocks, which reads as a form demanding all of them when a draft genuinely needs only a title.

- CVE and description fold behind one **"Add a CVE or description"** link.
- The timeline note — previously a bordered info panel, given the visual weight of a field — is one line in the footer, beside the button it describes.

Default height is roughly halved.

## More capable

An advisory routinely covers a product line — several products, or a run of consecutive versions — so ticking one box at a time was the wrong unit of work. The picker gains the idioms a file manager has:

- **Specific versions.** Each product with releases has a row that stays collapsed until asked for, and says what it holds: *All versions* until you narrow it, then *3 of 5 versions*.
- **Shift-click ranges**, on products and on versions within a product. Each product keeps its own version anchor, so a range never leaks across products.
- **Select all / Clear**, plus a per-product *Select every version*.
- **Half-ticked parents.** A product whose versions are only partly selected renders indeterminate.

Two rules the component enforces, both because the alternative is a state not worth being able to reach: dropping a product drops the versions selected under it, and ticking a version marks its product affected.

The half-tick rule is worth stating: no versions picked means the advisory covers the product whole, and every version picked is the same claim by a longer route — so both are a full tick, and only the middle ground is a dash.

## Notes on the implementation

**Selection lives in the component, not in the checkboxes.** Shift-click sets a whole range from one event, which an `x-model` binding cannot express. The boxes render `:checked` from that state and the form submits from hidden inputs, so a range-select and a plain click go through exactly one path.

**Rows are the control.** Each row was a `<label>` wrapping a checkbox, which asks the browser to forward a second click to the nested input — the likely source of a click landing on the wrong version. There is no label to forward now: the row carries `role="checkbox"`, its own tabindex and space/enter handling, and the box is painted from state with pointer events and tab stop removed.

**Two component-level CSS changes**, both of which apply app-wide:

- `.tw-checkbox` gained an `:indeterminate` rule. The control is `appearance: none` and draws its own tick, so the DOM property alone rendered nothing. Declared after `:checked`, since an indeterminate box is usually checked too and the dash has to win.
- Buttons gained `white-space: nowrap` and `flex-shrink: 0`. A label is a single action and should never break over two lines, and a button should never surrender width to whatever shares its flex row — which is what was cramping the modal footer.

## No backend change

Field names `products` and `affected_releases` are unchanged, so `AdvisoryCreateForm` and `create_advisory` are untouched. This is presentation only.

## Tests

20 unit tests on the selection logic: ranges in both directions, a range *clearing* rather than inverting each row, the per-product version anchor, the implied and cascading selections, the summary text, and the half-tick rule.

Verified end to end in the browser before the row rework: 8 products and a 3-version range submitted, producing 8 products, 8 per-product statuses and 3 version ranges.

Because the button change reaches every page, the full e2e snapshot suite was run: **64 passed, 32 skipped, no baseline drift**. Also clean: 414 frontend tests, 183 advisory tests, ruff, djlint, eslint, tsc.