### PR TITLE
fix(dt): a spec version DT has not caught up to is a skip, not an error

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -34,6 +34,22 @@ from sbomify.logging import getLogger
 logger = getLogger(__name__)
 
 
+def _is_unsupported_spec_version(error: Exception) -> bool:
+    """Whether Dependency Track refused the upload over its CycloneDX version.
+
+    Matched on the server's message because that is the only place it says so:
+    the rejection is a plain 400 shared with every other invalid-BOM reason, and
+    nothing in the payload distinguishes "malformed" from "a version I do not
+    know yet".
+
+    Deliberately narrow. A 400 that is not about the spec version is still a
+    real failure and keeps its error result — misreading a genuinely corrupt BOM
+    as "not applicable" would hide the thing worth knowing.
+    """
+    message = str(error).lower()
+    return "specversion" in message and ("unrecognized" in message or "unsupported" in message)
+
+
 def _first_float(*candidates: Any) -> float | None:
     """The first candidate that is a real number, else None.
 
@@ -209,6 +225,22 @@ class DependencyTrackPlugin(AssessmentPlugin):
                     current_release_names=current_release_names,
                 )
             except Exception as e:
+                # A spec version this DT does not know is a capability gap, not
+                # a fault: "Unrecognized specVersion 1.7" means CycloneDX moved
+                # ahead of the server, and every scan of that artifact would log
+                # an error and store a high-severity marker until DT catches up.
+                # The same reasoning the format gate already applies — DT simply
+                # cannot process it — so it skips rather than errors.
+                if _is_unsupported_spec_version(e):
+                    logger.info(f"[DT] SBOM {sbom_id} uses a spec version this Dependency Track does not accept: {e}")
+                    return self._create_skipped_result(
+                        finding_id="dependency-track:unsupported-spec-version",
+                        title="Spec Version Not Supported",
+                        description=(
+                            "This Dependency Track server does not accept this CycloneDX spec "
+                            f"version, so vulnerability scanning was skipped. Server response: {e}"
+                        ),
+                    )
                 logger.error(f"[DT] Failed to upload SBOM {sbom_id} to DT: {e}")
                 return self._create_error_result(f"DT upload failed: {e}")
 

--- a/sbomify/apps/plugins/tests/test_dt_unsupported_spec_version.py
+++ b/sbomify/apps/plugins/tests/test_dt_unsupported_spec_version.py
@@ -18,7 +18,9 @@ for SPDX. A spec version the server has not caught up to is the same situation.
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -116,3 +118,72 @@ class TestItDoesNotRenderAsPassingEither:
         )
 
         assert _is_run_passing(run) is False
+
+
+@pytest.mark.django_db
+class TestTheWiringInAssess:
+    """The branch itself, not just the pieces it is built from.
+
+    ``_is_unsupported_spec_version`` and ``_create_skipped_result`` can both be
+    correct while nothing calls them. These drive the real ``assess()`` with the
+    upload raising, which is the only way to know the two are connected.
+    """
+
+    @pytest.fixture
+    def scannable_sbom(self, tmp_path):
+        """An SBOM that gets all the way to the upload."""
+        from sbomify.apps.core.models import Component, Product
+        from sbomify.apps.sboms.models import SBOM
+        from sbomify.apps.teams.models import Team
+        from sbomify.apps.vulnerability_scanning.models import DependencyTrackServer
+
+        team = Team.objects.create(name="DT Spec Team", key="dtspecteam", billing_plan="business")
+        # A real row, not a mock: the plugin queries
+        # SbomDependencyTrackProjectVersion by this FK before it uploads, and a
+        # MagicMock has no primary key to resolve.
+        server = DependencyTrackServer.objects.create(
+            name="DT Spec Server",
+            url="https://dt-spec.example.com",
+            api_key="key",
+            health_status="healthy",
+            max_concurrent_scans=10,
+        )
+        component = Component.objects.create(name="DT Spec Component", team=team)
+        product = Product.objects.create(name="DT Spec Product", team=team)
+        product.components.add(component)
+        sbom = SBOM.objects.create(name="s", component=component, format="cyclonedx", format_version="1.7")
+
+        path = tmp_path / "sbom.cdx.json"
+        path.write_text(json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.7", "version": 1}))
+        return sbom, path, server
+
+    def _assess_with_upload_raising(self, plugin, sbom, path, server, error):
+        with (
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
+            patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
+            patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
+            patch.object(DependencyTrackPlugin, "_upload_new_sbom_version", side_effect=error),
+        ):
+            return _as_dict(plugin.assess(str(sbom.id), path))
+
+    def test_the_real_rejection_becomes_a_skip(self, scannable_sbom) -> None:
+        sbom, path, server = scannable_sbom
+
+        result = self._assess_with_upload_raising(DependencyTrackPlugin(), sbom, path, server, REAL_REJECTION)
+
+        assert result["metadata"].get("skipped") is True
+        assert result["findings"][0]["id"] == "dependency-track:unsupported-spec-version"
+        assert result["summary"]["error_count"] == 0
+
+    def test_any_other_upload_failure_is_still_an_error(self, scannable_sbom) -> None:
+        """The half that keeps the change honest: a real failure must not be
+        quietly reclassified as "not applicable"."""
+        sbom, path, server = scannable_sbom
+
+        result = self._assess_with_upload_raising(
+            DependencyTrackPlugin(), sbom, path, server, Exception("Dependency Track error (401): Unauthorized")
+        )
+
+        assert result["metadata"].get("skipped") is not True
+        assert result["findings"][0]["id"] == "dependency-track:error"
+        assert result["summary"]["error_count"] == 1

--- a/sbomify/apps/plugins/tests/test_dt_unsupported_spec_version.py
+++ b/sbomify/apps/plugins/tests/test_dt_unsupported_spec_version.py
@@ -1,0 +1,118 @@
+"""Dependency Track refusing a CycloneDX version is a gap, not a fault.
+
+From staging:
+
+    [DT] Failed to upload SBOM ZWiImVwsDLlZ to DT: Dependency Track error (400):
+    The uploaded BOM is invalid: Unrecognized specVersion 1.7
+
+The format gate only checks ``bomFormat``, so a CycloneDX 1.7 document passes
+it, gets uploaded, and is rejected by a server that only knows up to 1.6. Every
+scan of that artifact then logged an ERROR and stored a ``dependency-track:error``
+marker carrying ``severity="high"`` — which is the row Viktor reported seeing on
+the component page.
+
+The plugin already treats "DT cannot process this" as skipped rather than failed
+for SPDX. A spec version the server has not caught up to is the same situation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from sbomify.apps.plugins.builtins.dependency_track import (
+    DependencyTrackPlugin,
+    _is_unsupported_spec_version,
+)
+
+# The message Dependency Track actually returned, from the staging log.
+REAL_REJECTION = Exception(
+    "Dependency Track error (400): The uploaded BOM is invalid: Unrecognized specVersion 1.7"
+)
+
+
+def _as_dict(result: Any) -> dict[str, Any]:
+    return result.model_dump() if hasattr(result, "model_dump") else dataclasses.asdict(result)
+
+
+class TestRecognisingTheRejection:
+    def test_the_real_message_is_recognised(self) -> None:
+        assert _is_unsupported_spec_version(REAL_REJECTION) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Dependency Track error (400): The uploaded BOM is invalid: Unsupported specVersion 2.0",
+            "unrecognized specversion 1.9",
+        ],
+    )
+    def test_wording_variants_are_recognised(self, message: str) -> None:
+        assert _is_unsupported_spec_version(Exception(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # A genuinely broken document, which must keep its error result.
+            "Dependency Track error (400): The uploaded BOM is invalid: Unexpected end of input",
+            "Dependency Track error (401): Unauthorized",
+            "Connection refused",
+            "Dependency Track error (500): Internal Server Error",
+        ],
+    )
+    def test_other_failures_are_not_swallowed(self, message: str) -> None:
+        """The narrowness is the point. Reading a corrupt BOM or a dead server as
+        "not applicable" would hide the thing worth knowing."""
+        assert _is_unsupported_spec_version(Exception(message)) is False
+
+
+class TestTheResultItProduces:
+    @pytest.fixture
+    def result(self) -> dict[str, Any]:
+        plugin = DependencyTrackPlugin()
+        return _as_dict(
+            plugin._create_skipped_result(
+                finding_id="dependency-track:unsupported-spec-version",
+                title="Spec Version Not Supported",
+                description="This Dependency Track server does not accept this CycloneDX spec version.",
+            )
+        )
+
+    def test_it_is_skipped_not_errored(self, result: dict[str, Any]) -> None:
+        assert result["metadata"]["skipped"] is True
+        assert result["summary"]["error_count"] == 0
+
+    def test_it_carries_no_severity(self, result: dict[str, Any]) -> None:
+        """The error result it replaces carried ``severity="high"``, which is
+        what put a HIGH row on the component page."""
+        assert result["findings"][0]["severity"] != "high"
+
+    def test_it_is_not_a_vulnerability(self, result: dict[str, Any]) -> None:
+        from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
+
+        assert is_vulnerability(result["findings"][0]) is False
+
+
+@pytest.mark.django_db
+class TestItDoesNotRenderAsPassingEither:
+    def test_a_skipped_run_earns_no_public_badge(self) -> None:
+        """Not an error, but not a clean bill of health — nothing was scanned."""
+        from sbomify.apps.plugins.models import AssessmentRun, RunStatus
+        from sbomify.apps.plugins.public_assessment_utils import _is_run_passing
+
+        plugin = DependencyTrackPlugin()
+        run = AssessmentRun(
+            plugin_name="dependency-track",
+            category="security",
+            status=RunStatus.COMPLETED.value,
+            result=_as_dict(
+                plugin._create_skipped_result(
+                    finding_id="dependency-track:unsupported-spec-version",
+                    title="Spec Version Not Supported",
+                    description="x",
+                )
+            ),
+        )
+
+        assert _is_run_passing(run) is False


### PR DESCRIPTION
From staging:

```
[DT] Failed to upload SBOM ZWiImVwsDLlZ to DT: Dependency Track error (400):
The uploaded BOM is invalid: Unrecognized specVersion 1.7
```

The format gate only checks `bomFormat`, so a CycloneDX **1.7** document passes it, gets uploaded, and is refused by a server that knows up to 1.6. Every scan of that artifact then logged an ERROR and stored a `dependency-track:error` marker carrying `severity="high"`.

That marker is the **HIGH `dependency-track:error` row Viktor reported** on the component page. #1360 stopped it rendering as a vulnerability; this stops it being produced in the first place.

## The fix

The plugin already treats "DT cannot process this" as *skipped* rather than *failed* when the format is SPDX:

> Non-CycloneDX SBOMs aren't an error — DT simply can't process them. Return a skipped result so the UI shows "not applicable" rather than a hard error finding for a format choice the user made deliberately.

CycloneDX moving ahead of the server is the same situation and now gets the same answer. Skipped also withholds the public pass, which is correct: nothing was scanned, so there is no clean bill of health either.

## Matched on the message, deliberately narrowly

The rejection is a plain 400 shared with every other invalid-BOM reason — nothing in the payload separates "malformed" from "a version I do not know yet". The server's text is the only place it says which.

So the match requires `specversion` **and** one of `unrecognized`/`unsupported`. A 400 that is not about the spec version keeps its error result. Tested explicitly against a corrupt BOM, a 401, a 500 and a connection refusal, because reading any of those as "not applicable" would hide the thing worth knowing.

## Deliberately not version-pinning

I did not add a "max supported CycloneDX version" table. It would need updating every time DT ships, and it would be wrong for anyone running a newer or older server than the one we assume. Letting the server say what it accepts adapts to 1.8 without another change.

11 tests, fixtures copied from the staging log. 968 plugin tests pass.