### PR TITLE
fix(osv): a scan that recognised nothing is not a clean scan

### DIFF
--- a/sbomify/apps/plugins/builtins/osv.py
+++ b/sbomify/apps/plugins/builtins/osv.py
@@ -122,6 +122,19 @@ class OSVPlugin(AssessmentPlugin):
             # Parse results into findings
             findings = self._parse_scan_output(stdout, returncode)
 
+            # No findings can mean two opposite things: nothing was vulnerable,
+            # or nothing was recognised. A Yocto SPDX document carries
+            # ``pkg:yocto/...`` PURLs, which osv-scanner rejects as invalid and
+            # skips, and the scan reports "found 0 packages" while exiting
+            # cleanly. Reported as a pass, that renders a green "no known
+            # vulnerabilities" badge over a build nothing was ever matched
+            # against — the worst answer a security product can give.
+            if not findings and self._scanned_package_count(stderr) == 0:
+                logger.warning(
+                    f"[OSV] Scan of SBOM {sbom_id} recognised no packages; reporting as skipped rather than clean"
+                )
+                return self._create_no_packages_result()
+
             # Build severity summary
             by_severity: dict[str, int] = {
                 "critical": 0,
@@ -519,6 +532,57 @@ class OSVPlugin(AssessmentPlugin):
         elif score >= 4.0:
             return "medium"
         return "low"
+
+    _SCANNED_PACKAGES = re.compile(r"found (\d+) package", re.IGNORECASE)
+
+    def _scanned_package_count(self, stderr: str) -> int | None:
+        """How many packages osv-scanner said it recognised, or None if it did not say.
+
+        The count is only on stderr. The JSON output lists packages that *have*
+        vulnerabilities, so on a clean scan it cannot distinguish "500 scanned,
+        none vulnerable" from "none scanned at all".
+
+        None rather than 0 when the line is absent: a scanner version that
+        phrases it differently must not turn every clean scan into a skip.
+        """
+        match = self._SCANNED_PACKAGES.search(stderr or "")
+        return int(match.group(1)) if match else None
+
+    def _create_no_packages_result(self) -> AssessmentResult:
+        """A scan that recognised nothing, reported as skipped rather than clean.
+
+        Skipped is the shape that already means "the plugin never scanned
+        anything" — ``public_assessment_utils._is_run_skipped`` reads it and
+        withholds the public pass, which is the whole point here.
+        """
+        finding = Finding(
+            id="osv:no-packages",
+            title="No Packages Recognised",
+            description=(
+                "osv-scanner did not recognise any packages in this SBOM, so it was not "
+                "matched against any advisory source. This usually means the package URLs "
+                "use a type osv-scanner does not know, such as pkg:yocto. No vulnerability "
+                "result can be inferred from this scan."
+            ),
+            status="warning",
+            severity="info",
+        )
+        summary = AssessmentSummary(
+            total_findings=1,
+            pass_count=0,
+            fail_count=0,
+            warning_count=1,
+            error_count=0,
+        )
+        return AssessmentResult(
+            plugin_name="osv",
+            plugin_version=self.VERSION,
+            category=AssessmentCategory.SECURITY.value,
+            assessed_at=datetime.now(timezone.utc).isoformat(),
+            summary=summary,
+            findings=[finding],
+            metadata={"scanner": "osv-scanner", "skipped": True, "no_packages": True},
+        )
 
     def _create_error_result(self, error_message: str) -> AssessmentResult:
         """Create an error result when assessment cannot be completed.

--- a/sbomify/apps/plugins/tests/test_osv_no_packages.py
+++ b/sbomify/apps/plugins/tests/test_osv_no_packages.py
@@ -1,0 +1,131 @@
+"""A scan that recognised nothing is not a scan that found nothing.
+
+From staging, on a Yocto SPDX document:
+
+    Invalid PURL "pkg:yocto/netbase@6.4" for package: "netbase"
+    Neither CPE nor PURL found for package: ...
+    Scanned /tmp/tmpi1fa3vpf.spdx.json file and found 0 packages
+
+osv-scanner rejected every PURL, matched the document against nothing, and
+exited cleanly. The plugin built its result from the findings alone, so zero
+findings became a pass, and the component rendered a green "no known
+vulnerabilities" badge over a build that was never checked.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from sbomify.apps.plugins.builtins.osv import OSVPlugin
+
+
+def _as_dict(result: Any) -> dict[str, Any]:
+    return result.model_dump() if hasattr(result, "model_dump") else dataclasses.asdict(result)
+
+
+@pytest.fixture
+def plugin() -> OSVPlugin:
+    return OSVPlugin()
+
+
+# The line osv-scanner actually writes, from the staging log.
+YOCTO_STDERR = (
+    'Invalid PURL "pkg:yocto/netbase@6.4" for package: "netbase"\n'
+    "Neither CPE nor PURL found for package: &{IsUnpackaged:false PackageName:netbase}\n"
+    "Scanned /tmp/tmpi1fa3vpf.spdx.json file and found 0 packages\n"
+)
+HEALTHY_STDERR = "Scanned /tmp/x.spdx.json file and found 412 packages\n"
+
+
+class TestReadingTheScannedCount:
+    def test_zero_is_read_from_the_real_line(self, plugin: OSVPlugin) -> None:
+        assert plugin._scanned_package_count(YOCTO_STDERR) == 0
+
+    def test_a_healthy_scan_reports_its_count(self, plugin: OSVPlugin) -> None:
+        assert plugin._scanned_package_count(HEALTHY_STDERR) == 412
+
+    def test_a_missing_line_is_not_zero(self, plugin: OSVPlugin) -> None:
+        """None, not 0. A scanner version that words it differently must not
+        turn every clean scan into a skip — that would be the same defect
+        pointing the other way."""
+        assert plugin._scanned_package_count("") is None
+        assert plugin._scanned_package_count("some unrelated warning") is None
+
+    def test_the_singular_form_is_read_too(self, plugin: OSVPlugin) -> None:
+        assert plugin._scanned_package_count("Scanned x and found 1 package\n") == 1
+
+
+class TestTheResultItProduces:
+    def test_it_is_marked_skipped(self, plugin: OSVPlugin) -> None:
+        """``skipped`` is what withholds the public pass. ``_is_run_skipped``
+        reads exactly this flag, and its docstring is this situation: the
+        plugin never scanned anything, so "no findings" carries no signal."""
+        result = _as_dict(plugin._create_no_packages_result())
+
+        assert result["metadata"]["skipped"] is True
+
+    def test_it_asserts_no_severity(self, plugin: OSVPlugin) -> None:
+        """It must not read as a vulnerability either — the row would be as
+        wrong as the badge."""
+        summary = _as_dict(plugin._create_no_packages_result())["summary"]
+
+        assert summary["by_severity"] is None
+        assert summary["fail_count"] == 0
+        assert summary["error_count"] == 0
+        assert summary["warning_count"] == 1
+
+    def test_its_finding_is_operational_not_a_vulnerability(self, plugin: OSVPlugin) -> None:
+        """The id shares the ``osv:`` namespace the display filter already
+        drops, so it cannot surface as a finding row."""
+        from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
+
+        finding = _as_dict(plugin._create_no_packages_result())["findings"][0]
+
+        assert finding["id"] == "osv:no-packages"
+        assert is_vulnerability(finding) is False
+
+    def test_it_says_why(self, plugin: OSVPlugin) -> None:
+        """An operator seeing this has to be able to act on it, and the cause
+        is a PURL type the scanner does not know."""
+        finding = _as_dict(plugin._create_no_packages_result())["findings"][0]
+
+        assert "pkg:yocto" in finding["description"]
+
+
+@pytest.mark.django_db
+class TestItDoesNotRenderAsPassing:
+    """The point of the whole change."""
+
+    def _run(self, result: dict[str, Any]):
+        from sbomify.apps.plugins.models import AssessmentRun, RunStatus
+
+        return AssessmentRun(
+            plugin_name="osv",
+            category="security",
+            status=RunStatus.COMPLETED.value,
+            result=result,
+        )
+
+    def test_a_no_packages_run_earns_no_public_badge(self, plugin: OSVPlugin) -> None:
+        from sbomify.apps.plugins.public_assessment_utils import _is_run_passing
+
+        assert _is_run_passing(self._run(_as_dict(plugin._create_no_packages_result()))) is False
+
+    def test_a_genuinely_clean_run_still_does(self) -> None:
+        """The regression that would hurt most: a real scan of a real SBOM with
+        no vulnerabilities has to keep its badge."""
+        from sbomify.apps.plugins.public_assessment_utils import _is_run_passing
+
+        clean = {
+            "summary": {
+                "total_findings": 0,
+                "by_severity": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0},
+            },
+            "findings": [],
+            "metadata": {"scanner": "osv-scanner"},
+        }
+
+        assert _is_run_passing(self._run(clean)) is True


### PR DESCRIPTION
From staging, scanning a Yocto SPDX document:

```
Invalid PURL "pkg:yocto/netbase@6.4" for package: "netbase"
Neither CPE nor PURL found for package: ...
Scanned /tmp/tmpi1fa3vpf.spdx.json file and found 0 packages
```

osv-scanner rejected every PURL, matched the document against nothing, and **exited cleanly**. The plugin builds its result from the findings alone, so zero findings became a pass — and the component rendered a green *"no known vulnerabilities"* badge over a build that was never checked.

This is the worst answer a security product can give: not "we don't know", but a confident all-clear.

## The fix

A scan that recognises no packages reports as **skipped**. That shape already means "the plugin never scanned anything" — `_is_run_skipped` reads it and withholds the public pass, and its docstring describes this situation almost word for word:

> Skipped runs are NOT passing — the plugin never executed its scan, so "no findings" carries no signal.

## Two details worth the review

**The count comes from stderr, not the JSON.** osv-scanner's JSON lists packages that *have* vulnerabilities, so on a clean run it cannot distinguish "500 scanned, none vulnerable" from "none scanned at all". stderr is the only place the total appears.

**A missing line reads as `None`, not `0`.** If a future osv-scanner words that line differently, treating absence as zero would turn *every* clean scan into a skip — the same defect pointing the other way, and much louder. Absence means "it did not say", and the scan is reported as it was.

The finding keeps the `osv:` namespace the display filter already drops, so it cannot surface as a vulnerability row either — that would be as wrong as the badge.

## Tests

10, including the one that matters most in the other direction: a genuinely clean scan of a real SBOM keeps its badge. The stderr fixtures are copied from the staging log rather than invented. 967 plugin tests pass.

## Not fixed here

Why Yocto SBOMs carry `pkg:yocto/...` at all. That type is not in the purl spec, so no scanner will match it; the SBOMs need a recognised type (`pkg:generic`, or the distro's own) at generation time. This change stops us *reporting* those builds as clean — it does not make them scannable. Worth a separate issue against the Yocto path.