### PR TITLE
test(core): stop the purge test depending on row order

### DIFF
--- a/sbomify/apps/core/tests/test_cron.py
+++ b/sbomify/apps/core/tests/test_cron.py
@@ -20,7 +20,9 @@ class TestPurgeSoftDeletedUsers:
         from sbomify.apps.core.services.account_deletion import SOFT_DELETE_GRACE_DAYS
 
         user = django_user_model.objects.create_user(
-            username="expired_user", email="expired@example.com", password="test",
+            username="expired_user",
+            email="expired@example.com",
+            password="test",
             is_active=False,
         )
         user.deleted_at = timezone.now() - timedelta(days=SOFT_DELETE_GRACE_DAYS + 1)
@@ -38,7 +40,9 @@ class TestPurgeSoftDeletedUsers:
         from sbomify.apps.core.cron import purge_soft_deleted_users
 
         user = django_user_model.objects.create_user(
-            username="recent_user", email="recent@example.com", password="test",
+            username="recent_user",
+            email="recent@example.com",
+            password="test",
             is_active=False,
         )
         user.deleted_at = timezone.now() - timedelta(days=5)
@@ -56,7 +60,9 @@ class TestPurgeSoftDeletedUsers:
         from sbomify.apps.core.services.account_deletion import SOFT_DELETE_GRACE_DAYS
 
         user = django_user_model.objects.create_user(
-            username="active_user", email="active@example.com", password="test",
+            username="active_user",
+            email="active@example.com",
+            password="test",
             is_active=True,
         )
         user.deleted_at = timezone.now() - timedelta(days=SOFT_DELETE_GRACE_DAYS + 10)
@@ -81,26 +87,30 @@ class TestPurgeSoftDeletedUsers:
         from sbomify.apps.core.services.account_deletion import SOFT_DELETE_GRACE_DAYS
 
         user1 = django_user_model.objects.create_user(
-            username="fail_user", email="fail@example.com", password="test",
+            username="fail_user",
+            email="fail@example.com",
+            password="test",
             is_active=False,
         )
         user1.deleted_at = timezone.now() - timedelta(days=SOFT_DELETE_GRACE_DAYS + 1)
         user1.save()
 
         user2 = django_user_model.objects.create_user(
-            username="succeed_user", email="succeed@example.com", password="test",
+            username="succeed_user",
+            email="succeed@example.com",
+            password="test",
             is_active=False,
         )
         user2.deleted_at = timezone.now() - timedelta(days=SOFT_DELETE_GRACE_DAYS + 1)
         user2.save()
         user2_id = user2.id
 
-        call_count = 0
-
+        # Keyed on which user, not on call order. purge_soft_deleted_users
+        # iterates an unordered queryset, so Postgres is free to hand back
+        # either user first; failing "the first call" made the surviving user
+        # a matter of row order, and CI duly ordered it the other way.
         def mock_hard_delete(user):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+            if user.username == "fail_user":
                 raise Exception("Simulated failure")
             user.delete()
             return True


### PR DESCRIPTION
CI failure seen on #1289, which touches none of this code.

`purge_soft_deleted_users` iterates `users_to_purge.iterator()` with no `order_by`, so Postgres may hand back either soft-deleted user first. `test_continues_after_individual_failure` raised on **call number one** and then asserted that the second user was deleted, so which user survived came down to row order. Locally it ordered one way, in CI the other, and the assertion failed.

The mock now raises for `fail_user` by name rather than for whichever user arrives first — that is what the test is actually about, and it holds whichever order the database picks.

Left alone deliberately: the production queryset stays unordered. Adding an `order_by` to make a test deterministic would be the wrong place to fix it, and purge order carries no meaning.