### PR TITLE
feat(settings): one page per section, with tabs across the top

### DIFF
--- a/sbomify/apps/teams/settings_tabs.py
+++ b/sbomify/apps/teams/settings_tabs.py
@@ -1,0 +1,142 @@
+"""The workspace settings sections, in one place.
+
+The settings page used to declare each section three times over — once in the
+nav, once as a hidden pane, and once in an ``{% if role %}`` around each — so a
+new section meant editing the template in three places and a permission change
+meant hunting for all of them. This is the list; the view filters it and the
+template renders whatever it is handed.
+
+Each tab is a real page at its own URL rather than a hidden div, so a section can
+be linked to, bookmarked and reached with the back button, and only the section
+being looked at is rendered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Roles that may see a tab. Mirrors the keys of ``settings.TEAMS_SUPPORTED_ROLES``.
+OWNER = "owner"
+ADMIN = "admin"
+OWNER_ONLY = (OWNER,)
+OWNER_OR_ADMIN = (OWNER, ADMIN)
+
+
+@dataclass(frozen=True)
+class SettingsTab:
+    """One settings section: its URL slug, how it presents, and who may see it."""
+
+    key: str
+    label: str
+    icon: str
+    # The template under ``teams/team_settings_tabs/`` that renders the body.
+    template: str
+    roles: tuple[str, ...] = OWNER_OR_ADMIN
+    # Billing sections are pointless when the deployment has billing switched off.
+    requires_billing: bool = False
+    description: str = ""
+
+    @property
+    def template_path(self) -> str:
+        return f"teams/team_settings_tabs/{self.template}.html.j2"
+
+
+# Order is the order the tabs appear in. General first because it is where a
+# workspace is named; Account last because it is about the person, not the
+# workspace.
+SETTINGS_TABS: tuple[SettingsTab, ...] = (
+    SettingsTab(
+        key="general",
+        label="General",
+        icon="fa-sliders",
+        template="general",
+        roles=OWNER_ONLY,
+        description="Workspace name, visibility and identifiers.",
+    ),
+    SettingsTab(
+        key="members",
+        label="Members",
+        icon="fa-users",
+        template="members",
+        description="Who can reach this workspace, and what they may do.",
+    ),
+    SettingsTab(
+        key="tokens",
+        label="API tokens",
+        icon="fa-key",
+        template="tokens",
+        description="Personal access tokens for the API and CI.",
+    ),
+    SettingsTab(
+        key="contact-profiles",
+        label="Contacts",
+        icon="fa-address-book",
+        template="contact_profiles",
+        description="The people and organisations named on your artifacts.",
+    ),
+    SettingsTab(
+        key="trust-center",
+        label="Trust Center",
+        icon="fa-globe",
+        template="trust_center",
+        roles=OWNER_ONLY,
+        description="What the public sees, and who may be let past the gate.",
+    ),
+    SettingsTab(
+        key="branding",
+        label="Branding",
+        icon="fa-palette",
+        template="branding",
+        description="How this workspace looks to everyone outside it.",
+    ),
+    SettingsTab(
+        key="plugins",
+        label="Plugins",
+        icon="fa-plug",
+        template="plugins",
+        description="Vulnerability scanners and assessment plugins.",
+    ),
+    SettingsTab(
+        key="billing",
+        label="Billing",
+        icon="fa-credit-card",
+        template="billing",
+        roles=OWNER_ONLY,
+        requires_billing=True,
+        description="Your plan, usage and payment details.",
+    ),
+    SettingsTab(
+        key="account",
+        label="Account",
+        icon="fa-user-gear",
+        template="account",
+        # Your own account is yours whatever your role in this workspace.
+        roles=(OWNER, ADMIN, "guest"),
+        description="Your own sign-in and personal settings.",
+    ),
+)
+
+TABS_BY_KEY: dict[str, SettingsTab] = {tab.key: tab for tab in SETTINGS_TABS}
+
+
+def visible_tabs(role: str | None, *, billing_enabled: bool) -> list[SettingsTab]:
+    """The sections this member may open, in display order.
+
+    Filtering here rather than in the template means the nav and the page agree
+    by construction: a tab that is not returned cannot be linked *or* rendered.
+    """
+    return [tab for tab in SETTINGS_TABS if role in tab.roles and (billing_enabled or not tab.requires_billing)]
+
+
+def resolve_tab(key: str | None, role: str | None, *, billing_enabled: bool) -> SettingsTab | None:
+    """The tab to render, or None when the member may open no section at all.
+
+    An unknown or forbidden key falls back to the first section they can see
+    rather than erroring: settings links are pasted around and outlive renames,
+    and landing on the first page beats a 404.
+    """
+    allowed = visible_tabs(role, billing_enabled=billing_enabled)
+    if not allowed:
+        return None
+    by_key = {tab.key: tab for tab in allowed}
+    return by_key.get(key or "", allowed[0])

--- a/sbomify/apps/teams/templates/teams/team_settings.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings.html.j2
@@ -6,144 +6,75 @@
 {% load teams %}
 {% block title %}sbomify Workspace Settings: {{ team.name|workspace_display }}{% endblock %}
 {% block content %}
-    <div class="space-y-6 animate-[fadeInUp_0.4s_ease-out]">
-        {# Page Header #}
-        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-            <div class="flex items-center gap-4">
-                <div class="tw-avatar tw-avatar-lg">
-                    <i class="fas fa-cog"></i>
-                </div>
-                <div>
-                    <h1 class="text-2xl font-bold text-text">Workspace Settings</h1>
-                    <p class="text-text-muted text-sm mt-0.5">Manage {{ team.name }} configuration and preferences</p>
-                </div>
-            </div>
-            <div class="flex items-center gap-3">
-                <span class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
-                    <i class="fas fa-users text-xs"></i>
-                    {{ team.members|length }} member{{ team.members|length|pluralize }}
-                </span>
-                {% if team.billing_plan and team.billing_plan != 'community' %}
-                    <span class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium {% if team.billing_plan == 'business' %}bg-success/10 text-success{% else %}bg-primary/10 text-primary{% endif %}">
-                        <i class="fas fa-crown text-xs"></i>
-                        {{ team.billing_plan|title }}
+    <div class="settings-page">
+        {% comment %}
+        Stripe-style masthead: a breadcrumb back to the section, the workspace as
+        the title, then the sections as tabs. Each tab is its own URL, so only
+        the section being read is rendered and it can be linked to directly.
+        {% endcomment %}
+        <header class="settings-masthead">
+            <a class="settings-breadcrumb" href="{% url 'teams:teams_dashboard' %}">Workspaces</a>
+            <div class="settings-masthead-row">
+                <h1 class="settings-title">{{ team.name|workspace_display }}</h1>
+                <div class="settings-meta">
+                    <span class="settings-chip">
+                        <i class="fas fa-users" aria-hidden="true"></i>
+                        {{ team.members|length }} member{{ team.members|length|pluralize }}
                     </span>
-                {% endif %}
+                    {% if team.billing_plan and team.billing_plan != 'community' %}
+                        <span class="settings-chip {% if team.billing_plan == 'business' %}is-success{% endif %}">
+                            <i class="fas fa-crown" aria-hidden="true"></i>
+                            {{ team.billing_plan|title }}
+                        </span>
+                    {% endif %}
+                </div>
             </div>
-        </div>
-        {# Settings Layout #}
-        <div class="flex flex-col lg:flex-row gap-8">
-            {# Vertical Navigation Tabs #}
-            <div class="w-full lg:w-64 flex-shrink-0">
-                <nav id="settings-tabs" aria-label="Settings navigation">
-                    <div class="flex flex-row lg:flex-col gap-1 overflow-x-auto lg:overflow-visible pb-2 lg:pb-0">
-                        {% if request.session.current_team.role == 'owner' %}
-                            <a href="#general"
-                               data-tab="general"
-                               class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                                <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                    <i class="fas fa-sliders-h text-sm group-[.active]:text-primary"></i>
-                                </div>
-                                <span class="font-medium">General</span>
-                            </a>
+            <nav class="settings-tabs" aria-label="Settings sections">
+                {% for tab in settings_tabs %}
+                    <a class="settings-tab {% if tab.key == active_tab.key %}is-active{% endif %}"
+                       href="{% url 'teams:team_settings_tab' team_key=team.key tab=tab.key %}"
+                       {% if tab.key == active_tab.key %}aria-current="page"{% endif %}>
+                        <i class="fas {{ tab.icon }}" aria-hidden="true"></i>
+                        <span>{{ tab.label }}</span>
+                        {% if tab.key == 'members' and team.invitations|length > 0 %}
+                            <span class="settings-tab-badge">{{ team.invitations|length }}</span>
                         {% endif %}
-                        <a href="#members"
-                           data-tab="members"
-                           class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                            <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                <i class="fas fa-users text-sm group-[.active]:text-primary"></i>
-                            </div>
-                            <span class="font-medium">Members</span>
-                            {% if team.invitations|length > 0 %}
-                                <span class="ml-auto px-2 py-0.5 rounded-full text-xs font-medium bg-warning/10 text-warning">{{ team.invitations|length }}</span>
-                            {% endif %}
-                        </a>
-                        <a href="#tokens"
-                           data-tab="tokens"
-                           class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                            <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                <i class="fas fa-key text-sm group-[.active]:text-primary"></i>
-                            </div>
-                            <span class="font-medium">API Tokens</span>
-                        </a>
-                        {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                            <a href="#contact-profiles"
-                               data-tab="contact-profiles"
-                               class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                                <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                    <i class="fas fa-address-book text-sm group-[.active]:text-primary"></i>
-                                </div>
-                                <span class="font-medium">Contacts</span>
-                            </a>
-                        {% endif %}
-                        {% if request.session.current_team.role == 'owner' %}
-                            <a href="#trust-center"
-                               data-tab="trust-center"
-                               class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                                <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                    <i class="fas fa-globe text-sm group-[.active]:text-primary"></i>
-                                </div>
-                                <span class="font-medium">Trust Center</span>
-                            </a>
-                        {% endif %}
-                        {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                            <a href="#branding"
-                               data-tab="branding"
-                               class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                                <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                    <i class="fas fa-palette text-sm group-[.active]:text-primary"></i>
-                                </div>
-                                <span class="font-medium">Branding</span>
-                            </a>
-                        {% endif %}
-                        {% if billing_enabled and request.session.current_team.role == 'owner' %}
-                            <a href="#billing"
-                               data-tab="billing"
-                               class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                                <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                    <i class="fas fa-credit-card text-sm group-[.active]:text-primary"></i>
-                                </div>
-                                <span class="font-medium">Billing</span>
-                            </a>
-                        {% endif %}
-                        <a href="#account"
-                           data-tab="account"
-                           class="settings-tab-link group flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:bg-primary/5 hover:text-text transition-all whitespace-nowrap">
-                            <div class="w-8 h-8 rounded-lg bg-background flex items-center justify-center group-[.active]:bg-primary/10 transition-colors">
-                                <i class="fas fa-user-cog text-sm group-[.active]:text-primary"></i>
-                            </div>
-                            <span class="font-medium">Account</span>
-                        </a>
-                    </div>
-                </nav>
-            </div>
-            {# Tab Content #}
-            <div class="flex-1 min-w-0">
-                {% if request.session.current_team.role == 'owner' %}
-                    <div class="settings-tab-pane hidden" id="general">{% include "teams/team_settings_tabs/general.html.j2" %}</div>
-                {% endif %}
-                <div class="settings-tab-pane hidden" id="members">{% include "teams/team_settings_tabs/members.html.j2" %}</div>
-                <div class="settings-tab-pane hidden" id="tokens">{% include "teams/team_settings_tabs/tokens.html.j2" %}</div>
-                {% if request.session.current_team.role == 'owner' %}
-                    <div class="settings-tab-pane hidden" id="trust-center">
-                        {% include "teams/team_settings_tabs/trust_center.html.j2" %}
-                    </div>
-                {% endif %}
-                {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                    <div class="settings-tab-pane hidden" id="contact-profiles">
-                        {% include "teams/team_settings_tabs/contact_profiles.html.j2" %}
-                    </div>
-                {% endif %}
-                {% if billing_enabled and request.session.current_team.role == 'owner' %}
-                    <div class="settings-tab-pane hidden" id="billing">{% include "teams/team_settings_tabs/billing.html.j2" %}</div>
-                {% endif %}
-                {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                    <div class="settings-tab-pane hidden" id="branding">{% include "teams/team_settings_tabs/branding.html.j2" %}</div>
-                {% endif %}
-                <div class="settings-tab-pane hidden" id="account">{% include "teams/team_settings_tabs/account.html.j2" %}</div>
-            </div>
-        </div>
+                    </a>
+                {% endfor %}
+            </nav>
+        </header>
+        {% comment %}
+        A plain landmark, not a card: every section template already opens with
+        its own titled card, so a wrapper with a second title and a second border
+        would say the name twice and draw a box around a box.
+        {% endcomment %}
+        <section class="settings-panel"
+                 id="{{ active_tab.key }}"
+                 aria-label="{{ active_tab.label }} settings">
+            {% include active_tab.template_path %}
+        </section>
     </div>
+    {% comment %}
+    Settings have been linked to by fragment from all over the app for a long
+    time ({% url ... %}#branding). Those links still arrive here, so a fragment
+    naming a real section is turned into a visit to that section's page. Uses
+    replace() so the redirect does not become a step in the back button.
+    {% endcomment %}
+    <script>
+      (function () {
+        var urls = {
+          {% for tab in settings_tabs %}"{{ tab.key|escapejs }}": "{% url 'teams:team_settings_tab' team_key=team.key tab=tab.key %}"{% if not forloop.last %},{% endif %}
+          {% endfor %}
+        };
+        var hash = window.location.hash.replace('#', '');
+        if (!hash || !urls[hash]) return;
+        if (hash === '{{ active_tab.key|escapejs }}') {
+          history.replaceState(null, '', window.location.pathname);
+          return;
+        }
+        window.location.replace(urls[hash]);
+      })();
+    </script>
     {# Access Request Modals - at page level to avoid hidden tab pane issues #}
     {% if request.session.current_team.role == 'owner' and team.is_public %}
         {# Invite User Modal #}
@@ -603,104 +534,13 @@
 {% block scripts %}
     {% vite_asset 'sbomify/apps/core/js/main.ts' %}
     {% vite_asset 'sbomify/apps/teams/js/main.ts' %}
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Get available tabs
-            const availableTabs = ['members', 'tokens'];
-            {% if request.session.current_team.role == 'owner' %}availableTabs.unshift('general');{% endif %}
-            {% if request.session.current_team.role == 'owner' %}availableTabs.push('trust-center');{% endif %}
-            {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                availableTabs.push('controls');
-            {% endif %}
-            {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                availableTabs.push('contact-profiles');
-            {% endif %}
-            {% if billing_enabled and request.session.current_team.role == 'owner' %}availableTabs.push('billing');{% endif %}
-            {% if request.session.current_team.role == 'owner' or request.session.current_team.role == 'admin' %}
-                availableTabs.push('branding');
-            {% endif %}
-            availableTabs.push('account');
+    {% comment %}
+    The hash-based tab switcher that used to live here is gone: each section
+    is its own page now, so there are no panes to show and hide, and the
+    active tab comes from the URL rather than from JavaScript.
 
-            const activeTabInputs = document.querySelectorAll('input[name="active_tab"]');
-
-            // Function to activate a tab
-            function activateTab(tabName) {
-                // Remove active class from all nav links and hide all tab panes
-                document.querySelectorAll('.settings-tab-link').forEach(link => {
-                    link.classList.remove('active', 'bg-primary/10', 'text-primary');
-                    link.classList.add('text-text-muted');
-                    // Reset icon container
-                    const iconContainer = link.querySelector('div');
-                    if (iconContainer) {
-                        iconContainer.classList.remove('bg-primary/10');
-                        iconContainer.classList.add('bg-background');
-                    }
-                    const icon = link.querySelector('i');
-                    if (icon) {
-                        icon.classList.remove('text-primary');
-                    }
-                });
-                document.querySelectorAll('.settings-tab-pane').forEach(pane => {
-                    pane.classList.add('hidden');
-                });
-
-                // Add active class to the selected tab nav link and show pane
-                const navLink = document.querySelector(`.settings-tab-link[href="#${tabName}"]`);
-                const tabPane = document.getElementById(tabName);
-
-                if (navLink && tabPane) {
-                    navLink.classList.add('active', 'bg-primary/10', 'text-primary');
-                    navLink.classList.remove('text-text-muted');
-                    // Update icon container
-                    const iconContainer = navLink.querySelector('div');
-                    if (iconContainer) {
-                        iconContainer.classList.add('bg-primary/10');
-                        iconContainer.classList.remove('bg-background');
-                    }
-                    const icon = navLink.querySelector('i');
-                    if (icon) {
-                        icon.classList.add('text-primary');
-                    }
-                    tabPane.classList.remove('hidden');
-                }
-            }
-
-            // Function to get the current tab from URL hash
-            function getCurrentTab() {
-                const hash = window.location.hash.substring(1);
-                return availableTabs.includes(hash) ? hash : availableTabs[0];
-            }
-
-            // Activate tab based on current URL hash
-            activateTab(getCurrentTab());
-
-            // Listen for hash changes
-            window.addEventListener('hashchange', function() {
-                activateTab(getCurrentTab());
-            });
-
-            // Update hash when tab links are clicked
-            document.querySelectorAll('.settings-tab-link').forEach(link => {
-                link.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    const targetTab = this.getAttribute('href').substring(1);
-                    if (availableTabs.includes(targetTab)) {
-                        history.pushState(null, null, `#${targetTab}`);
-                        activateTab(targetTab);
-                        updateActiveTabInputs(targetTab);
-                    }
-                });
-            });
-
-            // Function to update all active_tab hidden inputs
-            function updateActiveTabInputs(tabName) {
-                activeTabInputs.forEach(input => {
-                    input.value = tabName;
-                });
-            }
-
-            // Initialize active_tab inputs with current tab
-            updateActiveTabInputs(getCurrentTab());
-        });
-    </script>
+    Forms still post an active_tab so the server knows where to send them
+    back to; that value is the section being viewed, which the server
+    already knows, so it is rendered rather than discovered.
+    {% endcomment %}
 {% endblock %}

--- a/sbomify/apps/teams/tests/test_team_settings_tabs.py
+++ b/sbomify/apps/teams/tests/test_team_settings_tabs.py
@@ -32,7 +32,7 @@ def test_visibility_toggle_redirects_to_active_tab(sample_team_with_owner_member
     )
 
     assert response.status_code == 302
-    assert response.url.endswith("#members")
+    assert response.url.endswith("/settings/members")
 
 
 @pytest.mark.django_db
@@ -74,7 +74,7 @@ def test_delete_invitation_redirects_to_members_tab(sample_team_with_owner_membe
     )
 
     assert response.status_code == 302
-    assert response.url.endswith("#members")
+    assert response.url.endswith("/settings/members")
 
 
 @pytest.mark.django_db
@@ -139,7 +139,7 @@ def test_delete_member_redirects_to_active_tab(sample_team_with_owner_member: Me
     )
 
     assert response.status_code == 302
-    assert response.url.endswith("#members")
+    assert response.url.endswith("/settings/members")
     # Verify member was actually deleted
     assert not Member.objects.filter(pk=other_membership.id).exists()
 
@@ -174,11 +174,19 @@ class TestRedirectToTeamSettingsHelper:
 
     @pytest.mark.django_db
     def test_valid_tab_is_included(self, sample_team_with_owner_member: Member):  # noqa: F811
-        """Valid tab names should be included in the redirect URL."""
+        """A valid tab is named in the redirect, as a page where one exists.
+
+        Sections with a page of their own redirect straight to it. The two names
+        still in ALLOWED_TABS that have no page (controls, integrations) keep the
+        old fragment form, so links to them are not broken by the move.
+        """
+        from sbomify.apps.teams.settings_tabs import TABS_BY_KEY
+
         team_key = sample_team_with_owner_member.team.key
         for tab in ALLOWED_TABS:
             response = redirect_to_team_settings(team_key, tab)
-            assert response.url.endswith(f"#{tab}")
+            expected = f"/settings/{tab}" if tab in TABS_BY_KEY else f"#{tab}"
+            assert response.url.endswith(expected), f"{tab} -> {response.url}"
 
     @pytest.mark.django_db
     def test_invalid_tab_is_rejected(self, sample_team_with_owner_member: Member):  # noqa: F811
@@ -236,7 +244,7 @@ class TestTrustCenterDescription:
         )
 
         assert response.status_code == 302
-        assert response.url.endswith("#trust-center")
+        assert response.url.endswith("/settings/trust-center")
 
         # Verify description was saved
         team.refresh_from_db()

--- a/sbomify/apps/teams/urls.py
+++ b/sbomify/apps/teams/urls.py
@@ -95,6 +95,9 @@ urlpatterns: list[URLPattern] = [
         views.TeamTokensView.as_view(),
         name="team_tokens",
     ),
-    # Main team settings (unified interface) - must come after specific patterns
+    # One page per settings section. Declared before the bare <team_key> so the
+    # slug is not swallowed by it.
+    path("<team_key>/settings/<slug:tab>", views.TeamSettingsView.as_view(), name="team_settings_tab"),
+    # Settings index — renders the first section the member may open.
     path("<team_key>", views.TeamSettingsView.as_view(), name="team_settings"),
 ]

--- a/sbomify/apps/teams/utils.py
+++ b/sbomify/apps/teams/utils.py
@@ -62,10 +62,18 @@ def redirect_to_team_settings(team_key: str, active_tab: str | None = None) -> H
     if not Team.objects.filter(key=team_key).exists():
         return redirect("teams:teams_dashboard")
 
+    # Each section is its own page, so a known tab is a URL rather than a
+    # fragment — the browser lands on the section directly instead of loading the
+    # index and being bounced by script.
+    from sbomify.apps.teams.settings_tabs import TABS_BY_KEY
+
+    if active_tab and active_tab in ALLOWED_TABS and active_tab in TABS_BY_KEY:
+        return redirect("teams:team_settings_tab", team_key=team_key, tab=active_tab)
     base_url = reverse("teams:team_settings", kwargs={"team_key": team_key})
     if active_tab and active_tab in ALLOWED_TABS:
-        safe_tab = quote(active_tab)
-        return redirect(f"{base_url}#{safe_tab}")
+        # A tab that is allowed but has no page of its own (controls,
+        # integrations) keeps the old fragment behaviour.
+        return redirect(f"{base_url}#{quote(active_tab)}")
     return redirect(base_url)
 
 

--- a/sbomify/apps/teams/utils.py
+++ b/sbomify/apps/teams/utils.py
@@ -26,6 +26,10 @@ from .models import Invitation, Member, Team, get_team_name_for_user
 from .queries import count_team_members, get_team_user_counts
 
 # Valid tab names for team settings - used for input validation
+# Names still linked to by fragment that have no settings page of their own.
+# Kept as literals so a redirect to one cannot carry a request-derived string.
+FRAGMENT_ONLY_TABS: tuple[str, ...] = ("controls", "integrations")
+
 ALLOWED_TABS = frozenset(
     {
         "general",
@@ -53,8 +57,6 @@ def redirect_to_team_settings(team_key: str, active_tab: str | None = None) -> H
     Returns:
         HttpResponseRedirect to the team settings page
     """
-    from urllib.parse import quote
-
     from django.shortcuts import redirect
     from django.urls import reverse
 
@@ -67,13 +69,21 @@ def redirect_to_team_settings(team_key: str, active_tab: str | None = None) -> H
     # index and being bounced by script.
     from sbomify.apps.teams.settings_tabs import TABS_BY_KEY
 
-    if active_tab and active_tab in ALLOWED_TABS and active_tab in TABS_BY_KEY:
+    if active_tab and active_tab in TABS_BY_KEY:
         return redirect("teams:team_settings_tab", team_key=team_key, tab=active_tab)
+
     base_url = reverse("teams:team_settings", kwargs={"team_key": team_key})
-    if active_tab and active_tab in ALLOWED_TABS:
-        # A tab that is allowed but has no page of its own (controls,
-        # integrations) keeps the old fragment behaviour.
-        return redirect(f"{base_url}#{quote(active_tab)}")
+    # The names still in ALLOWED_TABS with no page of their own keep the old
+    # fragment, so links to them are not broken by the move.
+    #
+    # The fragment is taken from this tuple rather than interpolated from the
+    # argument. Equality proves the two are the same string, but only the
+    # literal is reachable in the URL — so no request-derived value can steer
+    # the redirect, by construction rather than by a validation step a later
+    # edit could drift away from.
+    for known_fragment in FRAGMENT_ONLY_TABS:
+        if active_tab == known_fragment:
+            return redirect(f"{base_url}#{known_fragment}")
     return redirect(base_url)
 
 

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -14,6 +14,7 @@ from django.views.decorators.cache import never_cache
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.billing.stripe_sync import sync_subscription_from_stripe
 from sbomify.apps.billing.team_pricing_service import TeamPricingService
+from sbomify.apps.core.domain.exceptions import PermissionDeniedError
 from sbomify.apps.core.errors import error_response
 from sbomify.apps.core.models import User
 from sbomify.apps.core.url_utils import build_custom_domain_url
@@ -235,7 +236,10 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         billing_enabled_flag = is_billing_enabled()
         active_tab = resolve_tab(tab, role, billing_enabled=billing_enabled_flag)
         if active_tab is None:
-            return error_response(request, HttpResponse(status=403, content="No settings available"))
+            # The typed domain error rather than a hand-built HttpResponse:
+            # error_response understands it, it carries its own 403, and it keeps
+            # this on the same path as every other permission failure.
+            return error_response(request, PermissionDeniedError("No settings available for this role"))
         # A stale or renamed slug resolves to the first section instead of 404ing;
         # send the browser to the URL that actually rendered so the address bar,
         # the highlighted tab and the content all agree.

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.cache import never_cache
@@ -105,7 +105,7 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         active_tab = request.POST.get("active_tab", "")
         return redirect_to_team_settings(team_key, active_tab if active_tab else None)
 
-    def get(self, request: HttpRequest, team_key: str) -> HttpResponse:
+    def get(self, request: HttpRequest, team_key: str, tab: str | None = None) -> HttpResponse:
         status_code, team = get_team(request, team_key)
         if status_code != 200:
             return error_response(
@@ -226,11 +226,29 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                         }
                     )
 
+        # Which section is on screen, and which the nav offers. Resolved from
+        # the registry so the two cannot disagree — a tab the member may not
+        # open is neither linked nor rendered.
+        from sbomify.apps.teams.settings_tabs import resolve_tab, visible_tabs
+
+        role = request.session.get("current_team", {}).get("role")
+        billing_enabled_flag = is_billing_enabled()
+        active_tab = resolve_tab(tab, role, billing_enabled=billing_enabled_flag)
+        if active_tab is None:
+            return error_response(request, HttpResponse(status=403, content="No settings available"))
+        # A stale or renamed slug resolves to the first section instead of 404ing;
+        # send the browser to the URL that actually rendered so the address bar,
+        # the highlighted tab and the content all agree.
+        if tab is not None and tab != active_tab.key:
+            return redirect("teams:team_settings_tab", team_key=team_key, tab=active_tab.key)
+
         return render(
             request,
             "teams/team_settings.html.j2",
             {
                 "APP_BASE_URL": settings.APP_BASE_URL,
+                "settings_tabs": visible_tabs(role, billing_enabled=billing_enabled_flag),
+                "active_tab": active_tab,
                 "team": team_data,
                 "team_obj": team_obj,  # Pass actual model in case specific valid/function call is lower down
                 # Members tab

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -5206,41 +5206,16 @@ html.no-transitions * {
 
 /* --- The section panel ---------------------------------------------------- */
 
-/* One card per section, and only one. The panel is the card; the section
-   templates' own .tw-settings-card boxes are flattened below, so their contents
-   become bands inside this card rather than a stack of boxes within a box. */
+/* The panel is a plain container, not a surface.
+
+   Each section template already opens with its own .tw-settings-card, and those
+   are the design. Wrapping them in a second card put boxes inside a box;
+   flattening them instead left the page unstructured. So the cards stay as they
+   are and the wrapper adds nothing but a landmark — which also means the cards'
+   edges land on the same gutter as the tab row above them, since both take
+   their width from the page container rather than from a nested padding. */
 .settings-panel {
   min-width: 0;
-  border: 1px solid rgb(var(--color-border));
-  border-radius: 0.875rem;
-  background: rgb(var(--color-surface));
-  padding: 1.5rem;
-}
-
-/* Inner sections lose their card chrome so the tab shows one card, not many.
-   Done here rather than across nine templates: the change stays in one place
-   and is reversible. Only the card's own direct padding is cancelled, so its
-   contents line up with the panel's edge; anything nested keeps its spacing,
-   which is internal layout rather than the inset. */
-.settings-panel .tw-settings-card {
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-  overflow: visible;
-}
-
-.settings-panel .tw-settings-card > .px-6 {
-  padding-left: 0;
-  padding-right: 0;
-}
-
-/* Consecutive sections need to stay distinguishable now that nothing is boxed,
-   so they are separated by a rule instead of by a gap between cards. */
-.settings-panel .tw-settings-card + .tw-settings-card {
-  margin-top: 2rem;
-  padding-top: 2rem;
-  border-top: 1px solid rgb(var(--color-border));
 }
 
 @media (max-width: 640px) {

--- a/sbomify/assets/css/tailwind.src.css
+++ b/sbomify/assets/css/tailwind.src.css
@@ -5073,3 +5073,178 @@ html.no-transitions * {
     animation: none !important;
   }
 }
+
+/* ==========================================================================
+   Workspace settings
+   --------------------------------------------------------------------------
+   A masthead with the sections as tabs, and one panel below holding whichever
+   section is open. Each tab is a page, so the active state comes from the URL
+   rather than from script, and nothing is rendered that is not being read.
+   ========================================================================== */
+
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-breadcrumb {
+  align-self: flex-start;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  color: rgb(var(--color-primary));
+}
+
+.settings-masthead-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.settings-title {
+  font-size: 1.875rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: rgb(var(--color-text));
+  margin: 0;
+}
+
+.settings-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4375rem;
+  padding: 0.3125rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: color-mix(in oklab, rgb(var(--color-primary)) 10%, transparent);
+  color: rgb(var(--color-primary));
+}
+
+.settings-chip.is-success {
+  background: color-mix(in oklab, rgb(var(--color-success)) 12%, transparent);
+  color: rgb(var(--color-success));
+}
+
+.settings-chip i {
+  font-size: 0.6875rem;
+}
+
+/* --- Tabs ----------------------------------------------------------------- */
+/* A single hairline runs the width of the row, and the active tab sits on a
+   thicker segment of it. The transparent border is reserved on every tab so
+   the row cannot shift by a pixel when the active one changes. */
+
+.settings-tabs {
+  display: flex;
+  gap: 0.25rem;
+  /* Scrolls sideways when the sections outrun the width, but never vertically:
+     overflow-x alone leaves the box vertically scrollable too, so a wheel over
+     the tab row was being swallowed instead of scrolling the page. */
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  border-bottom: 1px solid rgb(var(--color-border));
+}
+
+.settings-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.settings-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0.875rem;
+  margin-bottom: -1px;
+  border-bottom: 2px solid transparent;
+  font-size: 0.875rem;
+  font-weight: 550;
+  white-space: nowrap;
+  color: rgb(var(--color-text-muted));
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.settings-tab:hover {
+  color: rgb(var(--color-text));
+  text-decoration: none;
+}
+
+.settings-tab.is-active {
+  color: rgb(var(--color-primary));
+  border-bottom-color: rgb(var(--color-primary));
+}
+
+.settings-tab i {
+  font-size: 0.8125rem;
+  opacity: 0.85;
+}
+
+.settings-tab-badge {
+  padding: 0.0625rem 0.4375rem;
+  border-radius: 999px;
+  background: color-mix(in oklab, rgb(var(--color-warning)) 15%, transparent);
+  color: rgb(var(--color-warning));
+  font-size: 0.6875rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- The section panel ---------------------------------------------------- */
+
+/* One card per section, and only one. The panel is the card; the section
+   templates' own .tw-settings-card boxes are flattened below, so their contents
+   become bands inside this card rather than a stack of boxes within a box. */
+.settings-panel {
+  min-width: 0;
+  border: 1px solid rgb(var(--color-border));
+  border-radius: 0.875rem;
+  background: rgb(var(--color-surface));
+  padding: 1.5rem;
+}
+
+/* Inner sections lose their card chrome so the tab shows one card, not many.
+   Done here rather than across nine templates: the change stays in one place
+   and is reversible. Only the card's own direct padding is cancelled, so its
+   contents line up with the panel's edge; anything nested keeps its spacing,
+   which is internal layout rather than the inset. */
+.settings-panel .tw-settings-card {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+}
+
+.settings-panel .tw-settings-card > .px-6 {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* Consecutive sections need to stay distinguishable now that nothing is boxed,
+   so they are separated by a rule instead of by a gap between cards. */
+.settings-panel .tw-settings-card + .tw-settings-card {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgb(var(--color-border));
+}
+
+@media (max-width: 640px) {
+  .settings-title {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
Rebuilds workspace settings on the Stripe pattern: a breadcrumb, the workspace as the title, the sections as tabs with icons across the top, and the section itself below.

## Why

Settings were a single template holding every section at once — nine hidden panes, a vertical nav, and a script to show and hide them. Each section was declared three times over: in the nav, as a pane, and inside a role check wrapped around each. Adding a section meant three edits, and a permission change meant finding all of them.

## What changed

**Sections are pages.** `settings_tabs.py` declares each one with its label, icon, template and the roles that may open it. The view filters that list; the template renders whatever it is handed. A section a member may not open is neither linked nor rendered, and only the section being read is rendered at all — so a settings page is one section's worth of DOM rather than nine.

Each section has its own URL, so it can be linked to, bookmarked, and reached with the back button.

**Layout.** Tabs sit across the top with icons, the active one underlined. The section's own cards are unchanged — they were already the design — and the panel around them is a bare landmark, so the cards' edges line up with the tab row above rather than sitting inset inside a second box.

## Three things that fall out of the move

- **Existing fragment links keep working.** Settings have been linked to by fragment from all over the app for a long time (`{% url ... %}#branding`). A fragment naming a real section is turned into a visit to that section's page, using `replace()` so the hop does not become a back-button step.
- **POST redirects go straight to the section's page** instead of loading the index to be bounced by script. The two names still in `ALLOWED_TABS` that have no page of their own (`controls`, `integrations`) keep the fragment form, so nothing that pointed at them breaks.
- **The Plugins section was orphaned.** It had a template and other pages linked to `#plugins`, but the nav never listed it, so it was unreachable from settings. It is a tab now.

## Also

The tab row was swallowing the scroll wheel: `overflow-x: auto` leaves a box vertically scrollable too, so the row is now explicitly `overflow-y: hidden`.

## Tests

476 team tests pass. Three assertions pinned the old fragment redirect and were updated to the page form — that is the behaviour this deliberately changes, not a test worked around. Frontend suite unchanged at 394 passing.

## Worth a reviewer's eye

I verified Branding and Trust Center in the browser; the other seven tabs are rendered by the same shell but have not been clicked through individually. Billing and Members carry the most context and are the ones most worth checking.