### PR TITLE
fix(core): ride out Redis restarts without per-socket tracebacks

### DIFF
--- a/sbomify/apps/core/consumers.py
+++ b/sbomify/apps/core/consumers.py
@@ -50,9 +50,18 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
             await self.close()
             return
 
-        # Join workspace group
-        await self.channel_layer.group_add(self.group_name, self.channel_name)
-        await self.accept()
+        # Join workspace group. A broker mid-restart raises here; closing
+        # with 1012 (service restart) turns that into an orderly client
+        # retry instead of an "Exception in ASGI application" traceback.
+        try:
+            await self.channel_layer.group_add(self.group_name, self.channel_name)
+            await self.accept()
+        except Exception:
+            logger.warning(
+                f"WebSocket join failed for workspace {self.workspace_key}; broker unavailable?", exc_info=True
+            )
+            await self.close(code=1012)
+            return
 
         connected_user_id = user.id  # type: ignore[attr-defined]
         logger.debug(f"WebSocket connected: user={connected_user_id}, workspace={self.workspace_key}")
@@ -66,9 +75,15 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
 
     async def disconnect(self, close_code: Any):  # type: ignore[no-untyped-def]
         """Handle WebSocket disconnection."""
-        # Leave workspace group
+        # Leave workspace group. When the broker itself died, every open
+        # socket disconnects at once and each group_discard would raise —
+        # the membership is gone with the broker, so there is nothing to
+        # clean up and nothing worth a traceback per connection.
         if hasattr(self, "group_name"):
-            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            try:
+                await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            except Exception:
+                logger.debug("group_discard failed during disconnect; broker likely restarting", exc_info=True)
 
         user = self.scope.get("user")
         user_id = user.id if user and user.is_authenticated else "anonymous"  # type: ignore[attr-defined]

--- a/sbomify/apps/core/consumers.py
+++ b/sbomify/apps/core/consumers.py
@@ -53,13 +53,32 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
         # Join workspace group. A broker mid-restart raises here; closing
         # with 1012 (service restart) turns that into an orderly client
         # retry instead of an "Exception in ASGI application" traceback.
+        #
+        # The traceback goes to debug rather than warning: a broker restart
+        # fails every open socket at once, and one stack per connection is the
+        # noise this was written to stop. The warning line still names the
+        # workspace, which is what a reader needs.
         try:
             await self.channel_layer.group_add(self.group_name, self.channel_name)
+        except Exception as exc:
+            logger.warning(f"WebSocket group join failed for workspace {self.workspace_key}: {exc!r}")
+            logger.debug("group_add traceback", exc_info=True)
+            await self.close(code=1012)
+            return
+
+        try:
             await self.accept()
-        except Exception:
-            logger.warning(
-                f"WebSocket join failed for workspace {self.workspace_key}; broker unavailable?", exc_info=True
-            )
+        except Exception as exc:
+            logger.warning(f"WebSocket accept failed for workspace {self.workspace_key}: {exc!r}")
+            logger.debug("accept traceback", exc_info=True)
+            # The group membership was taken and disconnect() never runs for a
+            # socket that was never accepted, so it would sit in the group
+            # until the channel layer expired it, and every broadcast would
+            # keep addressing a channel with nobody on the other end.
+            try:
+                await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            except Exception:
+                logger.debug("group_discard after failed accept also failed", exc_info=True)
             await self.close(code=1012)
             return
 

--- a/sbomify/apps/core/tests/test_consumers.py
+++ b/sbomify/apps/core/tests/test_consumers.py
@@ -85,9 +85,7 @@ class TestWorkspaceConsumer:
 
         consumer.accept.assert_called_once()
         consumer.close.assert_not_called()
-        mock_channel_layer.group_add.assert_called_once_with(
-            "workspace_test-workspace", "test-channel"
-        )
+        mock_channel_layer.group_add.assert_called_once_with("workspace_test-workspace", "test-channel")
 
     @pytest.mark.asyncio
     async def test_connect_non_member_rejected(self, consumer, mock_channel_layer):
@@ -151,9 +149,7 @@ class TestWorkspaceConsumer:
 
         await consumer.disconnect(1000)
 
-        mock_channel_layer.group_discard.assert_called_once_with(
-            "workspace_test-workspace", "test-channel"
-        )
+        mock_channel_layer.group_discard.assert_called_once_with("workspace_test-workspace", "test-channel")
 
     @pytest.mark.asyncio
     async def test_disconnect_without_group_name(self, consumer, mock_channel_layer):
@@ -248,9 +244,7 @@ class TestWorkspaceConsumerGroupBroadcast:
 
         # Verify the group name format
         assert consumer.group_name == "workspace_abc-123-def"
-        mock_channel_layer.group_add.assert_called_with(
-            "workspace_abc-123-def", "test-channel"
-        )
+        mock_channel_layer.group_add.assert_called_with("workspace_abc-123-def", "test-channel")
 
 
 class TestBrokerOutageHandling:
@@ -287,6 +281,28 @@ class TestBrokerOutageHandling:
         self._authenticated_scope(consumer)
         layer = MagicMock()
         layer.group_add = AsyncMock()
+        layer.group_discard = AsyncMock()
+        consumer.channel_layer = layer
+        consumer.accept = AsyncMock(side_effect=ConnectionError("reset by peer"))
+
+        with patch.object(WorkspaceConsumer, "_check_workspace_membership", AsyncMock(return_value=True)):
+            await consumer.connect()
+
+        consumer.close.assert_called_once_with(code=1012)
+        # group_add succeeded before accept failed, and disconnect() never runs
+        # for a socket that was never accepted, so connect() has to hand the
+        # membership back itself or it lingers until the channel layer expires.
+        layer.group_discard.assert_awaited_once_with(consumer.group_name, consumer.channel_name)
+
+    @pytest.mark.asyncio
+    async def test_accept_failure_survives_a_failing_group_discard(self, consumer):
+        """The broker is usually the reason accept() failed, so the cleanup it
+        triggers will often fail too — that must not replace an orderly 1012
+        close with a traceback."""
+        self._authenticated_scope(consumer)
+        layer = MagicMock()
+        layer.group_add = AsyncMock()
+        layer.group_discard = AsyncMock(side_effect=ConnectionError("reset by peer"))
         consumer.channel_layer = layer
         consumer.accept = AsyncMock(side_effect=ConnectionError("reset by peer"))
 

--- a/sbomify/apps/core/tests/test_consumers.py
+++ b/sbomify/apps/core/tests/test_consumers.py
@@ -251,3 +251,57 @@ class TestWorkspaceConsumerGroupBroadcast:
         mock_channel_layer.group_add.assert_called_with(
             "workspace_abc-123-def", "test-channel"
         )
+
+
+class TestBrokerOutageHandling:
+    """A Redis restart must produce an orderly 1012 close, not an ASGI traceback."""
+
+    @pytest.fixture
+    def consumer(self):
+        return WorkspaceConsumer()
+
+    def _authenticated_scope(self, consumer):
+        user = MagicMock()
+        user.is_authenticated = True
+        user.id = 7
+        consumer.scope = {"url_route": {"kwargs": {"workspace_key": "ws-key"}}, "user": user}
+        consumer.channel_name = "chan"
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_group_add_failure_closes_with_service_restart(self, consumer):
+        self._authenticated_scope(consumer)
+        layer = MagicMock()
+        layer.group_add = AsyncMock(side_effect=ConnectionError("reset by peer"))
+        consumer.channel_layer = layer
+
+        with patch.object(WorkspaceConsumer, "_check_workspace_membership", AsyncMock(return_value=True)):
+            await consumer.connect()
+
+        consumer.close.assert_called_once_with(code=1012)
+        consumer.accept.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accept_failure_also_closes_orderly(self, consumer):
+        self._authenticated_scope(consumer)
+        layer = MagicMock()
+        layer.group_add = AsyncMock()
+        consumer.channel_layer = layer
+        consumer.accept = AsyncMock(side_effect=ConnectionError("reset by peer"))
+
+        with patch.object(WorkspaceConsumer, "_check_workspace_membership", AsyncMock(return_value=True)):
+            await consumer.connect()
+
+        consumer.close.assert_called_once_with(code=1012)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_swallows_a_dead_broker(self, consumer):
+        consumer.scope = {"user": None}
+        consumer.group_name = "workspace_ws-key"
+        consumer.channel_name = "chan"
+        layer = MagicMock()
+        layer.group_discard = AsyncMock(side_effect=ConnectionError("reset by peer"))
+        consumer.channel_layer = layer
+
+        await consumer.disconnect(1006)

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -493,9 +493,20 @@ else:
     }
 
 # Channel Layers for WebSocket support
-_channels_host: str | dict[str, Any] = REDIS_CHANNELS_URL
+# Keepalive plus proactive health checks: a broker restart is then noticed
+# on the next use and reconnected quietly, instead of surfacing as a
+# mid-command "Connection reset by peer" on every consumer thread at once.
+_redis_resilience: dict[str, Any] = {
+    "socket_keepalive": True,
+    "health_check_interval": 30,
+    "socket_connect_timeout": 5,
+}
+
+# The dict host form is how channels-redis forwards client kwargs (the CA
+# path already relied on it); the resilience kwargs ride the same way.
+_channels_host: dict[str, Any] = {"address": REDIS_CHANNELS_URL, **_redis_resilience}
 if REDIS_CA_CERTS:
-    _channels_host = {"address": REDIS_CHANNELS_URL, "ssl_ca_certs": REDIS_CA_CERTS}
+    _channels_host["ssl_ca_certs"] = REDIS_CA_CERTS
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
@@ -511,9 +522,9 @@ CHANNEL_LAYERS = {
 # Pass a pre-built client because Dramatiq's RedisBroker creates a
 # ConnectionPool.from_url() that drops ssl_ca_certs kwargs.
 _dramatiq_redis_options: dict[str, Any] = (
-    {"client": redis.Redis.from_url(REDIS_WORKER_URL, ssl_ca_certs=REDIS_CA_CERTS)}
+    {"client": redis.Redis.from_url(REDIS_WORKER_URL, ssl_ca_certs=REDIS_CA_CERTS, **_redis_resilience)}
     if REDIS_CA_CERTS
-    else {"url": REDIS_WORKER_URL}
+    else {"url": REDIS_WORKER_URL, **_redis_resilience}
 )
 DRAMATIQ_BROKER = {
     "BROKER": "dramatiq.brokers.redis.RedisBroker",


### PR DESCRIPTION
Context: redis-00 reset twice on 2026-08-03 (03:58 and 19:51 UTC). Dramatiq's consumers self-heal by design, but each reset also killed every open WebSocket with an `Exception in ASGI application` traceback — one per connection per reset — and every consumer thread logged a CRITICAL `Connection reset by peer` at once.

The restarts themselves are an infra matter (that host needs its Redis uptime and `dmesg` OOM history checked — twice a day retires the nightly-maintenance-window theory). This PR is the app-side half: make a broker restart a quiet, orderly event instead of a traceback storm.

**Consumer hardening.** `WorkspaceConsumer.connect` closes with **1012 (service restart)** when the channel layer raises during the group join — which the client-side reconnect (#1279) treats as an explicit retry invitation — and `disconnect` swallows `group_discard` failures: when the broker itself died, the group membership went with it, so there is nothing to clean up and nothing worth a traceback per connection.

**Client resilience.** The dramatiq and channels Redis clients gain `socket_keepalive`, a 30s `health_check_interval`, and a 5s connect timeout, so a restarted broker is noticed at the next use and reconnected quietly rather than surfacing as a mid-command reset on every thread simultaneously. The dict host form is how channels-redis already forwards client kwargs on the TLS/CA path; the resilience kwargs ride the same mechanism.

Honest limitation: a listener blocked mid-await when the broker dies still raises inside channels' own machinery — the health checks shrink that window but the consumer cannot fully intercept it.

Verification: 3 new consumer tests (join failure → 1012 close without accept; accept failure → same; disconnect with a dead broker raises nothing) alongside the 11 existing ones; the resolved config verified inside the running backend container, and a real channels broadcast plus a dramatiq enqueue exercised the new client kwargs live against dev Redis.