### PR TITLE
fix(teams): keep OIDC binding bots out of the members list

### DIFF
--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -82,7 +82,16 @@ def _build_team_response(request: HttpRequest, team: Team) -> TeamSchema:
             is_default_team=member.is_default_team,
             is_me=(current_user_id == member.user.id),
         )
-        for member in team.member_set.select_related("user").exclude(role="guest").all()
+        # Bots are excluded alongside guests: a role="bot" membership is the
+        # synthetic identity behind an OIDC trusted-publisher binding, not a
+        # person with access, and one appears per binding — six bindings filled
+        # the workspace's member list with six "OIDC Bot" rows and counted them
+        # towards the member total. Bindings are managed on their own settings
+        # page, which is where removing that access belongs; the remove control
+        # on a member row would have deleted the membership and left the binding
+        # pointing at nothing. active_member_count and get_user_teams already
+        # exclude them.
+        for member in team.member_set.select_related("user").exclude(role__in=("guest", "bot")).all()
     ]
 
     invitations_data = [

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -2139,3 +2139,41 @@ def test_team_general_post__updates_session(
     # Verify session was updated
     session = client.session
     assert session["current_team"]["name"] == new_name
+
+
+@pytest.mark.django_db
+def test_team_response_omits_oidc_bot_memberships(
+    sample_team_with_owner_member: Member,  # noqa: F811
+    authenticated_api_client,  # noqa: F811
+):
+    """OIDC binding bots are not people with access to the workspace.
+
+    One synthetic ``role="bot"`` membership exists per trusted-publisher binding,
+    so a workspace with several bindings listed several "OIDC Bot" rows on its
+    members page and counted them towards the member total.
+    """
+    from django.contrib.auth import get_user_model
+
+    from sbomify.apps.teams.apis import _build_team_response
+
+    team = sample_team_with_owner_member.team
+    bot_user = get_user_model().objects.create_user(
+        username="oidc-bot-AbQf00M37nNj",
+        email="oidc-bot-AbQf00M37nNj@sbomify.local",
+        first_name="OIDC",
+        last_name="Bot",
+    )
+    # The same opt-out the OIDC provisioning path uses: the binding is attached
+    # after the membership, so the signal's binding lookup would reject it here.
+    bot_member = Member(user=bot_user, team=team, role="bot")
+    bot_member._is_oidc_bot_provisioning = True
+    bot_member.save()
+
+    request = RequestFactory().get("/")
+    request.user = sample_team_with_owner_member.user
+
+    response = _build_team_response(request, team)
+
+    emails = [member.user.email for member in response.members]
+    assert bot_user.email not in emails
+    assert sample_team_with_owner_member.user.email in emails

--- a/sbomify/apps/teams/tests/test_teams.py
+++ b/sbomify/apps/teams/tests/test_teams.py
@@ -2144,7 +2144,6 @@ def test_team_general_post__updates_session(
 @pytest.mark.django_db
 def test_team_response_omits_oidc_bot_memberships(
     sample_team_with_owner_member: Member,  # noqa: F811
-    authenticated_api_client,  # noqa: F811
 ):
     """OIDC binding bots are not people with access to the workspace.
 


### PR DESCRIPTION
Reported by Viktor: the Workspace Members list on workspace settings was showing six `OIDC Bot` rows above the two actual people, and counting them in the "8 members" badge.

Each OIDC trusted-publisher binding provisions a synthetic `role="bot"` member to own its uploads. `_build_team_response` excluded `guest` but not `bot`, so every binding added a row to the list of "People with access to this workspace".

Bots are excluded alongside guests now. Two reasons beyond the noise:

- The count next to the list already disagreed with it — `active_member_count` and `get_user_teams` both exclude `role="bot"` — so the badge and the rows were computed on different rules.
- The remove control on a member row would have deleted the membership and left the binding pointing at a bot with no workspace access. Revoking that access belongs on the bindings page, which is where the binding itself is managed.

## Testing

634 tests pass across `teams` and `oidc`. One new test asserts a provisioned bot membership stays out of the response while the human owner remains. It goes through the same `_is_oidc_bot_provisioning` opt-out the real provisioning path uses, since the signal guarding `role="bot"` rejects a membership created before its binding exists.