### PR TITLE
feat(onboarding): one Get started action instead of a checklist

### DIFF
--- a/sbomify/apps/core/services/dashboard_page.py
+++ b/sbomify/apps/core/services/dashboard_page.py
@@ -80,6 +80,12 @@ def _digest_rows(component_ids: list[str], component_names: dict[str, str]) -> l
     return findings[:_DIGEST_LIMIT]
 
 
+def get_first_component(team_id: int) -> Component | None:
+    """Uncached on purpose: the digest cache may lag a just-created component,
+    and the onboarding hero must reflect it immediately."""
+    return Component.objects.filter(team_id=team_id).first()
+
+
 def build_dashboard_context(team_id: int) -> dict[str, Any]:
     cache_key = f"dashboard-page:{team_id}"
     cached = django_cache.get(cache_key)

--- a/sbomify/apps/core/templates/core/components/onboarding_wizard.html.j2
+++ b/sbomify/apps/core/templates/core/components/onboarding_wizard.html.j2
@@ -281,13 +281,6 @@
                                     <p class="tw-form-helper">Helps us tailor your experience.</p>
                                 </div>
                             </div>
-                            <!-- Auto-create note -->
-                            <div class="flex items-start gap-2.5 mt-6 p-3 rounded-lg bg-primary/5 border border-primary/10">
-                                <i class="fas fa-magic text-primary/60 text-xs mt-0.5"></i>
-                                <p class="text-xs text-text-muted leading-relaxed">
-                                    We'll set up a sample product and component so you can start exploring right away.
-                                </p>
-                            </div>
                             <!-- Footer -->
                             <div class="flex items-center justify-between mt-8 pt-6 border-t border-border/50">
                                 <a href="{% url 'teams:onboarding_wizard' %}"

--- a/sbomify/apps/core/templates/core/dashboard.html.j2
+++ b/sbomify/apps/core/templates/core/dashboard.html.j2
@@ -24,115 +24,42 @@
                             -webkit-mask: url('{% static 'img/onboarding.svg' %}') center / contain no-repeat;
                             mask: url('{% static 'img/onboarding.svg' %}') center / contain no-repeat"></div>
                 <div class="relative p-6 sm:p-8 md:pr-[44%]">
-                    <div class="flex items-start justify-between gap-3 mb-7">
-                        <div>
-                            <h4 class="text-xl font-semibold text-text m-0">Finish setting up</h4>
-                            <p class="text-sm text-text-muted m-0 mt-1">A couple of steps and this page starts reporting.</p>
-                        </div>
-                        {# Segmented step indicator — mirrors the stepper node colours. #}
-                        <div class="shrink-0 text-right">
-                            <div class="flex items-center justify-end gap-1 mb-1.5">
-                                <span class="h-1.5 w-6 rounded-full transition-colors {% if onboarding.has_product %}bg-success{% else %}bg-primary{% endif %}"></span>
-                                <span class="h-1.5 w-6 rounded-full transition-colors {% if onboarding.has_component %}bg-success{% elif onboarding.has_product %}bg-primary{% else %}bg-border/50{% endif %}"></span>
-                                <span class="h-1.5 w-6 rounded-full transition-colors {% if onboarding.has_product and onboarding.has_component %}bg-primary{% else %}bg-border/50{% endif %}"></span>
-                            </div>
-                            <div class="text-xs text-text-muted whitespace-nowrap">
-                                <span class="font-semibold text-text">{{ onboarding.done_count }}</span> of 3
-                                {% if onboarding.done_count == 2 %}· <span class="text-primary font-medium">almost there</span>{% endif %}
-                            </div>
-                        </div>
-                    </div>
-                    {# Stepper — the connecting line carries the flow. #}
-                    <div class="max-w-xl">
-                        {# 1 — Product #}
-                        <div class="flex gap-4">
-                            <div class="flex flex-col items-center">
-                                {% if onboarding.has_product %}
-                                    <span class="w-8 h-8 rounded-full bg-success text-white flex items-center justify-center flex-shrink-0"><i class="fas fa-check text-xs"></i></span>
-                                {% else %}
-                                    <span class="w-8 h-8 rounded-full bg-primary text-white ring-4 ring-primary/20 text-sm font-semibold flex items-center justify-center flex-shrink-0">1</span>
-                                {% endif %}
-                                <span class="w-0.5 flex-1 my-1.5 rounded-full"
-                                      style="background-color: var(--color-border-light)"></span>
-                            </div>
-                            <div class="flex-1 min-w-0 pb-6 flex items-center justify-between gap-3">
-                                <div class="min-w-0">
-                                    <div class="font-medium {% if onboarding.has_product %}text-text-muted line-through{% else %}text-text{% endif %}">
-                                        Create a product
-                                    </div>
-                                    <div class="text-sm text-text-muted">The thing you ship — it groups your components together.</div>
-                                </div>
-                                {% if not onboarding.has_product and has_crud_permissions %}
-                                    <button type="button"
-                                            @click="$dispatch('open-product-modal')"
-                                            class="tw-btn-primary tw-btn-sm flex-shrink-0">Create product</button>
-                                {% endif %}
-                            </div>
-                        </div>
-                        {# 2 — Component #}
-                        <div class="flex gap-4">
-                            <div class="flex flex-col items-center">
-                                {% if onboarding.has_component %}
-                                    <span class="w-8 h-8 rounded-full bg-success text-white flex items-center justify-center flex-shrink-0"><i class="fas fa-check text-xs"></i></span>
-                                {% else %}
-                                    <span class="w-8 h-8 rounded-full text-sm font-semibold flex items-center justify-center flex-shrink-0 {% if onboarding.has_product %}bg-primary text-white ring-4 ring-primary/20{% else %}bg-border/40 text-text-muted{% endif %}">2</span>
-                                {% endif %}
-                                <span class="w-0.5 flex-1 my-1.5 rounded-full"
-                                      style="background-color: var(--color-border-light)"></span>
-                            </div>
-                            <div class="flex-1 min-w-0 pb-6 flex items-center justify-between gap-3">
-                                <div class="min-w-0">
-                                    <div class="font-medium {% if onboarding.has_component %}text-text-muted line-through{% else %}text-text{% endif %}">
-                                        Add a component
-                                    </div>
-                                    <div class="text-sm text-text-muted">What your pipeline pushes SBOMs to.</div>
-                                </div>
-                                {% if not onboarding.has_component and has_crud_permissions %}
-                                    <button type="button"
-                                            @click="$dispatch('open-component-modal')"
-                                            class="tw-btn-primary tw-btn-sm flex-shrink-0">Add component</button>
-                                {% endif %}
-                            </div>
-                        </div>
-                        {# 3 — First SBOM (goal) #}
-                        <div class="flex gap-4">
-                            <span class="w-8 h-8 rounded-full text-sm font-semibold flex items-center justify-center flex-shrink-0 {% if onboarding.has_product and onboarding.has_component %}bg-primary text-white ring-4 ring-primary/20{% else %}bg-border/40 text-text-muted{% endif %}">
-                                <i class="fas fa-flag-checkered text-xs"></i>
+                    {% comment %}
+                    One action, not a checklist. The wizard command sets a
+                    repository up end to end, so walking someone through
+                    creating a product and a component by hand duplicated work
+                    the command does — and stranded anyone who ran it first.
+                    {% endcomment %}
+                    <h4 class="text-xl font-semibold text-text m-0">Get started</h4>
+                    <p class="text-sm text-text-muted m-0 mt-1 max-w-md">
+                        Run one command in your repository and push — your first SBOM
+                        lands here and this page starts reporting.
+                    </p>
+                    <div class="mt-5 flex items-center gap-4 flex-wrap">
+                        <button type="button"
+                                @click="$dispatch('open-cicd')"
+                                class="tw-btn-primary flex-shrink-0">
+                            <i class="fas fa-rocket mr-2" aria-hidden="true"></i>Get started
+                        </button>
+                        {% if onboarding.first_component %}
+                            <span class="text-sm text-text-muted">
+                                Already have an SBOM file?
+                                <button type="button"
+                                        @click="$dispatch('open-upload')"
+                                        class="text-primary hover:underline font-medium">Upload it</button>
                             </span>
-                            <div class="flex-1 min-w-0">
-                                <div class="min-w-0">
-                                    <div class="font-semibold text-text">Create your first SBOM</div>
-                                    <div class="text-sm text-text-muted">
-                                        Add one step to CI/CD and push, or
-                                        {% if onboarding.first_component %}
-                                            <button type="button"
-                                                    @click="$dispatch('open-upload')"
-                                                    class="text-primary hover:underline font-medium">
-                                                upload a file
-                                            </button>
-                                            .
-                                        {% else %}
-                                            upload a file.
-                                        {% endif %}
-                                        This page then fills in.
-                                    </div>
-                                </div>
-                                {% if onboarding.first_component %}
-                                    <button type="button"
-                                            @click="$dispatch('open-cicd')"
-                                            class="tw-btn-primary tw-btn-sm mt-3">Connect CI/CD</button>
-                                {% endif %}
-                            </div>
-                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
-            {# Reuse the component-page CI/CD and upload modals here — no duplication. #}
+            {# Reuse the component-page modals — the command dialog works without a component. #}
             {% if onboarding.first_component %}
                 {% with component=onboarding.first_component %}
                     {% include "sboms/components/ci_cd_info.html.j2" %}
                     {% include "sboms/components/sbom_upload.html.j2" with component_id=component.id %}
                 {% endwith %}
+            {% else %}
+                {% include "sboms/components/ci_cd_info.html.j2" %}
             {% endif %}
         {% else %}
             {# Needs attention — the worst non-suppressed findings across the workspace #}

--- a/sbomify/apps/core/tests/templates/test_component_meta_info_templates.py
+++ b/sbomify/apps/core/tests/templates/test_component_meta_info_templates.py
@@ -110,7 +110,7 @@ class TestComponentMetaInfoTemplates:
         rendered = render_to_string("sboms/components/ci_cd_info.html.j2", context)
         
         # Assertions
-        assert "CI/CD Integration" in rendered
+        assert "Get started" in rendered
         assert component.id in rendered
         # The dialog is the wizard command now. Asserting on the command rather
         # than on an Alpine component name keeps this checking what the reader

--- a/sbomify/apps/core/views/dashboard.py
+++ b/sbomify/apps/core/views/dashboard.py
@@ -70,19 +70,15 @@ class DashboardView(GuestAccessBlockedMixin, ValidateWorkspaceMixin, LoginRequir
             "dashboard": build_dashboard_context(team.id) if team else {"is_first_visit": True},
         }
 
-        # Onboarding checklist progress — computed uncached so it reflects a newly
-        # created product/component immediately (the dashboard digest is cached).
+        # The hero is one Get-started action, not a checklist — the wizard
+        # command sets a repository up end to end. The only per-request lookup
+        # left is whether a component exists yet, which gates the
+        # upload-a-file alternative (an upload needs somewhere to land).
         if team and context["dashboard"].get("is_first_visit"):
-            from sbomify.apps.core.models import Component, Product
+            from sbomify.apps.core.models import Component
 
-            first_component = Component.objects.filter(team_id=team.id).first()
-            has_product = Product.objects.filter(team_id=team.id).exists()
             context["onboarding"] = {
-                "has_product": has_product,
-                "has_component": first_component is not None,
-                "first_component": first_component,
-                "first_component_id": first_component.id if first_component else None,
-                "done_count": (1 if has_product else 0) + (1 if first_component else 0),
+                "first_component": Component.objects.filter(team_id=team.id).first(),
             }
 
         return render(request, "core/dashboard.html.j2", context)

--- a/sbomify/apps/core/views/dashboard.py
+++ b/sbomify/apps/core/views/dashboard.py
@@ -54,7 +54,7 @@ class DashboardView(GuestAccessBlockedMixin, ValidateWorkspaceMixin, LoginRequir
 
         from django.utils import timezone
 
-        from sbomify.apps.core.services.dashboard_page import build_dashboard_context
+        from sbomify.apps.core.services.dashboard_page import build_dashboard_context, get_first_component
 
         hour = timezone.localtime().hour
         daypart = "morning" if hour < 12 else "afternoon" if hour < 17 else "evening"
@@ -75,10 +75,8 @@ class DashboardView(GuestAccessBlockedMixin, ValidateWorkspaceMixin, LoginRequir
         # left is whether a component exists yet, which gates the
         # upload-a-file alternative (an upload needs somewhere to land).
         if team and context["dashboard"].get("is_first_visit"):
-            from sbomify.apps.core.models import Component
-
             context["onboarding"] = {
-                "first_component": Component.objects.filter(team_id=team.id).first(),
+                "first_component": get_first_component(team.id),
             }
 
         return render(request, "core/dashboard.html.j2", context)

--- a/sbomify/apps/sboms/templates/sboms/components/ci_cd_info.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/ci_cd_info.html.j2
@@ -25,6 +25,7 @@ The ``as`` form swallows NoReverseMatch, so a session without a workspace
 leaves it empty and the button is not offered rather than 500ing the page.
 {% endcomment %}
 {% url 'teams:ci_token' team_key=request.session.current_team.key as ci_token_url %}
+{% firstof component.id 'onboarding' as cicd_copy_suffix %}
 <div x-data="{ cicdOpen: false }"
      @open-cicd.window="cicdOpen = true"
      @keydown.escape.window="if (cicdOpen) cicdOpen = false">
@@ -33,7 +34,7 @@ leaves it empty and the button is not offered rather than 500ing the page.
          class="fixed inset-0 z-[100]"
          role="dialog"
          aria-modal="true"
-         aria-label="CI/CD integration">
+         aria-label="Get started">
         <div x-show="cicdOpen"
              x-transition:enter="transition ease-out duration-200"
              x-transition:enter-start="opacity-0"
@@ -57,7 +58,7 @@ leaves it empty and the button is not offered rather than 500ing the page.
                  x-data="ciCdToken('{{ ci_token_url|escapejs }}')">
                 <div class="tw-modal-header">
                     <h4 class="tw-modal-title flex items-center gap-2">
-                        <i class="fas fa-gears text-primary"></i>CI/CD Integration
+                        <i class="fas fa-rocket text-primary"></i>Get started
                     </h4>
                     <button type="button"
                             class="tw-modal-close"
@@ -72,14 +73,14 @@ leaves it empty and the button is not offered rather than 500ing the page.
                         manager, then writes the pipeline configuration for you.
                     </p>
                     <div class="relative bg-[#1e1e1e] rounded-lg overflow-hidden">
-                        <pre class="p-4 m-0 overflow-x-auto"><code id="ci-cd-command-{{ component.id }}" class="text-sm text-white">docker run --rm -it \
+                        <pre class="p-4 m-0 overflow-x-auto"><code id="ci-cd-command-{{ component.id|default:'onboarding' }}" class="text-sm text-white">docker run --rm -it \
   -v "$(pwd):/github/workspace" \
   -w /github/workspace \
   -e SBOMIFY_TOKEN=<span x-text="token || '$SBOMIFY_TOKEN'">$SBOMIFY_TOKEN</span> \
   ghcr.io/sbomify/sbomify-action \
   sbomify-action wizard</code></pre>
                         <div class="absolute top-2 right-2">
-                            {% include "core/components/copyable_value.html.j2" with copy_from="ci-cd-command-"|add:component.id title="Copy command" hide_value=True %}
+                            {% include "core/components/copyable_value.html.j2" with copy_from="ci-cd-command-"|add:cicd_copy_suffix title="Copy command" hide_value=True %}
                         </div>
                     </div>
                     {# Before minting: the command reads an env var the reader may already have. #}

--- a/sbomify/apps/sboms/templates/sboms/components/ci_cd_info.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/components/ci_cd_info.html.j2
@@ -73,7 +73,7 @@ leaves it empty and the button is not offered rather than 500ing the page.
                         manager, then writes the pipeline configuration for you.
                     </p>
                     <div class="relative bg-[#1e1e1e] rounded-lg overflow-hidden">
-                        <pre class="p-4 m-0 overflow-x-auto"><code id="ci-cd-command-{{ component.id|default:'onboarding' }}" class="text-sm text-white">docker run --rm -it \
+                        <pre class="p-4 m-0 overflow-x-auto"><code id="ci-cd-command-{{ cicd_copy_suffix }}" class="text-sm text-white">docker run --rm -it \
   -v "$(pwd):/github/workspace" \
   -w /github/workspace \
   -e SBOMIFY_TOKEN=<span x-text="token || '$SBOMIFY_TOKEN'">$SBOMIFY_TOKEN</span> \


### PR DESCRIPTION
The dashboard's first-visit hero walked new users through **Create a product** and **Add a component** by hand — work the wizard command does itself, in the repository. Anyone who ran the command first found checklist steps already ticked that they never did; anyone who followed the checklist did by hand what the next step would have automated.

## The change

- **The hero is one action**: a *Get started* button opening the command dialog, with *Upload it* as the alternative once a component exists to upload into. The three-step stepper, segmented progress indicator, and "N of 3" counter are gone, along with the view's per-request product/component existence checks that only the checklist needed.
- **The dialog is retitled "Get started"** (rocket icon) — it *is* the getting-started path, not merely a pipeline configurator — and now renders without a component in context. The dashboard used to gate it on a component existing, which locked the primary onboarding action out of exactly the workspace state it exists for. The component page's ⋮ menu keeps its "CI/CD integration…" label, where that name is accurate.
- **Removes the onboarding wizard's stale promise** — "We'll set up a sample product and component so you can start exploring right away" — the auto-creation it describes was deliberately removed in #1375, and the sentence outlived it.

## Verified in the browser (fresh workspace, end to end)

Created a brand-new workspace through the real signup wizard: the hero renders as a single Get started block; the button opens the retitled dialog on a **component-less** workspace; the 7-day token mints in place ("Expires 18 Aug 2026"); no stepper, no "0 of 3" anywhere. 145 dashboard/onboarding tests pass; `djlint` clean on all three templates.

Note for review: the first-visit dashboard has e2e visual baselines — if CI's visual regression flags the hero, the new render is the intended baseline.