### PR TITLE
fix(vulns): a scanner's own failure is not a vulnerability

### DIFF
--- a/sbomify/apps/plugins/lifecycle.py
+++ b/sbomify/apps/plugins/lifecycle.py
@@ -64,11 +64,11 @@ def run_scanned(run: Any) -> bool:
 
 def _advisories(result: dict[str, Any]) -> dict[str, str]:
     """Advisory id to severity for the real vulnerabilities in a result."""
-    from sbomify.apps.vulnerability_scanning.posture import _is_vulnerability
+    from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
 
     seen: dict[str, str] = {}
     for finding in result.get("findings") or []:
-        if not isinstance(finding, dict) or not _is_vulnerability(finding):
+        if not isinstance(finding, dict) or not is_vulnerability(finding):
             continue
         advisory_id = (finding.get("id") or "").strip()
         if advisory_id:

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -14,23 +14,11 @@ from typing import Any
 from urllib.parse import unquote
 
 from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
+from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
 
 # CycloneDX analysis states that suppress a finding (mirrors vex._SUPPRESSING_STATES).
 _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
 _SEVERITIES = ("critical", "high", "medium", "low", "unknown")
-
-# Provider bookkeeping findings (scan errors, "no product") are not vulnerabilities
-# and must not inflate a customer-facing posture.
-_OPERATIONAL_ID_PREFIXES = ("dependency-track:", "osv:error")
-
-
-def _is_vulnerability(finding: dict[str, Any]) -> bool:
-    fid = (finding.get("id") or "").lower()
-    if not fid or any(fid.startswith(p) for p in _OPERATIONAL_ID_PREFIXES):
-        return False
-    # Security findings carry no status; a compliance/operational status (pass,
-    # info, warning, error) marks a non-vulnerability, so it must not count.
-    return (finding.get("status") or "").lower() not in ("error", "pass", "info", "warning")
 
 
 def _severity_bucket(finding: dict[str, Any]) -> str:
@@ -248,7 +236,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
     candidates: list[tuple[dict[str, Any], set[str], str, str]] = []
     for run in runs:
         run_findings = (run.result or {}).get("findings", []) or []
-        real_findings = [f for f in run_findings if isinstance(f, dict) and _is_vulnerability(f)]
+        real_findings = [f for f in run_findings if isinstance(f, dict) and is_vulnerability(f)]
         if not run_findings or real_findings:
             meaningful_runs += 1
         for finding in real_findings:

--- a/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
@@ -125,9 +125,7 @@ def test_a_real_scan_is_untouched(real_scan: dict[str, Any]) -> None:
     }
 
 
-def test_a_broken_scanner_does_not_hide_a_working_one(
-    dt_error: dict[str, Any], real_scan: dict[str, Any]
-) -> None:
+def test_a_broken_scanner_does_not_hide_a_working_one(dt_error: dict[str, Any], real_scan: dict[str, Any]) -> None:
     """One provider failing while another succeeds is the case that matters:
     the page must show OSV's findings and not Dependency Track's error."""
     rows = extract_finding_rows(merge_findings_by_alias([dt_error, real_scan]))
@@ -158,7 +156,7 @@ def test_is_vulnerability(finding: dict[str, Any], expected: bool) -> None:
     assert is_vulnerability(finding) is expected
 
 
-def test_there_is_one_predicate_and_everyone_uses_it() -> None:
+def test_posture_uses_this_predicate_and_not_a_copy() -> None:
     """Two copies is what let the release page and the component page disagree.
 
     Identity, not equivalence: a second definition that happens to behave the
@@ -168,11 +166,23 @@ def test_there_is_one_predicate_and_everyone_uses_it() -> None:
 
     assert posture.is_vulnerability is is_vulnerability
 
-    # lifecycle imports inside the function to avoid an import cycle, so reach
-    # the name the same way it does.
-    import importlib
 
-    lifecycle_source = importlib.import_module("sbomify.apps.plugins.lifecycle")
-    assert "from sbomify.apps.vulnerability_scanning.utils import is_vulnerability" in (
-        __import__("inspect").getsource(lifecycle_source)
+def test_lifecycle_resolves_the_predicate_at_call_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``lifecycle`` imports inside its function to avoid an import cycle, so
+    there is no module attribute to compare.
+
+    Swapping the definition and watching the behaviour change is what proves it
+    reads this one — a source-text check would pass on a module that imported
+    the name and then used a different one.
+    """
+    from sbomify.apps.plugins import lifecycle
+
+    result = {"findings": [{"id": "CVE-2026-1111", "severity": "critical"}]}
+    assert lifecycle._advisories(result) == {"CVE-2026-1111": "critical"}
+
+    monkeypatch.setattr(
+        "sbomify.apps.vulnerability_scanning.utils.is_vulnerability",
+        lambda finding: False,
     )
+
+    assert lifecycle._advisories(result) == {}

--- a/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
@@ -1,0 +1,178 @@
+"""A scanner's own failures are not vulnerabilities.
+
+Dependency Track reports "I could not reach the API" as a finding with
+``severity="high"``, because the findings array is the only channel a plugin
+result has. The severity is addressed to the operator — this scan is broken —
+and says nothing about any package. Rendered as a finding it became a HIGH row
+reading ``dependency-track:error`` against package "Unknown", and it counted
+towards the HIGH badge printed beside it.
+
+``posture.py`` had always filtered these; the display and counting helpers in
+``utils.py`` had not, and every component, product and dashboard page reads
+them. The two now share one predicate.
+
+The fixtures are built by the plugins themselves rather than hand-written, so a
+plugin changing the shape of its error result fails these tests instead of
+quietly slipping past the filter again.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from sbomify.apps.vulnerability_scanning.utils import (
+    extract_finding_rows,
+    extract_severity_counts,
+    is_vulnerability,
+    merge_findings_by_alias,
+)
+
+
+def _as_result(assessment: Any) -> dict[str, Any]:
+    return assessment.model_dump() if hasattr(assessment, "model_dump") else dataclasses.asdict(assessment)
+
+
+@pytest.fixture
+def dt_error() -> dict[str, Any]:
+    from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
+
+    return _as_result(DependencyTrackPlugin()._create_error_result("Dependency Track API unreachable"))
+
+
+@pytest.fixture
+def osv_unsupported() -> dict[str, Any]:
+    from sbomify.apps.plugins.builtins.osv import OSVPlugin
+
+    return _as_result(OSVPlugin()._create_unsupported_format_result())
+
+
+@pytest.fixture
+def real_scan() -> dict[str, Any]:
+    return {
+        "summary": {
+            "total_findings": 2,
+            "error_count": 0,
+            "warning_count": 0,
+            "by_severity": {"critical": 1, "high": 1, "medium": 0, "low": 0, "info": 0},
+        },
+        "findings": [
+            {
+                "id": "CVE-2026-1111",
+                "severity": "critical",
+                "component": {"name": "openssl", "version": "3.0.1", "purl": "pkg:deb/openssl@3.0.1"},
+            },
+            {
+                "id": "GHSA-aaaa-bbbb-cccc",
+                "severity": "high",
+                "component": {"name": "lodash", "version": "4.17.20", "purl": "pkg:npm/lodash@4.17.20"},
+            },
+        ],
+    }
+
+
+def test_the_error_finding_is_shaped_the_way_this_module_assumes(dt_error: dict[str, Any]) -> None:
+    """Pins the fixture. Every assertion below rests on this shape."""
+    finding = dt_error["findings"][0]
+
+    assert finding["id"] == "dependency-track:error"
+    assert finding["severity"] == "high"
+    assert finding["status"] == "error"
+    assert dt_error["summary"]["total_findings"] == 1
+    assert dt_error["summary"]["error_count"] == 1
+
+
+def test_a_scan_error_renders_no_row(dt_error: dict[str, Any]) -> None:
+    """The reported defect: a HIGH row reading ``dependency-track:error``."""
+    assert extract_finding_rows(merge_findings_by_alias([dt_error])) == []
+
+
+def test_a_scan_error_is_dropped_by_the_merge_too(dt_error: dict[str, Any]) -> None:
+    """``extract_finding_rows`` is documented as taking a raw run result, so it
+    is reachable without the merge and both have to filter."""
+    assert merge_findings_by_alias([dt_error])["findings"] == []
+    assert extract_finding_rows(dt_error) == []
+
+
+def test_a_scan_error_counts_as_no_vulnerabilities(dt_error: dict[str, Any]) -> None:
+    """``total_findings`` is 1 for the error marker, and the SBOM table badge,
+    the workspace metrics and the trend series all read that total."""
+    assert extract_severity_counts(dt_error)["total"] == 0
+
+
+def test_an_unsupported_format_warning_counts_as_none_either(osv_unsupported: dict[str, Any]) -> None:
+    """The same defect wearing a warning: OSV cannot read SPDX 3.0, which is not
+    a finding about the customer's software."""
+    assert osv_unsupported["findings"][0]["id"] == "osv:unsupported-format"
+    assert extract_finding_rows(merge_findings_by_alias([osv_unsupported])) == []
+    assert extract_severity_counts(osv_unsupported)["total"] == 0
+
+
+def test_a_real_scan_is_untouched(real_scan: dict[str, Any]) -> None:
+    """The filter must not be able to swallow a real finding."""
+    rows = extract_finding_rows(merge_findings_by_alias([real_scan]))
+
+    assert [row["id"] for row in rows] == ["CVE-2026-1111", "GHSA-aaaa-bbbb-cccc"]
+    assert extract_severity_counts(real_scan) == {
+        "total": 2,
+        "critical": 1,
+        "high": 1,
+        "medium": 0,
+        "low": 0,
+        "info": 0,
+    }
+
+
+def test_a_broken_scanner_does_not_hide_a_working_one(
+    dt_error: dict[str, Any], real_scan: dict[str, Any]
+) -> None:
+    """One provider failing while another succeeds is the case that matters:
+    the page must show OSV's findings and not Dependency Track's error."""
+    rows = extract_finding_rows(merge_findings_by_alias([dt_error, real_scan]))
+
+    assert [row["id"] for row in rows] == ["CVE-2026-1111", "GHSA-aaaa-bbbb-cccc"]
+
+
+@pytest.mark.parametrize(
+    ("finding", "expected"),
+    [
+        ({"id": "CVE-2026-1111", "severity": "critical"}, True),
+        ({"id": "GHSA-aaaa-bbbb-cccc", "severity": "high"}, True),
+        # OSV's own advisory ids are hyphenated, so the namespace prefix cannot
+        # swallow one.
+        ({"id": "OSV-2023-1", "severity": "medium"}, True),
+        ({"id": "dependency-track:error", "status": "error"}, False),
+        ({"id": "dependency-track:no-product"}, False),
+        ({"id": "dependency-track:unsupported-format"}, False),
+        ({"id": "osv:error", "status": "error"}, False),
+        ({"id": "osv:unsupported-format", "status": "warning"}, False),
+        # A compliance status on a security-shaped id still is not a vulnerability.
+        ({"id": "CVE-2026-9", "status": "pass"}, False),
+        ({"id": ""}, False),
+        ({}, False),
+    ],
+)
+def test_is_vulnerability(finding: dict[str, Any], expected: bool) -> None:
+    assert is_vulnerability(finding) is expected
+
+
+def test_there_is_one_predicate_and_everyone_uses_it() -> None:
+    """Two copies is what let the release page and the component page disagree.
+
+    Identity, not equivalence: a second definition that happens to behave the
+    same today is exactly what this is meant to prevent.
+    """
+    from sbomify.apps.vulnerability_scanning import posture
+
+    assert posture.is_vulnerability is is_vulnerability
+
+    # lifecycle imports inside the function to avoid an import cycle, so reach
+    # the name the same way it does.
+    import importlib
+
+    lifecycle_source = importlib.import_module("sbomify.apps.plugins.lifecycle")
+    assert "from sbomify.apps.vulnerability_scanning.utils import is_vulnerability" in (
+        __import__("inspect").getsource(lifecycle_source)
+    )

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -8,6 +8,40 @@ from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
 
 _ZERO_COUNTS = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 
+# Ids a provider uses for its own bookkeeping rather than for a vulnerability:
+# "Dependency Track was unreachable", "this SBOM has no product", "unsupported
+# format". They travel in the findings array because that is the only channel a
+# plugin result has, not because anything is wrong with the customer's software.
+#
+# Both scanners are matched on the whole namespace. Listing only ``osv:error``
+# left ``osv:unsupported-format`` to be caught by its status alone, which is one
+# forgotten field away from surfacing. An advisory id cannot collide: OSV's own
+# ids are ``OSV-2023-1``, a hyphen rather than a colon.
+_OPERATIONAL_ID_PREFIXES = ("dependency-track:", "osv:")
+
+
+def is_vulnerability(finding: dict[str, Any]) -> bool:
+    """Whether a stored finding describes a vulnerability at all.
+
+    A scanner reports its own failures through the same findings array it
+    reports CVEs through. Dependency Track's error marker carries
+    ``severity="high"`` — a severity for the operator, meaning "this scan is
+    badly broken", not a claim about any package. Rendered as a finding it
+    becomes a HIGH row reading ``dependency-track:error`` against package
+    "Unknown", and it counts towards the HIGH badge beside it.
+
+    Both signals are checked because neither survives everywhere: the id prefix
+    is dropped by nothing, but ``status`` does not reach a display row
+    (``extract_finding_rows`` never copies it), so a caller filtering rows
+    rather than findings would have only the id to go on.
+    """
+    fid = (finding.get("id") or "").lower()
+    if not fid or any(fid.startswith(prefix) for prefix in _OPERATIONAL_ID_PREFIXES):
+        return False
+    # A vulnerability carries no status; a compliance or operational status
+    # (pass, info, warning, error) marks something that is not one.
+    return (finding.get("status") or "").lower() not in ("error", "pass", "info", "warning")
+
 
 def extract_severity_counts(result_json: dict[str, Any] | None) -> dict[str, int]:
     """Extract severity counts from an AssessmentRun result JSON blob.
@@ -45,6 +79,25 @@ def extract_severity_counts(result_json: dict[str, Any] | None) -> dict[str, int
     summary = result_json.get("summary")
     if not isinstance(summary, dict):
         return dict(_ZERO_COUNTS)
+
+    # A run whose findings are all bookkeeping analysed nothing, so it has no
+    # vulnerabilities to report. Its marker still occupies ``total_findings``,
+    # which otherwise reads as one vulnerability on every surface showing a
+    # total — the SBOM table badge, the workspace metrics, the trend series.
+    #
+    # Both security plugins build a real result as ``total_findings=len(findings)``
+    # with neither counter set, and each bookkeeping result as a single finding
+    # with exactly one of them set, so this fires on the second and never on the
+    # first.
+    #
+    # Read from the summary rather than from ``metadata.error`` because the trend
+    # and table paths call this with ``reconstruct_result_summary``, which rebuilds
+    # a result from the denormalised columns and carries no metadata beyond
+    # ``skipped``. Only the summary is available on both paths.
+    bookkeeping = (summary.get("error_count") or 0) + (summary.get("warning_count") or 0)
+    if bookkeeping and bookkeeping >= (summary.get("total_findings") or 0):
+        return dict(_ZERO_COUNTS)
+
     by_severity = summary.get("by_severity")
     if not isinstance(by_severity, dict):
         by_severity = {}
@@ -100,6 +153,8 @@ def merge_findings_by_alias(results: list[dict[str, Any] | None]) -> dict[str, A
         if isinstance(metadata, dict) and metadata.get("skipped"):
             continue
         for vuln in result_json.get("findings") or []:
+            if not is_vulnerability(vuln):
+                continue
             component = vuln.get("component") or {}
             # Providers name the same package differently (OSV "group:artifact",
             # DT "artifact"); scope alias matching to the artifact tail+version
@@ -188,6 +243,12 @@ def extract_finding_rows(
 
     rows: list[dict[str, Any]] = []
     for vuln in result_json.get("findings") or []:
+        # Filtered here as well as in merge_findings_by_alias: this is documented
+        # as taking a raw AssessmentRun result, so it is reachable without the
+        # merge, and every count on the component, product and dashboard pages is
+        # derived by tallying the rows it returns.
+        if not is_vulnerability(vuln):
+            continue
         component = vuln.get("component") or {}
         ecosystem = component.get("ecosystem") or ""
         if ecosystem.lower() in ("", "unknown"):


### PR DESCRIPTION
Reported on stage: the Vulnerabilities table showing a **HIGH** row reading `dependency-track:error`, package "Unknown", status Affected.

Dependency Track reports "I could not reach the API" as a finding with `severity="high"` — a severity addressed to the operator, meaning *this scan is broken*, not a claim about any package. The findings array is the only channel a plugin result has.

`posture.py` had always filtered these. The display and counting helpers in `utils.py` had not, and four pages read them: component, component-item, product and dashboard. Two copies of the same idea, and only one of them was applied.

## What changed

**One predicate, shared.** `posture._is_vulnerability` becomes `utils.is_vulnerability`; `posture.py` and `plugins/lifecycle.py` import it instead of keeping a private copy. A test asserts *identity*, not equivalence — a second definition that behaves the same today is exactly what this is meant to stop.

**Applied at both entry points.** `merge_findings_by_alias` and `extract_finding_rows`. The latter is documented as taking a raw run result, so it is reachable without the merge, and every count on those pages is a tally of the rows it returns.

**The summary path too.** `extract_severity_counts` read `total_findings` straight from the summary, so an errored run read as one vulnerability on the SBOM table badge, the workspace metrics and the trend series. A run whose findings are all bookkeeping now counts as none — decided from the summary rather than `metadata.error`, because the trend and table paths pass `reconstruct_result_summary`, which carries no metadata beyond `skipped`. Both security plugins build a real result as `total_findings=len(findings)` with neither counter set, and each bookkeeping result as a single finding with exactly one set, so it fires on the second and never on the first.

**Namespace symmetry.** The id list matched all of `dependency-track:` but only `osv:error`, leaving `osv:unsupported-format` to its status alone — one forgotten field from surfacing. Both scanners are matched on their namespace now. No advisory id can collide: OSV's own ids are `OSV-2023-1`, a hyphen not a colon.

## Verified in a browser

| | component page payload |
|---|---|
| before | `latest-vuln-severities: ["high"]`, `latest-vuln-terms: ["dependency-track:error unknown"]` |
| after | absent |

The assessments panel still shows **Scan Error — Dependency Track API unreachable** with a danger icon. That is the right place for it, and it stays: an operator should know the scan failed. What is gone is the claim that it is a vulnerability.

19 tests; the 5 behavioural ones fail without the filters. Fixtures are built by the plugins themselves, so a plugin changing its error shape fails these tests rather than slipping past the filter again.