### PR TITLE
fix(core): swallow a dead socket, not a broken payload

### DIFF
--- a/sbomify/apps/core/consumers.py
+++ b/sbomify/apps/core/consumers.py
@@ -15,19 +15,26 @@ from sbomify.logging import getLogger
 
 logger = getLogger(__name__)
 
-# What a send raises when the socket is no longer there to send to.
-#
-# ``ConnectionError`` and the rest of ``OSError`` cover the transport dropping
-# under us; ``RuntimeError`` is what Channels and the ASGI servers raise for
-# "cannot send once a close message has been sent", which is the ordinary end
-# of a connection rather than a fault.
-#
-# Deliberately not ``Exception``. A payload that will not serialise raises
-# ``TypeError`` from the same call, and swallowing that logged one debug line
-# and dropped the broadcast to every socket in the workspace, for every
-# broadcast, until someone noticed the UI had quietly stopped updating. That is
-# a bug in the producer and it should be as loud as any other.
-_SOCKET_GONE = (ConnectionError, OSError, RuntimeError)
+# The transport dropping under us. ``ConnectionError`` is a subclass, named
+# here because it is the case this is actually about.
+_SOCKET_GONE = (ConnectionError, OSError)
+
+
+def _is_socket_closed(exc: RuntimeError) -> bool:
+    """Whether a ``RuntimeError`` is Channels saying the socket is already shut.
+
+    Channels and the ASGI servers raise a plain ``RuntimeError`` for "cannot
+    send once a close message has been sent", which is the ordinary end of a
+    connection rather than a fault.
+
+    Matched on the exact type rather than with ``isinstance``, because
+    ``RecursionError`` and ``NotImplementedError`` are ``RuntimeError``
+    subclasses and neither is a closed socket. A payload nested deeply enough
+    makes ``json.dumps`` raise ``RecursionError`` from the same call as a
+    dropped connection, so treating the base class as "socket gone" would put
+    back exactly the silent-drop this is here to remove.
+    """
+    return type(exc) is RuntimeError
 
 
 class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
@@ -164,7 +171,16 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
             logger.warning(f"Dropped a workspace_message with no data payload: {event!r}")
             return
 
+        # Deliberately narrow. A payload that will not serialise raises from
+        # this same call, and swallowing that logged one debug line and dropped
+        # the broadcast to every socket in the workspace, for every broadcast,
+        # until someone noticed the UI had quietly stopped updating. That is a
+        # bug in the producer and it should be as loud as any other.
         try:
             await self.send_json(data)
         except _SOCKET_GONE:
             logger.debug("workspace_message send failed; socket likely gone", exc_info=True)
+        except RuntimeError as exc:
+            if not _is_socket_closed(exc):
+                raise
+            logger.debug("workspace_message send failed; socket already closed", exc_info=True)

--- a/sbomify/apps/core/consumers.py
+++ b/sbomify/apps/core/consumers.py
@@ -15,6 +15,20 @@ from sbomify.logging import getLogger
 
 logger = getLogger(__name__)
 
+# What a send raises when the socket is no longer there to send to.
+#
+# ``ConnectionError`` and the rest of ``OSError`` cover the transport dropping
+# under us; ``RuntimeError`` is what Channels and the ASGI servers raise for
+# "cannot send once a close message has been sent", which is the ordinary end
+# of a connection rather than a fault.
+#
+# Deliberately not ``Exception``. A payload that will not serialise raises
+# ``TypeError`` from the same call, and swallowing that logged one debug line
+# and dropped the broadcast to every socket in the workspace, for every
+# broadcast, until someone noticed the UI had quietly stopped updating. That is
+# a bug in the producer and it should be as loud as any other.
+_SOCKET_GONE = (ConnectionError, OSError, RuntimeError)
+
 
 class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
     """
@@ -142,11 +156,15 @@ class WorkspaceConsumer(AsyncJsonWebsocketConsumer):
         # re-derives when it reconnects, so a socket that missed one has lost
         # nothing a reconnect does not restore.
         try:
-            await self.send_json(event["data"])
+            data = event["data"]
         except KeyError:
             # A producer sent an event without a data key. That is a bug in the
             # caller rather than a transport failure, so it is worth a real log
             # line instead of the debug the disconnect cases get.
             logger.warning(f"Dropped a workspace_message with no data payload: {event!r}")
-        except Exception:
+            return
+
+        try:
+            await self.send_json(data)
+        except _SOCKET_GONE:
             logger.debug("workspace_message send failed; socket likely gone", exc_info=True)

--- a/sbomify/apps/core/tests/test_consumers.py
+++ b/sbomify/apps/core/tests/test_consumers.py
@@ -347,6 +347,24 @@ class TestBroadcastResilience:
 
         await consumer.workspace_message({"type": "workspace_message", "data": {"x": 1}})
 
+        # Not raising is only half the claim: a handler that quietly stopped
+        # sending would pass on that alone.
+        consumer.send_json.assert_awaited_once_with({"x": 1})
+
+    @pytest.mark.asyncio
+    async def test_a_payload_that_will_not_serialise_is_not_swallowed(self, consumer):
+        """The half that must stay loud.
+
+        A non-serialisable payload raises from the same call a dead socket does,
+        so catching everything here dropped the broadcast to every socket in the
+        workspace, every time, and said so in one debug line. It is a producer
+        bug, and the only way it gets fixed is by being visible.
+        """
+        consumer.send_json = AsyncMock(side_effect=TypeError("Object of type datetime is not JSON serializable"))
+
+        with pytest.raises(TypeError):
+            await consumer.workspace_message({"type": "workspace_message", "data": {"when": object()}})
+
     @pytest.mark.asyncio
     async def test_an_event_with_no_data_is_dropped_not_raised(self, consumer):
         """A producer bug, not a transport failure — it must not take the socket

--- a/sbomify/apps/core/tests/test_consumers.py
+++ b/sbomify/apps/core/tests/test_consumers.py
@@ -366,6 +366,27 @@ class TestBroadcastResilience:
             await consumer.workspace_message({"type": "workspace_message", "data": {"when": object()}})
 
     @pytest.mark.asyncio
+    async def test_a_recursion_error_is_not_mistaken_for_a_closed_socket(self, consumer):
+        """``RecursionError`` subclasses ``RuntimeError``.
+
+        A payload nested deeply enough makes ``json.dumps`` raise it from the
+        same call Channels raises a plain ``RuntimeError`` from, so matching the
+        base class would swallow it and put the silent drop straight back.
+        """
+        consumer.send_json = AsyncMock(side_effect=RecursionError("maximum recursion depth exceeded"))
+
+        with pytest.raises(RecursionError):
+            await consumer.workspace_message({"type": "workspace_message", "data": {"deep": {}}})
+
+    @pytest.mark.asyncio
+    async def test_a_not_implemented_error_is_not_either(self, consumer):
+        """The other ``RuntimeError`` subclass, and squarely a programmer bug."""
+        consumer.send_json = AsyncMock(side_effect=NotImplementedError("encode_json"))
+
+        with pytest.raises(NotImplementedError):
+            await consumer.workspace_message({"type": "workspace_message", "data": {"x": 1}})
+
+    @pytest.mark.asyncio
     async def test_an_event_with_no_data_is_dropped_not_raised(self, consumer):
         """A producer bug, not a transport failure — it must not take the socket
         down with it, and it is the one case worth a warning."""


### PR DESCRIPTION
Follow-up to #1355, which was merged with two Copilot comments still open. Both were right; this addresses them.

## The catch was wider than the thing it was written for

`workspace_message` caught `Exception`. A payload that will not serialise raises `TypeError` from the same `send_json` call a dropped connection does, so it logged one debug line and dropped the broadcast — to every socket in the workspace, for every broadcast, until someone noticed the UI had quietly stopped updating.

Only the transport failures are swallowed now:

| | |
|---|---|
| `ConnectionError` / `OSError` | the connection went away under us |
| `RuntimeError` | Channels' "cannot send once a close message has been sent" — the ordinary end of a connection |
| anything else | raises |

That matches what #1355 set out to do. Its title says *a dead socket* must not raise into the ASGI server, not that nothing may.

While in there: the missing-`data` branch now reads the key before the send rather than wrapping the send in `except KeyError`. As written, a payload whose own serialisation raised `KeyError` would have been logged as a malformed event.

## The test proved half of what it claimed

`test_a_closed_socket_does_not_raise_either` asserted only that nothing raised — which a handler that had quietly stopped sending would also satisfy. It now asserts the send was attempted with the payload.

Both halves are checked against a build with the send removed, and the new serialisation test fails against the merged code:

```
FAILED TestBroadcastResilience::test_a_payload_that_will_not_serialise_is_not_swallowed
```

20 consumer tests pass.