### PR TITLE
fix(vulns): name SPDX 3 as SPDX when Dependency Track refuses it

### DIFF
--- a/sbomify/apps/vulnerability_scanning/clients.py
+++ b/sbomify/apps/vulnerability_scanning/clients.py
@@ -12,6 +12,23 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+def _is_spdx(content: dict[str, Any]) -> bool:
+    """Whether the document is SPDX, of either generation.
+
+    ``spdxVersion`` alone misses SPDX 3: the 3.0 serialisation dropped it in
+    favour of a JSON-LD ``@context``, so a spec-compliant 3.0.1 document was
+    told "Invalid SBOM format" when the accurate answer was that Dependency
+    Track does not take SPDX. Both rejections are refusals either way, so this
+    only ever changed which of the two the operator was shown.
+
+    ``is_spdx3`` is the same helper the OSV plugin detects with, rather than a
+    second reading of the same evidence.
+    """
+    from sbomify.apps.plugins.builtins._spdx3_helpers import is_spdx3
+
+    return bool(content.get("spdxVersion")) or is_spdx3(content)
+
+
 class DependencyTrackAPIError(Exception):
     """Exception raised for Dependency Track API errors."""
 
@@ -256,7 +273,7 @@ class DependencyTrackClient:
         try:
             content = json.loads(sbom_data.decode("utf-8"))
             if content.get("bomFormat") != "CycloneDX":
-                if content.get("spdxVersion"):
+                if _is_spdx(content):
                     raise DependencyTrackAPIError(
                         "SPDX format is not supported by Dependency Track. Only CycloneDX format is supported."
                     )
@@ -282,7 +299,7 @@ class DependencyTrackClient:
         try:
             content = json.loads(sbom_data.decode("utf-8"))
             if content.get("bomFormat") != "CycloneDX":
-                if content.get("spdxVersion"):
+                if _is_spdx(content):
                     raise DependencyTrackAPIError(
                         "SPDX format is not supported by Dependency Track. Only CycloneDX format is supported."
                     )

--- a/sbomify/apps/vulnerability_scanning/tests/test_dt_rejection_message.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_dt_rejection_message.py
@@ -1,0 +1,77 @@
+"""Dependency Track takes CycloneDX only, and should say which refusal this is.
+
+The SPDX branch keyed on ``spdxVersion``, which the 3.0 serialisation dropped in
+favour of a JSON-LD ``@context``. So a spec-compliant SPDX 3.0.1 document was
+told "Invalid SBOM format" when the accurate answer was that SPDX is not taken.
+
+Both paths refuse the upload, so this only ever changed which message the
+operator read — and the wrong one sends them looking for a malformed file.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sbomify.apps.vulnerability_scanning.clients import (
+    DependencyTrackAPIError,
+    DependencyTrackClient,
+)
+
+SPDX_3 = {
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [{"type": "SpdxDocument", "spdxId": "urn:doc"}],
+}
+SPDX_2 = {"spdxVersion": "SPDX-2.3", "name": "doc", "SPDXID": "SPDXRef-DOCUMENT"}
+CYCLONEDX = {"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1}
+
+
+@pytest.fixture
+def client() -> DependencyTrackClient:
+    return DependencyTrackClient(base_url="https://dt.example.test", api_key="k")
+
+
+def _upload(client: DependencyTrackClient, document: dict) -> str:
+    with pytest.raises(DependencyTrackAPIError) as excinfo:
+        client.upload_sbom("proj-uuid", json.dumps(document).encode())
+    return str(excinfo.value)
+
+
+def _upload_with_creation(client: DependencyTrackClient, document: dict) -> str:
+    with pytest.raises(DependencyTrackAPIError) as excinfo:
+        client.upload_sbom_with_project_creation("p", "1.0", json.dumps(document).encode())
+    return str(excinfo.value)
+
+
+def test_spdx_3_is_named_as_spdx(client: DependencyTrackClient) -> None:
+    """The reported defect. A 3.0.1 document carries no ``spdxVersion``."""
+    assert "spdxVersion" not in SPDX_3
+    assert "SPDX" in _upload(client, SPDX_3)
+
+
+def test_spdx_2_is_named_as_spdx(client: DependencyTrackClient) -> None:
+    assert "SPDX" in _upload(client, SPDX_2)
+
+
+def test_something_that_is_neither_is_still_an_invalid_format(client: DependencyTrackClient) -> None:
+    """The fallback has to keep meaning what it says, or widening the SPDX
+    branch would just move the misleading message somewhere else."""
+    message = _upload(client, {"hello": "world"})
+
+    assert "Invalid SBOM format" in message
+    assert "SPDX" not in message
+
+
+def test_malformed_json_is_reported_as_malformed(client: DependencyTrackClient) -> None:
+    with pytest.raises(DependencyTrackAPIError) as excinfo:
+        client.upload_sbom("proj-uuid", b"{not json")
+
+    assert "not valid JSON" in str(excinfo.value)
+
+
+def test_the_project_creating_upload_says_the_same_thing(client: DependencyTrackClient) -> None:
+    """Two call sites carried the same branch, and only fixing one would leave
+    the defect on whichever path the caller happened to take."""
+    assert "SPDX" in _upload_with_creation(client, SPDX_3)
+    assert "SPDX" in _upload_with_creation(client, SPDX_2)


### PR DESCRIPTION
Closes #1335.

The SPDX branch in `clients.py` keyed on `spdxVersion`. The SPDX 3.0 serialisation dropped that field in favour of a JSON-LD `@context`, so a spec-compliant 3.0.1 document fell through to the generic branch and was told:

> Invalid SBOM format. Dependency Track only supports CycloneDX format.

when the accurate answer is that Dependency Track does not take SPDX at all. Both branches refuse the upload, so this only ever changed *which* message the operator read — and the wrong one sends them looking for a malformed file that is not malformed.

Detected with `is_spdx3`, the same helper the OSV plugin uses (`osv.py`), rather than a second reading of the same evidence. The plugin's own gate (`dependency_track.py`) already got this right; only the client was behind.

Both call sites — `upload_sbom` and `upload_sbom_with_project_creation` — carried the branch. Fixing one would have left the defect on whichever path the caller happened to take.

## Acceptance criteria

| | |
|---|---|
| SPDX 3.0.1 → names SPDX | ✅ |
| SPDX 2.3 → names SPDX | ✅ |
| malformed JSON → still "not valid JSON" | ✅ |
| neither format → still "Invalid SBOM format", *without* mentioning SPDX | ✅ |

That last row matters: widening the SPDX branch could have moved the misleading message rather than removed it.

2 of 5 new tests fail against master. 408 vulnerability-scanning tests pass.