### PR TITLE
fix(products): section actions belong to the empty state, not floating above it

### DIFF
--- a/sbomify/apps/core/templates/core/components/product_identifiers_card.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_identifiers_card.html.j2
@@ -2,20 +2,29 @@
 <div class="tw-card shadow"
      id="product-identifiers-card"
      x-data="{ showAddModal: false, showEditModal: false, showDeleteModal: false, editId: '', editType: '', editValue: '', deleteId: '', deleteName: '', addType: '' }">
+    {% comment %}
+    Header actions render only when the table below gives them something to
+    sit above — same reasoning as the links card: inside the product page's
+    collapsible section (.tw-embed hides this header's title), an always-on
+    control floated alone over the empty state, which carries its own action
+    or explanation instead.
+    {% endcomment %}
     <div class="px-6 py-4 border-b border-border flex justify-between items-center">
         <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
             <i class="fas fa-barcode text-primary" aria-hidden="true"></i>Product Identifiers
         </h4>
-        {% if can_manage_identifiers %}
-            <button type="button"
-                    class="tw-btn-primary text-sm"
-                    @click="showAddModal = true">
-                <i class="fas fa-plus mr-1" aria-hidden="true"></i>Add Identifier
-            </button>
-        {% elif has_crud_permissions and not is_feature_allowed %}
-            <span class="text-text-muted text-sm">
-                <i class="fas fa-lock mr-1" aria-hidden="true"></i>Business feature
-            </span>
+        {% if identifiers %}
+            {% if can_manage_identifiers %}
+                <button type="button"
+                        class="tw-btn-primary text-sm"
+                        @click="showAddModal = true">
+                    <i class="fas fa-plus mr-1" aria-hidden="true"></i>Add Identifier
+                </button>
+            {% elif has_crud_permissions and not is_feature_allowed %}
+                <span class="text-text-muted text-sm">
+                    <i class="fas fa-lock mr-1" aria-hidden="true"></i>Business feature
+                </span>
+            {% endif %}
         {% endif %}
     </div>
     <div>
@@ -90,23 +99,13 @@
                 </table>
             </div>
         {% else %}
-            <div class="flex flex-col items-center justify-center py-12 px-6">
-                <div class="w-16 h-16 rounded-full bg-border/30 flex items-center justify-center mb-4">
-                    <i class="fas fa-barcode text-2xl text-text-muted" aria-hidden="true"></i>
-                </div>
-                {% if not has_crud_permissions %}
-                    <p class="text-text-muted m-0">No product identifiers available</p>
-                    <p class="text-text-muted text-sm mt-1">This product does not have any identifiers defined</p>
-                {% elif not is_feature_allowed %}
-                    <p class="text-text-muted m-0">Product identifiers are a business feature</p>
-                    <p class="text-text-muted text-sm mt-1">
-                        Upgrade to a business or enterprise plan to add identifiers like GTIN, SKU, MPN, etc.
-                    </p>
-                {% else %}
-                    <p class="text-text-muted m-0">No product identifiers added</p>
-                    <p class="text-text-muted text-sm mt-1">Add identifiers like GTIN, SKU, MPN, etc. to help identify this product</p>
-                {% endif %}
-            </div>
+            {% if not has_crud_permissions %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-barcode" title="No product identifiers available" message="This product does not have any identifiers defined" %}
+            {% elif not is_feature_allowed %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-lock" title="Product identifiers are a business feature" message="Upgrade to a business or enterprise plan to add identifiers like GTIN, SKU, MPN, etc." %}
+            {% else %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-barcode" title="No product identifiers added" message="Add identifiers like GTIN, SKU, MPN, etc. to help identify this product" action_text="Add Identifier" action_click="showAddModal = true" %}
+            {% endif %}
         {% endif %}
     </div>
     {% if can_manage_identifiers %}

--- a/sbomify/apps/core/templates/core/components/product_lifecycle_card.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_lifecycle_card.html.j2
@@ -8,14 +8,22 @@
             <i class="far fa-question-circle text-text-muted text-sm cursor-help"
                x-tooltip="'Key lifecycle dates aligned with Common Lifecycle Enumeration (CLE)'"></i>
         </h4>
+        {% comment %}
+        Rendered only when there are dates to edit — same reasoning as the
+        links and identifiers cards: in the product page's collapsible section
+        (.tw-embed hides this header's title), an always-on Edit floated alone
+        over the empty state, which offers Set Dates itself.
+        {% endcomment %}
         {% if can_edit %}
-            <template x-if="!editing">
-                <button type="button"
-                        class="tw-btn-secondary text-sm"
-                        @click="editing = true">
-                    <i class="fas fa-edit mr-1"></i>Edit
-                </button>
-            </template>
+            {% if product.release_date or product.end_of_support or product.end_of_life %}
+                <template x-if="!editing">
+                    <button type="button"
+                            class="tw-btn-secondary text-sm"
+                            @click="editing = true">
+                        <i class="fas fa-edit mr-1"></i>Edit
+                    </button>
+                </template>
+            {% endif %}
         {% endif %}
     </div>
     <div class="p-6">
@@ -50,20 +58,11 @@
                         </div>
                     </div>
                 {% else %}
-                    <div class="flex flex-col items-center justify-center py-8">
-                        <div class="w-16 h-16 rounded-full bg-border/30 flex items-center justify-center mb-4">
-                            <i class="fas fa-clock text-2xl text-text-muted"></i>
-                        </div>
-                        {% if can_edit %}
-                            <p class="text-text-muted m-0">No lifecycle dates set</p>
-                            <p class="text-text-muted text-sm mt-1">
-                                Add release date, end of support, and end of life dates to track product lifecycle
-                            </p>
-                        {% else %}
-                            <p class="text-text-muted m-0">No lifecycle dates available</p>
-                            <p class="text-text-muted text-sm mt-1">This product does not have lifecycle dates defined</p>
-                        {% endif %}
-                    </div>
+                    {% if can_edit %}
+                        {% include "components/tw/empty_state.html.j2" with icon="fas fa-clock" title="No lifecycle dates set" message="Add release date, end of support, and end of life dates to track product lifecycle" action_text="Set Dates" action_click="editing = true" compact=True %}
+                    {% else %}
+                        {% include "components/tw/empty_state.html.j2" with icon="fas fa-clock" title="No lifecycle dates available" message="This product does not have lifecycle dates defined" compact=True %}
+                    {% endif %}
                 {% endif %}
             </div>
         </template>

--- a/sbomify/apps/core/templates/core/components/product_links_card.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_links_card.html.j2
@@ -2,11 +2,17 @@
 <div class="tw-card shadow"
      id="product-links-card"
      x-data="{ showAddModal: false, showEditModal: false, showDeleteModal: false, editId: '', editType: '', editTitle: '', editUrl: '', editDescription: '', deleteId: '', deleteName: '' }">
+    {% comment %}
+    The header button renders only when the table below gives it something to
+    sit above. Inside the collapsible product page section (.tw-embed hides
+    this header's title), an always-on button floated alone over the empty
+    state — the empty state carries its own Add Link action instead.
+    {% endcomment %}
     <div class="px-6 py-4 border-b border-border flex justify-between items-center">
         <h4 class="text-lg font-semibold text-text flex items-center gap-2 m-0">
             <i class="fas fa-link text-primary" aria-hidden="true"></i>Product Links
         </h4>
-        {% if can_manage_links %}
+        {% if can_manage_links and links %}
             <button type="button"
                     class="tw-btn-primary text-sm"
                     @click="showAddModal = true">
@@ -77,20 +83,13 @@
                 </table>
             </div>
         {% else %}
-            <div class="flex flex-col items-center justify-center py-12 px-6">
-                <div class="w-16 h-16 rounded-full bg-border/30 flex items-center justify-center mb-4">
-                    <i class="fas fa-link text-2xl text-text-muted" aria-hidden="true"></i>
-                </div>
-                {% if not has_crud_permissions %}
-                    <p class="text-text-muted m-0">No product links available</p>
-                    <p class="text-text-muted text-sm mt-1">This product does not have any links defined</p>
-                {% else %}
-                    <p class="text-text-muted m-0">No product links added</p>
-                    <p class="text-text-muted text-sm mt-1">
-                        Add links like website, support, documentation, etc. to provide additional information about this product
-                    </p>
-                {% endif %}
-            </div>
+            {% if not has_crud_permissions %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links available" message="This product does not have any links defined" %}
+            {% elif can_manage_links %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links added" message="Add links like website, support, documentation, etc. to provide additional information about this product" action_text="Add Link" action_click="showAddModal = true" %}
+            {% else %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links added" message="Add links like website, support, documentation, etc. to provide additional information about this product" %}
+            {% endif %}
         {% endif %}
     </div>
     {% if can_manage_links %}

--- a/sbomify/apps/core/templates/core/components/product_links_card.html.j2
+++ b/sbomify/apps/core/templates/core/components/product_links_card.html.j2
@@ -83,12 +83,15 @@
                 </table>
             </div>
         {% else %}
-            {% if not has_crud_permissions %}
-                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links available" message="This product does not have any links defined" %}
-            {% elif can_manage_links %}
+            {% comment %}
+            Two branches, not three: build_links_context sets can_manage_links
+            to has_crud_permissions verbatim, so there is no reader who can
+            crud but not manage.
+            {% endcomment %}
+            {% if can_manage_links %}
                 {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links added" message="Add links like website, support, documentation, etc. to provide additional information about this product" action_text="Add Link" action_click="showAddModal = true" %}
             {% else %}
-                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links added" message="Add links like website, support, documentation, etc. to provide additional information about this product" %}
+                {% include "components/tw/empty_state.html.j2" with icon="fas fa-link" title="No product links available" message="This product does not have any links defined" %}
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
Viktor's screenshot: the Product links section with a lone **Add Link** button floating top-right above a centered "No product links added" empty state. The same defect exists on **Product identifiers** (Add Identifier) and **Lifecycle** (Edit).

Each card carries its own header (title + control). The product page embeds them in collapsible sections through `.tw-embed`, which hides the card's header **title** — leaving the control right-aligned in an otherwise empty strip, disconnected from the empty state below it.

## The fix, applied to all three cards

- **Empty states carry their action**, through the shared `components/tw/empty_state.html.j2` (which already has an `action_click` slot): *Add Link* and *Add Identifier* open their modals, *Set Dates* opens the inline lifecycle form. The hand-rolled empty-state markup in all three cards is replaced by the shared component.
- **Header controls render only when the table or date grid exists**, where they read as a toolbar. That includes the identifiers card's business-plan lock note — when the card is empty, the lock explanation lives in the empty state, which already said it.
- Read-only viewers keep plain empty states with no action.

## Verified in the browser (local dev)

For each card: empty state shows icon → title → description → centered action; clicking the action opens the right surface (modal / inline form); after creating the first row or date, the card re-renders with the content and the header control appears above it, and the empty state is gone.

`djlint` clean on all three templates; product-links API tests pass.