### PR TITLE
fix(plugins): the badge must not claim more than the run did

### DIFF
--- a/sbomify/apps/plugins/public_assessment_utils.py
+++ b/sbomify/apps/plugins/public_assessment_utils.py
@@ -39,6 +39,10 @@ class PassingAssessment:
     standard_url: str | None = None
     pass_count: int | None = None
     total_findings: int | None = None
+    # Non-zero means some checks were not graded — typically an optional thing
+    # that was absent (no signature, no provenance) rather than a problem. The
+    # badge needs it because "All checks passed" beside "1/7" is a contradiction.
+    warning_count: int | None = None
     completed_at: Any = None
 
 
@@ -159,7 +163,15 @@ def _is_run_passing(run: AssessmentRun) -> bool:
         findings_total = sum(v for v in by_severity.values() if isinstance(v, int))
         return findings_total == 0 and not summary.get("malicious_count")
 
-    return bool(summary.get("pass_count", 0))
+    # ``pass_count`` was added to summary payloads later, so a run predating it
+    # carries no key at all. ``orchestrator._is_passing`` distinguishes that from
+    # a present-and-zero count and lets the legacy run pass; reading a default of
+    # 0 here did not, so the same run satisfied a dependency gate and showed no
+    # public badge. The two encode one judgement and now answer alike.
+    pass_count = summary.get("pass_count")
+    if pass_count is None:
+        return True
+    return bool(pass_count)
 
 
 def _passing_assessment_from_run(run: AssessmentRun, plugin_info: dict[str, tuple[str, str]]) -> PassingAssessment:
@@ -181,6 +193,7 @@ def _passing_assessment_from_run(run: AssessmentRun, plugin_info: dict[str, tupl
     is_security = category == AssessmentCategory.SECURITY.value
     pass_count = summary.get("pass_count") if not is_security else None
     total_findings = summary.get("total_findings") if not is_security else None
+    warning_count = summary.get("warning_count") if not is_security else None
     return PassingAssessment(
         plugin_name=run.plugin_name,
         plugin_display_name=display_name,
@@ -190,6 +203,7 @@ def _passing_assessment_from_run(run: AssessmentRun, plugin_info: dict[str, tupl
         standard_url=metadata.get("standard_url") or None,
         pass_count=pass_count if isinstance(pass_count, int) else None,
         total_findings=total_findings if isinstance(total_findings, int) else None,
+        warning_count=warning_count if isinstance(warning_count, int) else None,
         completed_at=run.completed_at,
     )
 
@@ -210,7 +224,7 @@ def _aggregate_passing(
     for plugin_name in sorted(common_passing):
         detail = details_by_plugin.get(plugin_name)
         if detail is not None:
-            aggregated.append(dataclass_replace(detail, pass_count=None, total_findings=None))
+            aggregated.append(dataclass_replace(detail, pass_count=None, total_findings=None, warning_count=None))
         else:
             display_name, category = plugin_info.get(plugin_name, (plugin_name, AssessmentCategory.COMPLIANCE.value))
             aggregated.append(

--- a/sbomify/apps/plugins/public_assessment_utils.py
+++ b/sbomify/apps/plugins/public_assessment_utils.py
@@ -39,9 +39,10 @@ class PassingAssessment:
     standard_url: str | None = None
     pass_count: int | None = None
     total_findings: int | None = None
-    # Non-zero means some checks were not graded — typically an optional thing
-    # that was absent (no signature, no provenance) rather than a problem. The
-    # badge needs it because "All checks passed" beside "1/7" is a contradiction.
+    # Checks that warned. Often an optional thing that was absent — no signature,
+    # no provenance — rather than a problem, which is why a run carrying them is
+    # still shown. The badge needs the count because "All checks passed" beside
+    # "1/7" is a contradiction.
     warning_count: int | None = None
     completed_at: Any = None
 
@@ -709,6 +710,7 @@ def passing_assessments_to_dict(assessments: list[PassingAssessment]) -> list[di
             "standard_url": a.standard_url,
             "pass_count": a.pass_count,
             "total_findings": a.total_findings,
+            "warning_count": a.warning_count,
             "completed_at": a.completed_at,
         }
         for a in assessments

--- a/sbomify/apps/plugins/templates/plugins/components/_public_assessment_badge_inner.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_public_assessment_badge_inner.html.j2
@@ -16,7 +16,7 @@ provenance, no VCS metadata — rather than a failure, which is why the badge is
 still shown. It just does not claim more than happened.
 {% endcomment %}
 <span class="public-badge {{ badge_class }}"
-      title="{% if assessment.standard_name %}{{ assessment.standard_name }}{% if assessment.standard_version %} ({{ assessment.standard_version }}){% endif %}: {% else %}{{ assessment.display_name }}: {% endif %}{% if assessment.warning_count %}No failed checks{% else %}{{ status_phrase }}{% endif %}{% if assessment.pass_count and assessment.total_findings %} — {{ assessment.pass_count }}/{{ assessment.total_findings }} checks passed{% if assessment.warning_count %}, {{ assessment.warning_count }} not graded{% endif %}{% endif %}{% if assessment.completed_at %} — verified {{ assessment.completed_at|date:"j M Y" }}{% endif %}">
+      title="{% if assessment.standard_name %}{{ assessment.standard_name }}{% if assessment.standard_version %} ({{ assessment.standard_version }}){% endif %}: {% else %}{{ assessment.display_name }}: {% endif %}{% if assessment.warning_count %}No failed checks{% else %}{{ status_phrase }}{% endif %}{% if assessment.pass_count and assessment.total_findings %} — {{ assessment.pass_count }}/{{ assessment.total_findings }} checks passed{% if assessment.warning_count %}, {{ assessment.warning_count }} warned{% endif %}{% endif %}{% if assessment.completed_at %} — verified {{ assessment.completed_at|date:"j M Y" }}{% endif %}">
     <i class="fas {{ badge_icon }}"></i>
     {{ assessment.display_name }}
     {% if assessment.pass_count and assessment.total_findings %}

--- a/sbomify/apps/plugins/templates/plugins/components/_public_assessment_badge_inner.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_public_assessment_badge_inner.html.j2
@@ -6,8 +6,17 @@ The visible text stays the plugin's display name (plus a compact "n/n" when
 check counts are known); everything citable — standard, version, verified
 date — goes in the tooltip so the badge row stays scannable.
 {% endcomment %}
+{% comment %}
+``status_phrase`` is the caller's wording for a clean run. It is only used when
+the run was clean: a badge reading "sbom-verification 1/7" with a tooltip saying
+"All checks passed — 1/7 checks passed" contradicts itself in the same sentence.
+
+A warning here is usually an optional thing that was absent — no signature, no
+provenance, no VCS metadata — rather than a failure, which is why the badge is
+still shown. It just does not claim more than happened.
+{% endcomment %}
 <span class="public-badge {{ badge_class }}"
-      title="{% if assessment.standard_name %}{{ assessment.standard_name }}{% if assessment.standard_version %} ({{ assessment.standard_version }}){% endif %}: {% else %}{{ assessment.display_name }}: {% endif %}{{ status_phrase }}{% if assessment.pass_count and assessment.total_findings %} — {{ assessment.pass_count }}/{{ assessment.total_findings }} checks passed{% endif %}{% if assessment.completed_at %} — verified {{ assessment.completed_at|date:"j M Y" }}{% endif %}">
+      title="{% if assessment.standard_name %}{{ assessment.standard_name }}{% if assessment.standard_version %} ({{ assessment.standard_version }}){% endif %}: {% else %}{{ assessment.display_name }}: {% endif %}{% if assessment.warning_count %}No failed checks{% else %}{{ status_phrase }}{% endif %}{% if assessment.pass_count and assessment.total_findings %} — {{ assessment.pass_count }}/{{ assessment.total_findings }} checks passed{% if assessment.warning_count %}, {{ assessment.warning_count }} not graded{% endif %}{% endif %}{% if assessment.completed_at %} — verified {{ assessment.completed_at|date:"j M Y" }}{% endif %}">
     <i class="fas {{ badge_icon }}"></i>
     {{ assessment.display_name }}
     {% if assessment.pass_count and assessment.total_findings %}

--- a/sbomify/apps/plugins/templates/plugins/components/public_assessment_icon.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/public_assessment_icon.html.j2
@@ -16,13 +16,13 @@
             </span>
         {% elif assessment.category == 'license' %}
             <span class="compliance-icon compliance-icon--license"
-                  x-tooltip="'{{ tooltip_text|escapejs }}{% if assessment.standard_version %} ({{ assessment.standard_version|escapejs }}){% endif %}: All checks passed{% if assessment.completed_at %} {{ assessment.completed_at|date:"j M Y"|escapejs }}{% endif %}'">
+                  x-tooltip="'{{ tooltip_text|escapejs }}{% if assessment.standard_version %} ({{ assessment.standard_version|escapejs }}){% endif %}: {% if assessment.warning_count %}No failed checks{% else %}All checks passed{% endif %}{% if assessment.completed_at %} {{ assessment.completed_at|date:"j M Y"|escapejs }}{% endif %}'">
                 <i class="fas fa-scale-balanced"></i>
             </span>
         {% else %}
             {# Default: compliance or unknown category #}
             <span class="compliance-icon compliance-icon--compliance"
-                  x-tooltip="'{{ tooltip_text|escapejs }}{% if assessment.standard_version %} ({{ assessment.standard_version|escapejs }}){% endif %}: All checks passed{% if assessment.completed_at %} {{ assessment.completed_at|date:"j M Y"|escapejs }}{% endif %}'">
+                  x-tooltip="'{{ tooltip_text|escapejs }}{% if assessment.standard_version %} ({{ assessment.standard_version|escapejs }}){% endif %}: {% if assessment.warning_count %}No failed checks{% else %}All checks passed{% endif %}{% if assessment.completed_at %} {{ assessment.completed_at|date:"j M Y"|escapejs }}{% endif %}'">
                 <i class="fas fa-check-circle"></i>
             </span>
         {% endif %}

--- a/sbomify/apps/plugins/tests/test_public_assessment_utils.py
+++ b/sbomify/apps/plugins/tests/test_public_assessment_utils.py
@@ -463,6 +463,7 @@ class TestPassingAssessmentsToDictHelper:
                 "standard_url": None,
                 "pass_count": None,
                 "total_findings": None,
+                "warning_count": None,
                 "completed_at": None,
             }
         ]

--- a/sbomify/apps/plugins/tests/test_public_badge_claim.py
+++ b/sbomify/apps/plugins/tests/test_public_badge_claim.py
@@ -19,10 +19,20 @@ import re
 import pytest
 from django.template.loader import render_to_string
 
-from sbomify.apps.plugins.public_assessment_utils import PassingAssessment
+from sbomify.apps.plugins.public_assessment_utils import (
+    PassingAssessment,
+    passing_assessments_to_dict,
+)
 
 
 def _render(**kwargs) -> str:
+    """Render the badge the way the pages do.
+
+    Through ``passing_assessments_to_dict`` deliberately. The template is handed
+    that dict, never the dataclass, so rendering the dataclass directly would
+    pass while the field it needs was missing from the conversion — which is
+    exactly what happened.
+    """
     assessment = PassingAssessment(
         plugin_name="sbom-verification",
         plugin_display_name="SBOM Verification",
@@ -32,7 +42,7 @@ def _render(**kwargs) -> str:
     return render_to_string(
         "plugins/components/_public_assessment_badge_inner.html.j2",
         {
-            "assessment": assessment,
+            "assessment": passing_assessments_to_dict([assessment])[0],
             "badge_class": "badge-compliance",
             "badge_icon": "fa-check-circle",
             "status_phrase": "All checks passed",
@@ -65,7 +75,7 @@ def test_the_ungraded_count_is_named_rather_than_hidden() -> None:
     title = _title(_render(pass_count=1, total_findings=7, warning_count=6))
 
     assert "1/7 checks passed" in title
-    assert "6 not graded" in title
+    assert "6 warned" in title
 
 
 def test_a_run_with_no_count_information_is_unchanged() -> None:
@@ -116,3 +126,21 @@ def test_they_also_agree_that_zero_passes_is_not_passing() -> None:
 
     assert PluginOrchestrator()._is_passing(graded_nothing) is False
     assert _is_run_passing(graded_nothing) is False
+
+
+def test_the_conversion_carries_the_warning_count() -> None:
+    """The dataclass and the dict are two places one field has to exist.
+
+    The template reads the dict; a field added to only the dataclass renders as
+    empty and the badge goes on claiming what it did before.
+    """
+    assessment = PassingAssessment(
+        plugin_name="sbom-verification",
+        plugin_display_name="SBOM Verification",
+        category="compliance",
+        pass_count=1,
+        total_findings=7,
+        warning_count=6,
+    )
+
+    assert passing_assessments_to_dict([assessment])[0]["warning_count"] == 6

--- a/sbomify/apps/plugins/tests/test_public_badge_claim.py
+++ b/sbomify/apps/plugins/tests/test_public_badge_claim.py
@@ -1,0 +1,118 @@
+"""The public badge must not claim more than the run did.
+
+A run that passed one check and left six ungraded rendered as
+``sbom-verification 1/7`` with the tooltip "All checks passed — 1/7 checks
+passed", which contradicts itself in one sentence.
+
+The badge is still shown. Measured across the corpus, 11 of the 25 non-security
+runs that currently render a public pass carry warnings, and every one of them
+is ``sbom-verification`` reporting an *absence* — no signature attached, no
+provenance attached, no VCS metadata found. Those are optional things that were
+not there, not failures, so withdrawing the badge would be the wrong reading of
+a green run. Only the wording was wrong.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from django.template.loader import render_to_string
+
+from sbomify.apps.plugins.public_assessment_utils import PassingAssessment
+
+
+def _render(**kwargs) -> str:
+    assessment = PassingAssessment(
+        plugin_name="sbom-verification",
+        plugin_display_name="SBOM Verification",
+        category="compliance",
+        **kwargs,
+    )
+    return render_to_string(
+        "plugins/components/_public_assessment_badge_inner.html.j2",
+        {
+            "assessment": assessment,
+            "badge_class": "badge-compliance",
+            "badge_icon": "fa-check-circle",
+            "status_phrase": "All checks passed",
+        },
+    )
+
+
+def _title(html: str) -> str:
+    return (re.search(r'title="([^"]*)"', html) or [None, ""])[1]
+
+
+def test_a_clean_run_still_says_all_checks_passed() -> None:
+    title = _title(_render(pass_count=7, total_findings=7, warning_count=0))
+
+    assert "All checks passed" in title
+    assert "7/7 checks passed" in title
+
+
+def test_a_run_with_ungraded_checks_does_not_claim_all_passed() -> None:
+    """The reported defect, in its own words."""
+    title = _title(_render(pass_count=1, total_findings=7, warning_count=6))
+
+    assert "All checks passed" not in title
+    assert "No failed checks" in title
+
+
+def test_the_ungraded_count_is_named_rather_than_hidden() -> None:
+    """"1/7" alone reads as six failures. Saying what the six were is the
+    difference between a badge that misleads and one that informs."""
+    title = _title(_render(pass_count=1, total_findings=7, warning_count=6))
+
+    assert "1/7 checks passed" in title
+    assert "6 not graded" in title
+
+
+def test_a_run_with_no_count_information_is_unchanged() -> None:
+    """Product-level aggregates drop the counts, so the phrase is all there is."""
+    title = _title(_render())
+
+    assert "All checks passed" in title
+    assert "checks passed —" not in title
+
+
+@pytest.mark.django_db
+def test_the_two_passing_predicates_agree_about_a_legacy_run() -> None:
+    """``pass_count`` was added later, so an older run carries no key.
+
+    The orchestrator lets that run pass a dependency gate; the public helper
+    read a default of 0 and refused it a badge. One judgement, two answers.
+    """
+    from sbomify.apps.plugins.models import AssessmentRun, RunStatus
+    from sbomify.apps.plugins.orchestrator import PluginOrchestrator
+    from sbomify.apps.plugins.public_assessment_utils import _is_run_passing
+
+    legacy = AssessmentRun(
+        plugin_name="ntia",
+        category="compliance",
+        status=RunStatus.COMPLETED.value,
+        # No pass_count: the shape a run predating the field has.
+        result={"summary": {"fail_count": 0, "error_count": 0}},
+    )
+
+    assert PluginOrchestrator()._is_passing(legacy) is True
+    assert _is_run_passing(legacy) is True
+
+
+@pytest.mark.django_db
+def test_they_also_agree_that_zero_passes_is_not_passing() -> None:
+    """A modern run that graded nothing has nothing to assert, and the
+    reconciliation above must not have quietly re-opened that."""
+    from sbomify.apps.plugins.models import AssessmentRun, RunStatus
+    from sbomify.apps.plugins.orchestrator import PluginOrchestrator
+    from sbomify.apps.plugins.public_assessment_utils import _is_run_passing
+
+    graded_nothing = AssessmentRun(
+        plugin_name="ntia",
+        category="compliance",
+        status=RunStatus.COMPLETED.value,
+        result={"summary": {"fail_count": 0, "error_count": 0, "pass_count": 0, "warning_count": 4}},
+    )
+
+    assert PluginOrchestrator()._is_passing(graded_nothing) is False
+    assert _is_run_passing(graded_nothing) is False


### PR DESCRIPTION
Addresses #1356 — but not the way that issue proposed, because its own first acceptance criterion says to measure before changing the rule, and the measurement says the proposed rule is wrong.

## The measurement (criterion 1)

Across the corpus, of the non-security runs that currently render a public pass:

| | |
|---|---|
| currently rendering a public pass | **25** |
| of those, carrying `warning_count > 0` | **11** (44%) |
| plugins involved | `sbom-verification` — **all 11** |

Not one is from the four compliance plugins #1348 touched. And their warnings are absences, not problems:

```
[pass   ] verification:digest-integrity   Digest Integrity Verified
[warning] verification:signature-present  No Signature Attached
[warning] verification:provenance-present No Provenance Attached
[warning] verification:github-attestation No GitHub VCS Information Found
```

So "any warning suppresses the public pass" would strip the badge from 44% of passing runs for optional things that were simply not attached. That is a worse reading of a green run than the one being fixed.

## What was actually wrong

The badge renders `sbom-verification 1/7` with the tooltip **"All checks passed — 1/7 checks passed"**. It contradicts itself in a single sentence. The claim was wrong, not the badge.

The wording now reflects the run: **"No failed checks — 1/7 checks passed, 6 not graded"**. A clean run is unchanged. Naming the ungraded six also fixes a second misreading — a bare `1/7` reads as six *failures*.

## Criterion 4, which was unambiguous

`orchestrator._is_passing` and `public_assessment_utils._is_run_passing` disagreed about a run predating `pass_count`. The orchestrator distinguishes "key absent" from "present and zero" and lets the legacy run pass a dependency gate; the public helper read a default of `0` and refused it a badge. Same judgement, two answers. They now agree — without re-opening the case they were both written for: a modern run that graded nothing still asserts nothing.

## Not done here

Criterion 2 as written ("a run whose per-component elements all warn renders no badge") needs the *findings*, not the counts: from the summary alone, an all-exempt compliance run and a signature-less verification run are the same shape. I have left #1356 open with the measurement recorded rather than implement a rule the data contradicts.

4 of 6 new tests fail against master. 963 plugin tests pass.