### PR TITLE
fix(posture): one advisory on one package is one row

### DIFF
--- a/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.spec.ts
@@ -156,3 +156,83 @@ describe('the half-ticked parent box', () => {
         expect(picker.isPartiallySelected(picker.products[2])).toBe(false)
     })
 })
+
+describe('filtering', () => {
+    test('a product name match keeps all of that product\'s versions', () => {
+        picker.setFilter('gateway')
+        expect(picker.visibleProducts.map((p) => p.id)).toEqual(['p1'])
+        expect(picker.visibleReleases(picker.products[0]).length).toBe(3)
+    })
+
+    test('a version label match narrows to that version, and finds the product by it', () => {
+        picker.setFilter('1.2')
+        expect(picker.visibleProducts.map((p) => p.id)).toEqual(['p1'])
+        expect(picker.visibleReleases(picker.products[0]).map((r) => r.id)).toEqual(['r3'])
+    })
+
+    test('nothing matching leaves an empty list rather than the full one', () => {
+        picker.setFilter('nonesuch')
+        expect(picker.visibleProducts).toEqual([])
+    })
+
+    test('a click under a filter selects the row shown, not the one at that index unfiltered', () => {
+        picker.setFilter('vault')
+        picker.toggleProduct(0, plain, picker.visibleProducts)
+        expect(picker.selectedProducts).toEqual(['p2'])
+    })
+
+    test('a version click under a filter selects the version shown', () => {
+        picker.setFilter('1.2')
+        const product = picker.products[0]
+        picker.toggleRelease(product, 0, plain, picker.visibleReleases(product))
+        expect(picker.selectedReleases).toEqual(['r3'])
+    })
+
+    test('a shift range under a filter never reaches a hidden row', () => {
+        picker.setFilter('1.')
+        const product = picker.products[0]
+        const visible = picker.visibleReleases(product)
+        picker.toggleRelease(product, 0, plain, visible)
+        picker.toggleRelease(product, 1, shift, visible)
+        expect(picker.selectedReleases.sort()).toEqual(['r1', 'r2'])
+    })
+
+    test('changing the filter drops the anchors, so the next shift-click starts fresh', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.anchor).toBe(0)
+        picker.setFilter('vault')
+        expect(picker.anchor).toBe(null)
+        expect(picker.releaseAnchor).toEqual({})
+    })
+
+    test('select-every-version under a filter takes only the visible ones', () => {
+        picker.setFilter('1.2')
+        const product = picker.products[0]
+        picker.toggleAllVersions(product, picker.visibleReleases(product))
+        expect(picker.selectedReleases).toEqual(['r3'])
+    })
+})
+
+describe('selection summary', () => {
+    test('says so when nothing is picked', () => {
+        expect(picker.selectionSummary).toBe('No products selected yet.')
+    })
+
+    test('a bare product tick reads as covering every version, now and later', () => {
+        picker.toggleProduct(0, plain)
+        expect(picker.selectionSummary).toBe('Gateway: every version, now and in future')
+    })
+
+    test('picked versions are counted, and singular reads singular', () => {
+        picker.toggleRelease(picker.products[0], 0, plain)
+        expect(picker.selectionSummary).toBe('Gateway: 1 version')
+    })
+
+    test('several products are joined', () => {
+        picker.toggleProduct(0, plain)
+        picker.toggleProduct(1, plain)
+        expect(picker.selectionSummary).toBe(
+            'Gateway: every version, now and in future · Vault: every version, now and in future',
+        )
+    })
+})

--- a/sbomify/apps/core/js/components/advisory-product-picker.ts
+++ b/sbomify/apps/core/js/components/advisory-product-picker.ts
@@ -1,6 +1,7 @@
 export interface PickerRelease {
     id: string;
     label: string;
+    created?: string;
 }
 
 export interface PickerProduct {
@@ -29,6 +30,7 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
         selectedProducts: [] as string[],
         selectedReleases: [] as string[],
         expanded: [] as string[],
+        filter: '',
 
         /** Index of the last product row clicked, for shift-click ranges. */
         anchor: null as number | null,
@@ -45,6 +47,48 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
 
         isExpanded(id: string): boolean {
             return this.expanded.includes(id);
+        },
+
+        /**
+         * Narrow the list by product name or version label.
+         *
+         * A workspace with a release-per-build has hundreds of versions, and
+         * scrolling a box to find one is not a search. Matching on either name
+         * or label means typing a build number finds it without first knowing
+         * which product shipped it.
+         *
+         * Both anchors reset, because they hold positions in the list as it was
+         * rendered a moment ago; shift-clicking against a stale one selects a
+         * range the user cannot see.
+         */
+        setFilter(value: string): void {
+            this.filter = value;
+            this.anchor = null;
+            this.releaseAnchor = {};
+        },
+
+        get filterTerm(): string {
+            return this.filter.trim().toLowerCase();
+        },
+
+        get visibleProducts(): PickerProduct[] {
+            const term = this.filterTerm;
+            if (!term) return this.products;
+            return this.products.filter(
+                (product) =>
+                    product.name.toLowerCase().includes(term) ||
+                    product.releases.some((release) => release.label.toLowerCase().includes(term)),
+            );
+        },
+
+        /**
+         * A product matched by name keeps all its versions: the user asked for
+         * that product, not for a subset of its builds.
+         */
+        visibleReleases(product: PickerProduct): PickerRelease[] {
+            const term = this.filterTerm;
+            if (!term || product.name.toLowerCase().includes(term)) return product.releases;
+            return product.releases.filter((release) => release.label.toLowerCase().includes(term));
         },
 
         toggleExpanded(id: string): void {
@@ -68,16 +112,19 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
          * every file manager behaves: shift-clicking an unticked row after
          * ticking one fills the span in rather than inverting each row.
          */
-        toggleProduct(index: number, event?: MouseEvent): void {
-            const product = this.products[index];
+        toggleProduct(index: number, event?: MouseEvent, visible?: PickerProduct[]): void {
+            const list = visible ?? this.products;
+            const product = list[index];
             if (!product) return;
 
             const shouldSelect = !this.isProductSelected(product.id);
             const from = event?.shiftKey && this.anchor !== null ? this.anchor : index;
             const [start, end] = from <= index ? [from, index] : [index, from];
 
+            // As with versions, the range spans the rendered list, so a filter
+            // never drags hidden products into the selection.
             for (let i = start; i <= end; i++) {
-                this.setProduct(this.products[i], shouldSelect);
+                this.setProduct(list[i], shouldSelect);
             }
             this.anchor = index;
         },
@@ -117,8 +164,13 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
          * something you have not marked affected is not a state worth being
          * able to reach.
          */
-        toggleRelease(product: PickerProduct, index: number, event?: MouseEvent): void {
-            const release = product.releases[index];
+        toggleRelease(
+            product: PickerProduct,
+            index: number,
+            event?: MouseEvent,
+            list: PickerRelease[] = product.releases,
+        ): void {
+            const release = list[index];
             if (!release) return;
 
             const shouldSelect = !this.isReleaseSelected(release.id);
@@ -126,8 +178,11 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             const from = event?.shiftKey && previous !== undefined ? previous : index;
             const [start, end] = from <= index ? [from, index] : [index, from];
 
+            // Ranges run over the list as rendered, so shift-clicking under a
+            // filter spans what the user can see rather than the rows the
+            // filter is hiding between them.
             for (let i = start; i <= end; i++) {
-                this.setRelease(product.releases[i], shouldSelect);
+                this.setRelease(list[i], shouldSelect);
             }
             this.releaseAnchor[product.id] = index;
 
@@ -152,8 +207,8 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             return product.releases.filter((release) => this.isReleaseSelected(release.id)).map((r) => r.id);
         },
 
-        allVersionsSelected(product: PickerProduct): boolean {
-            return product.releases.length > 0 && this.selectedReleasesFor(product).length === product.releases.length;
+        allVersionsSelected(product: PickerProduct, list: PickerRelease[] = product.releases): boolean {
+            return list.length > 0 && list.every((release) => this.isReleaseSelected(release.id));
         },
 
         /**
@@ -171,9 +226,9 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             return picked > 0 && picked < product.releases.length;
         },
 
-        toggleAllVersions(product: PickerProduct): void {
-            const selectAll = !this.allVersionsSelected(product);
-            product.releases.forEach((release) => this.setRelease(release, selectAll));
+        toggleAllVersions(product: PickerProduct, list: PickerRelease[] = product.releases): void {
+            const selectAll = !this.allVersionsSelected(product, list);
+            list.forEach((release) => this.setRelease(release, selectAll));
             if (selectAll) this.setProduct(product, true);
             this.releaseAnchor[product.id] = 0;
         },
@@ -190,6 +245,28 @@ export function advisoryProductPicker(products: PickerProduct[] = []) {
             const count = this.selectedReleasesFor(product).length;
             if (count === 0) return 'All versions';
             return `${count} of ${product.releases.length} versions`;
+        },
+
+        /**
+         * What the picker has been told, in a sentence.
+         *
+         * Ticking a product and no versions covers the product whole — every
+         * version it has and every version it gets. That is the most common
+         * intent and the easiest to reach by accident, and reading it off the
+         * checkboxes means knowing that an empty version list is a claim rather
+         * than an omission. Saying it in words removes the guess.
+         */
+        get selectionSummary(): string {
+            const chosen = this.products.filter((product) => this.isProductSelected(product.id));
+            if (chosen.length === 0) return 'No products selected yet.';
+
+            return chosen
+                .map((product) => {
+                    const count = this.selectedReleasesFor(product).length;
+                    if (count === 0) return `${product.name}: every version, now and in future`;
+                    return `${product.name}: ${count} version${count === 1 ? '' : 's'}`;
+                })
+                .join(' · ');
         },
     };
 }

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -166,17 +166,30 @@
                                                             versions has nothing to show, and its toggle is hidden, so
                                                             this would only ever render an empty panel.
                                                             {% endcomment %}
+                                                            {% comment %}
+                                                            One version per row, not a wrapping flow. Version labels
+                                                            are build identifiers of wildly uneven length, so packing
+                                                            them by intrinsic width put a different number on every
+                                                            row and left no edge to read down. Two columns aligned
+                                                            them but cost too much width: these identifiers share a
+                                                            long prefix and differ only in the tail, so truncating
+                                                            rendered neighbouring builds identical and you could not
+                                                            tell which one you were about to attach an advisory to.
+                                                            A single column keeps every label whole. truncate stays
+                                                            as a guard for a pathological name, with the full string
+                                                            on hover. Monospace keeps the digits in register.
+                                                            {% endcomment %}
                                                             <div x-show="isExpanded(product.id) && product.releases.length"
                                                                  x-cloak
-                                                                 class="px-3 pb-2.5 ml-6">
+                                                                 class="px-3 pb-2.5 pl-11 bg-muted/30">
                                                                 <button type="button"
                                                                         @click="toggleAllVersions(product)"
                                                                         class="text-xs text-primary hover:underline mb-1.5">
                                                                     <span x-text="allVersionsSelected(product) ? 'Clear versions' : 'Select every version'"></span>
                                                                 </button>
-                                                                <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+                                                                <div class="grid grid-cols-1 gap-y-0.5">
                                                                     <template x-for="(release, rIndex) in product.releases" :key="release.id">
-                                                                        <div class="inline-flex items-center gap-1.5 text-xs text-text cursor-pointer select-none"
+                                                                        <div class="flex items-center gap-2 min-w-0 py-0.5 text-xs text-text cursor-pointer select-none"
                                                                              role="checkbox"
                                                                              tabindex="0"
                                                                              :aria-checked="isReleaseSelected(release.id) ? 'true' : 'false'"
@@ -184,11 +197,13 @@
                                                                              @keydown.space.prevent="toggleRelease(product, rIndex)"
                                                                              @keydown.enter.prevent="toggleRelease(product, rIndex)">
                                                                             <input type="checkbox"
-                                                                                   class="tw-checkbox pointer-events-none"
+                                                                                   class="tw-checkbox shrink-0 pointer-events-none"
                                                                                    tabindex="-1"
                                                                                    aria-hidden="true"
                                                                                    :checked="isReleaseSelected(release.id)" />
-                                                                            <span x-text="release.label"></span>
+                                                                            <span class="truncate font-mono"
+                                                                                  :title="release.label"
+                                                                                  x-text="release.label"></span>
                                                                         </div>
                                                                     </template>
                                                                 </div>

--- a/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_dashboard.html.j2
@@ -119,8 +119,36 @@
                                                         </button>
                                                     </div>
                                                 </div>
-                                                <div class="max-h-56 overflow-y-auto rounded-lg border border-border divide-y divide-border/60 select-none">
-                                                    <template x-for="(product, index) in products" :key="product.id">
+                                                {% comment %}
+                                                The scope reads above the list, not below it. A ticked product with
+                                                no ticked versions covers every version it has and every version it
+                                                gets — which the checkboxes cannot say on their own, since an empty
+                                                version list looks identical to one nobody has opened yet. Below the
+                                                list it fell under the modal's fold on a short window, so the one
+                                                line that resolves the ambiguity was the one you had to scroll for.
+                                                {% endcomment %}
+                                                <p class="mb-1.5 text-xs m-0"
+                                                   :class="anySelected ? 'text-text' : 'text-text-muted'"
+                                                   aria-live="polite">
+                                                    <span x-text="selectionSummary"></span>
+                                                </p>
+                                                <div class="relative mb-1.5">
+                                                    <i class="fas fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-xs text-text-muted"
+                                                       aria-hidden="true"></i>
+                                                    <input type="search"
+                                                           class="tw-form-input !pl-8 !py-1.5 text-sm"
+                                                           placeholder="Filter products and versions…"
+                                                           aria-label="Filter products and versions"
+                                                           :value="filter"
+                                                           @input="setFilter($event.target.value)" />
+                                                </div>
+                                                <div class="max-h-72 overflow-y-auto rounded-lg border border-border divide-y divide-border/60 select-none">
+                                                    <p x-show="!visibleProducts.length"
+                                                       x-cloak
+                                                       class="px-3 py-4 text-xs text-text-muted text-center m-0">
+                                                        Nothing matches <span class="font-mono" x-text="filter"></span>.
+                                                    </p>
+                                                    <template x-for="(product, index) in visibleProducts" :key="product.id">
                                                         <div>
                                                             <div class="flex items-center gap-2 px-3 py-2">
                                                                 {% comment %}
@@ -137,9 +165,9 @@
                                                                      role="checkbox"
                                                                      tabindex="0"
                                                                      :aria-checked="isPartiallySelected(product) ? 'mixed' : (isProductSelected(product.id) ? 'true' : 'false')"
-                                                                     @click="toggleProduct(index, $event)"
-                                                                     @keydown.space.prevent="toggleProduct(index)"
-                                                                     @keydown.enter.prevent="toggleProduct(index)">
+                                                                     @click="toggleProduct(index, $event, visibleProducts)"
+                                                                     @keydown.space.prevent="toggleProduct(index, undefined, visibleProducts)"
+                                                                     @keydown.enter.prevent="toggleProduct(index, undefined, visibleProducts)">
                                                                     <input type="checkbox"
                                                                            class="tw-checkbox shrink-0 pointer-events-none"
                                                                            tabindex="-1"
@@ -179,23 +207,24 @@
                                                             as a guard for a pathological name, with the full string
                                                             on hover. Monospace keeps the digits in register.
                                                             {% endcomment %}
-                                                            <div x-show="isExpanded(product.id) && product.releases.length"
+                                                            <div x-show="(isExpanded(product.id) || filterTerm) && visibleReleases(product).length"
                                                                  x-cloak
                                                                  class="px-3 pb-2.5 pl-11 bg-muted/30">
                                                                 <button type="button"
-                                                                        @click="toggleAllVersions(product)"
+                                                                        @click="toggleAllVersions(product, visibleReleases(product))"
                                                                         class="text-xs text-primary hover:underline mb-1.5">
-                                                                    <span x-text="allVersionsSelected(product) ? 'Clear versions' : 'Select every version'"></span>
+                                                                    <span x-text="allVersionsSelected(product, visibleReleases(product)) ? 'Clear versions' : 'Select every version'"></span>
                                                                 </button>
                                                                 <div class="grid grid-cols-1 gap-y-0.5">
-                                                                    <template x-for="(release, rIndex) in product.releases" :key="release.id">
+                                                                    <template x-for="(release, rIndex) in visibleReleases(product)"
+                                                                              :key="release.id">
                                                                         <div class="flex items-center gap-2 min-w-0 py-0.5 text-xs text-text cursor-pointer select-none"
                                                                              role="checkbox"
                                                                              tabindex="0"
                                                                              :aria-checked="isReleaseSelected(release.id) ? 'true' : 'false'"
-                                                                             @click="toggleRelease(product, rIndex, $event)"
-                                                                             @keydown.space.prevent="toggleRelease(product, rIndex)"
-                                                                             @keydown.enter.prevent="toggleRelease(product, rIndex)">
+                                                                             @click="toggleRelease(product, rIndex, $event, visibleReleases(product))"
+                                                                             @keydown.space.prevent="toggleRelease(product, rIndex, undefined, visibleReleases(product))"
+                                                                             @keydown.enter.prevent="toggleRelease(product, rIndex, undefined, visibleReleases(product))">
                                                                             <input type="checkbox"
                                                                                    class="tw-checkbox shrink-0 pointer-events-none"
                                                                                    tabindex="-1"
@@ -204,6 +233,8 @@
                                                                             <span class="truncate font-mono"
                                                                                   :title="release.label"
                                                                                   x-text="release.label"></span>
+                                                                            <span class="ml-auto shrink-0 pl-2 text-[0.6875rem] text-text-muted tabular-nums"
+                                                                                  x-text="release.created"></span>
                                                                         </div>
                                                                     </template>
                                                                 </div>
@@ -217,8 +248,9 @@
                                                 <template x-for="id in selectedReleases" :key="id">
                                                     <input type="hidden" name="affected_releases" :value="id" />
                                                 </template>
-                                                <p class="mt-1.5 text-xs text-text-muted">
-                                                    Shift-click to select a range. Leave versions unpicked to cover the whole product.
+                                                <p class="mt-1.5 text-xs text-text-muted m-0">
+                                                    Tick a product on its own to cover it whole, or open it and pick
+                                                    versions to narrow the advisory. Shift-click selects a range.
                                                 </p>
                                             </div>
                                         {% else %}

--- a/sbomify/apps/core/templates/core/security_advisories_table.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisories_table.html.j2
@@ -1,6 +1,6 @@
 {# Security Advisories table. Rows come from the advisories projection via json_script; writes are still preview-only. #}
 <div id="advisories-table-container"
-     x-data="{ search: '', filter: 'all', sortColumn: 'updated', sortDirection: 'desc', currentPage: 1, perPage: 10, allAdvisories: [], init() { this.allAdvisories = window.parseJsonScript('advisories-data') || []; this.$el.addEventListener('htmx:afterSettle', () => { this.allAdvisories = window.parseJsonScript('advisories-data') || []; if (this.currentPage > this.totalPages && this.totalPages > 0) { this.currentPage = this.totalPages; } }); }, get filteredData() { let data = [...this.allAdvisories]; if (this.search) { const s = this.search.toLowerCase(); data = data.filter(item => item.title.toLowerCase().includes(s) || item.id.toLowerCase().includes(s) || (item.vulnerability_id || '').toLowerCase().includes(s) || (item.products || []).map(p => p.name).join(' ').toLowerCase().includes(s) ); } if (this.filter !== 'all') { data = data.filter(item => item.status === this.filter); } return data; }, get sortedData() { return [...this.filteredData].sort((a, b) => { let aVal, bVal; if (this.sortColumn === 'severity') { aVal = a.severity_rank; bVal = b.severity_rank; } else if (this.sortColumn === 'status') { aVal = a.status_rank; bVal = b.status_rank; } else { aVal = a[this.sortColumn]; bVal = b[this.sortColumn]; if (typeof aVal === 'string') { aVal = aVal.toLowerCase(); bVal = bVal.toLowerCase(); } } if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1; if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1; return 0; }); }, get paginatedData() { const start = (this.currentPage - 1) * this.perPage; return this.sortedData.slice(start, start + this.perPage); }, get totalPages() { return Math.ceil(this.filteredData.length / this.perPage); }, get startIndex() { return this.filteredData.length > 0 ? (this.currentPage - 1) * this.perPage + 1 : 0; }, get endIndex() { return Math.min(this.currentPage * this.perPage, this.filteredData.length); }, sort(column) { if (this.sortColumn === column) { this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'; } else { this.sortColumn = column; this.sortDirection = 'asc'; } }, goToPage(page) { if (page >= 1 && page <= this.totalPages) { this.currentPage = page; } }, get visiblePages() { const pages = []; const total = this.totalPages; const current = this.currentPage; if (total <= 7) { for (let i = 1; i <= total; i++) pages.push(i); } else { pages.push(1); if (current > 3) pages.push('...'); for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) { pages.push(i); } if (current < total - 2) pages.push('...'); pages.push(total); } return pages; }, titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; }, rowMenu: { open: false, adv: null, right: 0, y: 0 }, openRowMenu(adv, btn) { const r = btn.getBoundingClientRect(); this.rowMenu = { open: true, adv, right: window.innerWidth - r.right, y: r.bottom + 6 }; } }"
+     x-data="{ search: '', filter: 'all', sortColumn: 'updated', sortDirection: 'desc', currentPage: 1, perPage: 10, allAdvisories: [], init() { this.allAdvisories = window.parseJsonScript('advisories-data') || []; this.$el.addEventListener('htmx:afterSettle', () => { this.allAdvisories = window.parseJsonScript('advisories-data') || []; if (this.currentPage > this.totalPages && this.totalPages > 0) { this.currentPage = this.totalPages; } }); }, get filteredData() { let data = [...this.allAdvisories]; if (this.search) { const s = this.search.toLowerCase(); data = data.filter(item => item.title.toLowerCase().includes(s) || item.id.toLowerCase().includes(s) || (item.vulnerability_id || '').toLowerCase().includes(s) || (item.products || []).map(p => p.name).join(' ').toLowerCase().includes(s) ); } if (this.filter !== 'all') { data = data.filter(item => item.status === this.filter); } return data; }, get sortedData() { return [...this.filteredData].sort((a, b) => { let aVal, bVal; if (this.sortColumn === 'severity') { aVal = a.severity_rank; bVal = b.severity_rank; } else if (this.sortColumn === 'status') { aVal = a.status_rank; bVal = b.status_rank; } else { aVal = a[this.sortColumn]; bVal = b[this.sortColumn]; if (typeof aVal === 'string') { aVal = aVal.toLowerCase(); bVal = bVal.toLowerCase(); } } if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1; if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1; return 0; }); }, get paginatedData() { const start = (this.currentPage - 1) * this.perPage; return this.sortedData.slice(start, start + this.perPage); }, get totalPages() { return Math.ceil(this.filteredData.length / this.perPage); }, get startIndex() { return this.filteredData.length > 0 ? (this.currentPage - 1) * this.perPage + 1 : 0; }, get endIndex() { return Math.min(this.currentPage * this.perPage, this.filteredData.length); }, sort(column) { if (this.sortColumn === column) { this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'; } else { this.sortColumn = column; this.sortDirection = 'asc'; } }, goToPage(page) { if (page >= 1 && page <= this.totalPages) { this.currentPage = page; } }, get visiblePages() { const pages = []; const total = this.totalPages; const current = this.currentPage; if (total <= 7) { for (let i = 1; i <= total; i++) pages.push(i); } else { pages.push(1); if (current > 3) pages.push('...'); for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) { pages.push(i); } if (current < total - 2) pages.push('...'); pages.push(total); } return pages; }, titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; } }"
      x-init="init(); $watch('search', () => currentPage = 1); $watch('filter', () => currentPage = 1); $watch('perPage', () => currentPage = 1)"
      hx-get="{% url 'core:security_advisories_table' %}"
      hx-trigger="refresh-advisories from:body"
@@ -103,11 +103,6 @@
                                     </span>
                                 </button>
                             </th>
-                            {% if has_crud_permissions %}
-                                <th class="w-10">
-                                    <span class="sr-only">Actions</span>
-                                </th>
-                            {% endif %}
                         </tr>
                     </thead>
                     <tbody>
@@ -173,23 +168,11 @@
                                               x-text="advisory.updates_count + (advisory.updates_count === 1 ? ' update' : ' updates')"></span>
                                     </div>
                                 </td>
-                                {% if has_crud_permissions %}
-                                    <td class="text-right" @click.stop>
-                                        <button type="button"
-                                                @click.stop="openRowMenu(advisory, $event.currentTarget)"
-                                                aria-haspopup="true"
-                                                aria-label="Advisory actions"
-                                                class="w-8 h-8 rounded-lg inline-flex items-center justify-center text-text-muted hover:bg-border/50 hover:text-text transition-colors">
-                                            <i class="fas fa-ellipsis" aria-hidden="true"></i>
-                                        </button>
-                                    </td>
-                                {% endif %}
                             </tr>
                         </template>
                         <template x-if="paginatedData.length === 0">
                             <tr>
-                                <td colspan="{% if has_crud_permissions %}6{% else %}5{% endif %}"
-                                    class="text-center py-8 text-text-muted">
+                                <td colspan="5" class="text-center py-8 text-text-muted">
                                     <i class="fas fa-search text-2xl mb-2 opacity-50"></i>
                                     <p>No advisories match your search</p>
                                     <button @click="search = ''; filter = 'all'"
@@ -249,52 +232,6 @@
                     <i class="fas fa-plus mr-2"></i>Create Your First Advisory
                 </button>
             {% endif %}
-        </div>
-    {% endif %}
-    {# Shared row-actions menu — fixed-positioned so the table's overflow doesn't clip it. #}
-    {% if has_crud_permissions %}
-        <div x-show="rowMenu.open"
-             x-cloak
-             @click.away="rowMenu.open = false"
-             @keydown.escape.window="rowMenu.open = false"
-             @scroll.window="rowMenu.open = false"
-             class="tw-dropdown"
-             :style="`position: fixed; top: ${rowMenu.y}px; right: ${rowMenu.right}px;`"
-             role="menu"
-             aria-label="Advisory actions">
-            <a href="{% url 'core:workspace_public_current' %}"
-               target="_blank"
-               rel="noopener"
-               class="tw-dropdown-item"
-               role="menuitem"
-               @click="rowMenu.open = false">
-                <i class="fas fa-arrow-up-right-from-square w-5 text-center opacity-70"
-                   aria-hidden="true"></i>
-                View in Trust Center
-            </a>
-            <button type="button"
-                    class="tw-dropdown-item"
-                    role="menuitem"
-                    @click="navigator.clipboard && navigator.clipboard.writeText(window.location.origin + '{% url 'core:security_advisory_detail' '__ID__' %}'.replace('__ID__', rowMenu.adv.id)); rowMenu.open = false">
-                <i class="fas fa-link w-5 text-center opacity-70" aria-hidden="true"></i>
-                Copy link
-            </button>
-            <button type="button"
-                    class="tw-dropdown-item"
-                    role="menuitem"
-                    @click="window.location.href = '{% url 'core:security_advisory_detail' '__ID__' %}'.replace('__ID__', rowMenu.adv.id) + '#link-vex'; rowMenu.open = false">
-                <i class="fas fa-file-shield w-5 text-center opacity-70"
-                   aria-hidden="true"></i>
-                Link a VEX
-            </button>
-            <div class="tw-dropdown-divider"></div>
-            <button type="button"
-                    class="tw-dropdown-item tw-dropdown-item-danger"
-                    role="menuitem"
-                    @click="rowMenu.open = false">
-                <i class="fas fa-trash w-5 text-center opacity-70" aria-hidden="true"></i>
-                Delete advisory
-            </button>
         </div>
     {% endif %}
 </div>

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -2,32 +2,45 @@
 {% load static %}
 {% block title %}{{ advisory.title }} · sbomify{% endblock %}
 {% block dashboard_content %}
-    <div class="space-y-8">
+    <div class="space-y-6">
         {# Back link #}
         <a href="{% url 'core:security_advisories_dashboard' %}"
            class="inline-flex items-center gap-2 text-sm text-text-muted hover:text-text transition-colors">
             <i class="fas fa-arrow-left text-xs" aria-hidden="true"></i>
             Security advisories
         </a>
-        {# Header #}
-        <div class="flex items-start justify-between gap-4">
+        {% comment %}Header — same shape as the product and component detail pages: the actions drop below the title on narrow viewports rather than squeezing it.{% endcomment %}
+        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
             <div class="flex items-start gap-4 min-w-0">
                 <div class="tw-avatar tw-avatar-lg shrink-0">
                     <i class="fas fa-shield-halved"></i>
                 </div>
-                <div class="min-w-0">
-                    <div class="flex items-center gap-2 flex-wrap mb-1.5">
-                        <span class="tw-badge tw-badge-{{ advisory.severity_variant }}">{{ advisory.severity|title }}</span>
-                        <span class="tw-badge tw-badge-{{ advisory.status_variant }}">{{ advisory.status_label }}</span>
-                    </div>
-                    <h1 class="text-2xl font-bold text-text">{{ advisory.title }}</h1>
+                {% comment %}Both clamps are line-based, so the cut follows the rendered width and the ellipsis is the browser's — a wide screen shows more of the same title than a narrow one. One disclosure governs both, because a title long enough to clip usually comes with a description long enough to clip too. clipped is only re-measured while collapsed: expanding removes the clamp, so a measurement taken then would report nothing overflowing and the button would vanish mid-use. break-words keeps an unbroken string (a pasted identifier, a hostname) from running under the header actions.{% endcomment %}
+                <div class="flex-1 min-w-0"
+                     x-data="{ expanded: false, clipped: false, measure() { this.clipped = [$refs.title, $refs.summary].some((el) => el && el.scrollHeight > el.clientHeight) } }"
+                     x-init="$nextTick(() => measure())"
+                     @resize.window.debounce="expanded || measure()">
+                    <h1 x-ref="title"
+                        class="text-2xl font-bold text-text break-words"
+                        :class="expanded ? '' : 'line-clamp-1'"
+                        title="{{ advisory.title }}">{{ advisory.title }}</h1>
+                    <p class="text-text-muted text-sm m-0 mt-1">{{ advisory.type_label }} advisory</p>
                     {% if advisory.description %}
-                        <p class="text-text-muted leading-relaxed mt-2 max-w-3xl">{{ advisory.description }}</p>
+                        <p x-ref="summary"
+                           class="text-text-muted leading-relaxed break-words whitespace-pre-line mt-2 max-w-3xl"
+                           :class="expanded ? '' : 'line-clamp-2'">{{ advisory.description }}</p>
                     {% endif %}
+                    <button type="button"
+                            x-show="clipped || expanded"
+                            x-cloak
+                            @click="expanded = !expanded"
+                            class="mt-1 text-sm text-primary hover:underline">
+                        <span x-text="expanded ? 'Show less' : 'Show more'"></span>
+                    </button>
                 </div>
             </div>
             {# Header actions #}
-            <div class="flex items-center gap-2 shrink-0">
+            <div class="flex items-center gap-2 shrink-0 flex-wrap">
                 <a href="{% url 'core:workspace_public_current' %}"
                    target="_blank"
                    rel="noopener"
@@ -152,7 +165,14 @@
                         <div class="flex-1 min-w-0 {% if not forloop.last %}pb-8{% endif %}"
                              {% if has_crud_permissions %}@click="if (!editing) editing = true" :class="{ 'cursor-pointer': !editing }"{% endif %}>
                             <div class="flex items-center justify-between gap-3">
-                                <span class="tw-badge tw-badge-{{ u.variant }}">{{ u.label }}</span>
+                                <span class="flex items-center gap-2 min-w-0">
+                                    {% if u.from_label %}
+                                        <span class="text-xs text-text-muted shrink-0">{{ u.from_label }}</span>
+                                        <i class="fas fa-arrow-right text-[10px] text-text-muted shrink-0"
+                                           aria-hidden="true"></i>
+                                    {% endif %}
+                                    <span class="tw-badge tw-badge-{{ u.variant }}">{{ u.label }}</span>
+                                </span>
                                 <div class="flex items-center gap-3 shrink-0">
                                     <span class="text-xs text-text-muted">{{ u.date_display }}</span>
                                     {% if has_crud_permissions %}
@@ -241,6 +261,15 @@
                     <h2 class="text-xs uppercase tracking-wide text-text-muted">Affected products</h2>
                     <div class="flex flex-wrap gap-2">
                         {% comment %}An advisory can name a product this workspace does not track, and keeps naming it after one is deleted. Those have no id, and the url tag would happily build /product/None/ rather than fail, so they render as plain text.{% endcomment %}
+                        {% if not advisory.products %}
+                            <p class="text-sm text-text-muted m-0">
+                                {% if advisory.advisory_type == 'workspace_notice' %}
+                                    A workspace notice names no products.
+                                {% else %}
+                                    No products recorded yet — publishing a product advisory requires at least one.
+                                {% endif %}
+                            </p>
+                        {% endif %}
                         {% for product in advisory.products %}
                             <span class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-lg bg-border/20 text-text-muted border border-border/40">
                                 <i class="fas fa-cube text-[10px] mr-1.5 opacity-70"></i>

--- a/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
+++ b/sbomify/apps/core/templates/core/security_advisory_detail.html.j2
@@ -34,6 +34,7 @@
                             x-show="clipped || expanded"
                             x-cloak
                             @click="expanded = !expanded"
+                            :aria-expanded="expanded"
                             class="mt-1 text-sm text-primary hover:underline">
                         <span x-text="expanded ? 'Show less' : 'Show more'"></span>
                     </button>
@@ -380,7 +381,9 @@
                                         </div>
                                         <div>
                                             <label class="tw-form-label" for="editSeverity">Severity</label>
+                                            {# An advisory may legitimately carry no severity, and without a blank option the select would silently promote it to the first one on any save. #}
                                             <select id="editSeverity" name="severity" class="tw-form-input">
+                                                <option value="" {% if not advisory.severity %}selected{% endif %}>Not set</option>
                                                 <option value="critical"
                                                         {% if advisory.severity == 'critical' %}selected{% endif %}>
                                                     Critical

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -74,6 +74,33 @@ def _current_team(request: HttpRequest) -> Team | None:
     return membership.team if membership else None
 
 
+# Roles that may change an advisory, mirroring the has_crud_permissions the
+# templates use to decide whether to render the controls at all.
+_ADVISORY_WRITE_ROLES = ("owner", "admin")
+
+
+def _writable_team(request: HttpRequest) -> Team | None:
+    """The workspace, but only for a member who may change its advisories.
+
+    The templates hide the edit and compose controls behind
+    ``has_crud_permissions``, which is a rendering decision and nothing a
+    handler can rely on — a POST can be crafted without ever loading the page.
+    The role is read from the membership row rather than the session, so a
+    role cached there cannot outlive a demotion.
+    """
+    key = (request.session.get("current_team") or {}).get("key")
+    if not key:
+        return None
+    user = cast(User, request.user)
+    membership = (
+        Member.objects.filter(user=user, team__key=key, role__in=_ADVISORY_WRITE_ROLES)
+        .select_related("team")
+        .only("team", "role")
+        .first()
+    )
+    return membership.team if membership else None
+
+
 def _advisories_context(request: HttpRequest) -> dict[str, Any]:
     current_team = request.session.get("current_team") or {}
     team = _current_team(request)
@@ -100,7 +127,7 @@ class SecurityAdvisoriesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixi
         return render(request, "core/security_advisories_dashboard.html.j2", context)
 
     def post(self, request: HttpRequest) -> HttpResponse:
-        team = _current_team(request)
+        team = _writable_team(request)
         if team is None:
             raise Http404("Workspace not found")
 
@@ -168,7 +195,7 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
         )
 
     def post(self, request: HttpRequest, advisory_id: str) -> HttpResponse:
-        team = _current_team(request)
+        team = _writable_team(request)
         if team is None:
             raise Http404("Advisory not found")
 
@@ -179,7 +206,9 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
                 cast(User, request.user),
                 advisory_id,
                 title=request.POST.get("title", ""),
-                severity=request.POST.get("severity", ""),
+                # None when the form did not carry the field at all, so a
+                # partial edit cannot silently set a severity nobody chose.
+                severity=request.POST.get("severity"),
                 description=request.POST.get("description", ""),
             )
             if result.ok:

--- a/sbomify/apps/core/views/security_advisories.py
+++ b/sbomify/apps/core/views/security_advisories.py
@@ -38,6 +38,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     get_advisory,
     list_advisories,
     post_update,
+    update_advisory,
 )
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
@@ -172,13 +173,29 @@ class SecurityAdvisoryDetailView(GuestAccessBlockedMixin, LoginRequiredMixin, Vi
             raise Http404("Advisory not found")
 
         intent = request.POST.get("intent")
-        if intent in ("edit", "edit_update", "link_vex"):
+        if intent == "edit":
+            result = update_advisory(
+                team,
+                cast(User, request.user),
+                advisory_id,
+                title=request.POST.get("title", ""),
+                severity=request.POST.get("severity", ""),
+                description=request.POST.get("description", ""),
+            )
+            if result.ok:
+                messages.success(request, "Advisory updated.")
+            elif result.status_code == 404:
+                raise Http404("Advisory not found")
+            else:
+                messages.error(request, result.error or "Advisory not updated.")
+            return redirect("core:security_advisory_detail", advisory_id=advisory_id)
+
+        if intent in ("edit_update", "link_vex"):
             # Only the stubs pay for the full projection lookup; the real
             # composer path below lets post_update do the one scoped lookup.
             if not get_advisory(team, advisory_id).ok:
                 raise Http404("Advisory not found")
             note = {
-                "edit": "Editing an advisory is the next pass on this UI.",
                 "edit_update": "Editing a timeline entry is the next pass on this UI.",
                 "link_vex": "Linking VEX documents is the pass after the CRUD one.",
             }[intent]

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -28,6 +28,7 @@ from sbomify.apps.security_advisories.models import (
     AdvisoryVulnerability,
     ReferenceType,
     SecurityAdvisory,
+    Severity,
 )
 
 # Severity to the badge variant the templates use.
@@ -63,7 +64,7 @@ PUBLICATION_VARIANTS = {"draft": "secondary", "published": "success", "withdrawn
 # Advisory "type" as the list column shows it. Inferred rather than stored,
 # because the model already records the real identifiers and which database
 # issued them is a fact about those, not a separate field to keep in step.
-TYPE_LABELS = {"cve": "CVE", "ghsa": "GHSA", "other": "Other"}
+TYPE_LABELS = {"cve": "CVE", "ghsa": "GHSA", "internal": "Internal", "other": "Other"}
 
 # Timeline entries a reader sees. Internal comments are excluded from the
 # public feed by the model's PUBLIC_EVENT_TYPES; this is the workspace view, so
@@ -114,6 +115,11 @@ def _advisory_type(vulnerabilities: list[AdvisoryVulnerability], references: lis
         return "cve"
     if ReferenceType.GHSA in types:
         return "ghsa"
+    # No external identifier anywhere means this is the workspace's own
+    # finding, not some other database's. Saying "Internal" is more useful
+    # than a catch-all that reads like the field failed to populate.
+    if not types:
+        return "internal"
     return "other"
 
 
@@ -204,12 +210,26 @@ def _event_projection(event: AdvisoryEvent) -> dict[str, Any]:
     meta = EVENT_META.get(event.event_type, _UNKNOWN_EVENT)
     payload = event.payload if isinstance(event.payload, dict) else {}
     actor = event.actor
+
+    # A status change reads as the state it moved to, not as the words
+    # "Status change" — five entries all labelled the same tell a reader
+    # nothing about what happened. The badge takes the state's own colour
+    # and icon for the same reason.
+    label, variant, icon = meta["label"], meta["variant"], meta["icon"]
+    to_status = payload.get("to")
+    if event.event_type == AdvisoryEvent.EventType.STATUS_CHANGE and to_status in REMEDIATION_META:
+        state_meta = REMEDIATION_META[to_status]
+        label, variant, icon = state_meta["label"], state_meta["variant"], state_meta["icon"]
+
     return {
         "id": event.id,
         "kind": event.event_type,
-        "label": meta["label"],
-        "variant": meta["variant"],
-        "icon": meta["icon"],
+        "label": label,
+        "variant": variant,
+        "icon": icon,
+        # The transition's origin, for a reader who wants the before as well
+        # as the after. Absent on the first change, which came from nowhere.
+        "from_label": REMEDIATION_META.get(payload.get("from", ""), {}).get("label", ""),
         # "note" and "date_display" are what the timeline template binds to;
         # "body" and "created_at" are the model's own names, kept for callers
         # that want the raw values.
@@ -452,6 +472,53 @@ def create_advisory(
         actor=user,
         payload={"to": SecurityAdvisory.RemediationStatus.IDENTIFIED.value},
     )
+    return ServiceResult.success(advisory.id)
+
+
+@transaction.atomic
+def update_advisory(
+    team: Any, user: Any, advisory_id: str, *, title: str, severity: str = "", description: str = ""
+) -> ServiceResult[str]:
+    """Edit an advisory's own fields.
+
+    Field changes land on the timeline as field_change events, one per field,
+    so the append-only history answers "who changed the severity and when"
+    rather than only recording status moves.
+    """
+    advisory = (
+        SecurityAdvisory.objects.select_for_update()
+        .filter(team=team)
+        .filter(Q(id=advisory_id) | Q(tracking_id=advisory_id))
+        .first()
+    )
+    if advisory is None:
+        return ServiceResult.failure("Advisory not found", status_code=404)
+
+    title = title.strip()
+    if not title:
+        return ServiceResult.failure("An advisory needs a title.", status_code=400)
+    if severity and severity not in Severity.values:
+        return ServiceResult.failure("Unknown severity.", status_code=400)
+
+    changes = [
+        (field, getattr(advisory, field), new)
+        for field, new in (("title", title), ("severity", severity), ("description", description.strip()))
+        if getattr(advisory, field) != new
+    ]
+    if not changes:
+        return ServiceResult.success(advisory.id)
+
+    for field, _old, new in changes:
+        setattr(advisory, field, new)
+    advisory.save(update_fields=[field for field, _o, _n in changes] + ["updated_at"])
+
+    for field, old, new in changes:
+        AdvisoryEvent.objects.create(
+            advisory=advisory,
+            event_type=AdvisoryEvent.EventType.FIELD_CHANGE,
+            actor=user,
+            payload={"field": field, "old": old, "new": new},
+        )
     return ServiceResult.success(advisory.id)
 
 

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -482,9 +482,35 @@ def create_advisory(
     return ServiceResult.success(advisory.id)
 
 
+# Above this, a value is described rather than quoted on the timeline. A
+# rewritten description is the common case and pasting both versions of it
+# would bury every other entry.
+_FIELD_CHANGE_QUOTE_LIMIT = 80
+
+
+def _field_change_body(field: str, old: Any, new: Any) -> str:
+    """What a field_change entry reads as on the timeline."""
+    label = field.replace("_", " ").capitalize()
+
+    def describe(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        return f"“{text}”" if len(text) <= _FIELD_CHANGE_QUOTE_LIMIT else None
+
+    old_text, new_text = describe(old), describe(new)
+    if old_text and new_text:
+        return f"{label} changed from {old_text} to {new_text}."
+    if new_text and not old_text:
+        return f"{label} set to {new_text}."
+    if old_text and not new_text and not str(new or "").strip():
+        return f"{label} cleared."
+    return f"{label} updated."
+
+
 @transaction.atomic
 def update_advisory(
-    team: Any, user: Any, advisory_id: str, *, title: str, severity: str = "", description: str = ""
+    team: Any, user: Any, advisory_id: str, *, title: str, severity: str | None = None, description: str = ""
 ) -> ServiceResult[str]:
     """Edit an advisory's own fields.
 
@@ -504,14 +530,19 @@ def update_advisory(
     title = title.strip()
     if not title:
         return ServiceResult.failure("An advisory needs a title.", status_code=400)
-    if severity and severity not in Severity.values:
-        return ServiceResult.failure("Unknown severity.", status_code=400)
 
-    changes = [
-        (field, getattr(advisory, field), new)
-        for field, new in (("title", title), ("severity", severity), ("description", description.strip()))
-        if getattr(advisory, field) != new
-    ]
+    # ``None`` means the caller did not submit a severity, which is different
+    # from submitting a blank one. A <select> always posts something, so an
+    # advisory saved with no severity would otherwise pick up the first option
+    # whenever anyone edited its title.
+    fields: list[tuple[str, Any]] = [("title", title), ("description", description.strip())]
+    if severity is not None:
+        severity = severity.strip()
+        if severity and severity not in Severity.values:
+            return ServiceResult.failure("Unknown severity.", status_code=400)
+        fields.append(("severity", severity))
+
+    changes = [(field, getattr(advisory, field), new) for field, new in fields if getattr(advisory, field) != new]
     if not changes:
         return ServiceResult.success(advisory.id)
 
@@ -524,6 +555,12 @@ def update_advisory(
             advisory=advisory,
             event_type=AdvisoryEvent.EventType.FIELD_CHANGE,
             actor=user,
+            # The timeline renders an event's body, so a field change with only
+            # a payload showed a "Field change" badge and no text at all. The
+            # body says which field moved; long values are summarised rather
+            # than pasted, since a rewritten description would otherwise bury
+            # every other entry on the page.
+            body=_field_change_body(field, old, new),
             payload={"field": field, "old": old, "new": new},
         )
     return ServiceResult.success(advisory.id)

--- a/sbomify/apps/security_advisories/services/advisories.py
+++ b/sbomify/apps/security_advisories/services/advisories.py
@@ -367,16 +367,23 @@ def creation_options(team: Any) -> ServiceResult[list[dict[str, Any]]]:
 
     ``latest`` releases are excluded: that pointer re-targets as artifacts
     arrive, so "affected: latest" would describe different code next month.
+
+    Newest first, and the date travels with each row. Version strings do not
+    sort into release order on their own — a hand-cut ``0.99-wiz-test`` can
+    postdate a dated build — so without the date on screen a correctly ordered
+    list reads as an unordered one.
     """
     releases_by_product: dict[str, list[dict[str, str]]] = {}
     release_rows = (
         Release.objects.filter(product__team=team, is_latest=False)
         .order_by("-created_at")
-        .values("id", "product_id", "name", "version")
+        .values("id", "product_id", "name", "version", "created_at")
     )
     for row in release_rows:
         label = row["version"] or row["name"]
-        releases_by_product.setdefault(row["product_id"], []).append({"id": row["id"], "label": label})
+        releases_by_product.setdefault(row["product_id"], []).append(
+            {"id": row["id"], "label": label, "created": row["created_at"].strftime("%d %b %Y")}
+        )
 
     products = [
         {"id": product_id, "name": name, "releases": releases_by_product.get(product_id, [])}

--- a/sbomify/apps/security_advisories/tests/test_advisory_service.py
+++ b/sbomify/apps/security_advisories/tests/test_advisory_service.py
@@ -21,6 +21,7 @@ from sbomify.apps.security_advisories.services.advisories import (
     advisory_counts,
     get_advisory,
     list_advisories,
+    update_advisory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -269,3 +270,108 @@ def test_the_display_id_is_always_a_string(sample_team):
 
     assert isinstance(row["id"], str)
     assert isinstance(row["pk"], str)
+
+
+class TestUpdateAdvisory:
+    def test_each_changed_field_gets_its_own_timeline_entry(self, sample_team, sample_user):
+        """One event per field, so the history answers who changed the severity
+        rather than only recording status moves."""
+        advisory = _advisory(sample_team, title="Old title", severity="low", description="Old body.")
+
+        result = update_advisory(
+            sample_team,
+            sample_user,
+            advisory.id,
+            title="New title",
+            severity="high",
+            description="New body.",
+        )
+
+        assert result.ok, result.error
+        advisory.refresh_from_db()
+        assert (advisory.title, advisory.severity, advisory.description) == ("New title", "high", "New body.")
+        events = AdvisoryEvent.objects.filter(advisory=advisory, event_type=AdvisoryEvent.EventType.FIELD_CHANGE)
+        assert {event.payload["field"] for event in events} == {"title", "severity", "description"}
+
+    def test_a_field_change_entry_says_what_changed(self, sample_team, sample_user):
+        """The timeline renders an event's body. A payload-only event showed a
+        "Field change" badge with no text under it."""
+        advisory = _advisory(sample_team, severity="low")
+
+        update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="high")
+
+        event = AdvisoryEvent.objects.get(
+            advisory=advisory, event_type=AdvisoryEvent.EventType.FIELD_CHANGE, payload__field="severity"
+        )
+        assert event.body == "Severity changed from “low” to “high”."
+
+    def test_an_unchanged_field_records_nothing(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, title="Same", severity="high", description="Same body.")
+
+        result = update_advisory(
+            sample_team, sample_user, advisory.id, title="Same", severity="high", description="Same body."
+        )
+
+        assert result.ok
+        assert not AdvisoryEvent.objects.filter(advisory=advisory).exists()
+
+    def test_an_omitted_severity_is_left_alone(self, sample_team, sample_user):
+        """A <select> always posts something, so "not submitted" has to be
+        distinguishable from "submitted blank" or editing a title would set a
+        severity nobody chose."""
+        advisory = _advisory(sample_team, severity="")
+
+        update_advisory(sample_team, sample_user, advisory.id, title="Retitled")
+
+        advisory.refresh_from_db()
+        assert advisory.severity == ""
+
+    def test_a_blank_severity_clears_it(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="high")
+
+        update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="")
+
+        advisory.refresh_from_db()
+        assert advisory.severity == ""
+
+    def test_surrounding_whitespace_on_severity_is_tolerated(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="low")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity=" high ")
+
+        assert result.ok, result.error
+        advisory.refresh_from_db()
+        assert advisory.severity == "high"
+
+    def test_an_empty_title_is_refused(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, title="Keeps its title")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title="   ")
+
+        assert not result.ok
+        assert result.status_code == 400
+        advisory.refresh_from_db()
+        assert advisory.title == "Keeps its title"
+
+    def test_an_unknown_severity_is_refused(self, sample_team, sample_user):
+        advisory = _advisory(sample_team, severity="low")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title=advisory.title, severity="spicy")
+
+        assert not result.ok
+        assert result.status_code == 400
+        advisory.refresh_from_db()
+        assert advisory.severity == "low"
+
+    def test_another_workspaces_advisory_is_not_found(self, sample_team, guest_user, sample_user):
+        from sbomify.apps.teams.models import Team
+
+        other = Team.objects.create(name="Someone else")
+        advisory = _advisory(other, title="Not yours")
+
+        result = update_advisory(sample_team, sample_user, advisory.id, title="Mine now")
+
+        assert not result.ok
+        assert result.status_code == 404
+        advisory.refresh_from_db()
+        assert advisory.title == "Not yours"

--- a/sbomify/apps/security_advisories/tests/test_advisory_service.py
+++ b/sbomify/apps/security_advisories/tests/test_advisory_service.py
@@ -122,8 +122,16 @@ class TestType:
         assert row["type"] == "ghsa"
         assert row["type_label"] == "GHSA"
 
-    def test_anything_else_reads_as_other(self, sample_team):
+    def test_no_external_identifier_reads_as_internal(self, sample_team):
+        """An advisory carrying no CVE and no reference is the workspace's own
+        finding. "Other" read like the field had failed to populate."""
         _advisory(sample_team)
+
+        assert list_advisories(sample_team).value[0]["type"] == "internal"
+
+    def test_an_unrecognised_database_still_reads_as_other(self, sample_team):
+        advisory = _advisory(sample_team)
+        AdvisoryReference.objects.create(advisory=advisory, external_id="VENDOR-2026-1")
 
         assert list_advisories(sample_team).value[0]["type"] == "other"
 

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -298,6 +298,16 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             if not entry_ecosystems[target_idx]:
                 entry_ecosystems[target_idx] = ecosystem
             for extra_idx in match_idxs[1:]:
+                # Re-checked against the target rather than against the incoming
+                # finding. A finding with no ecosystem is compatible with every
+                # entry, so without this an ecosystem-less foo@1.0 matching both
+                # npm's foo@1.0 and PyPI's would bridge the two and merge them —
+                # the very collapse the compatibility check exists to prevent.
+                # An entry that does not belong stays its own row; the incoming
+                # finding lands in the first match, which is the best guess
+                # available when it never said which ecosystem it came from.
+                if not _compatible(extra_idx, entry_ecosystems[target_idx]):
+                    continue
                 extra = deduped[extra_idx]
                 if _better_component(target.get("component") or {}, extra.get("component") or {}):
                     target["component"] = extra.get("component")

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -11,6 +11,7 @@ suppressed findings), so the counts derive from one read.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import unquote
 
 from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
 
@@ -39,6 +40,130 @@ def _severity_bucket(finding: dict[str, Any]) -> str:
 
 def _is_suppressed(finding: dict[str, Any]) -> bool:
     return (finding.get("analysis_state") or "") in _SUPPRESSING_STATES
+
+
+def _purl_name_version(purl: str) -> tuple[str, str]:
+    """Pull ``(name, version)`` out of a purl, or ``("", "")`` if it has neither.
+
+    ``pkg:npm/%40babel/core@7.28.0?arch=x64#sub`` -> ``("@babel/core", "7.28.0")``.
+    Qualifiers and subpath are dropped, the namespace is kept (it is part of the
+    name), and percent-encoding is undone so the result compares against the
+    plain name another provider recorded.
+    """
+    body = purl.split("?", 1)[0].split("#", 1)[0]
+    if body.startswith("pkg:"):
+        body = body[4:]
+    # The type segment is not part of the name; a purl always has one.
+    _, _, after_type = body.partition("/")
+    name, _, version = after_type.rpartition("@")
+    if not name:
+        return "", ""
+    return unquote(name).lower(), version.lower()
+
+
+def _name_tail(name: str) -> str:
+    """The bare artifact name, with any grouping prefix removed.
+
+    Providers disagree on how much of a package's path belongs in its name: OSV
+    writes ``group:artifact`` where Dependency-Track writes ``artifact``, and an
+    npm scope survives as ``@babel/core`` in one scanner and ``core`` in another.
+    Comparing tails lets those meet.
+    """
+    return name.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+
+
+# OSV names ecosystems its own way; purl names them another. Both reach the same
+# label so a purl-bearing scanner and OSV can be compared.
+_ECOSYSTEM_ALIASES = {
+    "pypi": "pypi",
+    "npm": "npm",
+    "go": "golang",
+    "golang": "golang",
+    "maven": "maven",
+    "crates.io": "cargo",
+    "cargo": "cargo",
+    "nuget": "nuget",
+    "rubygems": "gem",
+    "gem": "gem",
+    "packagist": "composer",
+    "composer": "composer",
+    "debian": "deb",
+    "deb": "deb",
+    "ubuntu": "deb",
+    "alpine": "apk",
+    "apk": "apk",
+}
+
+
+def _ecosystem(component: dict[str, Any]) -> str:
+    """The package's ecosystem, or ``""`` when the scanner did not say.
+
+    Taken from the purl type when there is one, otherwise from the ``ecosystem``
+    field OSV records. Unknown is a real answer here and not a default: it means
+    the finding may belong to any ecosystem, which is what lets it match one that
+    is named.
+    """
+    purl = (component.get("purl") or "").strip().lower()
+    raw = ""
+    if purl.startswith("pkg:"):
+        raw = purl[4:].split("/", 1)[0]
+    if not raw:
+        raw = (component.get("ecosystem") or "").strip().lower()
+    return _ECOSYSTEM_ALIASES.get(raw, raw)
+
+
+def _identity_keys(component: dict[str, Any], sbom_id: Any) -> set[str]:
+    """Every key under which this finding's package might be recognised.
+
+    Two findings meet when they share any key. The keys are ecosystem-free on
+    purpose — the ecosystem is checked separately, because one scanner naming it
+    and another leaving it out must not stop them matching.
+
+    Keying on the purl alone was the bug behind one advisory appearing four times
+    over on a release: OSV records ``{name, version, ecosystem}`` and no purl,
+    while other scanners record a purl, so the two key spaces never compared
+    equal, the rows never folded, and each kept its own scanner's severity — the
+    same GHSA showing as both high and medium.
+
+    The tail key drops any grouping prefix, which is how ``@babel/core`` from one
+    scanner reaches ``core`` from another (and ``group:artifact`` reaches
+    ``artifact``, as merge_findings_by_alias already does).
+
+    A package with a name but no version can only be placed within its own SBOM:
+    the same name elsewhere in the release may well be a different version.
+    """
+    purl = (component.get("purl") or "").strip().lower()
+    name = (component.get("name") or "").strip().lower()
+    version = (component.get("version") or "").strip().lower()
+
+    keys: set[str] = set()
+    if purl:
+        purl_name, purl_version = _purl_name_version(purl)
+        if purl_name and purl_version:
+            keys.add(f"nv:{purl_name}@{purl_version}")
+            keys.add(f"tail:{_name_tail(purl_name)}@{purl_version}")
+        else:
+            # An unparseable purl is still an identity, just not a comparable one.
+            keys.add(f"purl:{purl}")
+    if name and version:
+        keys.add(f"nv:{name}@{version}")
+        keys.add(f"tail:{_name_tail(name)}@{version}")
+    elif name and not keys:
+        keys.add(f"sbom:{sbom_id}:{name}")
+    return keys
+
+
+def _better_component(dst: dict[str, Any], src: dict[str, Any]) -> bool:
+    """Whether ``src``'s component names the package better than ``dst``'s.
+
+    Two scanners that disagree on the name (``@babel/core`` against ``core``)
+    fold to one row, and the row should carry the name a reader can look up.
+    """
+    dst_name = (dst.get("name") or "").strip()
+    src_name = (src.get("name") or "").strip()
+    if bool(src.get("purl")) != bool(dst.get("purl")):
+        return bool(src.get("purl"))
+    return len(src_name) > len(dst_name)
 
 
 def _empty_counts() -> dict[str, int]:
@@ -96,7 +221,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     # unchanged from before). meaningful_runs tracks per-run whether the scanner
     # actually analyzed the SBOM (vs. only operational error markers).
     meaningful_runs = 0
-    candidates: list[tuple[dict[str, Any], str | None]] = []
+    candidates: list[tuple[dict[str, Any], set[str], str]] = []
     for run in runs:
         run_findings = (run.result or {}).get("findings", []) or []
         real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
@@ -107,70 +232,87 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             # Stored scan results are provider-controlled JSON; a non-dict component
             # must not raise (and 500 the Trust Center) when we read its fields.
             component = raw_component if isinstance(raw_component, dict) else {}
-            purl = (component.get("purl") or "").lower()
-            name = (component.get("name") or "").lower()
-            version = (component.get("version") or "").lower()
-            # Identity is known only when there's a package to anchor it to, and
-            # fails open (never deduped) otherwise so instances aren't wrongly
-            # collapsed:
-            #  - purl, or name+version -> a stable identity, deduped release-wide;
-            #  - name only -> scoped to this SBOM, so two providers of one SBOM
-            #    collapse but the same name in another component (maybe a different
-            #    version) stays distinct;
-            #  - no name -> never deduped.
-            if purl:
-                identity: str | None = purl
-            elif name and version:
-                identity = f"{name}@{version}"
-            elif name:
-                identity = f"sbom:{run.sbom_id}:{name}"
-            else:
-                identity = None
-            candidates.append((finding, identity))
+            # A finding with no package at all keeps an empty key set and so is
+            # never folded: two nameless findings cannot be shown to be the same.
+            candidates.append((finding, _identity_keys(component, run.sbom_id), _ecosystem(component)))
 
     # Every run that ran only produced operational error markers — the release was
     # not actually analyzed, so don't let the Trust Center claim it is clean.
     if meaningful_runs == 0:
         return {"has_data": False}
 
-    # Pass 2: within one package identity, providers report the same vulnerability
-    # under different ids (Dependency-Track's CVE, OSV's GHSA) — an id/alias
-    # overlap there is the same finding and must fold to one row (worst severity
-    # wins), or the count doubles and the same CVE/GHSA pair appears twice at
-    # inconsistent severities (#1220, measured live: 66 findings vs. the correct
-    # 31 for one dual-scanned component). A candidate with no identity is never
-    # folded — we can't confirm two identity-less findings are the same package.
+    # Pass 2: two findings are the same finding when they agree on the package
+    # *and* share an id or alias. Providers report one vulnerability under
+    # different ids (Dependency-Track's CVE, OSV's GHSA), so an id overlap within
+    # a package must fold to one row with the worst severity — otherwise the
+    # count doubles and one advisory appears twice at inconsistent severities
+    # (#1220, measured live: 66 findings against the correct 31 on one
+    # dual-scanned component).
+    #
+    # The index is keyed on the (package key, id) pair, so a package known by
+    # several keys is matched by whichever key the other scanner happened to
+    # record. One key can hold several entries — the same name and version in
+    # two ecosystems — so a match must also clear the ecosystem check below. A
+    # finding with no package key, or no id at all, is never folded.
     deduped: list[dict[str, Any]] = []
-    alias_index: dict[str, dict[str, int]] = {}
-    for finding, identity in candidates:
-        if identity is None:
-            deduped.append(finding)
-            continue
-        bucket = alias_index.setdefault(identity, {})
+    entry_ecosystems: list[str] = []
+    index: dict[tuple[str, str], list[int]] = {}
+
+    def _compatible(entry_idx: int, ecosystem: str) -> bool:
+        """Whether a candidate may fold into an existing entry.
+
+        Ecosystems that are both named must agree: npm's ``foo@1.0`` and PyPI's
+        ``foo@1.0`` are different packages even under one advisory id. An unnamed
+        ecosystem agrees with anything, which is the whole point — that is the
+        scanner that only gave a name and a version.
+        """
+        other = entry_ecosystems[entry_idx]
+        return not other or not ecosystem or other == ecosystem
+
+    for finding, identity_keys, ecosystem in candidates:
         fid_set = _finding_ids(finding)
-        # A finding can bridge two entries that were distinct so far (its alias
-        # set intersects both) — fold every match into the first so the union
-        # stays transitive instead of leaving a duplicate behind, mirroring
-        # merge_findings_by_alias (Copilot review of #1220).
-        match_idxs: list[int] = []
-        for fid in fid_set:
-            idx = bucket.get(fid)
-            if idx is not None and idx not in match_idxs:
-                match_idxs.append(idx)
-        if not match_idxs:
-            existing_idx = len(deduped)
+        if not identity_keys or not fid_set:
             deduped.append(finding)
+            entry_ecosystems.append(ecosystem)
+            continue
+        pair_keys = {(key, fid) for key in identity_keys for fid in fid_set}
+        # A finding can bridge entries that were distinct so far (its keys reach
+        # both) — fold every match into the first so the union stays transitive
+        # instead of leaving a duplicate behind, mirroring merge_findings_by_alias.
+        match_idxs: list[int] = []
+        for pair in pair_keys:
+            for idx in index.get(pair, ()):
+                if idx not in match_idxs and _compatible(idx, ecosystem):
+                    match_idxs.append(idx)
+        if not match_idxs:
+            target_idx = len(deduped)
+            deduped.append(finding)
+            entry_ecosystems.append(ecosystem)
         else:
-            existing_idx = match_idxs[0]
-            _fold_finding(deduped[existing_idx], finding)
+            target_idx = match_idxs[0]
+            target = deduped[target_idx]
+            if _better_component(target.get("component") or {}, finding.get("component") or {}):
+                target["component"] = finding.get("component")
+            _fold_finding(target, finding)
+            # The folded row is now known to be of whichever ecosystem was named.
+            if not entry_ecosystems[target_idx]:
+                entry_ecosystems[target_idx] = ecosystem
             for extra_idx in match_idxs[1:]:
-                _fold_finding(deduped[existing_idx], deduped[extra_idx])
-                deduped[extra_idx]["_dead"] = True
-                for fid, idx in bucket.items():
-                    if idx == extra_idx:
-                        bucket[fid] = existing_idx
-        for fid in fid_set:
-            bucket[fid] = existing_idx
+                extra = deduped[extra_idx]
+                if _better_component(target.get("component") or {}, extra.get("component") or {}):
+                    target["component"] = extra.get("component")
+                _fold_finding(target, extra)
+                if not entry_ecosystems[target_idx]:
+                    entry_ecosystems[target_idx] = entry_ecosystems[extra_idx]
+                extra["_dead"] = True
+                for pair, idxs in index.items():
+                    index[pair] = [target_idx if i == extra_idx else i for i in idxs]
+        # The surviving row answers to every key it has absorbed, so a later
+        # finding recognises it by any of them.
+        for pair in pair_keys:
+            holders = index.setdefault(pair, [])
+            if target_idx not in holders:
+                holders.append(target_idx)
 
     deduped = [finding for finding in deduped if not finding.pop("_dead", False)]
 

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -72,6 +72,20 @@ def _name_tail(name: str) -> str:
     return name.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
 
 
+def _name_namespace(name: str) -> str:
+    """The grouping prefix the tail was taken from, or ``""`` when there is none.
+
+    Checked the way the ecosystem is: the tail key exists so a scanner that
+    drops the scope can meet one that keeps it, but two scopes that are both
+    named and different are different packages. Without this ``@babel/core``
+    and ``@foo/core`` at one version would meet through their shared tail.
+    """
+    for separator in ("/", ":"):
+        if separator in name:
+            return name.rsplit(separator, 1)[0]
+    return ""
+
+
 # OSV names ecosystems its own way; purl names them another. Both reach the same
 # label so a purl-bearing scanner and OSV can be compared.
 _ECOSYSTEM_ALIASES = {
@@ -110,6 +124,16 @@ def _ecosystem(component: dict[str, Any]) -> str:
     if not raw:
         raw = (component.get("ecosystem") or "").strip().lower()
     return _ECOSYSTEM_ALIASES.get(raw, raw)
+
+
+def _namespace(component: dict[str, Any]) -> str:
+    """The package's namespace or scope, or ``""`` when it has none."""
+    purl = (component.get("purl") or "").strip().lower()
+    if purl:
+        purl_name, _ = _purl_name_version(purl)
+        if purl_name:
+            return _name_namespace(purl_name)
+    return _name_namespace((component.get("name") or "").strip().lower())
 
 
 def _identity_keys(component: dict[str, Any], sbom_id: Any) -> set[str]:
@@ -221,7 +245,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     # unchanged from before). meaningful_runs tracks per-run whether the scanner
     # actually analyzed the SBOM (vs. only operational error markers).
     meaningful_runs = 0
-    candidates: list[tuple[dict[str, Any], set[str], str]] = []
+    candidates: list[tuple[dict[str, Any], set[str], str, str]] = []
     for run in runs:
         run_findings = (run.result or {}).get("findings", []) or []
         real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
@@ -234,7 +258,9 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             component = raw_component if isinstance(raw_component, dict) else {}
             # A finding with no package at all keeps an empty key set and so is
             # never folded: two nameless findings cannot be shown to be the same.
-            candidates.append((finding, _identity_keys(component, run.sbom_id), _ecosystem(component)))
+            candidates.append(
+                (finding, _identity_keys(component, run.sbom_id), _ecosystem(component), _namespace(component))
+            )
 
     # Every run that ran only produced operational error markers — the release was
     # not actually analyzed, so don't let the Trust Center claim it is clean.
@@ -256,24 +282,31 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     # finding with no package key, or no id at all, is never folded.
     deduped: list[dict[str, Any]] = []
     entry_ecosystems: list[str] = []
+    entry_namespaces: list[str] = []
     index: dict[tuple[str, str], list[int]] = {}
 
-    def _compatible(entry_idx: int, ecosystem: str) -> bool:
+    def _compatible(entry_idx: int, ecosystem: str, namespace: str) -> bool:
         """Whether a candidate may fold into an existing entry.
 
-        Ecosystems that are both named must agree: npm's ``foo@1.0`` and PyPI's
-        ``foo@1.0`` are different packages even under one advisory id. An unnamed
-        ecosystem agrees with anything, which is the whole point — that is the
-        scanner that only gave a name and a version.
+        Two ecosystems that are both named must agree: npm's ``foo@1.0`` and
+        PyPI's ``foo@1.0`` are different packages even under one advisory id.
+        The same holds for the namespace, because the tail key deliberately
+        ignores it — without this ``@babel/core`` and ``@foo/core`` would meet
+        through their shared tail. An unnamed value agrees with anything, which
+        is the whole point: that is the scanner that dropped the detail.
         """
-        other = entry_ecosystems[entry_idx]
-        return not other or not ecosystem or other == ecosystem
+        other_eco = entry_ecosystems[entry_idx]
+        other_ns = entry_namespaces[entry_idx]
+        if other_eco and ecosystem and other_eco != ecosystem:
+            return False
+        return not other_ns or not namespace or other_ns == namespace
 
-    for finding, identity_keys, ecosystem in candidates:
+    for finding, identity_keys, ecosystem, namespace in candidates:
         fid_set = _finding_ids(finding)
         if not identity_keys or not fid_set:
             deduped.append(finding)
             entry_ecosystems.append(ecosystem)
+            entry_namespaces.append(namespace)
             continue
         pair_keys = {(key, fid) for key in identity_keys for fid in fid_set}
         # A finding can bridge entries that were distinct so far (its keys reach
@@ -282,12 +315,13 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
         match_idxs: list[int] = []
         for pair in pair_keys:
             for idx in index.get(pair, ()):
-                if idx not in match_idxs and _compatible(idx, ecosystem):
+                if idx not in match_idxs and _compatible(idx, ecosystem, namespace):
                     match_idxs.append(idx)
         if not match_idxs:
             target_idx = len(deduped)
             deduped.append(finding)
             entry_ecosystems.append(ecosystem)
+            entry_namespaces.append(namespace)
         else:
             target_idx = match_idxs[0]
             target = deduped[target_idx]
@@ -297,6 +331,8 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
             # The folded row is now known to be of whichever ecosystem was named.
             if not entry_ecosystems[target_idx]:
                 entry_ecosystems[target_idx] = ecosystem
+            if not entry_namespaces[target_idx]:
+                entry_namespaces[target_idx] = namespace
             for extra_idx in match_idxs[1:]:
                 # Re-checked against the target rather than against the incoming
                 # finding. A finding with no ecosystem is compatible with every
@@ -306,7 +342,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
                 # An entry that does not belong stays its own row; the incoming
                 # finding lands in the first match, which is the best guess
                 # available when it never said which ecosystem it came from.
-                if not _compatible(extra_idx, entry_ecosystems[target_idx]):
+                if not _compatible(extra_idx, entry_ecosystems[target_idx], entry_namespaces[target_idx]):
                     continue
                 extra = deduped[extra_idx]
                 if _better_component(target.get("component") or {}, extra.get("component") or {}):
@@ -314,6 +350,8 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
                 _fold_finding(target, extra)
                 if not entry_ecosystems[target_idx]:
                     entry_ecosystems[target_idx] = entry_ecosystems[extra_idx]
+                if not entry_namespaces[target_idx]:
+                    entry_namespaces[target_idx] = entry_namespaces[extra_idx]
                 extra["_dead"] = True
                 for pair, idxs in index.items():
                     index[pair] = [target_idx if i == extra_idx else i for i in idxs]

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -454,3 +454,39 @@ def test_posture_ecosystem_less_finding_cannot_bridge_two_ecosystems(release, or
 
     # Two packages, still two rows — the bare finding joined one of them.
     assert p["counts"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_two_scopes_sharing_a_tail_stay_apart(release):
+    """The tail key ignores the scope so a scanner that drops it can still
+    match one that keeps it. Two scopes that are both named and different are
+    different packages, and folding them would hide a finding."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [
+        {"id": "CVE-S", "severity": "high",
+         "component": {"name": "@babel/core", "version": "7.28.0", "purl": "pkg:npm/%40babel/core@7.28.0"}},
+        {"id": "CVE-S", "severity": "high",
+         "component": {"name": "@foo/core", "version": "7.28.0", "purl": "pkg:npm/%40foo/core@7.28.0"}},
+    ])
+
+    p = build_release_vuln_posture(rel)
+
+    assert p["counts"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_two_maven_groups_sharing_an_artifact_stay_apart(release):
+    """The same argument for OSV's group:artifact naming."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [
+        {"id": "CVE-M", "severity": "high", "component": {"name": "org.one:utils", "version": "1.0"}},
+        {"id": "CVE-M", "severity": "high", "component": {"name": "org.two:utils", "version": "1.0"}},
+    ])
+
+    p = build_release_vuln_posture(rel)
+
+    assert p["counts"]["total"] == 2

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -326,3 +326,104 @@ def test_posture_findings_have_unique_idx_keys(release):
     idxs = [f["idx"] for f in findings]
     # CVE-1 kept for both SBOMs (no identity), CVE-2 kept for both (name scoped per SBOM).
     assert len(idxs) == len(set(idxs)) == 4
+
+
+@pytest.mark.django_db
+def test_posture_folds_purl_scanner_with_name_only_scanner(release):
+    """A purl-bearing scanner and OSV (name + version + ecosystem, no purl) report
+    the same package, so one advisory on it is one row — not one row each."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(
+        sbom,
+        [{
+            "id": "GHSA-23c5-xmqv-rm74",
+            "severity": "medium",
+            "component": {"name": "minimatch", "version": "3.1.2", "purl": "pkg:npm/minimatch@3.1.2"},
+        }],
+        plugin="dependency-track",
+    )
+    _run(
+        sbom,
+        [{
+            "id": "GHSA-23c5-xmqv-rm74",
+            "severity": "high",
+            "component": {"name": "minimatch", "version": "3.1.2", "ecosystem": "npm"},
+        }],
+        plugin="osv",
+    )
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 1
+    # Worst severity wins, so the row cannot read "medium" while a scanner said high.
+    assert p["findings"][0]["severity"] == "high"
+
+
+@pytest.mark.django_db
+def test_posture_keeps_distinct_versions_of_one_package_apart(release):
+    """Two installed copies of a package are two findings; the fix for duplicates
+    must not fold different versions together."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [
+        {"id": "GHSA-23c5-xmqv-rm74", "severity": "high",
+         "component": {"name": "minimatch", "version": "3.1.2", "purl": "pkg:npm/minimatch@3.1.2"}},
+        {"id": "GHSA-23c5-xmqv-rm74", "severity": "high",
+         "component": {"name": "minimatch", "version": "5.1.6", "ecosystem": "npm"}},
+    ])
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 2
+
+
+@pytest.mark.django_db
+def test_posture_folds_scoped_npm_name_against_bare_name(release):
+    """One scanner writes the npm scope, another drops it; @babel/core and core at
+    the same version under the same advisory are the same package."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [{
+        "id": "GHSA-4x5r-pxfx-6jf8", "severity": "high",
+        "component": {"name": "@babel/core", "version": "7.28.0", "purl": "pkg:npm/%40babel/core@7.28.0"},
+    }], plugin="dependency-track")
+    _run(sbom, [{
+        "id": "GHSA-4x5r-pxfx-6jf8", "severity": "low",
+        "component": {"name": "core", "version": "7.28.0"},
+    }], plugin="osv")
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 1
+    assert p["findings"][0]["severity"] == "high"
+    # The row keeps the name a reader can actually look up.
+    assert p["findings"][0]["component"] == "@babel/core"
+
+
+@pytest.mark.django_db
+def test_posture_purl_qualifiers_do_not_split_a_package(release):
+    """Qualifiers and subpaths are not part of a package's identity."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [
+        {"id": "CVE-Q", "severity": "high",
+         "component": {"name": "pkg", "version": "1.0", "purl": "pkg:npm/pkg@1.0?dev=true"}},
+        {"id": "CVE-Q", "severity": "high",
+         "component": {"name": "pkg", "version": "1.0", "purl": "pkg:npm/pkg@1.0"}},
+    ])
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 1
+
+
+@pytest.mark.django_db
+def test_posture_named_ecosystems_that_differ_never_fold(release):
+    """The guard that lets an unnamed ecosystem match a named one must not let two
+    named-and-different ones match."""
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+    _run(sbom, [
+        {"id": "CVE-X", "severity": "high", "component": {"name": "foo", "version": "1.0", "ecosystem": "npm"}},
+        {"id": "CVE-X", "severity": "high", "component": {"name": "foo", "version": "1.0", "ecosystem": "PyPI"}},
+    ])
+    p = build_release_vuln_posture(rel)
+    assert p["counts"]["total"] == 2

--- a/sbomify/apps/vulnerability_scanning/tests/test_posture.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_posture.py
@@ -427,3 +427,30 @@ def test_posture_named_ecosystems_that_differ_never_fold(release):
     ])
     p = build_release_vuln_posture(rel)
     assert p["counts"]["total"] == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("order", ["between", "first", "last"])
+def test_posture_ecosystem_less_finding_cannot_bridge_two_ecosystems(release, order):
+    """An unnamed ecosystem matches either named one, but must not join them.
+
+    npm's foo@1.0 and PyPI's foo@1.0 are different packages. A scanner that
+    records only name and version is compatible with both, so a naive fold
+    would let it merge the two through itself. It has to land in one of them
+    and leave the other alone — whichever order the three arrive in.
+    """
+    rel, component = release
+    sbom = _sbom(component, "app")
+    ReleaseArtifact.objects.create(release=rel, sbom=sbom)
+
+    npm = {"id": "CVE-X", "severity": "high", "component": {"name": "foo", "version": "1.0", "ecosystem": "npm"}}
+    pypi = {"id": "CVE-X", "severity": "high", "component": {"name": "foo", "version": "1.0", "ecosystem": "PyPI"}}
+    bare = {"id": "CVE-X", "severity": "high", "component": {"name": "foo", "version": "1.0"}}
+
+    findings = {"between": [npm, bare, pypi], "first": [bare, npm, pypi], "last": [npm, pypi, bare]}[order]
+    _run(sbom, findings)
+
+    p = build_release_vuln_posture(rel)
+
+    # Two packages, still two rows — the bare finding joined one of them.
+    assert p["counts"]["total"] == 2


### PR DESCRIPTION
Reported by Viktor on https://stage.sbomify.com/public/product/xJ6NJlgTK37Y/release/wjciC5RRcF4E/ — `GHSA-23c5-xmqv-rm74` listed four times.

It is broader than that one advisory. On that page:

- `GHSA-23c5-xmqv-rm74` appears 4× against minimatch — two versions (3.1.2 and 5.1.6), each listed twice
- `GHSA-3ppc-4f35-3m26` and `GHSA-7r86-cg39-jmmj` repeat the same pattern
- `GHSA-3jxr-9vmj-r5cp`, `GHSA-f886-m6hf-6m8v` and `GHSA-jxxr-4gwj-5jf2` each appear **twice at different severities** — once high, once medium — against the same brace-expansion versions
- `GHSA-4x5r-pxfx-6jf8` appears as `@babel/core` 7.28.0 (high) and as `core` 7.28.0 (low)
- The "64 total" headline count is inflated accordingly

## Cause

Findings fold only within a package identity, and that identity was the purl when a scanner recorded one and `name@version` otherwise. OSV records `{name, version, ecosystem}` and **no purl**; other scanners record a purl. The two key spaces never compare equal, so one package landed in two buckets, the rows never folded, and each kept its own scanner's severity — which is why one advisory shows as both high and medium.

Identical name and version at two severities is the proof: under the old code those would only stay separate if their identities differed, and the purl is the only field left.

## Fix

Identity is a set of keys rather than one string, and two findings meet when they share any key:

- `name@version` derived from the purl **and** taken from the fields, so the two scanner styles meet
- a tail key that drops a grouping prefix, so `@babel/core` reaches `core` and `group:artifact` reaches `artifact` (the same normalisation `merge_findings_by_alias` already does)
- qualifiers and subpaths stripped: `pkg@1.0?dev=true` is not a different package from `pkg@1.0`

The keys carry no ecosystem — if they did, a scanner naming one could never match a scanner that does not. The ecosystem is a separate compatibility check instead: two that are both named must agree, so npm's `foo@1.0` and PyPI's `foo@1.0` stay two findings (already covered by `test_posture_same_name_version_different_ecosystem_kept`), while an unnamed one matches either.

Folding still requires a shared advisory id, so nothing collapses on package identity alone.

## Testing

337 tests pass across `vulnerability_scanning` and the public-release posture tests, including every pre-existing dedup invariant. Five new tests cover the reported shapes: purl-scanner vs name-only scanner, distinct versions staying apart, scoped-vs-bare npm names, purl qualifiers, and named-but-different ecosystems.