### PR TITLE
feat(tokens): hour-scale expiry presets and an arbitrary custom TTL

### DIFF
--- a/sbomify/apps/core/forms.py
+++ b/sbomify/apps/core/forms.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from typing import Any
 
 import requests
@@ -15,25 +16,72 @@ class CreateAccessTokenForm(forms.Form):
     # #215); new tokens expire after 90 days unless the user explicitly
     # opts out via the "No expiration" choice.
     DEFAULT_EXPIRY_DAYS = 90
+    # Presets are stored in hours because the short end of the range is where
+    # they matter: a token minted for one CI run wants 12 or 24 hours, and
+    # expressing that in days would round it away.
+    HOUR = 1
+    DAY = 24
+    CUSTOM_CHOICE = "custom"
+    NEVER_CHOICE = "never"
     EXPIRY_CHOICES = [
-        ("30", "30 days"),
-        ("60", "60 days"),
-        ("90", "90 days"),
-        ("365", "1 year"),
-        ("never", "No expiration"),
+        (str(1 * HOUR), "1 hour"),
+        (str(12 * HOUR), "12 hours"),
+        (str(24 * HOUR), "24 hours"),
+        (str(7 * DAY), "7 days"),
+        (str(30 * DAY), "30 days"),
+        (str(60 * DAY), "60 days"),
+        (str(90 * DAY), "90 days"),
+        (str(365 * DAY), "1 year"),
+        (CUSTOM_CHOICE, "Custom…"),
+        (NEVER_CHOICE, "No expiration"),
     ]
+
+    CUSTOM_UNITS = [("hours", "hours"), ("days", "days")]
+    # A year of hours. Past this the row is indistinguishable from "never" in
+    # practice, and an unbounded value would overflow the date arithmetic.
+    MAX_CUSTOM_HOURS = 365 * DAY
 
     description = forms.CharField(
         max_length=255,
         error_messages={"required": "Please provide a name for the token."},
     )
-    expires_in_days = forms.ChoiceField(
+    expires_in_hours = forms.ChoiceField(
         choices=EXPIRY_CHOICES,
         required=False,
-        initial=str(DEFAULT_EXPIRY_DAYS),
+        initial=str(DEFAULT_EXPIRY_DAYS * DAY),
         label="Expiration",
+        widget=forms.Select(attrs={"class": "tw-form-select", "x-model": "expiryChoice"}),
+    )
+    custom_expiry_value = forms.IntegerField(
+        required=False,
+        min_value=1,
+        label="Custom expiry",
+        widget=forms.NumberInput(attrs={"class": "tw-form-input", "placeholder": "e.g. 8"}),
+    )
+    custom_expiry_unit = forms.ChoiceField(
+        choices=CUSTOM_UNITS,
+        required=False,
+        initial="hours",
+        label="Unit",
         widget=forms.Select(attrs={"class": "tw-form-select"}),
     )
+
+    def clean(self) -> dict[str, Any]:
+        cleaned = super().clean() or {}
+        if cleaned.get("expires_in_hours") != self.CUSTOM_CHOICE:
+            return cleaned
+
+        value = cleaned.get("custom_expiry_value")
+        if not value:
+            self.add_error("custom_expiry_value", "Enter how long the token should last.")
+            return cleaned
+        hours = value * (self.DAY if cleaned.get("custom_expiry_unit") == "days" else self.HOUR)
+        if hours > self.MAX_CUSTOM_HOURS:
+            self.add_error(
+                "custom_expiry_value",
+                'A custom expiry cannot exceed one year — choose "No expiration" if that is what you mean.',
+            )
+        return cleaned
 
     # Action scope (#215). "full" = unscoped (legacy default); the others narrow
     # what the token may do regardless of the user's role. Maps to a concrete
@@ -68,15 +116,21 @@ class CreateAccessTokenForm(forms.Form):
         # corrupt the shared SCOPE_PRESETS value (None stays None — full token).
         return list(preset) if preset is not None else None
 
-    def expiry_days(self) -> int | None:
-        """Chosen token lifetime in days, or ``None`` for no expiration.
+    def expiry_delta(self) -> timedelta | None:
+        """Chosen token lifetime, or ``None`` for no expiration.
 
-        An omitted/blank choice falls back to the secure default
-        (90 days); the explicit ``"never"`` sentinel maps to ``None``.
-        Only valid after ``is_valid()``.
+        An omitted or blank choice falls back to the secure default (90 days);
+        the explicit ``"never"`` sentinel maps to ``None``. Only valid after
+        ``is_valid()``.
         """
-        choice = self.cleaned_data.get("expires_in_days") or str(self.DEFAULT_EXPIRY_DAYS)
-        return None if choice == "never" else int(choice)
+        choice = self.cleaned_data.get("expires_in_hours") or str(self.DEFAULT_EXPIRY_DAYS * self.DAY)
+        if choice == self.NEVER_CHOICE:
+            return None
+        if choice == self.CUSTOM_CHOICE:
+            value = self.cleaned_data.get("custom_expiry_value") or 0
+            unit = self.DAY if self.cleaned_data.get("custom_expiry_unit") == "days" else self.HOUR
+            return timedelta(hours=value * unit)
+        return timedelta(hours=int(choice))
 
 
 class TogglePublicStatusForm(forms.Form):

--- a/sbomify/apps/core/forms.py
+++ b/sbomify/apps/core/forms.py
@@ -72,8 +72,13 @@ class CreateAccessTokenForm(forms.Form):
             return cleaned
 
         value = cleaned.get("custom_expiry_value")
-        if not value:
-            self.add_error("custom_expiry_value", "Enter how long the token should last.")
+        if value is None:
+            # Only when the field is genuinely empty. A value the field itself
+            # rejected — a 0, a negative, something non-numeric — is also absent
+            # from cleaned_data, and adding "enter how long" underneath the
+            # field's own message tells the user to do what they just did.
+            if "custom_expiry_value" not in self.errors:
+                self.add_error("custom_expiry_value", "Enter how long the token should last.")
             return cleaned
         hours = value * (self.DAY if cleaned.get("custom_expiry_unit") == "days" else self.HOUR)
         if hours > self.MAX_CUSTOM_HOURS:

--- a/sbomify/apps/teams/templates/teams/team_tokens.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_tokens.html.j2
@@ -63,8 +63,10 @@
                     <p class="text-text-muted text-sm m-0">Create a new personal access token scoped to this workspace</p>
                 </div>
             </div>
+            {# expiryChoice drives the custom TTL row; seeded from the bound value so a validation re-render keeps it open. #}
             <form method="post"
                   id="tokenGenerationForm"
+                  x-data="{ expiryChoice: '{{ create_access_token_form.expires_in_hours.value|default:"2160"|escapejs }}' }"
                   hx-post="{% url 'teams:team_tokens' team.key %}"
                   hx-target="#team-tokens-content"
                   hx-disabled-elt="find button[type='submit']"
@@ -95,8 +97,27 @@
                             {% endwith %}
                         </div>
                         <div>
-                            {% with field=create_access_token_form.expires_in_days %}
+                            {% with field=create_access_token_form.expires_in_hours %}
                                 <label for="{{ field.id_for_label }}" class="tw-form-label">Expiration</label>
+                                {{ field }}
+                                {% for error in field.errors %}<p class="tw-form-error mt-1">{{ error }}</p>{% endfor %}
+                            {% endwith %}
+                        </div>
+                    </div>
+                    {# Custom TTL — revealed only when the preset list says Custom. #}
+                    <div x-show="expiryChoice === 'custom'"
+                         x-cloak
+                         class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            {% with field=create_access_token_form.custom_expiry_value %}
+                                <label for="{{ field.id_for_label }}" class="tw-form-label">Expires after</label>
+                                {{ field }}
+                                {% for error in field.errors %}<p class="tw-form-error mt-1">{{ error }}</p>{% endfor %}
+                            {% endwith %}
+                        </div>
+                        <div>
+                            {% with field=create_access_token_form.custom_expiry_unit %}
+                                <label for="{{ field.id_for_label }}" class="tw-form-label">Unit</label>
                                 {{ field }}
                                 {% for error in field.errors %}<p class="tw-form-error mt-1">{{ error }}</p>{% endfor %}
                             {% endwith %}

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -304,22 +304,83 @@ class TestCreateAccessTokenFormExpiry:
         """Omitting the choice falls back to the secure default of 90 days."""
         form = CreateAccessTokenForm({"description": "CI token"})
         assert form.is_valid(), form.errors
-        assert form.expiry_days() == 90
+        assert form.expiry_delta() == timedelta(days=90)
 
     def test_explicit_expiry_choice_is_honoured(self):
-        form = CreateAccessTokenForm({"description": "CI token", "expires_in_days": "30"})
+        form = CreateAccessTokenForm({"description": "CI token", "expires_in_hours": str(30 * 24)})
         assert form.is_valid(), form.errors
-        assert form.expiry_days() == 30
+        assert form.expiry_delta() == timedelta(days=30)
+
+    def test_hour_scale_presets_survive_as_hours(self):
+        """The point of the hours switch: a CI token for one run wants 12
+        hours, and days would round that away."""
+        form = CreateAccessTokenForm({"description": "CI token", "expires_in_hours": "12"})
+        assert form.is_valid(), form.errors
+        assert form.expiry_delta() == timedelta(hours=12)
+
+    def test_a_custom_ttl_in_hours_is_honoured(self):
+        form = CreateAccessTokenForm(
+            {
+                "description": "CI token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "8",
+                "custom_expiry_unit": "hours",
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.expiry_delta() == timedelta(hours=8)
+
+    def test_a_custom_ttl_in_days_is_honoured(self):
+        form = CreateAccessTokenForm(
+            {
+                "description": "CI token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "3",
+                "custom_expiry_unit": "days",
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.expiry_delta() == timedelta(days=3)
+
+    def test_custom_without_a_value_is_rejected(self):
+        form = CreateAccessTokenForm({"description": "CI token", "expires_in_hours": "custom"})
+        assert not form.is_valid()
+        assert "custom_expiry_value" in form.errors
+
+    def test_a_custom_ttl_beyond_a_year_is_rejected(self):
+        """Past a year the row is indistinguishable from "never"; say so
+        rather than pretending to honour it."""
+        form = CreateAccessTokenForm(
+            {
+                "description": "CI token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "400",
+                "custom_expiry_unit": "days",
+            }
+        )
+        assert not form.is_valid()
+        assert "custom_expiry_value" in form.errors
+
+    def test_a_zero_custom_ttl_is_rejected(self):
+        form = CreateAccessTokenForm(
+            {
+                "description": "CI token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "0",
+                "custom_expiry_unit": "hours",
+            }
+        )
+        assert not form.is_valid()
 
     def test_no_expiration_choice_returns_none(self):
-        form = CreateAccessTokenForm({"description": "CI token", "expires_in_days": "never"})
+        form = CreateAccessTokenForm({"description": "CI token", "expires_in_hours": "never"})
         assert form.is_valid(), form.errors
-        assert form.expiry_days() is None
+        assert form.expiry_delta() is None
 
     def test_invalid_expiry_choice_is_rejected(self):
-        form = CreateAccessTokenForm({"description": "CI token", "expires_in_days": "forever-and-ever"})
+        form = CreateAccessTokenForm({"description": "CI token", "expires_in_hours": "forever-and-ever"})
         assert not form.is_valid()
-        assert "expires_in_days" in form.errors
+        assert "expires_in_hours" in form.errors
 
 
 @pytest.mark.django_db
@@ -349,18 +410,48 @@ class TestTeamTokenExpiry:
         user = sample_team_with_owner_member.user
         setup_authenticated_client_session(client, team, user)
 
-        self._post(client, team, {"description": "Short token", "expires_in_days": "30"})
+        self._post(client, team, {"description": "Short token", "expires_in_hours": str(30 * 24)})
 
         token = AccessToken.objects.get(user=user, description="Short token")
         assert token.expires_at is not None
         assert abs((token.expires_at - token.created_at) - timedelta(days=30)) <= timedelta(minutes=1)
+
+    def test_post_creates_a_twelve_hour_token(self, client: Client, sample_team_with_owner_member):
+        """Viktor's case: a token minted per action run, hours not days."""
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        self._post(client, team, {"description": "Action token", "expires_in_hours": "12"})
+
+        token = AccessToken.objects.get(user=user, description="Action token")
+        assert abs((token.expires_at - token.created_at) - timedelta(hours=12)) <= timedelta(minutes=1)
+
+    def test_post_creates_an_arbitrary_custom_token(self, client: Client, sample_team_with_owner_member):
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        self._post(
+            client,
+            team,
+            {
+                "description": "Custom token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "36",
+                "custom_expiry_unit": "hours",
+            },
+        )
+
+        token = AccessToken.objects.get(user=user, description="Custom token")
+        assert abs((token.expires_at - token.created_at) - timedelta(hours=36)) <= timedelta(minutes=1)
 
     def test_post_no_expiration_leaves_null(self, client: Client, sample_team_with_owner_member):
         team = sample_team_with_owner_member.team
         user = sample_team_with_owner_member.user
         setup_authenticated_client_session(client, team, user)
 
-        self._post(client, team, {"description": "Forever token", "expires_in_days": "never"})
+        self._post(client, team, {"description": "Forever token", "expires_in_hours": "never"})
 
         token = AccessToken.objects.get(user=user, description="Forever token")
         assert token.expires_at is None

--- a/sbomify/apps/teams/tests/test_team_tokens.py
+++ b/sbomify/apps/teams/tests/test_team_tokens.py
@@ -347,6 +347,21 @@ class TestCreateAccessTokenFormExpiry:
         assert not form.is_valid()
         assert "custom_expiry_value" in form.errors
 
+    def test_a_rejected_value_gets_one_message_not_two(self):
+        """A 0 is caught by the field's own min_value. Adding "enter how long"
+        underneath it tells the user to do the thing they just did."""
+        form = CreateAccessTokenForm(
+            {
+                "description": "CI token",
+                "expires_in_hours": "custom",
+                "custom_expiry_value": "0",
+                "custom_expiry_unit": "hours",
+            }
+        )
+
+        assert not form.is_valid()
+        assert len(form.errors["custom_expiry_value"]) == 1
+
     def test_a_custom_ttl_beyond_a_year_is_rejected(self):
         """Past a year the row is indistinguishable from "never"; say so
         rather than pretending to honour it."""

--- a/sbomify/apps/teams/views/team_tokens.py
+++ b/sbomify/apps/teams/views/team_tokens.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
 from functools import partial
 from typing import Any, cast
 
@@ -87,8 +86,8 @@ class TeamTokensView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         # those are reserved for short-lived OIDC tokens). ``get_user_and_token_record``
         # rejects a row once ``expires_at`` is in the past. ``None`` means
         # never expires (the explicit "No expiration" choice).
-        expiry_days = form.expiry_days()
-        expires_at = timezone.now() + timedelta(days=expiry_days) if expiry_days is not None else None
+        expiry_delta = form.expiry_delta()
+        expires_at = timezone.now() + expiry_delta if expiry_delta is not None else None
 
         access_token_str = create_personal_access_token(user)
         token = AccessToken(


### PR DESCRIPTION
From Viktor's request: he generates a token per sbomify-action run and wants them to live **24h tops, or even 12** — plus "presets and manual … an arbitrary TTL". The shortest option was 30 days, so every CI token carried about a month of blast radius past its useful life.

## What changed

**The internal unit becomes hours**, because that is where the short end of the range lives — 12 hours cannot be expressed in days without rounding it away. Presets now run:

`1 hour · 12 hours · 24 hours · 7 days · 30 days · 60 days · 90 days · 1 year · Custom… · No expiration`

The default stays **90 days**, so nothing changes for anyone who does not touch the field.

**"Custom…"** reveals a value + unit pair (hours/days) for an arbitrary TTL, capped at one year — past that the row is indistinguishable from "No expiration", so the form says so rather than pretending to honour it. The custom row is hidden until selected and stays open across a validation re-render.

`expiry_days()` becomes `expiry_delta()` returning a `timedelta`, since days can no longer express the answer. The field rename from `expires_in_days` to `expires_in_hours` is internal: the template and tests were its only readers — no API endpoint or JS client consumed it.

## Verification

- 13 form/view tests: default preserved, hour presets surviving as hours, custom in hours and in days, custom-without-a-value rejected, over-a-year rejected, zero rejected, invalid choice rejected, plus POST paths creating a 12-hour and an arbitrary 36-hour token.
- Browser-verified with devtools on the dev stack: all ten options render with 90 days preselected, the custom row is hidden by default and appears on "Custom…", and a real submission produced a token whose stored span is **exactly 12.0 hours** (test token cleaned up).
- Full `teams` + `access_tokens` suites green (44 in the token file); ruff, mypy and djlint clean. No migration — `expires_at` already held a datetime.

Pairs naturally with #1291 (expiry warnings), which will now warn on these short-lived tokens too — worth noting that a 12-hour token expires inside the tightest 1-day warning threshold, so it simply never warns, which is the right behaviour for something minted per CI run.