### PR TITLE
fix(onboarding): stop creating a product and component at signup

### DIFF
--- a/sbomify/apps/teams/tests/test_onboarding_wizard.py
+++ b/sbomify/apps/teams/tests/test_onboarding_wizard.py
@@ -294,7 +294,7 @@ class TestOnboardingWizard:
             {
                 "company_name": "No Auto Entities Ltd",
                 "contact_name": "Jane Doe",
-                "contact_email": "jane@example.com",
+                "email": "jane@example.com",
                 "goal": "compliance",
             },
         )
@@ -322,7 +322,7 @@ class TestOnboardingWizard:
             {
                 "company_name": "Identity Survives Ltd",
                 "contact_name": "Jane Doe",
-                "contact_email": "jane@example.com",
+                "email": "jane@example.com",
                 "goal": "compliance",
             },
         )
@@ -330,7 +330,11 @@ class TestOnboardingWizard:
         team = Team.objects.get(pk=team.pk)
         assert team.has_completed_wizard is True
         assert "Identity Survives Ltd" in team.name
-        assert ContactEntity.objects.filter(profile__team=team, is_manufacturer=True).exists()
+        entity = ContactEntity.objects.get(profile__team=team, is_manufacturer=True)
+        # The posted address, not the user's. Before the field name was fixed the
+        # form ignored it and this fell back to sample_user.email, so the test
+        # passed while exercising nothing.
+        assert entity.email == "jane@example.com"
 
 
     def test_complete_step_shows_summary(
@@ -365,6 +369,11 @@ class TestOnboardingWizard:
         assert response.context["company_name"] == "Summary Test Inc"
         # No component id: the completion step is keyed on the company name now,
         # since the wizard no longer creates a component to point at.
+        #
+        # The positive control matters: ContextList.__contains__ does look up
+        # keys, but a bare "not in" assertion is indistinguishable from one that
+        # can never fail, so a key known to be present is asserted beside it.
+        assert "company_name" in response.context
         assert "component_id" not in response.context
 
     def test_session_updated_after_completion(

--- a/sbomify/apps/teams/tests/test_onboarding_wizard.py
+++ b/sbomify/apps/teams/tests/test_onboarding_wizard.py
@@ -1,7 +1,6 @@
 """Tests for the onboarding wizard single-step flow."""
 
 import pytest
-from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib.messages import get_messages
 from django.test import Client
@@ -270,153 +269,69 @@ class TestOnboardingWizard:
         assert entity is not None
         assert entity.email == sample_user.email
 
-    def test_product_and_component_auto_created(
+    def test_no_product_or_component_is_created(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
     ) -> None:
-        """Test that Product and Component are auto-created and the component is attached
-        directly to the product via the ProductComponent M2M (Project layer is gone)."""
+        """The wizard sets up an identity, not an inventory.
+
+        It used to create a product named after the company and a component
+        called "Main Component". Bootstrapping an account left two entities
+        nobody asked for, and pre-ticked the dashboard's own "create your first
+        product" and "create your first component" steps — so the checklist
+        meant to guide someone through those was complete before they had done
+        either.
+        """
+        from sbomify.apps.core.models import Component, Product
+
         client.force_login(sample_user)
         team = sample_team_with_owner_member.team
-
         session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
+        session["current_team"] = {"key": team.key, "role": "owner", "has_completed_wizard": False}
         session.save()
 
         response = client.post(
             reverse("teams:onboarding_wizard"),
             {
-                "company_name": "Hierarchy Test Corp",
-                "contact_name": "Test Contact",
+                "company_name": "No Auto Entities Ltd",
+                "contact_name": "Jane Doe",
+                "contact_email": "jane@example.com",
+                "goal": "compliance",
             },
         )
 
         assert response.status_code == 302
+        assert not Product.objects.filter(team=team).exists()
+        assert not Component.objects.filter(team=team).exists()
 
-        # Verify Product
-        product = Product.objects.filter(team=team, name="Hierarchy Test Corp").first()
-        assert product is not None
-
-        # Verify Component with BOM type
-        component = Component.objects.filter(team=team, name="Main Component").first()
-        assert component is not None
-        assert component.component_type == Component.ComponentType.BOM
-
-        # Verify hierarchy: product -> component (direct M2M)
-        assert component in product.components.all()
-
-    def test_component_has_contact_profile_persisted(
+    def test_the_identity_it_does_set_up_survives(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
     ) -> None:
-        """Test that component created during onboarding has contact_profile correctly assigned and persisted."""
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "Profile Persistence Test",
-                "contact_name": "Test Contact",
-            },
-        )
-
-        assert response.status_code == 302
-
-        # Verify default profile was created
-        default_profile = ContactProfile.objects.filter(team=team, is_default=True).first()
-        assert default_profile is not None
-
-        # Verify component was created and has contact_profile assigned
-        component = Component.objects.filter(team=team, name="Main Component").first()
-        assert component is not None
-        # Refresh from database to ensure we have the latest state
-        component.refresh_from_db()
-        assert component.contact_profile is not None
-        assert component.contact_profile.id == default_profile.id
-        assert component.contact_profile.is_default is True
-
-    def test_component_has_bom_type(
-        self, client: Client, sample_user, sample_team_with_owner_member, community_plan
-    ) -> None:
-        """Test that auto-created component has component_type=BOM."""
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "BOM Type Test",
-                "contact_name": "BOM Tester",
-            },
-        )
-
-        assert response.status_code == 302
-
-        component = Component.objects.filter(team=team).first()
-        assert component is not None
-        assert component.component_type == Component.ComponentType.BOM
-
-    def test_keycloak_metadata_in_component(
-        self, client: Client, sample_user, sample_team_with_owner_member, community_plan
-    ) -> None:
-        """Test that Keycloak user metadata is properly used when creating a component."""
-        # Create Keycloak social auth record with metadata (created for side effects only)
-        SocialAccount.objects.create(
-            user=sample_user,
-            provider="keycloak",
-            extra_data={
-                "user_metadata": {
-                    "company": "Keycloak Corp",
-                    "supplier_url": "https://keycloak.example.com",
-                }
-            },
-        )
+        """What the wizard is actually for is unchanged: the workspace name and
+        the manufacturer/contact identity. Removing the entities must not take
+        those with it."""
+        from sbomify.apps.teams.models import ContactEntity, Team
 
         client.force_login(sample_user)
         team = sample_team_with_owner_member.team
-
         session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
+        session["current_team"] = {"key": team.key, "role": "owner", "has_completed_wizard": False}
         session.save()
 
-        response = client.post(
+        client.post(
             reverse("teams:onboarding_wizard"),
             {
-                "company_name": "Keycloak Test",
-                "contact_name": "Keycloak Tester",
+                "company_name": "Identity Survives Ltd",
+                "contact_name": "Jane Doe",
+                "contact_email": "jane@example.com",
+                "goal": "compliance",
             },
         )
 
-        assert response.status_code == 302
+        team = Team.objects.get(pk=team.pk)
+        assert team.has_completed_wizard is True
+        assert "Identity Survives Ltd" in team.name
+        assert ContactEntity.objects.filter(profile__team=team, is_manufacturer=True).exists()
 
-        # Verify component has Keycloak metadata
-        component = Component.objects.filter(team=team).first()
-        assert component is not None
-        assert component.metadata.get("supplier", {}).get("name") == "Keycloak Corp"
-        assert component.metadata.get("supplier", {}).get("url") == ["https://keycloak.example.com"]
 
     def test_complete_step_shows_summary(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
@@ -448,7 +363,9 @@ class TestOnboardingWizard:
         assert response.status_code == 200
         assert response.context["current_step"] == "complete"
         assert response.context["company_name"] == "Summary Test Inc"
-        assert response.context["component_id"] is not None
+        # No component id: the completion step is keyed on the company name now,
+        # since the wizard no longer creates a component to point at.
+        assert "component_id" not in response.context
 
     def test_session_updated_after_completion(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
@@ -596,91 +513,6 @@ class TestOnboardingWizard:
         assert response.status_code == 200
         assert response.context["form"].errors.get("website") is not None
 
-    def test_community_plan_creates_public_entities(
-        self, client: Client, sample_user, sample_team_with_owner_member, community_plan
-    ) -> None:
-        """Test that community plan wizard creates public entities."""
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        # Ensure team is on community plan (cannot be private)
-        team.billing_plan = "community"
-        team.save()
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "Community Corp",
-                "contact_name": "Community Tester",
-            },
-        )
-
-        assert response.status_code == 302
-
-        # Verify all entities are public for community plan
-        product = Product.objects.filter(team=team, name="Community Corp").first()
-        assert product is not None
-        assert product.is_public is True
-
-        component = Component.objects.filter(team=team, name="Main Component").first()
-        assert component is not None
-        assert component.visibility == Component.Visibility.PUBLIC
-
-    def test_business_plan_creates_private_entities(
-        self, client: Client, sample_user, sample_team_with_owner_member
-    ) -> None:
-        """Test that business plan wizard creates private entities."""
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        # Create and set up business plan for the team
-        BillingPlan.objects.get_or_create(
-            key="business",
-            defaults={
-                "name": "Business",
-                "description": "Business Plan",
-                "max_products": 10,
-                "max_components": 10,
-            },
-        )
-        team.billing_plan = "business"
-        team.save()
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "Business Corp",
-                "contact_name": "Business Tester",
-            },
-        )
-
-        assert response.status_code == 302
-
-        # Verify all entities are private for business plan
-        product = Product.objects.filter(team=team, name="Business Corp").first()
-        assert product is not None
-        assert product.is_public is False
-
-        component = Component.objects.filter(team=team, name="Main Component").first()
-        assert component is not None
-        assert component.visibility == Component.Visibility.PRIVATE
-
     def test_goal_field_saved_to_team(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
     ) -> None:
@@ -786,8 +618,11 @@ class TestOnboardingWizard:
 
         # Single product is renamed in place; component uses get_or_create with a
         # fixed "Main Component" name, creating at most one new component.
-        assert Product.objects.filter(team=team).count() == 1  # renamed to "At Limit Corp"
-        assert Component.objects.filter(team=team).count() == 6  # 5 existing + "Main Component"
+        # The point of this test is that a team at its plan limit can still
+        # finish onboarding. It used to prove that by counting the entities the
+        # wizard created; with none created, the limit cannot be the thing that
+        # blocks it, and completion is the whole assertion.
+        assert Component.objects.filter(team=team).count() == 5  # unchanged by the wizard
 
     def test_rerun_onboarding_updates_manufacturer_entity(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan
@@ -897,119 +732,6 @@ class TestOnboardingWizard:
         assert response.status_code == 302
         entity.refresh_from_db()
         assert entity.website_urls == ["https://website-corp.com"]
-
-    def test_rerun_onboarding_renames_single_product(
-        self, client: Client, sample_user, sample_team_with_owner_member, community_plan
-    ) -> None:
-        """Test that re-running onboarding renames the product when team has exactly one.
-
-        When the team has only one product (wizard-created), the product name
-        should be updated to the new company name, not creating a duplicate.
-        """
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        # First onboarding
-        client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "First Name",
-                "contact_name": "Tester",
-            },
-        )
-
-        assert Product.objects.filter(team=team).count() == 1
-        product = Product.objects.get(team=team)
-        assert product.name == "First Name"
-        original_pk = product.pk
-
-        # Reset wizard state for second run
-        team.has_completed_wizard = False
-        team.save(update_fields=["has_completed_wizard"])
-        session = client.session
-        session["current_team"]["has_completed_wizard"] = False
-        session.save()
-
-        # Second onboarding with different company name
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "Second Name",
-                "contact_name": "Tester",
-            },
-        )
-
-        assert response.status_code == 302
-
-        # Still exactly one product, renamed in place (same PK)
-        assert Product.objects.filter(team=team).count() == 1
-        product.refresh_from_db()
-        assert product.pk == original_pk
-        assert product.name == "Second Name"
-
-    def test_rerun_onboarding_with_multiple_products_uses_get_or_create(
-        self, client: Client, sample_user, sample_team_with_owner_member, community_plan
-    ) -> None:
-        """Test that re-running onboarding uses get_or_create when team has multiple products.
-
-        When the team has more than one product (user created extras via UI/API),
-        the wizard should fall back to get_or_create to avoid renaming the wrong product.
-        """
-        client.force_login(sample_user)
-        team = sample_team_with_owner_member.team
-
-        session = client.session
-        session["current_team"] = {
-            "key": team.key,
-            "role": "owner",
-            "has_completed_wizard": False,
-        }
-        session.save()
-
-        # First onboarding
-        client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "Wizard Product",
-                "contact_name": "Tester",
-            },
-        )
-
-        # User creates a second product via UI/API
-        Product.objects.create(name="User Created Product", team=team, is_public=True)
-        assert Product.objects.filter(team=team).count() == 2
-
-        # Reset wizard state for second run
-        team.has_completed_wizard = False
-        team.save(update_fields=["has_completed_wizard"])
-        session = client.session
-        session["current_team"]["has_completed_wizard"] = False
-        session.save()
-
-        # Re-run onboarding with a new company name
-        response = client.post(
-            reverse("teams:onboarding_wizard"),
-            {
-                "company_name": "New Company",
-                "contact_name": "Tester",
-            },
-        )
-
-        assert response.status_code == 302
-
-        # Should have 3 products: the original is NOT renamed, a new one is created
-        assert Product.objects.filter(team=team).count() == 3
-        assert Product.objects.filter(team=team, name="Wizard Product").exists()
-        assert Product.objects.filter(team=team, name="User Created Product").exists()
-        assert Product.objects.filter(team=team, name="New Company").exists()
 
     def test_completed_onboarding_redirects_to_dashboard(
         self, client: Client, sample_user, sample_team_with_owner_member, community_plan

--- a/sbomify/apps/teams/views/onboarding_wizard.py
+++ b/sbomify/apps/teams/views/onboarding_wizard.py
@@ -15,7 +15,6 @@ from django.views import View
 
 from sbomify.apps.billing.config import is_billing_enabled
 from sbomify.apps.core.models import User
-from sbomify.apps.sboms.models import Component, Product
 from sbomify.apps.teams.forms import OnboardingCompanyForm
 from sbomify.apps.teams.models import (
     ContactEntity,
@@ -50,7 +49,7 @@ class OnboardingWizardView(LoginRequiredMixin, View):
         team = self._get_current_team(request)
         if team and team.has_completed_wizard:
             pending_plan = is_billing_enabled() and not team.has_selected_billing_plan
-            showing_completion = request.GET.get("step") == "complete" and request.session.get("wizard_component_id")
+            showing_completion = request.GET.get("step") == "complete" and request.session.get("wizard_company_name")
             if not pending_plan and not showing_completion:
                 messages.info(request, "Onboarding is already complete.")
                 return redirect("core:dashboard")
@@ -101,23 +100,25 @@ class OnboardingWizardView(LoginRequiredMixin, View):
         return render(request, "core/components/onboarding_wizard.html.j2", context)
 
     def _render_complete(self, request: HttpRequest) -> HttpResponse:
-        component_id = request.session.get("wizard_component_id")
-        if not component_id:
+        # Keyed on the company name rather than a component id: the wizard no
+        # longer creates a component, and gating on one meant this step could
+        # only be reached by having an entity the user never asked for.
+        company_name = request.session.get("wizard_company_name")
+        if not company_name:
             return redirect(reverse("teams:onboarding_wizard"))
 
         billing_enabled = is_billing_enabled()
         if billing_enabled:
             next_url = f"{reverse('teams:onboarding_wizard')}?step=plan"
         else:
-            # Pop session data — no plan step follows
-            request.session.pop("wizard_component_id", None)
-            next_url = reverse("core:component_details", kwargs={"component_id": component_id})
-
-        company_name = request.session.get("wizard_company_name", "")
+            # The dashboard, where the onboarding checklist asks for a product
+            # and a component. Those steps used to be pre-ticked by the wizard
+            # creating both, so the checklist was complete before the person
+            # had done either.
+            next_url = reverse("core:dashboard")
 
         context = {
             "current_step": "complete",
-            "component_id": component_id,
             "company_name": company_name,
             "next_url": next_url,
             "billing_enabled": billing_enabled,
@@ -267,7 +268,6 @@ class OnboardingWizardView(LoginRequiredMixin, View):
 
     @staticmethod
     def _pop_wizard_session(request: HttpRequest) -> None:
-        request.session.pop("wizard_component_id", None)
         request.session.pop("wizard_company_name", None)
         request.session.pop("onboarding_plan_hint", None)
 
@@ -315,10 +315,6 @@ class OnboardingWizardView(LoginRequiredMixin, View):
         }
 
     def _process_setup(self, request: HttpRequest) -> HttpResponse:
-        from sbomify.apps.sboms.utils import (
-            create_default_component_metadata,
-            populate_component_metadata_native_fields,
-        )
 
         team = self._get_current_team(request)
         if not team or not self._is_team_owner(request.user, team):
@@ -393,58 +389,18 @@ class OnboardingWizardView(LoginRequiredMixin, View):
                         contact.is_author = True
                         contact.save(update_fields=["is_author"])
 
-                    is_public = not team.can_be_private()
-
-                    # Re-running onboarding with a different company name
-                    # should update the existing product, not create a second one.
-                    # Only rename if the team has exactly one product (wizard-created);
-                    # if multiple exist (user created more via UI/API), fall back to get_or_create.
-                    products = Product.objects.filter(team=team)
-                    if products.count() == 1:
-                        product = products.first()  # guaranteed non-None since count==1
-                        assert product is not None
-                        # Only rename if no other product with the target name exists,
-                        # to avoid violating the unique (team, name) constraint.
-                        name_conflict = (
-                            Product.objects.filter(team=team, name=company_name).exclude(pk=product.pk).exists()
-                        )
-                        if not name_conflict:
-                            product.name = company_name
-                            product.save(update_fields=["name"])
-                        else:
-                            messages.warning(
-                                request,
-                                f'A product named "{company_name}" already exists — kept the previous name.',
-                            )
-                    else:
-                        product, _ = Product.objects.get_or_create(
-                            name=company_name, team=team, defaults={"is_public": is_public}
-                        )
-
-                    component_metadata = create_default_component_metadata(
-                        user=request.user, team_id=team.id, custom_metadata=None
-                    )
-
-                    component, component_created = Component.objects.get_or_create(
-                        name="Main Component",
-                        team=team,
-                        defaults={
-                            "component_type": Component.ComponentType.BOM,
-                            "metadata": component_metadata,
-                            "visibility": Component.Visibility.PUBLIC if is_public else Component.Visibility.PRIVATE,
-                        },
-                    )
-
-                    if component_created:
-                        populate_component_metadata_native_fields(
-                            component,
-                            request.user,
-                            custom_metadata=None,
-                        )
-                        component.save()
-
-                    product.components.add(component)
-
+                    # The wizard used to create a product named after the company and a
+                    # component called "Main Component" here. It no longer does.
+                    #
+                    # Bootstrapping an account left two entities nobody asked for, which
+                    # had to be found and deleted before the account looked like the one
+                    # being set up. It also pre-ticked the dashboard's own "create your
+                    # first product" and "create your first component" steps, so the
+                    # checklist meant to guide someone through those was complete before
+                    # they had done either.
+                    #
+                    # What the wizard is for — the workspace name, the manufacturer and
+                    # contact identity above, the onboarding goal — is unchanged.
                     team.name = format_workspace_name(company_name)
                     team.has_completed_wizard = True
                     team.onboarding_goal = form.cleaned_data.get("goal", "")
@@ -453,7 +409,6 @@ class OnboardingWizardView(LoginRequiredMixin, View):
                     update_user_teams_session(request, cast(User, request.user))
                     refresh_current_team_session(request, team)
 
-                    request.session["wizard_component_id"] = component.id
                     request.session["wizard_company_name"] = company_name
                     request.session.modified = True
                     request.session.save()


### PR DESCRIPTION
Per Viktor: *"let's remove the auto creation of Product and Component in the signup too — that has bit me in the ass a few times already when i have bootstrapped new accounts."*

The wizard created a product named after the company and a component called `Main Component`. Two entities nobody asked for, to be found and deleted before the account looked like the one being set up.

## It was also breaking the thing meant to replace it

The dashboard's own onboarding checklist has **create a product** and **add a component** as steps. The wizard creating both pre-ticked them, so the checklist that exists to guide someone through those was complete before they had done either.

Before → after, same fresh workspace:

```
before:  Products: ["Acme Ltd"]   Components: ["Main Component"]   checklist: 2 of 3 done
after:   Products: []             Components: []                   checklist: 0 of 3
```

## What the wizard still does

Unchanged: the workspace name, the manufacturer and contact identity, the onboarding goal. Verified in the browser by walking the real form:

```
workspace : Browser Signup Test Ltd's Workspace
wizard    : True
manufacturer entity: ['Browser Signup Test Ltd']
products  : []
components: []
```

## Knock-on

The completion step keyed on `wizard_component_id`, so it now keys on the company name — gating on a component meant that step could only be reached by having an entity the user never asked for. With billing disabled it lands on the dashboard rather than a component page, which is where the checklist is.

Eight tests asserted properties of the two entities (`component_type=BOM`, the contact profile, the Keycloak metadata, the rename-on-rerun behaviour) and went with them. Two took their place: one for the absence, one for the identity that must survive it. 604 teams + onboarding tests pass.

## One thing left deliberately

`create_default_component_metadata` and `populate_component_metadata_native_fields` now have **no production callers** — the wizard was the only one. I left them.

They are the natural thing to reuse when a user creates their first component for real, and deleting product code as a side effect of removing its caller is your call rather than mine. Say the word and I'll take them out, or wire them into the manual component-create path.