### PR TITLE
feat(vulns): suppressed-findings toggle, state and KEV filters on the internal drill-down

### DIFF
--- a/sbomify/apps/core/templates/core/component_details_private_base.html.j2
+++ b/sbomify/apps/core/templates/core/component_details_private_base.html.j2
@@ -150,7 +150,7 @@
                 </span>
             </div>
             {# Latest-scan vulnerability summary (design review / mock). #}
-            {% if vuln_summary.critical or vuln_summary.high or vuln_summary.medium or vuln_summary.low %}
+            {% if vuln_summary.critical or vuln_summary.high or vuln_summary.medium or vuln_summary.low or vuln_summary.suppressed %}
                 <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm {% if vuln_summary.critical or vuln_summary.high %}bg-danger/10 border border-danger/20{% else %}bg-warning/10 border border-warning/20{% endif %}">
                     <i class="fas fa-triangle-exclamation text-xs {% if vuln_summary.critical or vuln_summary.high %}text-danger{% else %}text-warning{% endif %}"></i>
                     {% if vuln_summary.critical %}
@@ -169,6 +169,10 @@
                             <span class="text-text-muted">·</span>
                         {% endif %}
                         <span class="font-semibold text-text-muted">{{ vuln_summary.low }} Low</span>
+                    {% endif %}
+                    {% comment %}Counts above exclude what VEX cleared, matching the Trust Center posture; the suppressed tally says so rather than letting the numbers silently shrink.{% endcomment %}
+                    {% if vuln_summary.suppressed %}
+                        <span class="text-text-muted">· {{ vuln_summary.suppressed }} suppressed</span>
                     {% endif %}
                     <span class="text-text-muted">· latest scan</span>
                 </div>

--- a/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
@@ -3,7 +3,11 @@
 {% if latest_vulns %}
     {{ latest_vuln_terms|json_script:"latest-vuln-terms" }}
     {{ latest_vuln_severities|json_script:"latest-vuln-severities" }}
-    <div x-data="{ open: true, search: '', sevFilter: 'all', page: 1, perPage: 5, terms: (window.parseJsonScript('latest-vuln-terms') || []), severities: (window.parseJsonScript('latest-vuln-severities') || []), get sevOptions() { const order = ['critical', 'high', 'medium', 'low', 'info']; const present = new Set(this.severities); return order.filter(v => present.has(v)).concat([...present].filter(v => !order.includes(v)).sort()); }, get filteredIdx() { const q = this.search.trim().toLowerCase(); return this.terms.map((t, i) => i).filter(i => (!q || this.terms[i].includes(q)) && (this.sevFilter === 'all' || this.severities[i] === this.sevFilter)); }, get total() { return this.filteredIdx.length; }, get pageCount() { return Math.max(1, Math.ceil(this.total / this.perPage)); }, get pageSet() { return new Set(this.filteredIdx.slice((this.page - 1) * this.perPage, this.page * this.perPage)); }, get startIdx() { return this.total ? (this.page - 1) * this.perPage + 1 : 0; }, get endIdx() { return Math.min(this.page * this.perPage, this.total); }, }"
+    {{ latest_vuln_states|json_script:"latest-vuln-states" }}
+    {{ latest_vuln_suppressed|json_script:"latest-vuln-suppressed" }}
+    {{ latest_vuln_kev|json_script:"latest-vuln-kev" }}
+    <div x-data="{ open: true, search: '', sevFilter: 'all', stateFilter: 'all', kevOnly: false, showSuppressed: false, page: 1, perPage: 5, terms: (window.parseJsonScript('latest-vuln-terms') || []), severities: (window.parseJsonScript('latest-vuln-severities') || []), states: (window.parseJsonScript('latest-vuln-states') || []), suppressedArr: (window.parseJsonScript('latest-vuln-suppressed') || []), kevArr: (window.parseJsonScript('latest-vuln-kev') || []), get sevOptions() { const order = ['critical', 'high', 'medium', 'low', 'info']; const present = new Set(this.severities); return order.filter(v => present.has(v)).concat([...present].filter(v => !order.includes(v)).sort()); }, get stateOptions() { const order = ['open', 'in_triage', 'exploitable', 'resolved', 'not_affected', 'false_positive']; const present = new Set(this.states); return order.filter(v => present.has(v)).concat([...present].filter(v => !order.includes(v)).sort()); }, stateLabel(v) { return ({ open: 'No decision', in_triage: 'Under investigation', exploitable: 'Affected', resolved: 'Fixed', not_affected: 'Not affected', false_positive: 'False positive' })[v] || v; }, get suppressedShown() { return this.showSuppressed || ['not_affected', 'false_positive'].includes(this.stateFilter); }, get filteredIdx() { const q = this.search.trim().toLowerCase(); return this.terms.map((t, i) => i).filter(i => (!q || this.terms[i].includes(q)) && (this.sevFilter === 'all' || this.severities[i] === this.sevFilter) && (this.stateFilter === 'all' || this.states[i] === this.stateFilter) && (!this.kevOnly || this.kevArr[i]) && (this.suppressedShown || !this.suppressedArr[i])); }, get suppressedTotal() { return this.suppressedArr.filter(Boolean).length; }, get total() { return this.filteredIdx.length; }, get pageCount() { return Math.max(1, Math.ceil(this.total / this.perPage)); }, get pageSet() { return new Set(this.filteredIdx.slice((this.page - 1) * this.perPage, this.page * this.perPage)); }, get startIdx() { return this.total ? (this.page - 1) * this.perPage + 1 : 0; }, get endIdx() { return Math.min(this.page * this.perPage, this.total); }, }"
+         x-effect="search; sevFilter; stateFilter; kevOnly; showSuppressed; page = 1"
          x-init="$watch('search', () => { page = 1 }); $watch('sevFilter', () => { page = 1 })"
          class="tw-card">
         <div class="px-6 py-4 border-b border-border cursor-pointer flex items-center justify-between gap-3"
@@ -38,6 +42,25 @@
                         <option :value="v" x-text="v.charAt(0).toUpperCase() + v.slice(1)"></option>
                     </template>
                 </select>
+                <label for="vuln-state-filter" class="sr-only">Filter by VEX analysis state</label>
+                <select id="vuln-state-filter"
+                        x-model="stateFilter"
+                        class="tw-data-table-page-size-select">
+                    <option value="all">All States</option>
+                    <template x-for="v in stateOptions" :key="v">
+                        <option :value="v" x-text="stateLabel(v)"></option>
+                    </template>
+                </select>
+                <label class="inline-flex items-center gap-2 text-sm text-text cursor-pointer">
+                    <input type="checkbox" x-model="kevOnly" class="tw-checkbox" />
+                    KEV only
+                </label>
+                {% comment %}Suppressed rows are hidden by default so the working list matches the open counts; the toggle reveals them struck through with their VEX state. Picking a suppressing state in the filter implies visibility.{% endcomment %}
+                <label class="inline-flex items-center gap-2 text-sm text-text cursor-pointer"
+                       x-show="suppressedTotal > 0">
+                    <input type="checkbox" x-model="showSuppressed" class="tw-checkbox" />
+                    Show suppressed (<span x-text="suppressedTotal"></span>)
+                </label>
             </div>
             <div class="overflow-x-auto" x-cloak>
                 <table class="tw-table w-full">
@@ -79,6 +102,10 @@
                                             <span class="font-medium text-text-muted">{{ vuln.id }}</span>
                                         {% endif %}
                                     {% endwith %}
+                                    {% if vuln.kev %}
+                                        <span class="ml-1.5 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded bg-danger text-white align-middle"
+                                              title="In CISA's Known Exploited Vulnerabilities catalog">KEV</span>
+                                    {% endif %}
                                     {% if vuln.aliases %}<div class="text-xs text-text-muted mt-1">Aliases: {{ vuln.aliases|join:", " }}</div>{% endif %}
                                 </td>
                                 <td class="px-6 py-4">
@@ -96,8 +123,7 @@
                                 </td>
                                 <td class="px-6 py-4">
                                     {% if vuln.vex_suppressed %}
-                                        <span class="text-info"
-                                              title="VEX: {{ vuln.vex_justification|default:'suppressed' }}">
+                                        <span class="text-info">
                                             {% if vuln.vex_state == 'false_positive' %}
                                                 False positive
                                             {% else %}
@@ -110,6 +136,11 @@
                                                 VEX
                                             {% endif %}
                                         </span>
+                                        {% if vuln.vex_justification %}<div class="text-xs text-text-muted mt-1">{{ vuln.vex_justification }}</div>{% endif %}
+                                    {% elif vuln.vex_state == 'in_triage' %}
+                                        <span class="text-warning">Under investigation</span>
+                                    {% elif vuln.vex_state == 'resolved' %}
+                                        <span class="text-success">Fixed</span>
                                     {% else %}
                                         <span class="text-text-muted">Affected</span>
                                     {% endif %}
@@ -127,6 +158,8 @@
                 <div class="flex items-center gap-4">
                     <span class="text-sm text-text-muted">
                         Showing <span x-text="startIdx"></span> to <span x-text="endIdx"></span> of <span x-text="total"></span>
+                        <span x-show="!suppressedShown && suppressedTotal > 0"
+                              x-text="'· ' + suppressedTotal + ' suppressed hidden'"></span>
                     </span>
                     {% if latest_vuln_sbom_id %}
                         <a href="{% url 'sboms:sbom_vulnerabilities' latest_vuln_sbom_id %}"

--- a/sbomify/apps/core/tests/test_component_views.py
+++ b/sbomify/apps/core/tests/test_component_views.py
@@ -392,3 +392,106 @@ class TestComponentItemVexAliasEnrichment:
         assert summary["total"] == 1
         assert summary["critical"] == 1
         assert summary["high"] == 0
+
+
+@pytest.mark.django_db
+class TestComponentVulnFilterContext:
+    """The internal drill-down's filter data: suppressed rows stay in the list
+    (revealed by the toggle), the header counts exclude them so they reconcile
+    with the Trust Center posture, and the per-row parallel lists feed the
+    severity / analysis-state / KEV filters."""
+
+    def _component_with_vex(self, team):
+
+        from sbomify.apps.plugins.models import AssessmentRun
+        from sbomify.apps.sboms.models import SBOM
+
+        component = Component.objects.create(
+            name="Filtered Component",
+            team=team,
+            component_type=Component.ComponentType.BOM,
+            visibility=Component.Visibility.PRIVATE,
+        )
+        sbom = SBOM.objects.create(
+            name="app",
+            version="2.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="app.json",
+            bom_type=SBOM.BomType.SBOM,
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            category="security",
+            status="completed",
+            result={
+                "findings": [
+                    {"id": "CVE-2026-1", "severity": "critical", "component": {"name": "a", "version": "1"}},
+                    {"id": "CVE-2026-2", "severity": "high", "component": {"name": "b", "version": "1"}},
+                ]
+            },
+        )
+        vex_doc = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2026-2",
+                    "affects": [{"ref": "pkg:pypi/b@1"}],
+                    "analysis": {"state": "not_affected", "justification": "code_not_reachable"},
+                }
+            ],
+        }
+        SBOM.objects.create(
+            name="app-vex",
+            version="1",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="vex.json",
+            bom_type=SBOM.BomType.VEX,
+            source="manual_upload",
+        )
+        return component, vex_doc
+
+    def test_summary_excludes_suppressed_and_lists_feed_the_filters(
+        self, sample_team_with_owner_member, sample_user, mocker
+    ):
+        import json
+
+        from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+        mocker.patch(
+            "sbomify.apps.vulnerability_scanning.kev.kev_ids_for_serialization",
+            return_value=frozenset({"cve-2026-1"}),
+        )
+        member = sample_team_with_owner_member
+        component, vex_doc = self._component_with_vex(member.team)
+        mocker.patch("sbomify.apps.core.object_store.S3Client").return_value.get_sbom_data.return_value = json.dumps(
+            vex_doc
+        ).encode()
+        client = Client()
+        setup_authenticated_client_session(client, member.team, sample_user)
+
+        response = client.get(reverse("core:component_details", kwargs={"component_id": component.id}))
+
+        assert response.status_code == 200
+        context = response.context
+        assert context["vuln_summary"] == {
+            "total": 1,
+            "critical": 1,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+            "suppressed": 1,
+        }
+        rows = {v["id"]: v for v in context["latest_vulns"]}
+        assert rows["CVE-2026-2"]["vex_suppressed"] is True
+        assert rows["CVE-2026-2"]["vex_justification"] == "code_not_reachable"
+        assert rows["CVE-2026-1"]["kev"] is True
+        assert context["latest_vuln_suppressed"] == [False, True]
+        assert context["latest_vuln_states"] == ["open", "not_affected"]
+        assert context["latest_vuln_kev"] == [True, False]

--- a/sbomify/apps/core/views/component_details_private.py
+++ b/sbomify/apps/core/views/component_details_private.py
@@ -120,20 +120,26 @@ class ComponentDetailsPrivateView(GuestAccessBlockedMixin, LoginRequiredMixin, V
                 .distinct("plugin_name")
                 .values_list("result", flat=True)
             )
-            vex_statements = load_vex_suppressions(component_id)
-            latest_vulns = extract_finding_rows(merge_findings_by_alias(provider_results), vex_statements)
+            from sbomify.apps.vulnerability_scanning.kev import kev_ids_for_serialization
 
-        # The header badge counts the same merged, VEX-filtered view the table
-        # shows — counting a single run would disagree with the rows (e.g. OSV
-        # rates a finding high where DT said medium).
+            vex_statements = load_vex_suppressions(component_id)
+            latest_vulns = extract_finding_rows(
+                merge_findings_by_alias(provider_results), vex_statements, kev_ids_for_serialization()
+            )
+
+        # The header badge counts the same merged view the table shows, minus
+        # what VEX suppressed — matching the Trust Center posture, which lists
+        # suppressed findings separately rather than inside the severity counts.
         vuln_summary = None
+        open_vulns = [v for v in latest_vulns if not v["vex_suppressed"]]
         if latest_vulns:
             vuln_summary = {
-                "total": len(latest_vulns),
-                "critical": sum(1 for v in latest_vulns if v["severity"] == "critical"),
-                "high": sum(1 for v in latest_vulns if v["severity"] == "high"),
-                "medium": sum(1 for v in latest_vulns if v["severity"] == "medium"),
-                "low": sum(1 for v in latest_vulns if v["severity"] == "low"),
+                "total": len(open_vulns),
+                "critical": sum(1 for v in open_vulns if v["severity"] == "critical"),
+                "high": sum(1 for v in open_vulns if v["severity"] == "high"),
+                "medium": sum(1 for v in open_vulns if v["severity"] == "medium"),
+                "low": sum(1 for v in open_vulns if v["severity"] == "low"),
+                "suppressed": len(latest_vulns) - len(open_vulns),
             }
         elif latest_scan_result:
             vuln_summary = extract_severity_counts(latest_scan_result)
@@ -142,8 +148,12 @@ class ComponentDetailsPrivateView(GuestAccessBlockedMixin, LoginRequiredMixin, V
         latest_vuln_terms = [
             f"{v['id']} {' '.join(v['aliases'])} {v['package']} {v['ecosystem']}".lower() for v in latest_vulns
         ]
-        # Parallel severity list so the drill-down's type/severity dropdown can filter by index.
+        # Parallel per-row lists so the drill-down's dropdowns and toggles can
+        # filter by index without re-serializing the rows.
         latest_vuln_severities = [v["severity"] for v in latest_vulns]
+        latest_vuln_states = [v["vex_state"] or "open" for v in latest_vulns]
+        latest_vuln_suppressed = [v["vex_suppressed"] for v in latest_vulns]
+        latest_vuln_kev = [v["kev"] for v in latest_vulns]
 
         # CBOM issues drill-down: the newest crypto-bearing artifact's
         # fail/warning compliance findings (newest CBOM, else the newest mixed
@@ -166,6 +176,9 @@ class ComponentDetailsPrivateView(GuestAccessBlockedMixin, LoginRequiredMixin, V
             "latest_vulns": latest_vulns,
             "latest_vuln_terms": latest_vuln_terms,
             "latest_vuln_severities": latest_vuln_severities,
+            "latest_vuln_states": latest_vuln_states,
+            "latest_vuln_suppressed": latest_vuln_suppressed,
+            "latest_vuln_kev": latest_vuln_kev,
             "latest_vuln_version": latest_sbom["version"] if latest_sbom else None,
             "latest_vuln_sbom_id": latest_sbom_id,
             "latest_cbom_issues": cbom_issues.issues,

--- a/sbomify/apps/core/views/component_details_private.py
+++ b/sbomify/apps/core/views/component_details_private.py
@@ -124,7 +124,9 @@ class ComponentDetailsPrivateView(GuestAccessBlockedMixin, LoginRequiredMixin, V
 
             vex_statements = load_vex_suppressions(component_id)
             latest_vulns = extract_finding_rows(
-                merge_findings_by_alias(provider_results), vex_statements, kev_ids_for_serialization()
+                merge_findings_by_alias(provider_results),
+                vex_statements=vex_statements,
+                kev_ids=kev_ids_for_serialization(),
             )
 
         # The header badge counts the same merged view the table shows, minus

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -204,3 +204,29 @@ def test_merge_findings_by_alias_is_transitive():
     assert set(only["aliases"]) == {"GHSA-x", "OSV-9"}
     assert only["severity"] == "critical"
     assert only["cvss_score"] == 9.1
+
+
+def test_extract_finding_rows_stamps_kev_by_id_and_alias():
+    from sbomify.apps.vulnerability_scanning.utils import extract_finding_rows
+
+    result = {
+        "findings": [
+            {"id": "CVE-2021-44228", "severity": "critical"},
+            {"id": "GHSA-x", "aliases": ["CVE-2021-44228"], "severity": "high"},
+            {"id": "CVE-2026-1", "severity": "low"},
+        ]
+    }
+
+    rows = {r["id"]: r for r in extract_finding_rows(result, kev_ids=frozenset({"cve-2021-44228"}))}
+
+    assert rows["CVE-2021-44228"]["kev"] is True
+    assert rows["GHSA-x"]["kev"] is True
+    assert rows["CVE-2026-1"]["kev"] is False
+
+
+def test_extract_finding_rows_without_a_catalog_flags_nothing():
+    from sbomify.apps.vulnerability_scanning.utils import extract_finding_rows
+
+    rows = extract_finding_rows({"findings": [{"id": "CVE-2021-44228"}]})
+
+    assert rows[0]["kev"] is False

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any
 
+from sbomify.apps.vulnerability_scanning.kev import finding_in_kev
 from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
 
 _ZERO_COUNTS = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
@@ -150,7 +151,9 @@ def merge_findings_by_alias(results: list[dict[str, Any] | None]) -> dict[str, A
 
 
 def extract_finding_rows(
-    result_json: dict[str, Any] | None, vex_statements: list[dict[str, Any]] | None = None
+    result_json: dict[str, Any] | None,
+    vex_statements: list[dict[str, Any]] | None = None,
+    kev_ids: frozenset[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Flatten an AssessmentRun result's findings into severity-sorted display rows.
 
@@ -164,6 +167,10 @@ def extract_finding_rows(
     finding's VEX status live, so a finding cleared by a VEX uploaded after the
     scan still reads "not affected" without a re-scan. A finding's own stored
     ``analysis_state`` (set when the scan ran after the VEX) takes precedence.
+
+    ``kev_ids`` (the cached CISA catalog) stamps a ``kev`` flag per row the
+    same way the assessments panel does, so exploited findings can be badged
+    and filtered without another lookup layer.
     """
     if not result_json:
         return []
@@ -222,6 +229,7 @@ def extract_finding_rows(
                 "vex_suppressed": vex_state in _SUPPRESSING_VEX_STATES,
                 "vex_manual": vex_manual,
                 "malicious": is_malicious_finding(vuln),
+                "kev": bool(kev_ids) and finding_in_kev(vuln, kev_ids or frozenset()),
                 "source": vuln.get("source") or "",
             }
         )


### PR DESCRIPTION
Closes #1196.

## The gap

The component page's vulnerabilities drill-down mixed VEX-suppressed rows into the list, and the header badge counted them — so the internal numbers disagreed with the Trust Center posture, which lists suppressed findings separately from the severity counts. The only filters were search and severity.

## What changed

- **Show suppressed toggle.** Suppressed rows hide by default; `Show suppressed (N)` reveals them struck through with their VEX state, origin (manual triage vs imported VEX), and the justification text now visible in the Status column rather than buried in a tooltip.
- **Analysis-state filter.** All states / No decision / Under investigation / Affected / Fixed / Not affected / False positive, driven by a per-row parallel list. Picking a suppressing state implies visibility, so the filter can never select rows the toggle is hiding — no confusing empty lists.
- **KEV-only filter.** `extract_finding_rows` now stamps a `kev` flag per row from the cached CISA catalog (id or alias), the same read-time derivation the assessments panel uses, and the row renders a KEV chip. Every caller of `extract_finding_rows` keeps its behaviour — the flag is false without a catalog.
- **Counts reconcile.** The header badge counts open findings only and names the suppressed tally beside them (`2 Critical · 1 High · 2 suppressed · latest scan`), so the reconciliation with the Trust Center is visible rather than silent. A fully-suppressed component still shows its suppressed count instead of a blank header.
- Status column also distinguishes `Under investigation` and `Fixed` states that previously all rendered as `Affected`.

## Verification

- Live browser drill on a component with 4 findings / 2 suppressed: default view shows 2 open rows with "2 suppressed hidden", the toggle reveals both struck-through rows with `code_not_reachable` justification text, the state filter surfaces suppressed rows with the toggle off, and the header badge reads "· 2 suppressed".
- New view test pinning the context: summary excludes suppressed and carries the suppressed count; parallel state/suppressed/KEV lists line up per row; VEX justification and KEV flags land on rows. Two new `extract_finding_rows` tests for KEV stamping by id and alias, and the no-catalog default.
- 345 tests across the touched apps pass; ruff, mypy, djlint clean.