### PR TITLE
fix(tokens): stop warning that a 7-day token expires in 7 days

### DIFF
--- a/sbomify/apps/access_tokens/notifications.py
+++ b/sbomify/apps/access_tokens/notifications.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 from django.http import HttpRequest
 from django.urls import reverse
@@ -17,6 +18,9 @@ from django.utils import timezone
 
 from sbomify.apps.notifications.schemas import NotificationSchema
 from sbomify.logging import getLogger
+
+if TYPE_CHECKING:
+    from sbomify.apps.access_tokens.models import AccessToken
 
 logger = getLogger(__name__)
 
@@ -30,6 +34,25 @@ def days_until(expires_at: datetime, now: datetime) -> int:
     "in 5 days", and anything inside the final 24 hours reads "tomorrow".
     """
     return max(0, math.ceil((expires_at - now).total_seconds() / 86400))
+
+
+def lifetime_days(token: "AccessToken") -> int | None:
+    """How long the token was issued for, or None when that is unknowable."""
+    if token.expires_at is None or token.created_at is None:
+        return None
+    return max(0, math.ceil((token.expires_at - token.created_at).total_seconds() / 86400))
+
+
+def is_short_lived(token: "AccessToken") -> bool:
+    """True when the token's whole life fits inside the warning window.
+
+    Such a token is inside the window from the moment it exists, so a warning
+    reports back a lifetime the reader just chose rather than telling them
+    anything. The CI/CD dialog issues 7-day tokens, which is well inside the
+    14-day window.
+    """
+    lifetime = lifetime_days(token)
+    return lifetime is not None and lifetime <= WARNING_WINDOW_DAYS
 
 
 def get_notifications(request: HttpRequest) -> list[NotificationSchema]:
@@ -63,6 +86,10 @@ def get_notifications(request: HttpRequest) -> list[NotificationSchema]:
         if token.expires_at is None:
             continue
         days = days_until(token.expires_at, now)
+        # Keep the final day for short-lived tokens: silence for the whole life
+        # would let a pipeline start failing with no notice at all.
+        if days > 1 and is_short_lived(token):
+            continue
         when = "today" if days == 0 else ("tomorrow" if days == 1 else f"in {days} days")
         action_url = None
         if token.team is not None:

--- a/sbomify/apps/access_tokens/tasks.py
+++ b/sbomify/apps/access_tokens/tasks.py
@@ -71,9 +71,11 @@ def warn_expiring_tokens() -> int:
         from sbomify.apps.access_tokens.notifications import lifetime_days
 
         already = {warning.threshold_days for warning in token.expiry_warnings.all()}
-        # A threshold wider than the token's whole life was already true when
-        # the token was issued, so crossing it is not news: a 7-day CI token
-        # would otherwise be mailed about on the first sweep after creation.
+        # A threshold that reaches at least as far as the token's whole life
+        # was already true the moment it was issued, so crossing it is not
+        # news. The equal case is the one that matters: a 7-day CI token sits
+        # exactly on the 7-day threshold at creation, and would otherwise be
+        # mailed about on the first sweep after it was made.
         lifetime = lifetime_days(token)
         thresholds = [t for t in EXPIRY_WARNING_THRESHOLDS if lifetime is None or t < lifetime]
         due = [t for t in thresholds if token.expires_at <= now + timedelta(days=t)]

--- a/sbomify/apps/access_tokens/tasks.py
+++ b/sbomify/apps/access_tokens/tasks.py
@@ -68,8 +68,15 @@ def warn_expiring_tokens() -> int:
     for token in tokens:
         if token.expires_at is None:
             continue
+        from sbomify.apps.access_tokens.notifications import lifetime_days
+
         already = {warning.threshold_days for warning in token.expiry_warnings.all()}
-        due = [t for t in EXPIRY_WARNING_THRESHOLDS if token.expires_at <= now + timedelta(days=t)]
+        # A threshold wider than the token's whole life was already true when
+        # the token was issued, so crossing it is not news: a 7-day CI token
+        # would otherwise be mailed about on the first sweep after creation.
+        lifetime = lifetime_days(token)
+        thresholds = [t for t in EXPIRY_WARNING_THRESHOLDS if lifetime is None or t < lifetime]
+        due = [t for t in thresholds if token.expires_at <= now + timedelta(days=t)]
         unsent = [t for t in due if t not in already]
         if not unsent:
             continue

--- a/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
+++ b/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
@@ -174,6 +174,28 @@ class TestShortLivedTokensAreNotNagged:
         assert warn_expiring_tokens.fn() == 1
         assert "expires in 1 day" in mail.outbox[0].subject
 
+    def test_a_threshold_equal_to_the_lifetime_is_skipped(self, sample_team_with_owner_member: Any) -> None:
+        """The boundary the rule turns on: a token issued for exactly 14 days
+        sits on the 14-day threshold the moment it exists, so it says nothing.
+        """
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=14, lifetime=14)
+
+        assert warn_expiring_tokens.fn() == 0
+        assert mail.outbox == []
+
+    def test_the_tighter_thresholds_fire_once_it_has_aged(self, sample_team_with_owner_member: Any) -> None:
+        """The same 14-day token a week on, expressed as a second fixture
+        rather than by moving ``expires_at``: shifting it also moves the
+        computed lifetime, and the sub-second remainder decides whether the
+        ceiling lands on 7 or 8, which is a coin toss to hang a test on.
+        """
+        member = sample_team_with_owner_member
+        token = _token(member.user, member.team, days=7, lifetime=14)
+
+        assert warn_expiring_tokens.fn() == 1
+        assert {w.threshold_days for w in token.expiry_warnings.all()} == {7}
+
 
 class TestEmailSweep:
     def test_first_run_sends_the_tightest_threshold_only(self, sample_team_with_owner_member: Any) -> None:

--- a/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
+++ b/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
@@ -24,14 +24,28 @@ def _bot_member(user: Any, team: Any) -> Member:
     return member
 
 
-def _token(user: Any, team: Any = None, days: int = 10, description: str = "ci token") -> AccessToken:
-    return AccessToken.objects.create(
+def _token(
+    user: Any, team: Any = None, days: int = 10, description: str = "ci token", lifetime: int = 90
+) -> AccessToken:
+    """A token with ``days`` left to run, issued for ``lifetime`` days total.
+
+    ``created_at`` is ``auto_now_add``, so a token created in a test always
+    starts out with its lifetime equal to its remaining time — the one shape
+    where "issued short" and "issued long and since aged" are indistinguishable.
+    The default backdates to 90 days, which is what a token sitting at 5 days
+    remaining looks like in practice; the short-lived cases ask for a small
+    ``lifetime`` explicitly.
+    """
+    token = AccessToken.objects.create(
         user=user,
         team=team,
         description=description,
         encoded_token=f"tok-{description}-{days}-{user.pk}",
         expires_at=timezone.now() + timedelta(days=days),
     )
+    AccessToken.objects.filter(pk=token.pk).update(created_at=token.expires_at - timedelta(days=lifetime))
+    token.refresh_from_db()
+    return token
 
 
 class TestBellProvider:
@@ -92,6 +106,73 @@ class TestBellProvider:
         _token(guest_user, member.team, days=3)
 
         assert get_notifications(self._request(rf, member.user, member.team, role="guest")) == []
+
+
+class TestShortLivedTokensAreNotNagged:
+    """A token made short-lived on purpose must not be reported as expiring.
+
+    From staging, seconds after clicking "Add a 7-day token" in the CI/CD
+    dialog:
+
+        Access token "CI/CD setup (07 Aug 2026)" expires in 7 days. Just now
+
+    The warning window is 14 days, so a 7-day token is inside it for its whole
+    life: the bell fires at creation and never clears, and the daily sweep
+    mails about a lifetime the reader chose a day earlier. The warning is for
+    a long-lived token drifting toward expiry unnoticed, which this is not.
+    """
+
+    def _request(self, rf: Any, user: Any, team: Any) -> Any:
+        request = rf.get("/")
+        request.user = user
+        request.session = {"current_team": {"key": team.key, "role": "owner"}}
+        return request
+
+    def test_a_freshly_minted_ci_token_does_not_warn(self, rf: Any, sample_team_with_owner_member: Any) -> None:
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=7, lifetime=7)
+
+        assert get_notifications(self._request(rf, member.user, member.team)) == []
+
+    def test_a_long_token_that_has_aged_into_the_window_still_warns(
+        self, rf: Any, sample_team_with_owner_member: Any
+    ) -> None:
+        """The case the warning exists for: 5 days left of an original 90."""
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=5, lifetime=90)
+
+        notifications = get_notifications(self._request(rf, member.user, member.team))
+
+        assert len(notifications) == 1
+        assert "expires in 5 days" in notifications[0].message
+
+    def test_the_last_day_warns_even_for_a_short_token(self, rf: Any, sample_team_with_owner_member: Any) -> None:
+        """Silence for the whole life would let a pipeline break unannounced."""
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=1, lifetime=7)
+
+        notifications = get_notifications(self._request(rf, member.user, member.team))
+
+        assert len(notifications) == 1
+        assert notifications[0].severity == "error"
+
+    def test_the_sweep_skips_a_threshold_already_true_at_creation(
+        self, sample_team_with_owner_member: Any
+    ) -> None:
+        """A 7-day token is inside the 14- and 7-day thresholds the moment it
+        exists, so neither says anything the reader did not just decide."""
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=7, lifetime=7)
+
+        assert warn_expiring_tokens.fn() == 0
+        assert mail.outbox == []
+
+    def test_the_sweep_still_mails_that_token_on_its_final_day(self, sample_team_with_owner_member: Any) -> None:
+        member = sample_team_with_owner_member
+        _token(member.user, member.team, days=1, lifetime=7)
+
+        assert warn_expiring_tokens.fn() == 1
+        assert "expires in 1 day" in mail.outbox[0].subject
 
 
 class TestEmailSweep:


### PR DESCRIPTION
Found while QA-ing staging for the production uplift.

The CI/CD dialog issues 7-day tokens. The expiry warning window is 14 days, so one of these tokens is inside the window for its whole life. Seconds after clicking **Add a 7-day token** on staging:

> Access token "CI/CD setup (07 Aug 2026)" expires in 7 days. **Just now**

The bell warning shows up at creation and never clears, because the token never leaves the window. The daily sweep then mails about the 14- and 7-day thresholds, both already true when the token was issued. One click buys a permanent warning and two emails about a lifetime the reader picked.

## The change

That warning exists to catch a long-lived token drifting toward expiry unnoticed. It now compares the time left against the token's own lifetime rather than a fixed window:

- an email threshold wider than the token's whole life is skipped
- the bell holds until the final day, so a short token still gives notice before CI starts failing

| Token | Before | After |
|---|---|---|
| 7-day CI token, just minted | bell + 2 emails | silent |
| 7-day CI token, final day | bell + email | bell + email |
| 90-day token, 5 days left | bell + email | bell + email |

## On the tests

Every existing test created its token fresh, so lifetime and remaining time were always equal. That is the one shape where issued-short and issued-long-then-aged look identical, which is why nothing caught this. The fixture now backdates `created_at` and defaults to 90 days, so `_token(days=5)` means what it reads as: a long-lived token with 5 days to go.

Both new failing cases were confirmed red before the fix.