### PR TITLE
fix(compliance): say why the export is refused

### DIFF
--- a/sbomify/apps/compliance/js/cra-step-5.ts
+++ b/sbomify/apps/compliance/js/cra-step-5.ts
@@ -7,6 +7,10 @@ import { getAssessmentId } from './cra-shared';
 
 interface StepStatus {
   complete: boolean;
+  /** Why the EU-representation block is not settled, if it is not. A step can
+   *  be complete and still carry one: the establishment determination is
+   *  recorded rather than demanded, and it blocks the export instead. */
+  eu_representation_problems?: string[];
   controls?: {
     total: number;
     satisfied: number;
@@ -88,6 +92,9 @@ function craStep5() {
     isLoadingPreview: false,
     downloadingDocPdf: false,
     stepUrls: {} as Record<string, string>,
+    // Named reasons the export is refused, for when "complete every step" is
+    // not the reason and saying so sends the reader to look in the wrong place.
+    blockers: [] as string[],
 
     init() {
       const data = window.parseJsonScript('step-data') as ComplianceSummary | null;
@@ -97,6 +104,8 @@ function craStep5() {
         this.lastExport = data.last_export || null;
         this.overallReady = !!(data.overall_ready);
         this.exportAvailable = !!(data.export_available);
+        this.blockers = Object.values(data.steps || {})
+          .flatMap((s) => s.eu_representation_problems || []);
       }
       this.assessmentId = getAssessmentId();
       this.stepUrls = (window.parseJsonScript('step-urls') as Record<string, string>) || {};

--- a/sbomify/apps/compliance/templates/compliance/cra_step_5.html.j2
+++ b/sbomify/apps/compliance/templates/compliance/cra_step_5.html.j2
@@ -202,7 +202,28 @@
                                     {% include "core/components/brand/loader.html.j2" with class="tw-loader-inline mr-2" %}
                                 Exporting...</span>
                             </button>
-                            <template x-if="!overallReady">
+                            {% comment %}
+                            A named reason where there is one. An assessment can
+                            show every step complete and 21/21 controls satisfied
+                            and still be refused, because the EU-establishment
+                            determination is recorded rather than demanded. Saying
+                            "complete all steps" there sends the reader to look at
+                            steps that are already done.
+                            {% endcomment %}
+                            <template x-if="!overallReady && blockers.length">
+                                <div class="tw-alert tw-alert-warning" data-testid="export-blockers">
+                                    <i class="fas fa-triangle-exclamation tw-alert-icon" aria-hidden="true"></i>
+                                    <div class="tw-alert-content">
+                                        <p class="tw-alert-title">Not ready to export</p>
+                                        <ul class="text-xs list-disc list-inside m-0">
+                                            <template x-for="reason in blockers" :key="reason">
+                                                <li x-text="reason"></li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </template>
+                            <template x-if="!overallReady && !blockers.length">
                                 <p class="text-xs text-text-muted text-center">Complete all steps and answer all controls to enable export.</p>
                             </template>
                         </div>

--- a/sbomify/apps/compliance/tests/test_step_5_export_blockers.py
+++ b/sbomify/apps/compliance/tests/test_step_5_export_blockers.py
@@ -1,0 +1,98 @@
+"""Step 5 must say why it will not export.
+
+Found on staging: an assessment showing every step complete and 21/21 controls
+satisfied, with the export button disabled and the caption "Complete all steps
+and answer all controls to enable export." Both halves of that sentence were
+already done. The real reason — the EU-establishment determination was never
+recorded — was in the payload and rendered nowhere.
+
+Driven through the real URL rather than ``render_to_string``: the reason has to
+survive the summary, the step context and the template, and rendering the
+template alone would prove only the last of those.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.tests.shared_fixtures import (  # noqa: F401
+    setup_authenticated_client_session,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def blocked_assessment(sample_team_with_owner_member, sample_user):  # noqa: F811
+    """An assessment whose outstanding item is the determination."""
+    from sbomify.apps.compliance.services.wizard_service import get_or_create_assessment
+    from sbomify.apps.core.models import Product
+    from sbomify.apps.teams.models import ContactEntity, ContactProfile
+
+    team = sample_team_with_owner_member.team
+    # The wizard is gated on a CRA-eligible plan; without one the page is a 403
+    # and the test would be measuring the billing gate.
+    from sbomify.apps.billing.models import BillingPlan
+
+    team.billing_plan = sorted(BillingPlan.CRA_ELIGIBLE_PLAN_KEYS)[0]
+    team.save(update_fields=["billing_plan"])
+
+    profile = ContactProfile.objects.create(name="Default", team=team, is_default=True)
+    ContactEntity.objects.create(
+        profile=profile, name="Acme Labs GmbH", email="legal@acme.example", is_manufacturer=True
+    )
+    product = Product.objects.create(name="Blocker Product", team=team)
+    result = get_or_create_assessment(product.id, sample_user, team)
+    assert result.ok
+    return result.value
+
+
+@pytest.fixture
+def step_5_html(blocked_assessment, sample_team_with_owner_member) -> str:  # noqa: F811
+    member = sample_team_with_owner_member
+    client = Client()
+    client.force_login(member.user)
+    setup_authenticated_client_session(client, member.team, member.user)
+    response = client.get(
+        reverse("compliance:cra_step", kwargs={"assessment_id": blocked_assessment.id, "step": 5})
+    )
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+def _guards(html: str) -> list[str]:
+    return re.findall(r'x-if="([^"]+)"', html)
+
+
+def test_the_generic_caption_no_longer_fires_on_its_own(step_5_html: str) -> None:
+    """It used to render whenever the assessment was not ready, which is how it
+    came to be shown beside a step list with nothing left to do."""
+    unconditional = [g for g in _guards(step_5_html) if g.strip() == "!overallReady"]
+
+    assert not unconditional, f"still shown for every blocked assessment: {unconditional}"
+
+
+def test_a_named_reason_is_preferred_when_there_is_one(step_5_html: str) -> None:
+    assert "!overallReady && blockers.length" in _guards(step_5_html)
+
+
+def test_the_generic_caption_survives_for_the_case_it_was_written_for(step_5_html: str) -> None:
+    """Steps genuinely outstanding still get the original wording — there is no
+    named reason to show, and silence would be worse."""
+    assert "!overallReady && !blockers.length" in _guards(step_5_html)
+
+
+def test_the_reason_list_is_rendered(step_5_html: str) -> None:
+    assert 'x-for="reason in blockers"' in step_5_html
+    assert 'data-testid="export-blockers"' in step_5_html
+
+
+def test_the_page_is_handed_a_reason_to_show(step_5_html: str) -> None:
+    """The template only helps if the payload carries one, so pin the whole
+    chain rather than the template on its own."""
+    assert "eu_representation_problems" in step_5_html
+    assert "Record whether the manufacturer is established in the EU" in step_5_html

--- a/sbomify/apps/compliance/tests/test_step_5_export_blockers.py
+++ b/sbomify/apps/compliance/tests/test_step_5_export_blockers.py
@@ -19,16 +19,20 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
-from sbomify.apps.core.tests.shared_fixtures import (  # noqa: F401
-    setup_authenticated_client_session,
-)
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def blocked_assessment(sample_team_with_owner_member, sample_user):  # noqa: F811
-    """An assessment whose outstanding item is the determination."""
+def blocked_assessment(sample_team_with_owner_member, sample_user):
+    """A fresh assessment on a CRA-eligible plan.
+
+    Nothing is completed on it — the point is only that the determination is
+    unanswered, which is what puts a reason in the summary for Step 5 to show.
+    Completing the other steps would make the page prettier and prove nothing
+    more.
+    """
     from sbomify.apps.compliance.services.wizard_service import get_or_create_assessment
     from sbomify.apps.core.models import Product
     from sbomify.apps.teams.models import ContactEntity, ContactProfile
@@ -52,7 +56,7 @@ def blocked_assessment(sample_team_with_owner_member, sample_user):  # noqa: F81
 
 
 @pytest.fixture
-def step_5_html(blocked_assessment, sample_team_with_owner_member) -> str:  # noqa: F811
+def step_5_html(blocked_assessment, sample_team_with_owner_member) -> str:
     member = sample_team_with_owner_member
     client = Client()
     client.force_login(member.user)


### PR DESCRIPTION
Found during a QA pass over staging, in the change I made for #1321.

An assessment on stage showed:

- every step complete
- **100% — 21 / 21 controls satisfied**
- **Export Compliance Bundle** disabled
- and beneath it: *"Complete all steps and answer all controls to enable export."*

Both halves of that sentence were already done. The actual reason was that the EU-establishment determination had never been recorded — which is *supposed* to block the export, and does. It was sitting in the payload the page already receives, as `steps.1.eu_representation_problems`, and no template or script read it.

That combination is the worst case for a support queue: a correct refusal with a caption that points at the one place there is nothing to fix.

## What changed

Step 5 lists the named reasons when it has any, and falls back to the original wording only for the case it was written for — steps genuinely outstanding, where there is no named reason and silence would be worse.

The determination is deliberately *recorded rather than demanded* (blocking Step 1 on it would strand every assessment made before the question existed), so an assessment can be complete and still blocked. That is exactly the case the old caption could not describe.

## Verified

Driven through the real URL rather than `render_to_string`, because the reason has to survive the summary, the step context and the template — rendering the template alone would prove only the last of those.

4 of the 5 new tests fail against master. 706 compliance tests pass.