### PR TITLE
fix(cache): a Redis outage should cost latency, not the page

### DIFF
--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 from math import ceil
 
 from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
 from django.http import HttpRequest, HttpResponse
 from ninja.throttling import SimpleRateThrottle
 
@@ -25,6 +27,23 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
 
     def __init__(self, rate: str | None = None) -> None:
         super().__init__(rate or settings.API_TOKEN_RATE_LIMIT)
+
+    @property
+    def cache(self) -> BaseCache:  # type: ignore[override]
+        """The Redis alias that still raises when Redis is unreachable.
+
+        The default alias swallows connection failures so a page renders without
+        its cache instead of 500ing. A throttle cannot borrow that: it decides
+        from the window it reads back, and a swallowed failure reads as an empty
+        window, so every caller is handed a full budget for as long as Redis is
+        unwell. Raising here refuses the request instead, and the subclasses
+        below inherit it — including the per-IP limit on the anonymous surfaces,
+        which is the one an attacker would want gone.
+
+        Resolved per access rather than bound at import so a test that overrides
+        ``CACHES`` is honoured.
+        """
+        return caches["throttle"]
 
     def get_cache_key(self, request: HttpRequest) -> str | None:
         record = getattr(request, "access_token_record", None)

--- a/sbomify/apps/core/tests/test_cache_outage.py
+++ b/sbomify/apps/core/tests/test_cache_outage.py
@@ -1,0 +1,127 @@
+"""A Redis outage should cost latency, not pages — except where it costs a limit.
+
+django-redis re-raises connection failures out of ``cache.get``/``cache.set``
+unless ``IGNORE_EXCEPTIONS`` is set. Every authenticated page renders its sidebar
+and header inside ``{% cache %}``, so an unreachable or merely slow Redis turned
+a page that had already done all its work into a 500.
+
+Switching that on trades one failure for another: a rate limiter decides from the
+window it reads back, and a swallowed failure reads as an empty window, so the
+limit disappears for as long as Redis is unwell. The throttle therefore keeps its
+own alias that still raises.
+
+Both halves are pinned here, because the pair is the point. Turning either one
+round on its own is a regression the other test would not catch.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from django.core.cache import caches
+from django.test import Client, RequestFactory, override_settings
+
+from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+from sbomify.apps.core.tests.shared_fixtures import (  # noqa: F401
+    setup_authenticated_client_session,
+)
+from sbomify.apps.teams.models import Member, Team
+from sbomify.settings import build_redis_caches
+
+# A port with nothing listening: connecting fails at once rather than after the
+# socket timeout, so the tests stay fast while taking the same path a timed-out
+# connection takes.
+_DEAD_REDIS = "redis://127.0.0.1:6399/0"
+
+
+def _caches_with_redis_down() -> dict[str, dict[str, Any]]:
+    """The production pair, pointed at a Redis that is not there.
+
+    Built by the same function settings.py calls, so these tests exercise the
+    real configuration rather than a copy of it that could drift.
+    """
+    config = build_redis_caches(_DEAD_REDIS)
+    for alias in config.values():
+        alias["OPTIONS"]["SOCKET_CONNECT_TIMEOUT"] = 1
+        alias["OPTIONS"]["SOCKET_TIMEOUT"] = 1
+    return config
+
+
+@pytest.mark.django_db
+def test_settings_page_renders_while_redis_is_unreachable(
+    sample_team_with_owner_member: Member,  # noqa: F811
+) -> None:
+    """The symptom: a 500 on a page the user could otherwise see.
+
+    Nothing on this page needs Redis to produce a correct answer. The cached
+    fragments are the sidebar and header, and every other cache read on the path
+    falls through to the database on a miss.
+    """
+    team: Team = sample_team_with_owner_member.team
+    client = Client()
+    client.force_login(sample_team_with_owner_member.user)
+    setup_authenticated_client_session(client, team, sample_team_with_owner_member.user)
+
+    with override_settings(CACHES=_caches_with_redis_down()):
+        caches.close_all()
+        response = client.get(f"/workspaces/{team.key}/settings/members")
+
+    assert response.status_code == 200
+
+
+def test_throttle_refuses_rather_than_forgetting_its_window() -> None:
+    """The half that must not be swallowed.
+
+    Reading the window back is how the throttle decides. If a failed read looked
+    like "no requests yet", every caller would get a fresh budget at exactly the
+    moment Redis is struggling, and a caller hammering the API is one reason it
+    might be. The alias the throttle uses still raises, so the request fails
+    instead of passing unlimited.
+    """
+    throttle = AccessTokenRateThrottle(rate="1/min")
+    request = RequestFactory().get("/api/v1/whatever")
+    request.access_token_record = SimpleNamespace(pk=1234)  # type: ignore[attr-defined]
+
+    with override_settings(CACHES=_caches_with_redis_down()):
+        caches.close_all()
+        with pytest.raises(Exception) as excinfo:
+            throttle.allow_request(request)
+
+    # Whichever exception redis-py or django-redis raises, the point is that one
+    # arrives: a silent True here is the failure mode this pins.
+    assert "6399" in str(excinfo.value) or "onnect" in str(excinfo.value)
+
+
+def test_the_anonymous_ip_limit_inherits_that_refusal() -> None:
+    """The per-IP limit on the public surfaces is the one worth losing least.
+
+    It subclasses the token throttle, so it picks up the strict alias; a future
+    subclass that reached for the default cache would go quiet during an outage
+    on the endpoints that have no other protection.
+    """
+    from sbomify.apps.access_tokens.throttling import AnonymousIPRateThrottle
+
+    throttle = AnonymousIPRateThrottle(rate="1/min")
+    request = RequestFactory().get("/api/v1/public", REMOTE_ADDR="203.0.113.9")
+
+    with override_settings(CACHES=_caches_with_redis_down()):
+        caches.close_all()
+        with pytest.raises(Exception):
+            throttle.allow_request(request)
+
+
+def test_the_two_aliases_differ_in_exactly_one_option() -> None:
+    """``IGNORE_EXCEPTIONS`` on default is the fix; its absence on throttle is
+    the containment. Everything else about the two should stay identical, so a
+    later timeout or pool change is made once and applies to both."""
+    config = build_redis_caches("redis://example.test:6379/0")
+
+    default_options = config["default"]["OPTIONS"]
+    throttle_options = config["throttle"]["OPTIONS"]
+
+    assert default_options["IGNORE_EXCEPTIONS"] is True
+    assert "IGNORE_EXCEPTIONS" not in throttle_options
+    assert {k: v for k, v in default_options.items() if k != "IGNORE_EXCEPTIONS"} == throttle_options
+    assert config["default"]["LOCATION"] == config["throttle"]["LOCATION"]

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -464,33 +464,78 @@ if REDIS_CA_CERTS and not _redis_is_tls:
         "Either use rediss:// or remove REDIS_CA_CERTS."
     )
 
+
 # Cache Configuration
-CACHES: dict[str, dict[str, Any]]
-if DEBUG:
-    # Disable caching in development mode
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-        }
+def build_redis_caches(location: str, ca_certs: str = "") -> dict[str, dict[str, Any]]:
+    """The two Redis cache aliases, which differ in one option only.
+
+    A function rather than an inline literal so a test can read the real pair
+    back and check that the difference between them is the only difference
+    there is.
+
+    Both point at the same Redis. ``default`` swallows connection failures;
+    ``throttle`` does not, and nothing else about them may drift apart.
+    """
+    pool_kwargs: dict[str, Any] = {"max_connections": 10}
+    if ca_certs:
+        pool_kwargs["ssl_ca_certs"] = ca_certs
+    options: dict[str, Any] = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        "SOCKET_CONNECT_TIMEOUT": 5,
+        "SOCKET_TIMEOUT": 5,
+        "RETRY_ON_TIMEOUT": True,
+        "CONNECTION_POOL_KWARGS": pool_kwargs,
     }
-else:
-    # Use Redis cache in production
-    _cache_pool_kwargs: dict[str, Any] = {"max_connections": 10}
-    if REDIS_CA_CERTS:
-        _cache_pool_kwargs["ssl_ca_certs"] = REDIS_CA_CERTS
-    CACHES = {
+    return {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": REDIS_CACHE_URL,
+            "LOCATION": location,
             "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                "SOCKET_CONNECT_TIMEOUT": 5,
-                "SOCKET_TIMEOUT": 5,
-                "RETRY_ON_TIMEOUT": True,
-                "CONNECTION_POOL_KWARGS": _cache_pool_kwargs,
+                **options,
+                # Without this, django-redis re-raises every Redis failure out
+                # of cache.get()/cache.set(). Each authenticated page renders
+                # its sidebar and header through {% cache %}, so a socket
+                # timeout (five seconds is easy to blow when the box is
+                # mid-checkpoint) became a 500 on a page that had already done
+                # all its work. A cache that is unreachable should cost
+                # latency, not the page.
+                #
+                # Every read on this alias falls through to the database or to
+                # S3 on a miss, including the custom-domain host checks in
+                # core.middleware, so an outage returns the same answers more
+                # slowly rather than a wrong or more permissive one.
+                "IGNORE_EXCEPTIONS": True,
             },
-        }
+        },
+        # A rate limiter is the exception, because it decides from the counter
+        # it reads back: a swallowed failure reads as an empty window and hands
+        # out a fresh budget, so the limit disappears for as long as Redis is
+        # unwell — which is when a caller hammering the API is a plausible
+        # reason for it being unwell. Raising refuses the call instead.
+        "throttle": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": location,
+            "OPTIONS": dict(options),
+        },
     }
+
+
+CACHES: dict[str, dict[str, Any]]
+if DEBUG:
+    # Disable caching in development mode. The throttle alias is declared here
+    # too so it always resolves; against DummyCache it accumulates no window,
+    # which is the same absence of rate limiting development already had.
+    CACHES = {
+        "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+        "throttle": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+    }
+else:
+    CACHES = build_redis_caches(REDIS_CACHE_URL, REDIS_CA_CERTS)
+
+# django-redis only logs the failures it swallows when this is on; without it an
+# outage is invisible except as latency.
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
+DJANGO_REDIS_LOGGER = "sbomify.cache"
 
 # Channel Layers for WebSocket support
 # Keepalive plus proactive health checks: a broker restart is then noticed

--- a/sbomify/test_settings.py
+++ b/sbomify/test_settings.py
@@ -179,7 +179,15 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "unique-snowflake",
-    }
+    },
+    # Same LOCATION as default, so the two aliases share one LocMemCache store
+    # and a test that clears the default alias still clears the throttle's
+    # window. In production they are the same Redis but differ in whether a
+    # connection failure is swallowed, which is not a distinction tests make.
+    "throttle": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    },
 }
 
 # Effectively unlimited so the per-token throttle (#1060) doesn't trip existing API


### PR DESCRIPTION
Found while chasing the settings 500 in #1358. Separate cause, separate fix.

`django-redis` re-raises every connection failure out of `cache.get()`/`cache.set()` unless `IGNORE_EXCEPTIONS` is set, and it is not set. Every authenticated page renders its sidebar and header inside `{% cache %}`, so an unreachable or merely slow Redis turns a page that has already done all its work into a 500. `SOCKET_TIMEOUT` is 5s, which is easy to blow when the box is mid-checkpoint.

`sboms/utils.py:270` already documents this hazard and hand-wraps one call site. This does it once, for all of them.

Every read on the default alias falls through to the database or to S3 on a miss, including the custom-domain host checks in `core.middleware`, so an outage returns the same answers more slowly rather than a wrong or a more permissive one.

## The rate limiter cannot take that deal

A throttle decides from the counter it reads back. A swallowed failure reads as an *empty window*, so every caller is handed a fresh budget for as long as Redis is unwell — which is when a caller hammering the API is a plausible reason for it being unwell. So the throttles move to a second alias on the same Redis that still raises. `AnonymousIPRateThrottle` inherits it, which is the limit worth losing least: it covers the public `auth=None` routes.

**This does not make the API worse.** The API already 500s during an outage today, by this exact mechanism. The change fixes the pages and deliberately leaves the API where it is.

## Verified in a browser, against the running app

| Scenario | Page | API (limit set to 3/min) |
|---|---|---|
| master config, Redis down | **500** `ConnectionError` | 500 |
| this PR, Redis down | **200**, fully rendered | 500 — refused, not unlimited |
| this PR, Redis healthy | 200 | `200,200,200,429,429…` |
| *throttle on the swallowing alias* | 200 | `200×8` — **limit gone** |

That last row is the regression this PR's second alias exists to prevent.

## Tests

Four, and each half fails without its own change: dropping `IGNORE_EXCEPTIONS` breaks the page test, pointing the throttle back at the default alias breaks both throttle tests. The pair is built by one function so a test can read the real config back and assert `IGNORE_EXCEPTIONS` is the only way the two aliases differ.

## Knock-on worth knowing

`delete_pattern`-based TEA cache invalidation becomes a silent no-op during an outage, so a TEA response can serve stale until its TTL expires. `DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS` is on so swallowed failures still appear in the logs rather than only as latency.