### PR TITLE
fix(trust-center): a public release page must not name private components

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import DatabaseError, IntegrityError, OperationalError, transaction
+from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Query, Router
@@ -2789,20 +2790,34 @@ def list_all_releases(
 
 def _build_release_response(request: HttpRequest, release: Release, include_artifacts: bool = False) -> dict[str, Any]:
     """Build a standardized response for releases."""
+    from sbomify.apps.core.models import Component
     from sbomify.apps.sboms.models import SBOM
 
-    # Count artifacts for this release
-    artifact_count = release.artifacts.count()
+    has_crud_permissions = can(request, "release:manage", release.product).allowed
+
+    # To anyone who cannot manage the release, an artifact from a private
+    # component does not exist: the Trust Center's component panel refuses to
+    # list the component, its public page 403s, and the aggregate download
+    # already leaves it out (builders._members_with_files) — so a row for it
+    # here named a component every other public surface denies. Same predicate
+    # as the component panel: public and gated are listable, private is not.
+    # Every derived field below (count, capability flags, rows) comes from this
+    # one queryset so none of them can disagree about what the release holds.
+    artifacts_qs = release.artifacts.all()
+    if not has_crud_permissions:
+        listable = (Component.Visibility.PUBLIC, Component.Visibility.GATED)
+        artifacts_qs = artifacts_qs.filter(
+            Q(sbom__component__visibility__in=listable) | Q(document__component__visibility__in=listable)
+        )
+
+    artifact_count = artifacts_qs.count()
 
     # Which bom_types the release carries — one query drives all the download
     # capability flags (SBOM download, and the Trust Center VEX/CBOM downloads).
-    bom_types_present = set(
-        release.artifacts.filter(sbom__isnull=False).values_list("sbom__bom_type", flat=True).distinct()
-    )
+    bom_types_present = set(artifacts_qs.filter(sbom__isnull=False).values_list("sbom__bom_type", flat=True).distinct())
     has_sboms = SBOM.BomType.SBOM.value in bom_types_present
     has_vex = SBOM.BomType.VEX.value in bom_types_present
     has_cbom = SBOM.BomType.CBOM.value in bom_types_present
-    has_crud_permissions = can(request, "release:manage", release.product).allowed
 
     response = {
         "id": str(release.id),
@@ -2832,7 +2847,7 @@ def _build_release_response(request: HttpRequest, release: Release, include_arti
 
     if include_artifacts:
         artifacts: Any = []
-        for artifact in release.artifacts.select_related("sbom__component", "document__component"):
+        for artifact in artifacts_qs.select_related("sbom__component", "document__component"):
             if artifact.sbom:
                 artifacts.append(
                     {

--- a/sbomify/apps/core/middleware.py
+++ b/sbomify/apps/core/middleware.py
@@ -80,6 +80,14 @@ class RequestTimingLoggingMiddleware:
         return response
 
 
+def _comparable_trust_center_domain() -> str:
+    """TRUST_CENTER_DOMAIN in the same form incoming hosts take after
+    normalize_host: lowercase, port stripped. The setting itself keeps the
+    port because URL generation embeds it in links."""
+    domain = getattr(settings, "TRUST_CENTER_DOMAIN", "") or ""
+    return normalize_host(domain) if domain else ""
+
+
 class DynamicHostValidationMiddleware:
     """
     Validate Host headers dynamically using Redis-backed cache.
@@ -125,8 +133,12 @@ class DynamicHostValidationMiddleware:
             # or APP_BASE_URL might be malformed
             logger.debug(f"Could not parse APP_BASE_URL during middleware init: {e}")
 
-        # TRUST_CENTER_DOMAIN is already normalized (strip + lowercase) in settings.py
-        self._trust_center_domain: str = getattr(settings, "TRUST_CENTER_DOMAIN", "") or ""
+        # The setting keeps its port on purpose (URL generation needs
+        # ``slug.127.0.0.1:8000`` in dev). Every comparison below is against a
+        # host normalize_host has stripped the port from, so strip it here the
+        # same way — otherwise a ported domain can never match and its
+        # subdomains are rejected as invalid hosts.
+        self._trust_center_domain: str = _comparable_trust_center_domain()
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         try:
@@ -273,8 +285,9 @@ class CustomDomainContextMiddleware:
         except (ImportError, AttributeError, ValueError) as e:
             logger.debug(f"Could not parse APP_BASE_URL during middleware init: {e}")
 
-        # TRUST_CENTER_DOMAIN is already normalized (strip + lowercase) in settings.py
-        self._trust_center_domain: str = getattr(settings, "TRUST_CENTER_DOMAIN", "") or ""
+        # Port-stripped like the hosts it is compared against — see the same
+        # assignment in DynamicHostValidationMiddleware.
+        self._trust_center_domain: str = _comparable_trust_center_domain()
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         try:

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -467,7 +467,6 @@ class TestPublicReleaseHidesPrivateComponents:
         function (ReleaseDetailsPublicView bypasses the ninja serializer, so
         the HTTP endpoint would not reproduce the leak — its Detail schema
         drops the flat artifact keys entirely)."""
-        from django.contrib.auth.models import AnonymousUser
         from django.test import RequestFactory
 
         from sbomify.apps.core.apis import get_release
@@ -508,6 +507,27 @@ class TestPublicReleaseHidesPrivateComponents:
         artifacts = data["artifacts"]
         assert {a["component_name"] for a in artifacts} == {"public component", "private component", "gated component"}
         assert "private doc" in {a["artifact_name"] for a in artifacts}
+
+    def test_product_page_release_counts_follow_the_same_caller_rule(
+        self,
+        sample_product: Product,  # noqa: F811
+    ):
+        """The public product page's releases table must advertise the same
+        number of rows the release page will show to that caller: the filtered
+        count for visitors, the full count for a manager — otherwise a manager
+        reads "2 artifacts" here and finds 4 there."""
+        from sbomify.apps.core.views.product_details_public import _get_public_releases
+
+        release, _ = self._release_with_mixed_visibility(sample_product)
+        # The mixed release is named v1.0.0, so it survives the synthetic
+        # `latest` exclusion. 4 artifacts total; listable = the public and
+        # gated components' SBOMs (the document hangs off the private one).
+        as_visitor = _get_public_releases(str(sample_product.id), False, "slug", sees_all_components=False)
+        as_manager = _get_public_releases(str(sample_product.id), False, "slug", sees_all_components=True)
+
+        by_name = lambda rows: {r["name"]: r["artifacts_count"] for r in rows}  # noqa: E731
+        assert by_name(as_visitor)["v1.0.0"] == 2
+        assert by_name(as_manager)["v1.0.0"] == 4
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/core/tests/test_release_apis.py
+++ b/sbomify/apps/core/tests/test_release_apis.py
@@ -417,6 +417,100 @@ def test_build_release_response_has_vex_flag(
 
 
 @pytest.mark.django_db
+class TestPublicReleaseHidesPrivateComponents:
+    """A public release page must not name components the Trust Center refuses to show.
+
+    From production: a public product's release listed an artifact from a
+    private component — name, id, format — while the product page's Components
+    panel (correctly) left that component out. A visitor sees a component in
+    the release that does not exist anywhere else on the trust center, and its
+    per-artifact download 403s. The aggregate download already excludes
+    non-public members (builders._members_with_files); the metadata listing was
+    the one surface without the filter.
+    """
+
+    def _release_with_mixed_visibility(self, product: Product) -> tuple[Release, dict[str, Component]]:
+        product.is_public = True
+        product.save(update_fields=["is_public"])
+        release = Release.objects.create(product=product, name="v1.0.0")
+        components = {}
+        for visibility in ("public", "private", "gated"):
+            component = Component.objects.create(
+                name=f"{visibility} component", team_id=product.team_id, visibility=visibility
+            )
+            product.components.add(component)
+            sbom = SBOM.objects.create(
+                name=f"{visibility} sbom",
+                format="cyclonedx",
+                format_version="1.6",
+                sbom_filename=f"{visibility}.json",
+                component=component,
+            )
+            ReleaseArtifact.objects.create(release=release, sbom=sbom)
+            components[visibility] = component
+        # A private component's document leaks through the same loop.
+        document = Document.objects.create(
+            name="private doc",
+            version="1.0",
+            document_filename="d.pdf",
+            component=components["private"],
+            source="manual_upload",
+            content_type="application/pdf",
+            file_size=1,
+            document_type="license",
+        )
+        ReleaseArtifact.objects.create(release=release, document=document)
+        return release, components
+
+    def _get_release_as(self, user) -> dict:
+        """The path the public view actually takes: ``get_release`` called as a
+        function (ReleaseDetailsPublicView bypasses the ninja serializer, so
+        the HTTP endpoint would not reproduce the leak — its Detail schema
+        drops the flat artifact keys entirely)."""
+        from django.contrib.auth.models import AnonymousUser
+        from django.test import RequestFactory
+
+        from sbomify.apps.core.apis import get_release
+
+        request = RequestFactory().get("/")
+        request.user = user
+        request.session = {}
+        status_code, release = get_release(request, self.release_id)
+        assert status_code == 200
+        return release
+
+    def test_anonymous_caller_sees_only_public_and_gated(
+        self,
+        sample_product: Product,  # noqa: F811
+    ):
+        from django.contrib.auth.models import AnonymousUser
+
+        release, _ = self._release_with_mixed_visibility(sample_product)
+        self.release_id = release.id
+
+        data = self._get_release_as(AnonymousUser())
+
+        names = {a["component_name"] for a in data["artifacts"]}
+        assert names == {"public component", "gated component"}
+
+    def test_team_member_still_sees_everything(
+        self,
+        sample_product: Product,  # noqa: F811
+    ):
+        """The owner manages the release through the same code path — hiding
+        rows from them would read as artifacts silently vanishing."""
+        release, _ = self._release_with_mixed_visibility(sample_product)
+        self.release_id = release.id
+        member = sample_product.team.members.first()
+
+        data = self._get_release_as(member)
+
+        artifacts = data["artifacts"]
+        assert {a["component_name"] for a in artifacts} == {"public component", "private component", "gated component"}
+        assert "private doc" in {a["artifact_name"] for a in artifacts}
+
+
+@pytest.mark.django_db
 def test_update_release_success(
     sample_product: Product,  # noqa: F811
     sample_access_token: AccessToken,  # noqa: F811

--- a/sbomify/apps/core/tests/test_trust_center_subdomain_middleware.py
+++ b/sbomify/apps/core/tests/test_trust_center_subdomain_middleware.py
@@ -101,6 +101,47 @@ class TestTrustCenterSubdomainDetection:
 
 
 @pytest.mark.django_db
+class TestPortedTrustCenterDomain:
+    """TRUST_CENTER_DOMAIN keeps its port on purpose (URL generation needs
+    ``slug.127.0.0.1:8000`` in dev), but the middleware compares it against a
+    host that ``normalize_host`` has already stripped the port from. With a
+    ported setting the endswith test could never be true, so every trust
+    center subdomain fell through to the BYOD lookup and the host validator
+    400'd the request — the trust center was unreachable in any environment
+    whose domain carries a port."""
+
+    PORTED = "trustcenters.test:8000"
+
+    def test_subdomain_of_ported_domain_is_detected(self, request_factory, trust_center_team):
+        request = request_factory.get("/")
+        request.META["HTTP_HOST"] = "acme.trustcenters.test:8000"
+
+        def get_response(req):
+            assert req.is_trust_center_subdomain is True
+            assert req.custom_domain_team.id == trust_center_team.id
+            return None
+
+        with override_settings(TRUST_CENTER_DOMAIN=self.PORTED):
+            CustomDomainContextMiddleware(get_response)(request)
+
+    def test_host_validator_admits_the_same_subdomain(self, request_factory, trust_center_team):
+        from sbomify.apps.core.middleware import DynamicHostValidationMiddleware
+
+        request = request_factory.get("/")
+        request.META["HTTP_HOST"] = "acme.trustcenters.test:8000"
+        reached = {}
+
+        def get_response(req):
+            reached["yes"] = True
+            return None
+
+        with override_settings(TRUST_CENTER_DOMAIN=self.PORTED):
+            response = DynamicHostValidationMiddleware(get_response)(request)
+
+        assert reached.get("yes"), f"request was rejected: {getattr(response, 'content', b'')!r}"
+
+
+@pytest.mark.django_db
 class TestTrustCenterSlugValidation:
     """Test that slug format validation rejects malformed slugs before DB query."""
 

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -77,18 +77,25 @@ def _prepare_public_components(product_id: str, is_custom_domain: bool) -> list[
     return public_components
 
 
-def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: str, limit: int = 5) -> list[Any]:
+def _get_public_releases(
+    product_id: str, is_custom_domain: bool, product_slug: str, limit: int = 5, sees_all_components: bool = False
+) -> list[Any]:
     """Get releases for a public product (releases inherit visibility from their product)."""
     from sbomify.apps.core.models import Component
 
-    # Count what the release page will actually list: artifacts from private
-    # components are absent there (get_release filters them for anyone who
-    # cannot manage the release), so counting them here would advertise rows
-    # the click-through does not show.
-    listable = (Component.Visibility.PUBLIC, Component.Visibility.GATED)
-    listable_artifacts = Q(artifacts__sbom__component__visibility__in=listable) | Q(
-        artifacts__document__component__visibility__in=listable
-    )
+    # Count what the release page will actually list for this caller: for
+    # anyone who cannot manage the release, get_release hides artifacts from
+    # private components, so counting them here would advertise rows the
+    # click-through does not show. A manager sees every artifact there, so
+    # their counts stay unfiltered for the same reason.
+    count_filter: Q | None = None
+    sbom_visibility_filter = Q()
+    if not sees_all_components:
+        listable = (Component.Visibility.PUBLIC, Component.Visibility.GATED)
+        count_filter = Q(artifacts__sbom__component__visibility__in=listable) | Q(
+            artifacts__document__component__visibility__in=listable
+        )
+        sbom_visibility_filter = Q(sbom__component__visibility__in=listable)
 
     # Use annotations to avoid N+1 queries for artifacts_count and has_sboms
     # Exclude the synthetic auto-`latest` release — the product page surfaces it
@@ -99,13 +106,13 @@ def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: 
         .exclude(name=LATEST_RELEASE_NAME)
         .select_related("product")
         .annotate(
-            annotated_artifacts_count=Count("artifacts", filter=listable_artifacts),
+            annotated_artifacts_count=Count("artifacts", filter=count_filter),
             annotated_has_sboms=Exists(
                 ReleaseArtifact.objects.filter(
+                    sbom_visibility_filter,
                     release=OuterRef("pk"),
                     sbom__isnull=False,
                     sbom__bom_type=SBOM.BomType.SBOM,
-                    sbom__component__visibility__in=listable,
                 )
             ),
         )
@@ -209,9 +216,17 @@ class ProductDetailsPublicView(View):
         back_url = get_back_url_from_referrer(request, team, workspace_public_url)
 
         # Prepare server-side data for Django templates
+        from sbomify.apps.core.authz import can
+
         public_components = _prepare_public_components(resolved_id, is_custom_domain)
         public_releases = _get_public_releases(
-            resolved_id, is_custom_domain, product.get("slug") or resolved_id, limit=3
+            resolved_id,
+            is_custom_domain,
+            product.get("slug") or resolved_id,
+            limit=3,
+            # Same caller test as get_release: a manager's release page lists
+            # every artifact, so their counts here must match it.
+            sees_all_components=can(request, "release:manage", product_obj).allowed,
         )
         product_identifiers = _get_product_identifiers(resolved_id)
         product_links = _get_product_links(resolved_id)

--- a/sbomify/apps/core/views/product_details_public.py
+++ b/sbomify/apps/core/views/product_details_public.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count, Exists, OuterRef, Q
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -79,6 +79,17 @@ def _prepare_public_components(product_id: str, is_custom_domain: bool) -> list[
 
 def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: str, limit: int = 5) -> list[Any]:
     """Get releases for a public product (releases inherit visibility from their product)."""
+    from sbomify.apps.core.models import Component
+
+    # Count what the release page will actually list: artifacts from private
+    # components are absent there (get_release filters them for anyone who
+    # cannot manage the release), so counting them here would advertise rows
+    # the click-through does not show.
+    listable = (Component.Visibility.PUBLIC, Component.Visibility.GATED)
+    listable_artifacts = Q(artifacts__sbom__component__visibility__in=listable) | Q(
+        artifacts__document__component__visibility__in=listable
+    )
+
     # Use annotations to avoid N+1 queries for artifacts_count and has_sboms
     # Exclude the synthetic auto-`latest` release — the product page surfaces it
     # via the "Download Latest Release" CTA, so it shouldn't also occupy a row
@@ -88,10 +99,13 @@ def _get_public_releases(product_id: str, is_custom_domain: bool, product_slug: 
         .exclude(name=LATEST_RELEASE_NAME)
         .select_related("product")
         .annotate(
-            annotated_artifacts_count=Count("artifacts"),
+            annotated_artifacts_count=Count("artifacts", filter=listable_artifacts),
             annotated_has_sboms=Exists(
                 ReleaseArtifact.objects.filter(
-                    release=OuterRef("pk"), sbom__isnull=False, sbom__bom_type=SBOM.BomType.SBOM
+                    release=OuterRef("pk"),
+                    sbom__isnull=False,
+                    sbom__bom_type=SBOM.BomType.SBOM,
+                    sbom__component__visibility__in=listable,
                 )
             ),
         )


### PR DESCRIPTION
Viktor's report from the trust center: *"This project has multiple components, but only one shows up for whatever reason."*

The reason: the second component is **private**. The Components panel and the component's own page enforce that (the panel lists public + gated only; the private component's page 403s). The **release page does not** — it listed the private component's artifact with its name, component id, and SBOM format, to anonymous visitors:

| Surface | Private component visible? |
|---|---|
| Product page → Components panel | no (correct) |
| Component public page | 403 (correct) |
| Release aggregate download | filtered out by `builders._members_with_files` (correct) |
| **Release page → artifacts list** | **yes — the leak** |

So the product page was right, and the release page was the inconsistency that made it look broken. (Making the component public lists it everywhere, which resolves the original complaint.)

## The fix

`_build_release_response` now filters for callers without `release:manage`: only artifacts from **public and gated** components — the same predicate the Components panel uses. The artifact count and the `has_sboms`/`has_vex`/`has_cbom` flags derive from the same queryset, so no field disagrees with the rows. The public product page's releases table counts through the same predicate too (it advertised "2 artifacts" where the click-through now shows 1).

Team members keep the full listing — hiding rows from the person managing the release would read as artifacts vanishing.

## Also: trust center subdomains were unreachable in dev

Verifying this in a browser was impossible: any `TRUST_CENTER_DOMAIN` carrying a port (every dev setup: `127.0.0.1:8000`) made both middlewares reject the subdomain — they compare against a host `normalize_host` has already port-stripped, so the `endswith` never matched and the host validator 400'd every trust-center request. Both middlewares now strip the port before comparing. That's also why no browser test ever caught the leak locally.

## Verification

- TDD: anonymous-filter test and owner-sees-all test, red before the fix; middleware tests red before the port fix. 152 core tests pass.
- Browser (local, full stack through Caddy): anonymous release page shows "Showing 1 of 1 artifacts" with only the public component; the same release via an owner session returns `artifacts_count: 2`.