### PR TITLE
fix(settings): let a settings section handle the forms it renders

### DIFF
--- a/sbomify/apps/teams/tests/test_settings_tab_post.py
+++ b/sbomify/apps/teams/tests/test_settings_tab_post.py
@@ -1,0 +1,104 @@
+"""Every form on a settings section posts back to that section's own URL.
+
+Settings moved from one page of hidden panes to one page per section, and the
+per-section route carries a ``tab``. ``TeamSettingsView.get`` was given the
+parameter; ``post`` was not, so Django handed it a keyword argument it did not
+declare and the request died in ``View.dispatch`` with a ``TypeError`` before
+reaching any of this view's code. Removing a member and cancelling an invitation
+are the two forms that post to ``request.path``, and both 500ed.
+
+The tests go through the URL rather than calling the handler, because calling
+``view.post(request, team_key)`` directly is exactly the call that worked while
+production was broken.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+
+from sbomify.apps.core.tests.shared_fixtures import (  # noqa: F401
+    setup_authenticated_client_session,
+)
+from sbomify.apps.teams.models import Invitation, Member
+from sbomify.apps.teams.settings_tabs import SETTINGS_TABS
+
+
+@pytest.fixture
+def owner_client(sample_team_with_owner_member: Member) -> tuple[Client, Member]:  # noqa: F811
+    client = Client()
+    client.force_login(sample_team_with_owner_member.user)
+    setup_authenticated_client_session(
+        client, sample_team_with_owner_member.team, sample_team_with_owner_member.user
+    )
+    return client, sample_team_with_owner_member
+
+
+@pytest.mark.django_db
+def test_cancelling_an_invitation_from_the_members_tab(owner_client: tuple[Client, Member]) -> None:
+    """The reported failure, end to end."""
+    client, owner = owner_client
+    invitation = Invitation.objects.create(team=owner.team, email="luc@example.test", role="admin")
+
+    response = client.post(
+        f"/workspaces/{owner.team.key}/settings/members",
+        {"_method": "DELETE", "invitation_id": invitation.id, "active_tab": "members"},
+    )
+
+    assert response.status_code == 302
+    assert not Invitation.objects.filter(pk=invitation.pk).exists()
+
+
+@pytest.mark.django_db
+def test_removing_a_member_from_the_members_tab(owner_client: tuple[Client, Member]) -> None:
+    """The other form on the same page, which posts to the same URL."""
+    from django.contrib.auth import get_user_model
+
+    client, owner = owner_client
+    victim = get_user_model().objects.create_user(username="removable", email="removable@example.test")
+    membership = Member.objects.create(user=victim, team=owner.team, role="admin")
+
+    response = client.post(
+        f"/workspaces/{owner.team.key}/settings/members",
+        {"_method": "DELETE", "member_id": membership.id, "active_tab": "members"},
+    )
+
+    assert response.status_code == 302
+    assert not Member.objects.filter(pk=membership.pk).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("tab", [tab.key for tab in SETTINGS_TABS])
+def test_no_section_url_rejects_a_post(owner_client: tuple[Client, Member], tab: str) -> None:
+    """Posting to any section is handled, not refused by the dispatcher.
+
+    Only the members tab posts to ``request.path`` today, so pinning that one
+    alone would let the next section that does so reintroduce the same 500. An
+    unrecognised body is answered with "Invalid request method" and a redirect,
+    which is this view's own reply — a 500 here means the request never arrived.
+    """
+    client, owner = owner_client
+
+    response = client.post(f"/workspaces/{owner.team.key}/settings/{tab}", {})
+
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_a_form_without_active_tab_returns_to_its_own_section(owner_client: tuple[Client, Member]) -> None:
+    """The URL knows the section even when the form forgets to say so.
+
+    ``active_tab`` is a hidden field every settings form is supposed to carry.
+    Falling back to the tab in the URL means one that forgets it returns to the
+    page it was submitted from instead of the first section in the list.
+    """
+    client, owner = owner_client
+    invitation = Invitation.objects.create(team=owner.team, email="luc@example.test", role="guest")
+
+    response = client.post(
+        f"/workspaces/{owner.team.key}/settings/members",
+        {"_method": "DELETE", "invitation_id": invitation.id},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings/members")

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -99,14 +99,37 @@ PLAN_LIMITS = {
 class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
     allowed_roles = ["owner", "admin"]
 
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        """Take ``tab`` off the URL and hold it, rather than pass it to a handler.
+
+        Two URLs reach this view: the settings index, which has no tab, and one
+        section per tab, which does. Only ``get`` declared the parameter, so
+        every form on a section page — all of which post back to their own URL —
+        died on ``post() got an unexpected keyword argument 'tab'`` before it
+        reached a line of this class. Removing a member and cancelling an
+        invitation both 500ed.
+
+        Absorbing it here keeps the handlers free of it, so adding one cannot
+        reintroduce the mismatch, and gives POST the section it was submitted
+        from as somewhere to send the browser back to.
+        """
+        self.tab: str | None = kwargs.pop("tab", None)
+        return super().dispatch(request, *args, **kwargs)
+
     def _redirect_with_tab(self, request: HttpRequest, team_key: str) -> HttpResponse:
-        """Redirect to team settings, preserving the active tab if provided."""
+        """Redirect back to the section the form was submitted from.
+
+        Forms carry an ``active_tab``, but the URL already knows which section
+        rendered them; falling back to it means a form that forgets the hidden
+        field returns to its own page instead of bouncing to the first one.
+        """
         from sbomify.apps.teams.utils import redirect_to_team_settings
 
-        active_tab = request.POST.get("active_tab", "")
+        active_tab = request.POST.get("active_tab", "") or self.tab
         return redirect_to_team_settings(team_key, active_tab if active_tab else None)
 
-    def get(self, request: HttpRequest, team_key: str, tab: str | None = None) -> HttpResponse:
+    def get(self, request: HttpRequest, team_key: str) -> HttpResponse:
+        tab = self.tab
         status_code, team = get_team(request, team_key)
         if status_code != 200:
             return error_response(


### PR DESCRIPTION
Cancelling an invitation on stage returned a 500:

```
django.request:ERROR:Internal Server Error: /workspaces/JYcZlC2Fcb/settings/members
```

Settings moved to one page per section, and the section route carries a `tab`. `get` was given the parameter, `post` was not, so Django passed a keyword argument the handler did not declare and the request died in `View.dispatch` with `TypeError: TeamSettingsView.post() got an unexpected keyword argument 'tab'` before reaching a line of this view.

Two forms post back to their own URL, and both were dead: **Cancel Invitation** and **Remove Member**. Everything else on the settings page posts to the index route, which has no `tab`, so it kept working — which is also why no test caught this. Every existing test posts to the index.

## The fix

`dispatch` takes `tab` off the URL and holds it on the instance, so no handler carries it and adding one cannot repeat the mismatch.

POST gains the section it was submitted from as well. Forms carry a hidden `active_tab`, but the URL already knows which section rendered them, so one that omits the field returns to its own page instead of bouncing to the first section.

## Verification

In a browser, against the same URL shape, driving the real modal form:

| | Status | Result |
|---|---|---|
| before | `500` | `TypeError at /workspaces/.../settings/members` |
| after | `200` | redirected to `/settings/members`, invitation deleted, "All caught up!" |

The new tests go through the URL rather than calling the handler, and all 12 fail without the fix.