### PR TITLE
fix(advisories): repair the advisory detail page

### DIFF
--- a/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
@@ -156,3 +156,83 @@ describe('the half-ticked parent box', () => {
         expect(picker.isPartiallySelected(picker.products[2])).toBe(false)
     })
 })
+
+describe('filtering', () => {
+    test('a product name match keeps all of that product\'s versions', () => {
+        picker.setFilter('gateway')
+        expect(picker.visibleProducts.map((p) => p.id)).toEqual(['p1'])
+        expect(picker.visibleReleases(picker.products[0]).length).toBe(3)
+    })
+
+    test('a version label match narrows to that version, and finds the product by it', () => {
+        picker.setFilter('1.2')
+        expect(picker.visibleProducts.map((p) => p.id)).toEqual(['p1'])
+        expect(picker.visibleReleases(picker.products[0]).map((r) => r.id)).toEqual(['r3'])
+    })
+
+    test('nothing matching leaves an empty list rather than the full one', () => {
+        picker.setFilter('nonesuch')
+        expect(picker.visibleProducts).toEqual([])
+    })
+
+    test('a click under a filter selects the row shown, not the one at that index unfiltered', () => {
+        picker.setFilter('vault')
+        picker.toggleProduct(0, plain, picker.visibleProducts)
+        expect(picker.selectedProducts).toEqual(['p2'])
+    })
+
+    test('a version click under a filter selects the version shown', () => {
+        picker.setFilter('1.2')
+        const product = picker.products[0]
+        picker.toggleRelease(product, 0, plain, picker.visibleReleases(product))
+        expect(picker.selectedReleases).toEqual(['r3'])
+    })
+
+    test('a shift range under a filter never reaches a hidden row', () => {
+        picker.setFilter('1.')
+        const product = picker.products[0]
+        const visible = picker.visibleReleases(product)
+        picker.toggleRelease(product, 0, plain, visible)
+        picker.toggleRelease(product, 1, shift, visible)
+        expect(picker.selectedReleases.sort()).toEqual(['r1', 'r2'])
+    })
+
+    test('changing the filter drops the anchors, so the next shift-click starts fresh', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.anchor).toBe(0)
+        picker.setFilter('vault')
+        expect(picker.anchor).toBe(null)
+        expect(picker.releaseAnchor).toEqual({})
+    })
+
+    test('select-every-version under a filter takes only the visible ones', () => {
+        picker.setFilter('1.2')
+        const product = picker.products[0]
+        picker.toggleAllVersions(product, picker.visibleReleases(product))
+        expect(picker.selectedReleases).toEqual(['r3'])
+    })
+})
+
+describe('selection summary', () => {
+    test('says so when nothing is picked', () => {
+        expect(picker.selectionSummary).toBe('No products selected yet.')
+    })
+
+    test('a bare product tick reads as covering every version, now and later', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.selectionSummary).toBe('Gateway: every version, now and in future')
+    })
+
+    test('picked versions are counted, and singular reads singular', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        expect(picker.selectionSummary).toBe('Gateway: 1 version')
+    })
+
+    test('several products are joined', () => {
+        picker.toggleProduct(0, plain)
+        picker.toggleProduct(1, plain)
+        expect(picker.selectionSummary).toBe(
+            'Gateway: every version, now and in future · Vault: every version, now and in future',
+        )
+    })
+})

--- a/sbomify/apps/core/js/components/advisory-product-picker.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.ts
@@ -1,6 +1,7 @@
 export interface PickerRelease {
     id: string;
     label: string;
+    created?: string;
 }
 
 export interface PickerProduct {
@@ -29,6 +30,7 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
         selectedProducts: [] as string[],
         selectedReleases: [] as string[],
         expanded: [] as string[],
+        filter: '',
 
         /** Index of the last product row clicked, for shift-click ranges. */
         anchor: null as number | null,
@@ -45,6 +47,48 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
 
         isExpanded(id: string): boolean {
             return this.expanded.includes(id);
+        },
+
+        /**
+         * Narrow the list by product name or version label.
+         *
+         * A workspace with a release-per-build has hundreds of versions, and
+         * scrolling a box to find one is not a search. Matching on either name
+         * or label means typing a build number finds it without first knowing
+         * which product shipped it.
+         *
+         * Both anchors reset, because they hold positions in the list as it was
+         * rendered a moment ago; shift-clicking against a stale one selects a
+         * range the user cannot see.
+         */
+        setFilter(value: string): void {
+            this.filter = value;
+            this.anchor = null;
+            this.releaseAnchor = {};
+        },
+
+        get filterTerm(): string {
+            return this.filter.trim().toLowerCase();
+        },
+
+        get visibleProducts(): PickerProduct[] {
+            const term = this.filterTerm;
+            if (!term) return this.products;
+            return this.products.filter(
+                (product) =>
+                    product.name.toLowerCase().includes(term) ||
+                    product.releases.some((release) => release.label.toLowerCase().includes(term)),
+            );
+        },
+
+        /**
+         * A product matched by name keeps all its versions: the user asked for
+         * that product, not for a subset of its builds.
+         */
+        visibleReleases(product: PickerProduct): PickerRelease[] {
+            const term = this.filterTerm;
+            if (!term || product.name.toLowerCase().includes(term)) return product.releases;
+            return product.releases.filter((release) => release.label.toLowerCase().includes(term));
         },
 
         toggleExpanded(id: string): void {
@@ -68,16 +112,19 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
          * every file manager behaves: shift-clicking an unticked row after
          * ticking one fills the span in rather than inverting each row.
          */
-        toggleProduct(index: number, event?: MouseEvent): void {
-            const product = this.products[index];
+        toggleProduct(index: number, event?: MouseEvent, visible?: PickerProduct[]): void {
+            const list = visible ?? this.products;
+            const product = list[index];
             if (!product) return;
 
             const shouldSelect = !this.isProductSelected(product.id);
             const from = event?.shiftKey && this.anchor !== null ? this.anchor : index;
             const [start, end] = from <= index ? [from, index] : [index, from];
 
+            // As with versions, the range spans the rendered list, so a filter
+            // never drags hidden products into the selection.
             for (let i = start; i <= end; i++) {
-                this.setProduct(this.products[i], shouldSelect);
+                this.setProduct(list[i], shouldSelect);
             }
             this.anchor = index;
         },
@@ -117,8 +164,13 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
          * something you have not marked affected is not a state worth being
          * able to reach.
          */
-        toggleRelease(product: PickerProduct, index: number, event?: MouseEvent): void {
-            const release = product.releases[index];
+        toggleRelease(
+            product: PickerProduct,
+            index: number,
+            event?: MouseEvent,
+            list: PickerRelease[] = product.releases,
+        ): void {
+            const release = list[index];
             if (!release) return;
 
             const shouldSelect = !this.isReleaseSelected(release.id);
@@ -126,8 +178,11 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             const from = event?.shiftKey && previous !== undefined ? previous : index;
             const [start, end] = from <= index ? [from, index] : [index, from];
 
+            // Ranges run over the list as rendered, so shift-clicking under a
+            // filter spans what the user can see rather than the rows the
+            // filter is hiding between them.
             for (let i = start; i <= end; i++) {
-                this.setRelease(product.releases[i], shouldSelect);
+                this.setRelease(list[i], shouldSelect);
             }
             this.releaseAnchor[product.id] = index;
 
@@ -152,8 +207,8 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             return product.releases.filter((release) => this.isReleaseSelected(release.id)).map((r) => r.id);
         },
 
-        allVersionsSelected(product: PickerProduct): boolean {
-            return product.releases.length > 0 && this.selectedReleasesFor(product).length === product.releases.length;
+        allVersionsSelected(product: PickerProduct, list: PickerRelease[] = product.releases): boolean {
+            return list.length > 0 && list.every((release) => this.isReleaseSelected(release.id));
         },
 
         /**
@@ -171,9 +226,9 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             return picked > 0 && picked < product.releases.length;
         },
 
-        toggleAllVersions(product: PickerProduct): void {
-            const selectAll = !this.allVersionsSelected(product);
-            product.releases.forEach((release) => this.setRelease(release, selectAll));
+        toggleAllVersions(product: PickerProduct, list: PickerRelease[] = product.releases): void {
+            const selectAll = !this.allVersionsSelected(product, list);
+            list.forEach((release) => this.setRelease(release, selectAll));
             if (selectAll) this.setProduct(product, true);
             this.releaseAnchor[product.id] = 0;
         },
@@ -190,6 +245,28 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             const count = this.selectedReleasesFor(product).length;
             if (count === 0) return 'All versions';
             return `${count} of ${product.releases.length} versions`;
+        },
+
+        /**
+         * What the picker has been told, in a sentence.
+         *
+         * Ticking a product and no versions covers the product whole — every
+         * version it has and every version it gets. That is the most common
+         * intent and the easiest to reach by accident, and reading it off the
+         * checkboxes means knowing that an empty version list is a claim rather
+         * than an omission. Saying it in words removes the guess.
+         */
+        get selectionSummary(): string {
+            const chosen = this.products.filter((product) => this.isProductSelected(product.id));
+            if (chosen.length === 0) return 'No products selected yet.';
+
+            return chosen
+                .map((product) => {
+                    const count = this.selectedReleasesFor(product).length;
+                    if (count === 0) return `${product.name}: every version, now and in future`;
+                    return `${product.name}: ${count} version${count === 1 ? '' : 's'}`;
+                })
+                .join(' · ');
         },
     };
 }

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -166,17 +166,30 @@
                                                             versions has nothing to show, and its toggle is hidden, so
                                                             this would only ever render an empty panel.
                                                             {% endcomment %}
+                                                            {% comment %}
+                                                            One version per row, not a wrapping flow. Version labels
+                                                            are build identifiers of wildly uneven length, so packing
+                                                            them by intrinsic width put a different number on every
+                                                            row and left no edge to read down. Two columns aligned
+                                                            them but cost too much width: these identifiers share a
+                                                            long prefix and differ only in the tail, so truncating
+                                                            rendered neighbouring builds identical and you could not
+                                                            tell which one you were about to attach an advisory to.
+                                                            A single column keeps every label whole. truncate stays
+                                                            as a guard for a pathological name, with the full string
+                                                            on hover. Monospace keeps the digits in register.
+                                                            {% endcomment %}
                                                             <div x-show="isExpanded(product.id) && product.releases.length"
                                                                  x-cloak
-                                                                 class="px-3 pb-2.5 ml-6">
+                                                                 class="px-3 pb-2.5 pl-11 bg-muted/30">
                                                                 <button type="button"
                                                                         @click="toggleAllVersions(product)"
                                                                         class="text-xs text-primary hover:underline mb-1.5">
                                                                     <span x-text="allVersionsSelected(product) ? 'Clear versions' : 'Select every version'"></span>
                                                                 </button>
-                                                                <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+                                                                <div class="grid grid-cols-1 gap-y-0.5">
                                                                     <template x-for="(release, rIndex) in product.releases" :key="release.id">
-                                                                        <div class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer select-none"
+                                                                        <div class="flex items-center gap-2 min-w-0 py-0.5 text-xs text-text cursor-pointer select-none"
                                                                              role="checkbox"
                                                                              tabindex="0"
                                                                              :aria-checked="isReleaseSelected(release.id) ? 'true' : 'false'"
@@ -184,11 +197,13 @@
                                                                              @keydown.space.prevent="toggleRelease(product, rIndex)"
                                                                              @keydown.enter.prevent="toggleRelease(product, rIndex)">
                                                                             <input type="checkbox"
-                                                                                   class="tw-checkbox pointer-events-none"
+                                                                                   class="tw-checkbox shrink-0 pointer-events-none"
                                                                                    tabindex="-1"
                                                                                    aria-hidden="true"
                                                                                    :checked="isReleaseSelected(release.id)" />
-                                                                            <span x-text="release.label"></span>
+                                                                            <span class="truncate font-mono"
+                                                                                  :title="release.label"
+                                                                                  x-text="release.label"></span>
                                                                         </div>
                                                                     </template>
                                                                 </div>

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -119,8 +119,36 @@
                                                         </button>
                                                     </div>
                                                 </div>
-                                                <div class="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border/60 select-none">
-                                                    <template x-for="(product, index) in products" :key="product.id">
+                                                {% comment %}
+                                                The scope reads above the list, not below it. A ticked product with
+                                                no ticked versions covers every version it has and every version it
+                                                gets — which the checkboxes cannot say on their own, since an empty
+                                                version list looks identical to one nobody has opened yet. Below the
+                                                list it fell under the modal's fold on a short window, so the one
+                                                line that resolves the ambiguity was the one you had to scroll for.
+                                                {% endcomment %}
+                                                <p class="mb-1.5 text-xs m-0"
+                                                   :class="anySelected ? 'text-text' : 'text-text-muted'"
+                                                   aria-live="polite">
+                                                    <span x-text="selectionSummary"></span>
+                                                </p>
+                                                <div class="relative mb-1.5">
+                                                    <i class="fas fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-xs text-text-muted"
+                                                       aria-hidden="true"></i>
+                                                    <input type="search"
+                                                           class="tw-form-input !pl-8 !py-1.5 text-sm"
+                                                           placeholder="Filter products and versions…"
+                                                           aria-label="Filter products and versions"
+                                                           :value="filter"
+                                                           @input="setFilter($event.target.value)" />
+                                                </div>
+                                                <div class="max-h-72 overflow-y-auto rounded-lg border border-border divide-y divide-border/60 select-none">
+                                                    <p x-show="!visibleProducts.length"
+                                                       x-cloak
+                                                       class="px-3 py-4 text-xs text-text-muted text-center m-0">
+                                                        Nothing matches <span class="font-mono" x-text="filter"></span>.
+                                                    </p>
+                                                    <template x-for="(product, index) in visibleProducts" :key="product.id">
                                                         <div>
                                                             <div class="flex items-center gap-2 px-3 py-2">
                                                                 {% comment %}
@@ -137,9 +165,9 @@
                                                                      role="checkbox"
                                                                      tabindex="0"
                                                                      :aria-checked="isPartiallySelected(product) ? 'mixed' : (isProductSelected(product.id) ? 'true' : 'false')"
-                                                                     @click="toggleProduct(index, $event)"
-                                                                     @keydown.space.prevent="toggleProduct(index)"
-                                                                     @keydown.enter.prevent="toggleProduct(index)">
+                                                                     @click="toggleProduct(index, $event, visibleProducts)"
+                                                                     @keydown.space.prevent="toggleProduct(index, undefined, visibleProducts)"
+                                                                     @keydown.enter.prevent="toggleProduct(index, undefined, visibleProducts)">
                                                                     <input type="checkbox"
                                                                            class="tw-checkbox shrink-0 pointer-events-none"
                                                                            tabindex="-1"
@@ -179,23 +207,24 @@
                                                             as a guard for a pathological name, with the full string
                                                             on hover. Monospace keeps the digits in register.
                                                             {% endcomment %}
-                                                            <div x-show="isExpanded(product.id) && product.releases.length"
+                                                            <div x-show="(isExpanded(product.id) || filterTerm) && visibleReleases(product).length"
                                                                  x-cloak
                                                                  class="px-3 pb-2.5 pl-11 bg-muted/30">
                                                                 <button type="button"
-                                                                        @click="toggleAllVersions(product)"
+                                                                        @click="toggleAllVersions(product, visibleReleases(product))"
                                                                         class="text-xs text-primary hover:underline mb-1.5">
-                                                                    <span x-text="allVersionsSelected(product) ? 'Clear versions' : 'Select every version'"></span>
+                                                                    <span x-text="allVersionsSelected(product, visibleReleases(product)) ? 'Clear versions' : 'Select every version'"></span>
                                                                 </button>
                                                                 <div class="grid grid-cols-1 gap-y-0.5">
-                                                                    <template x-for="(release, rIndex) in product.releases" :key="release.id">
+                                                                    <template x-for="(release, rIndex) in visibleReleases(product)"
+                                                                              :key="release.id">
                                                                         <div class="flex items-center gap-2 min-w-0 py-0.5 text-xs text-text cursor-pointer select-none"
                                                                              role="checkbox"
                                                                              tabindex="0"
                                                                              :aria-checked="isReleaseSelected(release.id) ? 'true' : 'false'"
-                                                                             @click="toggleRelease(product, rIndex, $event)"
-                                                                             @keydown.space.prevent="toggleRelease(product, rIndex)"
-                                                                             @keydown.enter.prevent="toggleRelease(product, rIndex)">
+                                                                             @click="toggleRelease(product, rIndex, $event, visibleReleases(product))"
+                                                                             @keydown.space.prevent="toggleRelease(product, rIndex, undefined, visibleReleases(product))"
+                                                                             @keydown.enter.prevent="toggleRelease(product, rIndex, undefined, visibleReleases(product))">
                                                                             <input type="checkbox"
                                                                                    class="tw-checkbox shrink-0 pointer-events-none"
                                                                                    tabindex="-1"
@@ -204,6 +233,8 @@
                                                                             <span class="truncate font-mono"
                                                                                   :title="release.label"
                                                                                   x-text="release.label"></span>
+                                                                            <span class="ml-auto shrink-0 pl-2 text-[0.6875rem] text-text-muted tabular-nums"
+                                                                                  x-text="release.created"></span>
                                                                         </div>
                                                                     </template>
                                                                 </div>
@@ -217,8 +248,9 @@
                                                 <template x-for="id in selectedReleases" :key="id">
                                                     <input type="hidden" name="affected_releases" :value="id" />
                                                 </template>
-                                                <p class="mt-1.5 text-xs text-text-muted">
-                                                    Shift-click to select a range. Leave versions unpicked to cover the whole product.
+                                                <p class="mt-1.5 text-xs text-text-muted m-0">
+                                                    Tick a product on its own to cover it whole, or open it and pick
+                                                    versions to narrow the advisory. Shift-click selects a range.
                                                 </p>
                                             </div>
                                         {% else %}

--- a/sbomify/apps/core/templates/core/security_advisories_table.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_table.html.j2
@@ -1,6 +1,6 @@
 {# Security Advisories table. Rows come from the advisories projection via json_script; writes are still preview-only. #}
 <div id="advisories-table-container"
-     x-data="{ search: '', filter: 'all', sortColumn: 'updated', sortDirection: 'desc', currentPage: 1, perPage: 10, allAdvisories: [], init() { this.allAdvisories = window.parseJsonScript('advisories-data') || []; this.$el.addEventListener('htmx:afterSettle', () => { this.allAdvisories = window.parseJsonScript('advisories-data') || []; if (this.currentPage > this.totalPages && this.totalPages > 0) { this.currentPage = this.totalPages; } }); }, get filteredData() { let data = [...this.allAdvisories]; if (this.search) { const s = this.search.toLowerCase(); data = data.filter(item => item.title.toLowerCase().includes(s) || item.id.toLowerCase().includes(s) || (item.vulnerability_id || '').toLowerCase().includes(s) || (item.products || []).map(p => p.name).join(' ').toLowerCase().includes(s) ); } if (this.filter !== 'all') { data = data.filter(item => item.status === this.filter); } return data; }, get sortedData() { return [...this.filteredData].sort((a, b) => { let aVal, bVal; if (this.sortColumn === 'severity') { aVal = a.severity_rank; bVal = b.severity_rank; } else if (this.sortColumn === 'status') { aVal = a.status_rank; bVal = b.status_rank; } else { aVal = a[this.sortColumn]; bVal = b[this.sortColumn]; if (typeof aVal === 'string') { aVal = aVal.toLowerCase(); bVal = bVal.toLowerCase(); } } if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1; if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1; return 0; }); }, get paginatedData() { const start = (this.currentPage - 1) * this.perPage; return this.sortedData.slice(start, start + this.perPage); }, get totalPages() { return Math.ceil(this.filteredData.length / this.perPage); }, get startIndex() { return this.filteredData.length > 0 ? (this.currentPage - 1) * this.perPage + 1 : 0; }, get endIndex() { return Math.min(this.currentPage * this.perPage, this.filteredData.length); }, sort(column) { if (this.sortColumn === column) { this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'; } else { this.sortColumn = column; this.sortDirection = 'asc'; } }, goToPage(page) { if (page >= 1 && page <= this.totalPages) { this.currentPage = page; } }, get visiblePages() { const pages = []; const total = this.totalPages; const current = this.currentPage; if (total <= 7) { for (let i = 1; i <= total; i++) pages.push(i); } else { pages.push(1); if (current > 3) pages.push('...'); for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) { pages.push(i); } if (current < total - 2) pages.push('...'); pages.push(total); } return pages; }, titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; }, rowMenu: { open: false, adv: null, right: 0, y: 0 }, openRowMenu(adv, btn) { const r = btn.getBoundingClientRect(); this.rowMenu = { open: true, adv, right: window.innerWidth - r.right, y: r.bottom + 6 }; } }"
+     x-data="{ search: '', filter: 'all', sortColumn: 'updated', sortDirection: 'desc', currentPage: 1, perPage: 10, allAdvisories: [], init() { this.allAdvisories = window.parseJsonScript('advisories-data') || []; this.$el.addEventListener('htmx:afterSettle', () => { this.allAdvisories = window.parseJsonScript('advisories-data') || []; if (this.currentPage > this.totalPages && this.totalPages > 0) { this.currentPage = this.totalPages; } }); }, get filteredData() { let data = [...this.allAdvisories]; if (this.search) { const s = this.search.toLowerCase(); data = data.filter(item => item.title.toLowerCase().includes(s) || item.id.toLowerCase().includes(s) || (item.vulnerability_id || '').toLowerCase().includes(s) || (item.products || []).map(p => p.name).join(' ').toLowerCase().includes(s) ); } if (this.filter !== 'all') { data = data.filter(item => item.status === this.filter); } return data; }, get sortedData() { return [...this.filteredData].sort((a, b) => { let aVal, bVal; if (this.sortColumn === 'severity') { aVal = a.severity_rank; bVal = b.severity_rank; } else if (this.sortColumn === 'status') { aVal = a.status_rank; bVal = b.status_rank; } else { aVal = a[this.sortColumn]; bVal = b[this.sortColumn]; if (typeof aVal === 'string') { aVal = aVal.toLowerCase(); bVal = bVal.toLowerCase(); } } if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1; if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1; return 0; }); }, get paginatedData() { const start = (this.currentPage - 1) * this.perPage; return this.sortedData.slice(start, start + this.perPage); }, get totalPages() { return Math.ceil(this.filteredData.length / this.perPage); }, get startIndex() { return this.filteredData.length > 0 ? (this.currentPage - 1) * this.perPage + 1 : 0; }, get endIndex() { return Math.min(this.currentPage * this.perPage, this.filteredData.length); }, sort(column) { if (this.sortColumn === column) { this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'; } else { this.sortColumn = column; this.sortDirection = 'asc'; } }, goToPage(page) { if (page >= 1 && page <= this.totalPages) { this.currentPage = page; } }, get visiblePages() { const pages = []; const total = this.totalPages; const current = this.currentPage; if (total <= 7) { for (let i = 1; i <= total; i++) pages.push(i); } else { pages.push(1); if (current > 3) pages.push('...'); for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) { pages.push(i); } if (current < total - 2) pages.push('...'); pages.push(total); } return pages; }, titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; } }"
      x-init="init(); $watch('search', () => currentPage = 1); $watch('filter', () => currentPage = 1); $watch('perPage', () => currentPage = 1)"
      hx-get="{% url 'core:security_advisories_table' %}"
      hx-trigger="refresh-advisories from:body"
@@ -103,11 +103,6 @@
                                     </span>
                                 </button>
                             </th>
-                            {% if has_crud_permissions %}
-                                <th class="w-10">
-                                    <span class="sr-only">Actions</span>
-                                </th>
-                            {% endif %}
                         </tr>
                     </thead>
                     <tbody>
@@ -173,23 +168,11 @@
                                               x-text="advisory.updates_count + (advisory.updates_count === 1 ? ' update' : ' updates')"></span>
                                     </div>
                                 </td>
-                                {% if has_crud_permissions %}
-                                    <td class="text-right" @click.stop>
-                                        <button type="button"
-                                                @click.stop="openRowMenu(advisory, $event.currentTarget)"
-                                                aria-haspopup="true"
-                                                aria-label="Advisory actions"
-                                                class="w-8 h-8 rounded-lg inline-flex items-center justify-center text-text-muted hover:bg-border/50 hover:text-text transition-colors">
-                                            <i class="fas fa-ellipsis" aria-hidden="true"></i>
-                                        </button>
-                                    </td>
-                                {% endif %}
                             </tr>
                         </template>
                         <template x-if="paginatedData.length === 0">
                             <tr>
-                                <td colspan="{% if has_crud_permissions %}6{% else %}5{% endif %}"
-                                    class="text-center py-8 text-text-muted">
+                                <td colspan="5" class="text-center py-8 text-text-muted">
                                     <i class="fas fa-search text-2xl mb-2 opacity-50"></i>
                                     <p>No advisories match your search</p>
                                     <button @click="search = ''; filter = 'all'"
@@ -249,52 +232,6 @@
                     <i class="fas fa-plus mr-2"></i>Create Your First Advisory
                 </button>
             {% endif %}
-        </div>
-    {% endif %}
-    {# Shared row-actions menu — fixed-positioned so the table's overflow doesn't clip it. #}
-    {% if has_crud_permissions %}
-        <div x-show="rowMenu.open"
-             x-cloak
-             @click.away="rowMenu.open = false"
-             @keydown.escape.window="rowMenu.open = false"
-             @scroll.window="rowMenu.open = false"
-             class="tw-dropdown"
-             :style="`position: fixed; top: ${rowMenu.y}px; right: ${rowMenu.right}px;`"
-             role="menu"
-             aria-label="Advisory actions">
-            <a href="{% url 'core:workspace_public_current' %}"
-               target="_blank"
-               rel="noopener"
-               class="tw-dropdown-item"
-               role="menuitem"
-               @click="rowMenu.open = false">
-                <i class="fas fa-arrow-up-right-from-square w-5 text-center opacity-70"
-                   aria-hidden="true"></i>
-                View in Trust Center
-            </a>
-            <button type="button"
-                    class="tw-dropdown-item"
-                    role="menuitem"
-                    @click="navigator.clipboard && navigator.clipboard.writeText(window.location.origin + '{% url 'core:security_advisory_detail' '__ID__' %}'.replace('__ID__', rowMenu.adv.id)); rowMenu.open = false">
-                <i class="fas fa-link w-5 text-center opacity-70" aria-hidden="true"></i>
-                Copy link
-            </button>
-            <button type="button"
-                    class="tw-dropdown-item"
-                    role="menuitem"
-                    @click="window.location.href = '{% url 'core:security_advisory_detail' '__ID__' %}'.replace('__ID__', rowMenu.adv.id) + '#link-vex'; rowMenu.open = false">
-                <i class="fas fa-file-shield w-5 text-center opacity-70"
-                   aria-hidden="true"></i>
-                Link a VEX
-            </button>
-            <div class="tw-dropdown-divider"></div>
-            <button type="button"
-                    class="tw-dropdown-item tw-dropdown-item-danger"
-                    role="menuitem"
-                    @click="rowMenu.open = false">
-                <i class="fas fa-trash w-5 text-center opacity-70" aria-hidden="true"></i>
-                Delete advisory
-            </button>
         </div>
     {% endif %}
 </div>

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -2,32 +2,45 @@
 {% load static %}
 {% block title %}{{ advisory.title }} · sbomify{% endblock %}
 {% block dashboard_content %}
-    <div class="space-y-8">
+    <div class="space-y-6">
         {# Back link #}
         <a href="{% url 'core:security_advisories_dashboard' %}"
            class="inline-flex items-center gap-2 text-sm text-text-muted hover:text-text transition-colors">
             <i class="fas fa-arrow-left text-xs" aria-hidden="true"></i>
             Security advisories
         </a>
-        {# Header #}
-        <div class="flex items-start justify-between gap-4">
+        {% comment %}Header — same shape as the product and component detail pages: the actions drop below the title on narrow viewports rather than squeezing it.{% endcomment %}
+        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
             <div class="flex items-start gap-4 min-w-0">
                 <div class="tw-avatar tw-avatar-lg shrink-0">
                     <i class="fas fa-shield-halved"></i>
                 </div>
-                <div class="min-w-0">
-                    <div class="flex items-center gap-2 flex-wrap mb-1.5">
-                        <span class="tw-badge tw-badge-{{ advisory.severity_variant }}">{{ advisory.severity|title }}</span>
-                        <span class="tw-badge tw-badge-{{ advisory.status_variant }}">{{ advisory.status_label }}</span>
-                    </div>
-                    <h1 class="text-2xl font-bold text-text">{{ advisory.title }}</h1>
+                {% comment %}Both clamps are line-based, so the cut follows the rendered width and the ellipsis is the browser's — a wide screen shows more of the same title than a narrow one. One disclosure governs both, because a title long enough to clip usually comes with a description long enough to clip too. clipped is only re-measured while collapsed: expanding removes the clamp, so a measurement taken then would report nothing overflowing and the button would vanish mid-use. break-words keeps an unbroken string (a pasted identifier, a hostname) from running under the header actions.{% endcomment %}
+                <div class="flex-1 min-w-0"
+                     x-data="{ expanded: false, clipped: false, measure() { this.clipped = [$refs.title, $refs.summary].some((el) => el && el.scrollHeight > el.clientHeight) } }"
+                     x-init="$nextTick(() => measure())"
+                     @resize.window.debounce="expanded || measure()">
+                    <h1 x-ref="title"
+                        class="text-2xl font-bold text-text break-words"
+                        :class="expanded ? '' : 'line-clamp-1'"
+                        title="{{ advisory.title }}">{{ advisory.title }}</h1>
+                    <p class="text-text-muted text-sm m-0 mt-1">{{ advisory.type_label }} advisory</p>
                     {% if advisory.description %}
-                        <p class="text-text-muted leading-relaxed mt-2 max-w-3xl">{{ advisory.description }}</p>
+                        <p x-ref="summary"
+                           class="text-text-muted leading-relaxed break-words whitespace-pre-line mt-2 max-w-3xl"
+                           :class="expanded ? '' : 'line-clamp-2'">{{ advisory.description }}</p>
                     {% endif %}
+                    <button type="button"
+                            x-show="clipped || expanded"
+                            x-cloak
+                            @click="expanded = !expanded"
+                            class="mt-1 text-sm text-primary hover:underline">
+                        <span x-text="expanded ? 'Show less' : 'Show more'"></span>
+                    </button>
                 </div>
             </div>
             {# Header actions #}
-            <div class="flex items-center gap-2 shrink-0">
+            <div class="flex items-center gap-2 shrink-0 flex-wrap">
                 <a href="{% url 'core:workspace_public_current' %}"
                    target="_blank"
                    rel="noopener"
@@ -152,7 +165,14 @@
                         <div class="flex-1 min-w-0 {% if not forloop.last %}pb-8{% endif %}"
                              {% if has_crud_permissions %}@click="if (!editing) editing = true" :class="{ 'cursor-pointer': !editing }"{% endif %}>
                             <div class="flex items-center justify-between gap-3">
-                                <span class="tw-badge tw-badge-{{ u.variant }}">{{ u.label }}</span>
+                                <span class="flex items-center gap-2 min-w-0">
+                                    {% if u.from_label %}
+                                        <span class="text-xs text-text-muted shrink-0">{{ u.from_label }}</span>
+                                        <i class="fas fa-arrow-right text-[10px] text-text-muted shrink-0"
+                                           aria-hidden="true"></i>
+                                    {% endif %}
+                                    <span class="tw-badge tw-badge-{{ u.variant }}">{{ u.label }}</span>
+                                </span>
                                 <div class="flex items-center gap-3 shrink-0">
                                     <span class="text-xs text-text-muted">{{ u.date_display }}</span>
                                     {% if has_crud_permissions %}
@@ -241,6 +261,15 @@
                     <h2 class="text-xs uppercase tracking-wide text-text-muted">Affected products</h2>
                     <div class="flex flex-wrap gap-2">
                         {% comment %}An advisory can name a product this workspace does not track, and keeps naming it after one is deleted. Those have no id, and the url tag would happily build /product/None/ rather than fail, so they render as plain text.{% endcomment %}
+                        {% if not advisory.products %}
+                            <p class="text-sm text-text-muted m-0">
+                                {% if advisory.advisory_type == 'workspace_notice' %}
+                                    A workspace notice names no products.
+                                {% else %}
+                                    No products recorded yet — publishing a product advisory requires at least one.
+                                {% endif %}
+                            </p>
+                        {% endif %}
                         {% for product in advisory.products %}
                             <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-lg bg-border/20 text-text-muted border border-border/40">
                                 <i class="fas fa-cube text-[10px] mr-1.5 opacity-70"></i>

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -68,6 +68,17 @@
                              role="menu"
                              aria-orientation="vertical"
                              aria-label="Advisory actions">
+                            {% if advisory.publication_status == 'draft' %}
+                                {# Publishing is what puts an advisory on the Trust Center — until it runs, an advisory is a draft with private visibility and both are filtered out there. #}
+                                <button type="button"
+                                        class="tw-dropdown-item"
+                                        role="menuitem"
+                                        @click="open = false; $dispatch('open-publish-advisory-modal')">
+                                    <i class="fas fa-bullhorn w-5 text-center opacity-70" aria-hidden="true"></i>
+                                    Publish advisory
+                                </button>
+                                <div class="tw-dropdown-divider"></div>
+                            {% endif %}
                             <button type="button"
                                     class="tw-dropdown-item"
                                     role="menuitem"
@@ -312,7 +323,97 @@
                 {% endif %}
             </aside>
         </div>
-        {# Edit Advisory Modal (Alpine.js) — front-end preview, does not persist yet (#1172) #}
+        {% comment %}Publish Advisory Modal. Disclosure is irreversible in the sense that matters — the tracking id is allocated here and immutable, and made_public_at records when disclosure happened — so this asks rather than firing from the menu.{% endcomment %}
+        {% if has_crud_permissions and advisory.publication_status == 'draft' %}
+            <div x-data="{ open: false }"
+                 @open-publish-advisory-modal.window="open = true">
+                <template x-teleport="body">
+                    <div x-show="open"
+                         x-cloak
+                         class="fixed inset-0 z-[100]"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="publishAdvisoryModalLabel">
+                        <div x-show="open"
+                             x-transition:enter="transition ease-out duration-200"
+                             x-transition:enter-start="opacity-0"
+                             x-transition:enter-end="opacity-100"
+                             x-transition:leave="transition ease-in duration-150"
+                             x-transition:leave-start="opacity-100"
+                             x-transition:leave-end="opacity-0"
+                             class="tw-modal-overlay"
+                             @click="open = false"></div>
+                        <div class="tw-modal"
+                             x-show="open"
+                             x-trap.noscroll="open"
+                             x-transition:enter="transition ease-out duration-200"
+                             x-transition:enter-start="opacity-0 scale-95"
+                             x-transition:enter-end="opacity-100 scale-100"
+                             x-transition:leave="transition ease-in duration-150"
+                             x-transition:leave-start="opacity-100 scale-100"
+                             x-transition:leave-end="opacity-0 scale-95"
+                             @click.stop
+                             @keydown.escape="if(open) open = false">
+                            <div class="tw-modal-content">
+                                <div class="tw-modal-header">
+                                    <div class="flex items-center gap-3">
+                                        <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                                            <i class="fas fa-bullhorn text-primary"></i>
+                                        </div>
+                                        <h4 id="publishAdvisoryModalLabel" class="tw-modal-title">Publish advisory</h4>
+                                    </div>
+                                    <button type="button"
+                                            class="tw-modal-close"
+                                            @click="open = false"
+                                            aria-label="Close">
+                                        <i class="fas fa-times" aria-hidden="true"></i>
+                                    </button>
+                                </div>
+                                <form method="post"
+                                      action="{% url 'core:security_advisory_detail' advisory.id %}">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="intent" value="publish" />
+                                    <div class="tw-modal-body space-y-4">
+                                        {# Clamped like the page header: a pasted identifier for a title would otherwise run past the modal's edge. #}
+                                        <p class="text-sm text-text-muted m-0">
+                                            <strong class="text-text block break-words line-clamp-2"
+                                                    title="{{ advisory.title }}">{{ advisory.title }}</strong>
+                                            becomes readable outside this workspace and is assigned a permanent
+                                            tracking id.
+                                        </p>
+                                        <fieldset class="space-y-2 pt-1">
+                                            <legend class="tw-form-label mb-1">Who can read it</legend>
+                                            {% for value, meta in publish_visibilities.items %}
+                                                <label class="flex items-start gap-3 p-3 rounded-lg border border-border cursor-pointer hover:bg-muted/40">
+                                                    <input type="radio"
+                                                           name="visibility"
+                                                           value="{{ value }}"
+                                                           class="tw-radio mt-0.5"
+                                                           {% if forloop.first %}checked{% endif %} />
+                                                    <span class="min-w-0">
+                                                        <span class="block text-sm font-medium text-text">{{ meta.label }}</span>
+                                                        <span class="block text-xs text-text-muted">{{ meta.help }}</span>
+                                                    </span>
+                                                </label>
+                                            {% endfor %}
+                                        </fieldset>
+                                    </div>
+                                    <div class="tw-modal-footer">
+                                        <p class="text-xs text-text-muted m-0 mr-auto">The tracking id and the disclosure date are recorded permanently.</p>
+                                        <button type="button" class="tw-btn-secondary" @click="open = false">Cancel</button>
+                                        <button type="submit" class="tw-btn-primary gap-2">
+                                            <i class="fas fa-bullhorn" aria-hidden="true"></i>
+                                            Publish
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        {% endif %}
+        {# Edit Advisory Modal (Alpine.js) #}
         {% if has_crud_permissions %}
             <div x-data="{ open: false, showRef:
                 {% if advisory.vulnerability_id %}

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -34,6 +34,7 @@
                             x-show="clipped || expanded"
                             x-cloak
                             @click="expanded = !expanded"
+                            :aria-expanded="expanded"
                             class="mt-1 text-sm text-primary hover:underline">
                         <span x-text="expanded ? 'Show less' : 'Show more'"></span>
                     </button>
@@ -380,7 +381,9 @@
                                         </div>
                                         <div>
                                             <label class="tw-form-label" for="editSeverity">Severity</label>
+                                            {# An advisory may legitimately carry no severity, and without a blank option the select would silently promote it to the first one on any save. #}
                                             <select id="editSeverity" name="severity" class="tw-form-input">
+                                                <option value="" {% if not advisory.severity %}selected{% endif %}>Not set</option>
                                                 <option value="critical"
                                                         {% if advisory.severity == 'critical' %}selected{% endif %}>
                                                     Critical

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -31,6 +31,7 @@ from django.views import View
 from sbomify.apps.core.models import User
 from sbomify.apps.security_advisories.forms import AdvisoryCreateForm
 from sbomify.apps.security_advisories.services.advisories import (
+    PUBLISHABLE_VISIBILITIES,
     REMEDIATION_META,
     advisory_counts,
     create_advisory,
@@ -38,6 +39,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     get_advisory,
     list_advisories,
     post_update,
+    publish_advisory,
     update_advisory,
 )
 from sbomify.apps.teams.models import Member, Team
@@ -188,6 +190,7 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
                 "advisory": advisory,
                 "timeline": advisory["timeline"],
                 "update_kinds": UPDATE_KINDS,
+                "publish_visibilities": PUBLISHABLE_VISIBILITIES,
                 # Real VEX candidates need the linking pass; an empty list renders
                 # the section's own empty state rather than inventing documents.
                 "vex_candidates": [],
@@ -200,6 +203,21 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
             raise Http404("Advisory not found")
 
         intent = request.POST.get("intent")
+        if intent == "publish":
+            result = publish_advisory(
+                team,
+                cast(User, request.user),
+                advisory_id,
+                visibility=request.POST.get("visibility", ""),
+            )
+            if result.ok:
+                messages.success(request, "Advisory published.")
+            elif result.status_code == 404:
+                raise Http404("Advisory not found")
+            else:
+                messages.error(request, result.error or "Advisory not published.")
+            return redirect("core:security_advisory_detail", advisory_id=advisory_id)
+
         if intent == "edit":
             result = update_advisory(
                 team,

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -74,6 +74,33 @@ def _current_team(request: HttpRequest) -> Team | None:
     return membership.team if membership else None
 
 
+# Roles that may change an advisory, mirroring the has_crud_permissions the
+# templates use to decide whether to render the controls at all.
+_ADVISORY_WRITE_ROLES = ("owner", "admin")
+
+
+def _writable_team(request: HttpRequest) -> Team | None:
+    """The workspace, but only for a member who may change its advisories.
+
+    The templates hide the edit and compose controls behind
+    ``has_crud_permissions``, which is a rendering decision and nothing a
+    handler can rely on — a POST can be crafted without ever loading the page.
+    The role is read from the membership row rather than the session, so a
+    role cached there cannot outlive a demotion.
+    """
+    key = (request.session.get("current_team") or {}).get("key")
+    if not key:
+        return None
+    user = cast(User, request.user)
+    membership = (
+        Member.objects.filter(user=user, team__key=key, role__in=_ADVISORY_WRITE_ROLES)
+        .select_related("team")
+        .only("team", "role")
+        .first()
+    )
+    return membership.team if membership else None
+
+
 def _advisories_context(request: HttpRequest) -> dict[str, Any]:
     current_team = request.session.get("current_team") or {}
     team = _current_team(request)
@@ -100,7 +127,7 @@ class SecurityAdvisoriesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixi
         return render(request, "core/security_advisories_dashboard.html.j2", context)
 
     def post(self, request: HttpRequest) -> HttpResponse:
-        team = _current_team(request)
+        team = _writable_team(request)
         if team is None:
             raise Http404("Workspace not found")
 
@@ -168,7 +195,7 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
         )
 
     def post(self, request: HttpRequest, advisory_id: str) -> HttpResponse:
-        team = _current_team(request)
+        team = _writable_team(request)
         if team is None:
             raise Http404("Advisory not found")
 
@@ -179,7 +206,9 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
                 cast(User, request.user),
                 advisory_id,
                 title=request.POST.get("title", ""),
-                severity=request.POST.get("severity", ""),
+                # None when the form did not carry the field at all, so a
+                # partial edit cannot silently set a severity nobody chose.
+                severity=request.POST.get("severity"),
                 description=request.POST.get("description", ""),
             )
             if result.ok:

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -38,6 +38,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     get_advisory,
     list_advisories,
     post_update,
+    update_advisory,
 )
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
@@ -172,13 +173,29 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
             raise Http404("Advisory not found")
 
         intent = request.POST.get("intent")
-        if intent in ("edit", "edit_update", "link_vex"):
+        if intent == "edit":
+            result = update_advisory(
+                team,
+                cast(User, request.user),
+                advisory_id,
+                title=request.POST.get("title", ""),
+                severity=request.POST.get("severity", ""),
+                description=request.POST.get("description", ""),
+            )
+            if result.ok:
+                messages.success(request, "Advisory updated.")
+            elif result.status_code == 404:
+                raise Http404("Advisory not found")
+            else:
+                messages.error(request, result.error or "Advisory not updated.")
+            return redirect("core:security_advisory_detail", advisory_id=advisory_id)
+
+        if intent in ("edit_update", "link_vex"):
             # Only the stubs pay for the full projection lookup; the real
             # composer path below lets post_update do the one scoped lookup.
             if not get_advisory(team, advisory_id).ok:
                 raise Http404("Advisory not found")
             note = {
-                "edit": "Editing an advisory is the next pass on this UI.",
                 "edit_update": "Editing a timeline entry is the next pass on this UI.",
                 "link_vex": "Linking VEX documents is the pass after the CRUD one.",
             }[intent]

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import Prefetch, Q, QuerySet
+from django.utils import timezone
 
 from sbomify.apps.core.models import Product, Release
 from sbomify.apps.core.services.results import ServiceResult
@@ -29,6 +31,7 @@ from sbomify.apps.security_advisories.models import (
     ReferenceType,
     SecurityAdvisory,
     Severity,
+    validate_publishable,
 )
 
 # Severity to the badge variant the templates use.
@@ -563,6 +566,89 @@ def update_advisory(
             body=_field_change_body(field, old, new),
             payload={"field": field, "old": old, "new": new},
         )
+    return ServiceResult.success(advisory.id)
+
+
+# Publishing to "private" is not publishing: the Trust Center excludes private
+# advisories in SQL, so it would move the status and disclose nothing. The two
+# real destinations are a gated (embargoed, signed-NDA) disclosure and a public
+# one; changing visibility afterwards is its own action.
+PUBLISHABLE_VISIBILITIES: dict[str, dict[str, str]] = {
+    SecurityAdvisory.Visibility.PUBLIC.value: {
+        "label": "Public",
+        "help": "Anyone can read it on your Trust Center.",
+    },
+    SecurityAdvisory.Visibility.GATED.value: {
+        "label": "Gated",
+        "help": "Only readers who have signed your NDA and can see an affected product.",
+    },
+}
+
+
+@transaction.atomic
+def publish_advisory(team: Any, user: Any, advisory_id: str, *, visibility: str) -> ServiceResult[str]:
+    """Disclose an advisory: the one write that makes it readable outside the workspace.
+
+    Until this runs an advisory is a draft with private visibility, and the
+    Trust Center filters both out — which is why a workspace could write
+    advisories all day and see nothing published.
+
+    Both axes move together here. Status alone would leave it private and still
+    invisible; visibility alone would expose a draft. The tracking id is
+    allocated now and is immutable afterwards, ``published_at`` records the
+    disclosure, and ``made_public_at`` records it separately for a public one
+    because a gated disclosure is not public disclosure.
+
+    The team row is locked because ``allocate_tracking_id`` counts by reading
+    the highest existing id for the year: two publishes racing would read the
+    same maximum and one would lose to the unique constraint.
+    """
+    if visibility not in PUBLISHABLE_VISIBILITIES:
+        return ServiceResult.failure("Choose whether to publish publicly or to NDA readers.", status_code=400)
+
+    from sbomify.apps.teams.models import Team
+
+    Team.objects.select_for_update().filter(pk=team.pk).first()
+
+    advisory = (
+        SecurityAdvisory.objects.select_for_update()
+        .filter(team=team)
+        .filter(Q(id=advisory_id) | Q(tracking_id=advisory_id))
+        .first()
+    )
+    if advisory is None:
+        return ServiceResult.failure("Advisory not found", status_code=404)
+    if advisory.status != SecurityAdvisory.Status.DRAFT:
+        return ServiceResult.failure("This advisory has already been published.", status_code=409)
+
+    # The graph-wide rules: a product advisory needs products, every
+    # vulnerability needs a status per product, a fixed status names the fix.
+    if problems := validate_publishable(advisory):
+        return ServiceResult.failure(" ".join(problems), status_code=400)
+
+    now = timezone.now()
+    advisory.status = SecurityAdvisory.Status.PUBLISHED
+    advisory.published_at = now
+    advisory.visibility = visibility
+    if visibility == SecurityAdvisory.Visibility.PUBLIC:
+        advisory.made_public_at = now
+    advisory.tracking_id = SecurityAdvisory.allocate_tracking_id(team)
+
+    try:
+        advisory.full_clean()
+    except DjangoValidationError as error:
+        # The model holds the disclosure invariants; surfacing them beats
+        # letting a 500 out of save().
+        return ServiceResult.failure("; ".join(m for messages in error.message_dict.values() for m in messages), 400)
+
+    advisory.save(update_fields=["status", "published_at", "visibility", "made_public_at", "tracking_id", "updated_at"])
+    AdvisoryEvent.objects.create(
+        advisory=advisory,
+        event_type=AdvisoryEvent.EventType.PUBLISHED,
+        actor=user,
+        body=f"Published as {advisory.tracking_id} ({PUBLISHABLE_VISIBILITIES[visibility]['label'].lower()}).",
+        payload={"visibility": visibility, "tracking_id": advisory.tracking_id},
+    )
     return ServiceResult.success(advisory.id)
 
 

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -28,6 +28,7 @@ from sbomify.apps.security_advisories.models import (
     AdvisoryVulnerability,
     ReferenceType,
     SecurityAdvisory,
+    Severity,
 )
 
 # Severity to the badge variant the templates use.
@@ -63,7 +64,7 @@ PUBLICATION_VARIANTS = {"draft": "secondary", "published": "success", "withdrawn
 # Advisory "type" as the list column shows it. Inferred rather than stored,
 # because the model already records the real identifiers and which database
 # issued them is a fact about those, not a separate field to keep in step.
-TYPE_LABELS = {"cve": "CVE", "ghsa": "GHSA", "other": "Other"}
+TYPE_LABELS = {"cve": "CVE", "ghsa": "GHSA", "internal": "Internal", "other": "Other"}
 
 # Timeline entries a reader sees. Internal comments are excluded from the
 # public feed by the model's PUBLIC_EVENT_TYPES; this is the workspace view, so
@@ -114,6 +115,11 @@ def _advisory_type(vulnerabilities: list[AdvisoryVulnerability], references: lis
         return "cve"
     if ReferenceType.GHSA in types:
         return "ghsa"
+    # No external identifier anywhere means this is the workspace's own
+    # finding, not some other database's. Saying "Internal" is more useful
+    # than a catch-all that reads like the field failed to populate.
+    if not types:
+        return "internal"
     return "other"
 
 
@@ -204,12 +210,26 @@ def _event_projection(event: AdvisoryEvent) -> dict[str, Any]:
     meta = EVENT_META.get(event.event_type, _UNKNOWN_EVENT)
     payload = event.payload if isinstance(event.payload, dict) else {}
     actor = event.actor
+
+    # A status change reads as the state it moved to, not as the words
+    # "Status change" — five entries all labelled the same tell a reader
+    # nothing about what happened. The badge takes the state's own colour
+    # and icon for the same reason.
+    label, variant, icon = meta["label"], meta["variant"], meta["icon"]
+    to_status = payload.get("to")
+    if event.event_type == AdvisoryEvent.EventType.STATUS_CHANGE and to_status in REMEDIATION_META:
+        state_meta = REMEDIATION_META[to_status]
+        label, variant, icon = state_meta["label"], state_meta["variant"], state_meta["icon"]
+
     return {
         "id": event.id,
         "kind": event.event_type,
-        "label": meta["label"],
-        "variant": meta["variant"],
-        "icon": meta["icon"],
+        "label": label,
+        "variant": variant,
+        "icon": icon,
+        # The transition's origin, for a reader who wants the before as well
+        # as the after. Absent on the first change, which came from nowhere.
+        "from_label": REMEDIATION_META.get(payload.get("from", ""), {}).get("label", ""),
         # "note" and "date_display" are what the timeline template binds to;
         # "body" and "created_at" are the model's own names, kept for callers
         # that want the raw values.
@@ -452,6 +472,53 @@ def create_advisory(
         actor=user,
         payload={"to": SecurityAdvisory.RemediationStatus.IDENTIFIED.value},
     )
+    return ServiceResult.success(advisory.id)
+
+
+@transaction.atomic
+def update_advisory(
+    team: Any, user: Any, advisory_id: str, *, title: str, severity: str = "", description: str = ""
+) -> ServiceResult[str]:
+    """Edit an advisory's own fields.
+
+    Field changes land on the timeline as field_change events, one per field,
+    so the append-only history answers "who changed the severity and when"
+    rather than only recording status moves.
+    """
+    advisory = (
+        SecurityAdvisory.objects.select_for_update()
+        .filter(team=team)
+        .filter(Q(id=advisory_id) | Q(tracking_id=advisory_id))
+        .first()
+    )
+    if advisory is None:
+        return ServiceResult.failure("Advisory not found", status_code=404)
+
+    title = title.strip()
+    if not title:
+        return ServiceResult.failure("An advisory needs a title.", status_code=400)
+    if severity and severity not in Severity.values:
+        return ServiceResult.failure("Unknown severity.", status_code=400)
+
+    changes = [
+        (field, getattr(advisory, field), new)
+        for field, new in (("title", title), ("severity", severity), ("description", description.strip()))
+        if getattr(advisory, field) != new
+    ]
+    if not changes:
+        return ServiceResult.success(advisory.id)
+
+    for field, _old, new in changes:
+        setattr(advisory, field, new)
+    advisory.save(update_fields=[field for field, _o, _n in changes] + ["updated_at"])
+
+    for field, old, new in changes:
+        AdvisoryEvent.objects.create(
+            advisory=advisory,
+            event_type=AdvisoryEvent.EventType.FIELD_CHANGE,
+            actor=user,
+            payload={"field": field, "old": old, "new": new},
+        )
     return ServiceResult.success(advisory.id)
 
 

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -482,9 +482,35 @@ def create_advisory(
     return ServiceResult.success(advisory.id)
 
 
+# Above this, a value is described rather than quoted on the timeline. A
+# rewritten description is the common case and pasting both versions of it
+# would bury every other entry.
+_FIELD_CHANGE_QUOTE_LIMIT = 80
+
+
+def _field_change_body(field: str, old: Any, new: Any) -> str:
+    """What a field_change entry reads as on the timeline."""
+    label = field.replace("_", " ").capitalize()
+
+    def describe(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        return f"“{text}”" if len(text) <= _FIELD_CHANGE_QUOTE_LIMIT else None
+
+    old_text, new_text = describe(old), describe(new)
+    if old_text and new_text:
+        return f"{label} changed from {old_text} to {new_text}."
+    if new_text and not old_text:
+        return f"{label} set to {new_text}."
+    if old_text and not new_text and not str(new or "").strip():
+        return f"{label} cleared."
+    return f"{label} updated."
+
+
 @transaction.atomic
 def update_advisory(
-    team: Any, user: Any, advisory_id: str, *, title: str, severity: str = "", description: str = ""
+    team: Any, user: Any, advisory_id: str, *, title: str, severity: str | None = None, description: str = ""
 ) -> ServiceResult[str]:
     """Edit an advisory's own fields.
 
@@ -504,14 +530,19 @@ def update_advisory(
     title = title.strip()
     if not title:
         return ServiceResult.failure("An advisory needs a title.", status_code=400)
-    if severity and severity not in Severity.values:
-        return ServiceResult.failure("Unknown severity.", status_code=400)
 
-    changes = [
-        (field, getattr(advisory, field), new)
-        for field, new in (("title", title), ("severity", severity), ("description", description.strip()))
-        if getattr(advisory, field) != new
-    ]
+    # ``None`` means the caller did not submit a severity, which is different
+    # from submitting a blank one. A <select> always posts something, so an
+    # advisory saved with no severity would otherwise pick up the first option
+    # whenever anyone edited its title.
+    fields: list[tuple[str, Any]] = [("title", title), ("description", description.strip())]
+    if severity is not None:
+        severity = severity.strip()
+        if severity and severity not in Severity.values:
+            return ServiceResult.failure("Unknown severity.", status_code=400)
+        fields.append(("severity", severity))
+
+    changes = [(field, getattr(advisory, field), new) for field, new in fields if getattr(advisory, field) != new]
     if not changes:
         return ServiceResult.success(advisory.id)
 
@@ -524,6 +555,12 @@ def update_advisory(
             advisory=advisory,
             event_type=AdvisoryEvent.EventType.FIELD_CHANGE,
             actor=user,
+            # The timeline renders an event's body, so a field change with only
+            # a payload showed a "Field change" badge and no text at all. The
+            # body says which field moved; long values are summarised rather
+            # than pasted, since a rewritten description would otherwise bury
+            # every other entry on the page.
+            body=_field_change_body(field, old, new),
             payload={"field": field, "old": old, "new": new},
         )
     return ServiceResult.success(advisory.id)

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -367,16 +367,23 @@ def creation_options(team: Any) -> ServiceResult[list[dict[str, Any]]]:
 
     ``latest`` releases are excluded: that pointer re-targets as artifacts
     arrive, so "affected: latest" would describe different code next month.
+
+    Newest first, and the date travels with each row. Version strings do not
+    sort into release order on their own — a hand-cut ``0.99-wiz-test`` can
+    postdate a dated build — so without the date on screen a correctly ordered
+    list reads as an unordered one.
     """
     releases_by_product: dict[str, list[dict[str, str]]] = {}
     release_rows = (
         Release.objects.filter(product__team=team, is_latest=False)
         .order_by("-created_at")
-        .values("id", "product_id", "name", "version")
+        .values("id", "product_id", "name", "version", "created_at")
     )
     for row in release_rows:
         label = row["version"] or row["name"]
-        releases_by_product.setdefault(row["product_id"], []).append({"id": row["id"], "label": label})
+        releases_by_product.setdefault(row["product_id"], []).append(
+            {"id": row["id"], "label": label, "created": row["created_at"].strftime("%d %b %Y")}
+        )
 
     products = [
         {"id": product_id, "name": name, "releases": releases_by_product.get(product_id, [])}

--- a/sbomify/apps/security_advisories/tests/test_advisory_service.py
+++ b/sbomify/apps/security_advisories/tests/test_advisory_service.py
@@ -21,6 +21,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     advisory_counts,
     get_advisory,
     list_advisories,
+    publish_advisory,
     update_advisory,
 )
 
@@ -375,3 +376,121 @@ class TestUpdateAdvisory:
         assert result.status_code == 404
         advisory.refresh_from_db()
         assert advisory.title == "Not yours"
+
+
+class TestPublishAdvisory:
+    """Publishing is what puts an advisory on the Trust Center: until it runs the
+    advisory is a draft with private visibility, and that page filters out both."""
+
+    def _publishable(self, team, name="Gateway"):
+        from sbomify.apps.core.models import Product
+
+        advisory = _advisory(team)
+        product, _ = Product.objects.get_or_create(team=team, name=name)
+        AdvisoryProduct.objects.create(advisory=advisory, product=product)
+        return advisory
+
+    def test_publishing_public_makes_it_externally_visible(self, sample_team, sample_user):
+        advisory = self._publishable(sample_team)
+
+        result = publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        assert result.ok, result.error
+        advisory.refresh_from_db()
+        assert advisory.status == SecurityAdvisory.Status.PUBLISHED
+        assert advisory.visibility == SecurityAdvisory.Visibility.PUBLIC
+        assert advisory.is_externally_visible
+
+    def test_publishing_records_the_disclosure(self, sample_team, sample_user):
+        """published_at is when it left the workspace; made_public_at is when it
+        became public, which a gated disclosure is not."""
+        advisory = self._publishable(sample_team)
+
+        publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        advisory.refresh_from_db()
+        assert advisory.published_at is not None
+        assert advisory.made_public_at is not None
+
+    def test_a_gated_disclosure_is_not_public_disclosure(self, sample_team, sample_user):
+        advisory = self._publishable(sample_team)
+
+        publish_advisory(sample_team, sample_user, advisory.id, visibility="gated")
+
+        advisory.refresh_from_db()
+        assert advisory.visibility == SecurityAdvisory.Visibility.GATED
+        assert advisory.published_at is not None
+        assert advisory.made_public_at is None
+
+    def test_a_tracking_id_is_allocated_and_sequential(self, sample_team, sample_user):
+        first = self._publishable(sample_team)
+        second = self._publishable(sample_team)
+
+        publish_advisory(sample_team, sample_user, first.id, visibility="public")
+        publish_advisory(sample_team, sample_user, second.id, visibility="public")
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.tracking_id.endswith("-0001")
+        assert second.tracking_id.endswith("-0002")
+        assert first.tracking_id[:-4] == second.tracking_id[:-4]
+
+    def test_publishing_lands_on_the_timeline(self, sample_team, sample_user):
+        advisory = self._publishable(sample_team)
+
+        publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        advisory.refresh_from_db()
+        event = AdvisoryEvent.objects.get(advisory=advisory, event_type=AdvisoryEvent.EventType.PUBLISHED)
+        assert advisory.tracking_id in event.body
+        assert event.payload["visibility"] == "public"
+
+    def test_publishing_private_is_refused(self, sample_team, sample_user):
+        """It would move the status and disclose nothing — the Trust Center
+        excludes private advisories in SQL."""
+        advisory = self._publishable(sample_team)
+
+        result = publish_advisory(sample_team, sample_user, advisory.id, visibility="private")
+
+        assert not result.ok
+        assert result.status_code == 400
+        advisory.refresh_from_db()
+        assert advisory.status == SecurityAdvisory.Status.DRAFT
+
+    def test_a_product_advisory_with_no_products_is_refused(self, sample_team, sample_user):
+        advisory = _advisory(sample_team)
+
+        result = publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        assert not result.ok
+        assert result.status_code == 400
+        assert "at least one product" in result.error
+        advisory.refresh_from_db()
+        assert advisory.status == SecurityAdvisory.Status.DRAFT
+        assert advisory.tracking_id == ""
+
+    def test_publishing_twice_is_refused(self, sample_team, sample_user):
+        advisory = self._publishable(sample_team)
+        publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+        advisory.refresh_from_db()
+        first_id = advisory.tracking_id
+
+        result = publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        assert not result.ok
+        assert result.status_code == 409
+        advisory.refresh_from_db()
+        assert advisory.tracking_id == first_id
+
+    def test_another_workspaces_advisory_is_not_found(self, sample_team, sample_user):
+        from sbomify.apps.teams.models import Team
+
+        other = Team.objects.create(name="Someone else")
+        advisory = _advisory(other)
+
+        result = publish_advisory(sample_team, sample_user, advisory.id, visibility="public")
+
+        assert not result.ok
+        assert result.status_code == 404
+        advisory.refresh_from_db()
+        assert advisory.status == SecurityAdvisory.Status.DRAFT

--- a/sbomify/apps/security_advisories/tests/test_advisory_service.py
+++ b/sbomify/apps/security_advisories/tests/test_advisory_service.py
@@ -21,6 +21,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     advisory_counts,
     get_advisory,
     list_advisories,
+    update_advisory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -269,3 +270,108 @@ def test_the_display_id_is_always_a_string(sample_team):
 
     assert isinstance(row["id"], str)
     assert isinstance(row["pk"], str)
+
+
+class TestUpdateAdvisory:
+    def test_each_changed_field_gets_its_own_timeline_entry(self, sample_team, sample_user):
+        """One event per field, so the history answers who changed the severity
+        rather than only recording status moves."""
+        advisory = _advisory(sample_team, title="Old title", severity="low", description="Old body.")
+
+        result = update_advisory(
+            sample_team,
+            sample_user,
+            advisory.id,
+            title="New title",
+            severity="high",
+            description="New body.",
+        )
+
+        assert result.ok, result.error
+        advisory.refresh_from_db()
+        assert (advisory.title, advisory.severity, advisory.description) == ("New title", "high", "New body.")
+        events = AdvisoryEvent.objects.filter(advisory=advisory, event_type=AdvisoryEvent.EventType.FIELD_CHANGE)
+        assert {event.payload["field"] for event in events} == {"title", "severity", "description"}
+
+    def test_a_field_change_entry_says_what_changed(self, sample_team, sample_user):
+        """The timeline renders an event's body. A payload-only event showed a
+        "Field change" badge with no text under it."""
+        advisory = _advisory(sample_team, severity="low")
+
+        update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="high")
+
+        event = AdvisoryEvent.objects.get(
+            advisory=advisory, event_type=AdvisoryEvent.EventType.FIELD_CHANGE, payload__field="severity"
+        )
+        assert event.body == "Severity changed from “low” to “high”."
+
+    def test_an_unchanged_field_records_nothing(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, title="Same", severity="high", description="Same body.")
+
+        result = update_advisory(
+            sample_team, sample_user, advisory.id, title="Same", severity="high", description="Same body."
+        )
+
+        assert result.ok
+        assert not AdvisoryEvent.objects.filter(advisory=advisory).exists()
+
+    def test_an_omitted_severity_is_left_alone(self, sample_team, sample_user):
+        """A <select> always posts something, so "not submitted" has to be
+        distinguishable from "submitted blank" or editing a title would set a
+        severity nobody chose."""
+        advisory = _advisory(sample_team, severity="")
+
+        update_advisory(sample_team, sample_user, advisory.id, title="Retitled")
+
+        advisory.refresh_from_db()
+        assert advisory.severity == ""
+
+    def test_a_blank_severity_clears_it(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="high")
+
+        update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="")
+
+        advisory.refresh_from_db()
+        assert advisory.severity == ""
+
+    def test_surrounding_whitespace_on_severity_is_tolerated(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="low")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity=" high ")
+
+        assert result.ok, result.error
+        advisory.refresh_from_db()
+        assert advisory.severity == "high"
+
+    def test_an_empty_title_is_refused(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, title="Keeps its title")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title="   ")
+
+        assert not result.ok
+        assert result.status_code == 400
+        advisory.refresh_from_db()
+        assert advisory.title == "Keeps its title"
+
+    def test_an_unknown_severity_is_refused(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="low")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="spicy")
+
+        assert not result.ok
+        assert result.status_code == 400
+        advisory.refresh_from_db()
+        assert advisory.severity == "low"
+
+    def test_another_workspaces_advisory_is_not_found(self, sample_team, guest_user, sample_user):
+        from sbomify.apps.teams.models import Team
+
+        other = Team.objects.create(name="Someone else")
+        advisory = _advisory(other, title="Not yours")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title="Mine now")
+
+        assert not result.ok
+        assert result.status_code == 404
+        advisory.refresh_from_db()
+        assert advisory.title == "Not yours"

--- a/sbomify/apps/security_advisories/tests/test_advisory_service.py
+++ b/sbomify/apps/security_advisories/tests/test_advisory_service.py
@@ -122,8 +122,16 @@ class TestType:
         assert row["type"] == "ghsa"
         assert row["type_label"] == "GHSA"
 
-    def test_anything_else_reads_as_other(self, sample_team):
+    def test_no_external_identifier_reads_as_internal(self, sample_team):
+        """An advisory carrying no CVE and no reference is the workspace's own
+        finding. "Other" read like the field had failed to populate."""
         _advisory(sample_team)
+
+        assert list_advisories(sample_team).value[0]["type"] == "internal"
+
+    def test_an_unrecognised_database_still_reads_as_other(self, sample_team):
+        advisory = _advisory(sample_team)
+        AdvisoryReference.objects.create(advisory=advisory, external_id="VENDOR-2026-1")
 
         assert list_advisories(sample_team).value[0]["type"] == "other"
 


### PR DESCRIPTION
The advisory detail page had five problems, all visible from the page itself.

**Editing did nothing.** The meatball menu opened an edit form that posted `intent=edit` straight into a stub, which toasted "not saved yet" and dropped the input. `update_advisory` now persists title, severity and description under `select_for_update`, and writes one `field_change` event per changed field, so the append-only history answers who changed the severity rather than only who moved the status.

**Type always read "Other".** An advisory carrying no CVE and no reference is the workspace's own finding, so it now reads "Internal". "Other" looked like the field had failed to populate.

**The timeline showed "Status change" five times over,** naming the event class instead of the state. Each entry now names the state it moved to, in that state's own colour and icon, and names the state it came from: Identified → Investigating → Fix in progress → Resolved.

**Affected products vanished entirely when empty,** so a reader could not tell "none recorded" from "the page forgot to render it". It now says which.

**The layout matched no other page** — `space-y-8` against everyone else's `space-y-6`, a header that squeezed rather than stacked, and no clamping at all, so a long title ran underneath the action buttons and a long description pushed the timeline off screen. The header now follows the component detail page. The title clamps to one line and the description to two, both line-based rather than character-based so the cut follows the rendered width and the ellipsis is the browser's, under a single Show more that governs both. The id chip is gone from the header; Details already lists it.

## Testing

239 security_advisories tests pass, including two new ones covering the internal-vs-other split. Browser-verified against a short advisory and a deliberately long-title/long-description one at 1400, 900 and 600px: the clamp holds and the disclosure survives expansion in both directions.