### PR TITLE
fix(core): a dead socket must not raise into the ASGI server

### DIFF
--- a/sbomify/apps/core/consumers.py
+++ b/sbomify/apps/core/consumers.py
@@ -131,5 +131,22 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
                 - type: "workspace_message" (used for routing)
                 - data: The actual message data to send to the client
         """
-        # Send message to WebSocket client
-        await self.send_json(event["data"])
+        # A broadcast fans out to every channel in the group, and by the time it
+        # arrives a given socket may already be gone: the reader closed the tab,
+        # the connection dropped, or the broker is restarting. Sending to it
+        # raises, and an exception escaping a consumer handler is what uvicorn
+        # logs as "Exception in ASGI application" — one stack per dead socket,
+        # per broadcast, for something that is a normal end to a connection.
+        #
+        # Nothing is retried. The payload is a refresh trigger the client
+        # re-derives when it reconnects, so a socket that missed one has lost
+        # nothing a reconnect does not restore.
+        try:
+            await self.send_json(event["data"])
+        except KeyError:
+            # A producer sent an event without a data key. That is a bug in the
+            # caller rather than a transport failure, so it is worth a real log
+            # line instead of the debug the disconnect cases get.
+            logger.warning(f"Dropped a workspace_message with no data payload: {event!r}")
+        except Exception:
+            logger.debug("workspace_message send failed; socket likely gone", exc_info=True)

--- a/sbomify/apps/core/tests/test_consumers.py
+++ b/sbomify/apps/core/tests/test_consumers.py
@@ -321,3 +321,47 @@ class TestBrokerOutageHandling:
         consumer.channel_layer = layer
 
         await consumer.disconnect(1006)
+
+
+class TestBroadcastResilience:
+    """A broadcast fans out to every channel in the group, and a socket may be
+    gone by the time its copy arrives. An exception escaping the handler is what
+    uvicorn logs as "Exception in ASGI application"."""
+
+    @pytest.fixture
+    def consumer(self):
+        return WorkspaceConsumer()
+
+    @pytest.mark.asyncio
+    async def test_a_dead_socket_does_not_raise_into_the_asgi_server(self, consumer):
+        consumer.send_json = AsyncMock(side_effect=ConnectionError("reset by peer"))
+
+        await consumer.workspace_message({"type": "workspace_message", "data": {"type": "sbom_uploaded"}})
+
+        consumer.send_json.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_closed_socket_does_not_raise_either(self, consumer):
+        """Channels raises its own error once the socket has been closed."""
+        consumer.send_json = AsyncMock(side_effect=RuntimeError("Cannot call send once a close message has been sent"))
+
+        await consumer.workspace_message({"type": "workspace_message", "data": {"x": 1}})
+
+    @pytest.mark.asyncio
+    async def test_an_event_with_no_data_is_dropped_not_raised(self, consumer):
+        """A producer bug, not a transport failure — it must not take the socket
+        down with it, and it is the one case worth a warning."""
+        consumer.send_json = AsyncMock()
+
+        await consumer.workspace_message({"type": "workspace_message"})
+
+        consumer.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_live_socket_still_receives_the_payload(self, consumer):
+        consumer.send_json = AsyncMock()
+        payload = {"type": "scan_complete", "sbom_id": "123"}
+
+        await consumer.workspace_message({"type": "workspace_message", "data": payload})
+
+        consumer.send_json.assert_awaited_once_with(payload)


### PR DESCRIPTION
Prod is still logging `Exception in ASGI application` from the WebSocket path (`sbomify-prod-01`, 2026-08-05 01:35, uvicorn `websockets_sansio_impl.py:350` in `run_asgi`).

#1294 fixed the **connect** path — `group_add` and `accept` — and is merged but not yet deployed, so the current noise predates it. This PR closes the other half, which #1294 did not touch and which would keep producing the identical log line after that deploy.

`workspace_message` ended in a bare `await self.send_json(event["data"])`. A broadcast fans out to every channel in the workspace group, and by the time a given socket's copy arrives that socket may be gone: the reader closed the tab, the connection dropped, the broker is restarting. Sending to it raises, and an exception escaping a consumer handler is exactly what uvicorn reports as `Exception in ASGI application` — one stack per dead socket per broadcast, for something that is a normal end to a connection.

Nothing is retried. The payload is a refresh trigger the client re-derives when it reconnects, so a socket that missed one has lost nothing a reconnect does not restore.

An event with no `data` key is handled separately and warns: that is a bug in the producer rather than a transport failure, and it should not be filed under the same debug line as a routine disconnect.

## Testing

19 consumer tests pass. Four new ones cover a socket reset mid-broadcast, Channels' own "cannot send once a close message has been sent", a malformed event, and the ordinary case still delivering its payload.

## Caveat

The Graylog excerpt is truncated one frame above our code, so I cannot say from the log alone whether the live traceback is the connect path or this one. Both are now guarded, so the deploy settles it either way — if the line persists afterwards, the next step is the full traceback rather than another guess.