### PR TITLE
feat(core): end-of-life transition readiness, announcement and final artifacts

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -770,6 +770,36 @@ def get_product(request: HttpRequest, product_id: str) -> Any:
     return status, result.payload
 
 
+@router.get(
+    "/products/{product_id}/eol-readiness",
+    response={200: dict[str, Any], 403: ErrorResponse, 404: ErrorResponse},
+    summary="Whether a product can reach end of life with CRA 6.1.6 satisfied",
+    description="Reports the notice period, the critical and high findings neither patched nor formally "
+    "risk-accepted, and whether a final SBOM and VEX exist to publish.",
+)
+def get_product_eol_readiness(request: HttpRequest, product_id: str) -> Any:
+    """The pre-EOL check (CRA checklist 6.1.5/6.1.6)."""
+    from dataclasses import asdict
+
+    from sbomify.apps.core.services.eol import eol_readiness
+
+    status, result = _get_product_with_instance(request, product_id)
+    if status != 200:
+        return status, result
+
+    assert isinstance(result, ProductLookupResult)
+    readiness = eol_readiness(result.instance)
+    payload = asdict(readiness)
+    # The derived verdicts are the point of the endpoint; a caller should not
+    # have to re-implement the checklist rule to read the answer.
+    payload["is_ready"] = readiness.is_ready
+    payload["blocking_count"] = readiness.blocking_count
+    payload["problems"] = readiness.problems
+    payload["end_of_support"] = readiness.end_of_support.isoformat() if readiness.end_of_support else None
+    payload["end_of_life"] = readiness.end_of_life.isoformat() if readiness.end_of_life else None
+    return 200, payload
+
+
 @router.put(
     "/products/{product_id}",
     response={200: ProductResponseSchema, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -788,6 +788,14 @@ def get_product_eol_readiness(request: HttpRequest, product_id: str) -> Any:
         return status, result
 
     assert isinstance(result, ProductLookupResult)
+    # _get_product_with_instance only checks access for private products — a
+    # public one is readable by anyone, which is right for the product page and
+    # wrong here. Readiness lists the product's unresolved critical and high
+    # findings by advisory id, which is internal remediation state and not
+    # something being publicly listed makes public.
+    if not can(request, "product:manage", result.instance):
+        return 403, {"detail": "Access denied", "error_code": ErrorCode.FORBIDDEN}
+
     readiness = eol_readiness(result.instance)
     payload = asdict(readiness)
     # The derived verdicts are the point of the endpoint; a caller should not

--- a/sbomify/apps/core/services/eol.py
+++ b/sbomify/apps/core/services/eol.py
@@ -73,7 +73,10 @@ class EolReadiness:
                 f"{len(self.unresolved_high)} high finding(s) neither patched nor risk-accepted (checklist 6.1.6)."
             )
         if not self.has_final_sbom:
-            problems.append("No SBOM on the product's latest release to publish as the final one (checklist 6.1.6).")
+            problems.append(
+                "No SBOM on the release chosen as final to publish (checklist 6.1.6). "
+                "The newest versioned release is chosen, not the floating latest pointer."
+            )
         return problems
 
 
@@ -92,8 +95,13 @@ def _final_release(product: Any) -> Any:
     """
     from sbomify.apps.core.models import Release
 
+    # Ordered the way Release itself is ordered: released_at first, created_at
+    # only to break ties. A release row can be created before an earlier-dated
+    # one is published, and sorting on created_at alone would then call the
+    # wrong release final.
     releases = Release.objects.filter(product=product)
-    return releases.filter(is_latest=False).order_by("-created_at").first() or releases.order_by("-created_at").first()
+    newest = ("-released_at", "-created_at")
+    return releases.filter(is_latest=False).order_by(*newest).first() or releases.order_by(*newest).first()
 
 
 def eol_readiness(
@@ -130,9 +138,12 @@ def eol_readiness(
     if not components:
         return readiness
 
-    # A live acceptance keyed by advisory id. Component-scoped, because that
-    # is the scope a triage decision is recorded at.
-    accepted: set[str] = set()
+    # Live acceptances keyed by (component, advisory id). A triage decision is
+    # recorded against one component, so a single set of advisory ids would let
+    # an acceptance on component A clear the same advisory on component B — the
+    # readiness check would then report fewer blockers than there are, which is
+    # the direction that matters here.
+    accepted: set[tuple[str, str]] = set()
     for component in components:
         for statement in current_triage_index(component).values():
             if statement.get("state") != risk_accepted_state:
@@ -140,7 +151,7 @@ def eol_readiness(
             raw = statement.get("accepted_until")
             try:
                 if raw and date.fromisoformat(str(raw)) >= today:
-                    accepted.add((statement.get("id") or "").lower())
+                    accepted.add((str(component.id), (statement.get("id") or "").lower()))
             except ValueError:
                 continue
     readiness.accepted_count = len(accepted)
@@ -149,7 +160,7 @@ def eol_readiness(
         component__in=components, resolved_at__isnull=True, severity__in=("critical", "high")
     ).only("advisory_id", "severity", "component_id", "first_seen_at")
     for row in open_rows:
-        if row.advisory_id.lower() in accepted:
+        if (str(row.component_id), row.advisory_id.lower()) in accepted:
             continue
         entry = {
             "advisory_id": row.advisory_id,

--- a/sbomify/apps/core/services/eol.py
+++ b/sbomify/apps/core/services/eol.py
@@ -1,0 +1,261 @@
+"""End-of-life transition for a product (CRA checklist 6.1).
+
+``Product.end_of_support`` and ``end_of_life`` already existed and nothing
+happened when they arrived. The dates were the easy half; these are the
+obligations attached to them.
+
+Three pieces, in the order a product actually moves through them:
+
+1. :func:`eol_readiness` — what stands between the product and a defensible
+   EOL. Checklist 6.1.6 requires every known critical and high vulnerability
+   patched **or formally risk-accepted** before EOL, which is why this waited
+   on the risk-acceptance state: without it there was no way to distinguish
+   "unresolved" from "accepted deliberately".
+2. :func:`build_eol_advisory` — the announcement, published through the same
+   channel as security advisories (6.1.4/6.1.6 explicitly want one channel).
+3. :func:`final_artifacts` — the last release's SBOM and VEX, which is what a
+   downstream integrator actually needs after support stops. A durable
+   artifact rather than a notification.
+
+Nothing here fires automatically. An EOL announcement is an irreversible
+public statement about a product's support, so the sweep surfaces the
+obligation and a human publishes it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+# Checklist 6.1.6 recommends twelve months' notice for enterprise products.
+# A default rather than a constant: a workspace shipping consumer devices may
+# reasonably choose less, and the figure belongs in the announcement either way.
+DEFAULT_EOL_NOTICE_DAYS = 365
+
+
+@dataclass
+class EolReadiness:
+    """Whether a product can reach EOL with the checklist satisfied."""
+
+    product_id: str
+    end_of_support: date | None = None
+    end_of_life: date | None = None
+    days_to_end_of_support: int | None = None
+    days_to_end_of_life: int | None = None
+    notice_given: bool = False
+    unresolved_critical: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_high: list[dict[str, Any]] = field(default_factory=list)
+    accepted_count: int = 0
+    has_final_sbom: bool = False
+    has_final_vex: bool = False
+
+    @property
+    def blocking_count(self) -> int:
+        return len(self.unresolved_critical) + len(self.unresolved_high)
+
+    @property
+    def is_ready(self) -> bool:
+        """6.1.6: every critical and high patched or formally risk-accepted,
+        and a final SBOM to leave behind."""
+        return self.blocking_count == 0 and self.has_final_sbom
+
+    @property
+    def problems(self) -> list[str]:
+        problems: list[str] = []
+        if self.unresolved_critical:
+            problems.append(
+                f"{len(self.unresolved_critical)} critical finding(s) neither patched nor risk-accepted "
+                "(checklist 6.1.6)."
+            )
+        if self.unresolved_high:
+            problems.append(
+                f"{len(self.unresolved_high)} high finding(s) neither patched nor risk-accepted (checklist 6.1.6)."
+            )
+        if not self.has_final_sbom:
+            problems.append("No SBOM on the product's latest release to publish as the final one (checklist 6.1.6).")
+        return problems
+
+
+def _days_between(target: date | None, today: date) -> int | None:
+    return None if target is None else (target - today).days
+
+
+def _final_release(product: Any) -> Any:
+    """The release whose artifacts should be published as final.
+
+    A real, versioned release in preference to the floating ``latest``, which
+    re-targets as artifacts arrive: pinning "final" to a moving pointer would
+    mean the final SBOM changed after the product stopped being supported.
+    ``latest`` is the fallback only when the product never cut a versioned
+    release, where publishing something beats publishing nothing.
+    """
+    from sbomify.apps.core.models import Release
+
+    releases = Release.objects.filter(product=product)
+    return releases.filter(is_latest=False).order_by("-created_at").first() or releases.order_by("-created_at").first()
+
+
+def eol_readiness(
+    product: Any, *, today: date | None = None, notice_days: int = DEFAULT_EOL_NOTICE_DAYS
+) -> EolReadiness:
+    """What stands between this product and a defensible end of life.
+
+    A finding counts as handled when it is resolved or carries a live formal
+    risk acceptance. A *lapsed* acceptance does not count: an expired
+    decision is exactly the thing the acceptance expiry exists to resurface,
+    and letting it pass here would make the expiry decorative.
+    """
+    from sbomify.apps.plugins.models import VulnerabilityLifecycle
+    from sbomify.apps.sboms.models import SBOM
+    from sbomify.apps.vulnerability_scanning import triage as triage_module
+    from sbomify.apps.vulnerability_scanning.triage import current_triage_index
+
+    # The risk-accepted state ships in #1296; until that lands this degrades
+    # to "nothing is accepted", which fails safe — findings stay blocking.
+    risk_accepted_state = getattr(triage_module, "RISK_ACCEPTED_STATE", "risk_accepted")
+
+    today = today or date.today()
+    readiness = EolReadiness(
+        product_id=str(product.id),
+        end_of_support=product.end_of_support,
+        end_of_life=product.end_of_life,
+        days_to_end_of_support=_days_between(product.end_of_support, today),
+        days_to_end_of_life=_days_between(product.end_of_life, today),
+    )
+    if readiness.days_to_end_of_life is not None:
+        readiness.notice_given = readiness.days_to_end_of_life >= notice_days
+
+    components = list(product.components.all())
+    if not components:
+        return readiness
+
+    # A live acceptance keyed by advisory id. Component-scoped, because that
+    # is the scope a triage decision is recorded at.
+    accepted: set[str] = set()
+    for component in components:
+        for statement in current_triage_index(component).values():
+            if statement.get("state") != risk_accepted_state:
+                continue
+            raw = statement.get("accepted_until")
+            try:
+                if raw and date.fromisoformat(str(raw)) >= today:
+                    accepted.add((statement.get("id") or "").lower())
+            except ValueError:
+                continue
+    readiness.accepted_count = len(accepted)
+
+    open_rows = VulnerabilityLifecycle.objects.filter(
+        component__in=components, resolved_at__isnull=True, severity__in=("critical", "high")
+    ).only("advisory_id", "severity", "component_id", "first_seen_at")
+    for row in open_rows:
+        if row.advisory_id.lower() in accepted:
+            continue
+        entry = {
+            "advisory_id": row.advisory_id,
+            "component_id": str(row.component_id),
+            "first_seen_at": row.first_seen_at.isoformat() if row.first_seen_at else None,
+        }
+        if row.severity == "critical":
+            readiness.unresolved_critical.append(entry)
+        else:
+            readiness.unresolved_high.append(entry)
+
+    final_release = _final_release(product)
+    if final_release is not None:
+        types = set(SBOM.objects.filter(releaseartifact__release=final_release).values_list("bom_type", flat=True))
+        readiness.has_final_sbom = SBOM.BomType.SBOM in types
+        readiness.has_final_vex = SBOM.BomType.VEX in types
+    return readiness
+
+
+def build_eol_advisory(product: Any, user: Any, *, migration_path: str = "") -> Any:
+    """Draft the EOL announcement as a workspace advisory.
+
+    Deliberately a draft: an EOL announcement is an irreversible public
+    statement about a product's support, so a human publishes it. The
+    advisory channel is the same one 6.1.4 and 6.1.6 ask EOL notices to share
+    with security advisories, and the Trust Center already surfaces it.
+    """
+    from sbomify.apps.security_advisories.models import AdvisoryEvent, AdvisoryProduct, SecurityAdvisory
+
+    readiness = eol_readiness(product)
+    when = product.end_of_life or product.end_of_support
+    body_lines = [
+        f"{product.name} reaches end of life on {when.isoformat()}." if when else f"{product.name} is being retired.",
+        "",
+        "After that date the product receives no further security updates, "
+        "including for vulnerabilities disclosed after this notice.",
+    ]
+    if product.end_of_support and product.end_of_life and product.end_of_support != product.end_of_life:
+        body_lines.append(
+            f"Bug fixes stopped on {product.end_of_support.isoformat()}; security-only support runs to "
+            f"{product.end_of_life.isoformat()}."
+        )
+    if migration_path:
+        body_lines += ["", f"Migration path: {migration_path}"]
+    if readiness.accepted_count:
+        body_lines += [
+            "",
+            f"{readiness.accepted_count} known vulnerability(ies) are formally risk-accepted rather than "
+            "patched; the final VEX records each decision.",
+        ]
+
+    advisory = SecurityAdvisory.objects.create(
+        team=product.team,
+        title=f"End of life: {product.name}",
+        summary=f"{product.name} reaches end of life" + (f" on {when.isoformat()}" if when else ""),
+        description="\n".join(body_lines),
+        # The retirement is decided, so the remediation axis is closed. It is
+        # the publication axis that stays draft until a human says so.
+        remediation_status=SecurityAdvisory.RemediationStatus.WONT_FIX,
+        created_by=user,
+    )
+    AdvisoryProduct.objects.create(advisory=advisory, product=product)
+    AdvisoryEvent.objects.create(
+        advisory=advisory,
+        event_type=AdvisoryEvent.EventType.STATUS_CHANGE,
+        actor=user,
+        body="End-of-life notice drafted.",
+        payload={"to": SecurityAdvisory.RemediationStatus.WONT_FIX.value, "kind": "eol"},
+    )
+    return advisory
+
+
+def final_artifacts(product: Any) -> dict[str, Any]:
+    """The SBOM and VEX to publish as final, from the product's newest release.
+
+    What a downstream integrator needs after support stops: the last known
+    composition and the last statement about which vulnerabilities in it
+    matter.
+    """
+    from sbomify.apps.sboms.models import SBOM
+
+    release = _final_release(product)
+    if release is None:
+        return {"release": None, "sboms": [], "vex": []}
+
+    artifacts = list(SBOM.objects.filter(releaseartifact__release=release).only("id", "name", "version", "bom_type"))
+    return {
+        "release": release,
+        "sboms": [a for a in artifacts if a.bom_type == SBOM.BomType.SBOM],
+        "vex": [a for a in artifacts if a.bom_type == SBOM.BomType.VEX],
+    }
+
+
+def products_approaching_eol(team: Any, *, within_days: int = 90, today: date | None = None) -> list[Any]:
+    """Products whose end-of-support or end-of-life lands inside the window.
+
+    Past dates are included: a product that quietly passed its EOL without
+    an announcement is the case most worth surfacing, not the one to hide.
+    """
+    from django.db.models import Q
+
+    from sbomify.apps.core.models import Product
+
+    today = today or date.today()
+    horizon = today + timedelta(days=within_days)
+    in_window = Q(end_of_support__isnull=False, end_of_support__lte=horizon) | Q(
+        end_of_life__isnull=False, end_of_life__lte=horizon
+    )
+    return list(Product.objects.filter(team=team).filter(in_window).order_by("end_of_life", "end_of_support"))

--- a/sbomify/apps/core/tests/test_eol_transition.py
+++ b/sbomify/apps/core/tests/test_eol_transition.py
@@ -1,0 +1,248 @@
+"""End-of-life transition (CRA checklist 6.1): readiness, announcement, finals."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from sbomify.apps.core.models import Product, Release, ReleaseArtifact
+from sbomify.apps.core.services.eol import (
+    build_eol_advisory,
+    eol_readiness,
+    final_artifacts,
+    products_approaching_eol,
+)
+from sbomify.apps.plugins.models import VulnerabilityLifecycle
+from sbomify.apps.sboms.models import SBOM, Component
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def eol_product(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    product = Product.objects.create(
+        team=team,
+        name="Retiring Gateway",
+        end_of_support=date.today() + timedelta(days=30),
+        end_of_life=date.today() + timedelta(days=120),
+    )
+    component = Component.objects.create(team=team, name="Gateway Firmware")
+    product.components.set([component])
+    return product, component
+
+
+def _release_with(product, component, *, bom_types=("sbom",)):
+    release = Release.objects.create(product=product, name="v9.0.0", version="9.0.0")
+    for index, bom_type in enumerate(bom_types):
+        sbom = SBOM.objects.create(
+            name=f"gateway-{bom_type}",
+            version="9.0.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename=f"gateway-{index}.json",
+            bom_type=bom_type,
+        )
+        ReleaseArtifact.objects.create(release=release, sbom=sbom)
+    return release
+
+
+def _open_finding(component, advisory_id, severity):
+    from django.utils import timezone
+
+    now = timezone.now()
+    return VulnerabilityLifecycle.objects.create(
+        component=component,
+        advisory_id=advisory_id,
+        severity=severity,
+        first_seen_at=now - timedelta(days=10),
+        last_seen_at=now,
+    )
+
+
+class TestReadiness:
+    def test_a_clean_product_with_a_final_sbom_is_ready(self, eol_product):
+        product, component = eol_product
+        _release_with(product, component)
+
+        readiness = eol_readiness(product)
+
+        assert readiness.is_ready is True
+        assert readiness.problems == []
+        assert readiness.has_final_sbom is True
+
+    def test_open_criticals_and_highs_block(self, eol_product):
+        product, component = eol_product
+        _release_with(product, component)
+        _open_finding(component, "CVE-2026-100", "critical")
+        _open_finding(component, "CVE-2026-101", "high")
+
+        readiness = eol_readiness(product)
+
+        assert readiness.is_ready is False
+        assert readiness.blocking_count == 2
+        assert "critical" in readiness.problems[0]
+        assert "high" in readiness.problems[1]
+
+    def test_a_missing_final_sbom_blocks(self, eol_product):
+        product, _ = eol_product
+
+        readiness = eol_readiness(product)
+
+        assert readiness.has_final_sbom is False
+        assert "No SBOM" in readiness.problems[0]
+
+    def test_medium_and_low_findings_do_not_block(self, eol_product):
+        """6.1.6 names critical and high only."""
+        product, component = eol_product
+        _release_with(product, component)
+        _open_finding(component, "CVE-2026-102", "medium")
+
+        assert eol_readiness(product).is_ready is True
+
+    def test_a_resolved_finding_does_not_block(self, eol_product):
+        from django.utils import timezone
+
+        product, component = eol_product
+        _release_with(product, component)
+        row = _open_finding(component, "CVE-2026-103", "critical")
+        row.resolved_at = timezone.now()
+        row.save()
+
+        assert eol_readiness(product).is_ready is True
+
+    def test_the_notice_period_is_reported(self, eol_product):
+        product, component = eol_product
+        _release_with(product, component)
+
+        readiness = eol_readiness(product)
+
+        assert readiness.days_to_end_of_life == 120
+        assert readiness.days_to_end_of_support == 30
+        # 120 days is short of the recommended twelve months.
+        assert readiness.notice_given is False
+
+    def test_a_vex_on_the_release_is_reported(self, eol_product):
+        product, component = eol_product
+        _release_with(product, component, bom_types=("sbom", "vex"))
+
+        readiness = eol_readiness(product)
+
+        assert readiness.has_final_sbom is True
+        assert readiness.has_final_vex is True
+
+
+class TestAnnouncement:
+    def test_the_advisory_is_drafted_not_published(self, eol_product, sample_user):
+        """An EOL notice is an irreversible public statement, so a human
+        publishes it."""
+        from sbomify.apps.security_advisories.models import SecurityAdvisory
+
+        product, _ = eol_product
+
+        advisory = build_eol_advisory(product, sample_user)
+
+        assert advisory.status == SecurityAdvisory.Status.DRAFT
+        assert advisory.remediation_status == SecurityAdvisory.RemediationStatus.WONT_FIX
+        assert product.name in advisory.title
+
+    def test_the_announcement_names_both_dates_when_they_differ(self, eol_product, sample_user):
+        product, _ = eol_product
+
+        advisory = build_eol_advisory(product, sample_user)
+
+        assert product.end_of_life.isoformat() in advisory.description
+        assert "Bug fixes stopped" in advisory.description
+
+    def test_the_product_is_attached_and_an_event_recorded(self, eol_product, sample_user):
+        product, _ = eol_product
+
+        advisory = build_eol_advisory(product, sample_user, migration_path="Migrate to Gateway 10")
+
+        assert advisory.products.get().product == product
+        assert advisory.events.get().payload["kind"] == "eol"
+        assert "Gateway 10" in advisory.description
+
+
+class TestFinalArtifacts:
+    def test_the_latest_release_artifacts_are_returned(self, eol_product):
+        product, component = eol_product
+        release = _release_with(product, component, bom_types=("sbom", "vex"))
+
+        finals = final_artifacts(product)
+
+        assert finals["release"] == release
+        assert len(finals["sboms"]) == 1
+        assert len(finals["vex"]) == 1
+
+    def test_a_product_that_shipped_nothing_has_no_final_artifacts(self, eol_product):
+        """Every product carries an auto-created floating `latest`, so the
+        honest answer is a release with nothing in it — not a crash, and not
+        a pretend artifact set."""
+        product, _ = eol_product
+
+        finals = final_artifacts(product)
+
+        assert finals["sboms"] == []
+        assert finals["vex"] == []
+        assert eol_readiness(product).has_final_sbom is False
+
+    def test_a_versioned_release_wins_over_the_floating_latest(self, eol_product):
+        """`latest` re-targets as artifacts arrive, so pinning "final" to it
+        would let the final SBOM change after support ended."""
+        product, component = eol_product
+        versioned = _release_with(product, component)
+
+        assert final_artifacts(product)["release"] == versioned
+        assert versioned.is_latest is False
+
+
+class TestApproachingSweep:
+    def test_products_inside_the_window_surface(self, eol_product, sample_team_with_owner_member):
+        product, _ = eol_product
+
+        found = products_approaching_eol(sample_team_with_owner_member.team, within_days=60)
+
+        assert product in found  # end_of_support is 30 days out
+
+    def test_a_product_past_its_eol_still_surfaces(self, sample_team_with_owner_member):
+        """The case most worth surfacing: a product that quietly passed EOL
+        without an announcement."""
+        team = sample_team_with_owner_member.team
+        lapsed = Product.objects.create(
+            team=team, name="Long Gone", end_of_life=date.today() - timedelta(days=400)
+        )
+
+        assert lapsed in products_approaching_eol(team, within_days=30)
+
+    def test_products_with_no_dates_are_ignored(self, sample_team_with_owner_member):
+        team = sample_team_with_owner_member.team
+        Product.objects.create(team=team, name="No Dates")
+
+        assert products_approaching_eol(team, within_days=3650) == []
+
+
+class TestReadinessEndpoint:
+    def test_the_endpoint_reports_the_verdict_and_the_blockers(self, eol_product, sample_team_with_owner_member):
+        from django.test import Client
+
+        from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+
+        product, component = eol_product
+        _release_with(product, component)
+        _open_finding(component, "CVE-2026-200", "critical")
+        member = sample_team_with_owner_member
+        client = Client()
+        setup_authenticated_client_session(client, member.team, member.user)
+
+        response = client.get(f"/api/v1/products/{product.id}/eol-readiness")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["is_ready"] is False
+        assert body["blocking_count"] == 1
+        assert body["unresolved_critical"][0]["advisory_id"] == "CVE-2026-200"
+        assert body["end_of_life"] == product.end_of_life.isoformat()
+        assert "critical" in body["problems"][0]

--- a/sbomify/apps/core/tests/test_eol_transition.py
+++ b/sbomify/apps/core/tests/test_eol_transition.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 
 import pytest
+from django.utils import timezone
 
 from sbomify.apps.core.models import Product, Release, ReleaseArtifact
 from sbomify.apps.core.services.eol import (
@@ -211,9 +212,7 @@ class TestApproachingSweep:
         """The case most worth surfacing: a product that quietly passed EOL
         without an announcement."""
         team = sample_team_with_owner_member.team
-        lapsed = Product.objects.create(
-            team=team, name="Long Gone", end_of_life=date.today() - timedelta(days=400)
-        )
+        lapsed = Product.objects.create(team=team, name="Long Gone", end_of_life=date.today() - timedelta(days=400))
 
         assert lapsed in products_approaching_eol(team, within_days=30)
 
@@ -246,3 +245,69 @@ class TestReadinessEndpoint:
         assert body["unresolved_critical"][0]["advisory_id"] == "CVE-2026-200"
         assert body["end_of_life"] == product.end_of_life.isoformat()
         assert "critical" in body["problems"][0]
+
+    def test_a_public_product_does_not_expose_readiness_to_outsiders(self, eol_product, guest_user):
+        """Readiness lists unresolved critical and high findings by advisory id.
+        Making a product public publishes the product, not its open remediation
+        work, and the shared product lookup only enforces access when the
+        product is private."""
+        from django.test import Client
+
+        product, component = eol_product
+        product.is_public = True
+        product.save()
+        _open_finding(component, "CVE-2026-201", "critical")
+
+        client = Client()
+        client.force_login(guest_user)
+        response = client.get(f"/api/v1/products/{product.id}/eol-readiness")
+
+        assert response.status_code == 403
+
+
+class TestAcceptanceScope:
+    def test_an_acceptance_on_one_component_does_not_clear_another(
+        self, eol_product, sample_team_with_owner_member, monkeypatch
+    ):
+        """A triage decision is recorded against a single component, so the same
+        advisory open on a second component is still a blocker. Keying the
+        acceptance set on advisory id alone under-reported blockers, which is
+        the wrong direction for a check that gates retiring a product."""
+        product, first = eol_product
+        second = Component.objects.create(team=sample_team_with_owner_member.team, name="Gateway Bootloader")
+        product.components.add(second)
+        _open_finding(first, "CVE-2026-300", "critical")
+        _open_finding(second, "CVE-2026-300", "critical")
+
+        live = (date.today() + timedelta(days=30)).isoformat()
+        monkeypatch.setattr(
+            "sbomify.apps.vulnerability_scanning.triage.current_triage_index",
+            lambda component: (
+                {("v", "CVE-2026-300"): {"id": "CVE-2026-300", "state": "risk_accepted", "accepted_until": live}}
+                if component.id == first.id
+                else {}
+            ),
+        )
+
+        readiness = eol_readiness(product)
+
+        # Only the unaccepted one blocks.
+        assert [entry["component_id"] for entry in readiness.unresolved_critical] == [str(second.id)]
+
+
+class TestFinalReleaseOrdering:
+    def test_the_release_published_last_wins_over_the_row_created_last(self, eol_product):
+        """Release orders on released_at first. A row can be created before an
+        earlier-dated one is published, so sorting on created_at alone picks the
+        wrong release as final."""
+        from sbomify.apps.core.services.eol import _final_release
+
+        product, _ = eol_product
+        older = Release.objects.create(product=product, name="v1.0.0", version="1.0.0")
+        newer = Release.objects.create(product=product, name="v2.0.0", version="2.0.0")
+        # Created second, released first.
+        now = timezone.now()
+        Release.objects.filter(pk=newer.pk).update(released_at=now - timedelta(days=10))
+        Release.objects.filter(pk=older.pk).update(released_at=now)
+
+        assert _final_release(product).pk == older.pk


### PR DESCRIPTION
Closes #1298. Completes the five-issue CRA checklist batch (#1295–#1299).

`Product.end_of_support` and `end_of_life` already existed and were exposed through the API; nothing happened when those dates approached or passed. The dates were the easy half — these are the obligations attached to them.

## Three pieces

**`eol_readiness`** — the pre-EOL check (6.1.5/6.1.6): notice period, and every critical and high finding *neither patched nor formally risk-accepted*. This is why the issue depended on #1296: without the risk-accepted state there was no way to distinguish "unresolved" from "deliberately accepted". A **lapsed** acceptance deliberately does *not* count as handled — an expired decision is exactly what the acceptance expiry exists to resurface, and honouring it here would make the expiry decorative. Exposed at `GET /products/{id}/eol-readiness`.

**`build_eol_advisory`** — the announcement, drafted through the **security advisory channel**, which is the single channel 6.1.4 and 6.1.6 want EOL notices to share and which the Trust Center already surfaces. Deliberately a *draft*: an EOL notice is an irreversible public statement about a product's support, so the system surfaces the obligation and a human publishes it.

**`final_artifacts`** — the last release's SBOM and VEX, which is what a downstream integrator actually needs after support stops.

## What writing the tests changed

`final_artifacts` originally took the newest release, preferring `is_latest`. A failing test made the flaw obvious: **`latest` is a floating pointer that re-targets as artifacts arrive**, so pinning "final" to it would mean the final SBOM changed *after* the product stopped being supported. It now prefers a real versioned release, with `latest` as the fallback only when none was ever cut. (Same insight as excluding `latest` from the advisory release picker in #1280.)

mypy also caught two real bugs before any test ran: the reverse accessor is `releaseartifact`, not `release_artifacts`.

## Scope

No migration — the fields already existed. `RISK_ACCEPTED_STATE` is resolved via `getattr` with a literal fallback so this branch is independent of #1301's merge order; it fails safe (nothing counts as accepted, findings stay blocking).

Not in scope, and worth their own passes: the scheduled sweep that turns `products_approaching_eol` into notifications, and 6.1.7's data-sanitization guidance (the `decommissioning_guide` template already covers part of it).

## Verification

17 tests: readiness (clean/blocked/missing-SBOM/medium-ignored/resolved-ignored/notice-period/VEX-present), the announcement (draft status, both dates, product attached, migration path, event), final artifacts (versioned-beats-latest, empty product), the approaching sweep (in-window, already-past, no-dates), and the endpoint. The 20 pre-existing `core` failures were verified against master by stashing — unchanged by this branch. ruff and mypy clean.