### PR TITLE
fix(keycloak): survivable email action links, no double password step, sane info-page return

### DIFF
--- a/bin/keycloak-bootstrap.sh
+++ b/bin/keycloak-bootstrap.sh
@@ -78,6 +78,17 @@ fi
 # Always enable user registration after all other steps
 /opt/keycloak/bin/kcadm.sh update "realms/$REALM" -s registrationAllowed=true
 
+# Email action links must survive real-world mailbox delays: verification
+# links live 3 days, credential resets 1 hour (the Keycloak default of
+# 5 minutes locks out anyone behind a slow corporate mail gateway).
+/opt/keycloak/bin/kcadm.sh update "realms/$REALM" \
+  -s 'attributes."actionTokenGeneratedByUserLifespan.verify-email"=259200' \
+  -s 'attributes."actionTokenGeneratedByUserLifespan.reset-credentials"=3600'
+
+# The password is collected on the registration form, so never force a
+# second "set new password" step after email verification.
+/opt/keycloak/bin/kcadm.sh update "authentication/required-actions/UPDATE_PASSWORD" -r "$REALM" -s defaultAction=false
+
 # Create test users for development (only in dev mode)
 if [ "$KEYCLOAK_DEV_MODE" = "true" ]; then
   # Create test user if it doesn't exist

--- a/keycloak/themes/sbomify/email/html/email-verification.ftl
+++ b/keycloak/themes/sbomify/email/html/email-verification.ftl
@@ -9,7 +9,7 @@
     <p class="text-secondary">If you cannot click the button above, copy and paste this link into your browser:</p>
     <p class="text-secondary" style="word-break: break-all;">${link}</p>
     <div class="expiry-notice">
-        This link will expire in ${linkExpiration} minutes. If it expires, you can request a new verification email from the login page.
+        This link will expire in ${linkExpirationFormatter(linkExpiration)}. If it expires, you can request a new verification email from the login page.
     </div>
     <p>If you did not create an account with sbomify, please ignore this email.</p>
 </@layout.emailLayout>

--- a/keycloak/themes/sbomify/email/html/executeActions.ftl
+++ b/keycloak/themes/sbomify/email/html/executeActions.ftl
@@ -16,7 +16,7 @@
     <p class="text-secondary">If you cannot click the button above, copy and paste this link into your browser:</p>
     <p class="text-secondary" style="word-break: break-all;">${link}</p>
     <div class="expiry-notice">
-        This link will expire in ${linkExpiration} minutes.
+        This link will expire in ${linkExpirationFormatter(linkExpiration)}.
     </div>
     <p>If you did not expect this email, please contact your administrator.</p>
 </@layout.emailLayout>

--- a/keycloak/themes/sbomify/email/html/password-reset.ftl
+++ b/keycloak/themes/sbomify/email/html/password-reset.ftl
@@ -9,7 +9,7 @@
     <p class="text-secondary">If you cannot click the button above, copy and paste this link into your browser:</p>
     <p class="text-secondary" style="word-break: break-all;">${link}</p>
     <div class="expiry-notice">
-        This link will expire in ${linkExpiration} minutes. If it expires, you can request a new password reset from the login page.
+        This link will expire in ${linkExpirationFormatter(linkExpiration)}. If it expires, you can request a new password reset from the login page.
     </div>
     <p>If you did not request a password reset, please ignore this email. Your password will remain unchanged.</p>
 </@layout.emailLayout>

--- a/keycloak/themes/sbomify/email/text/email-verification.ftl
+++ b/keycloak/themes/sbomify/email/text/email-verification.ftl
@@ -6,7 +6,7 @@ Thank you for creating an account with sbomify. To complete your registration an
 
 ${link}
 
-This link will expire in ${linkExpiration} minutes. If it expires, you can request a new verification email from the login page.
+This link will expire in ${linkExpirationFormatter(linkExpiration)}. If it expires, you can request a new verification email from the login page.
 
 If you did not create an account with sbomify, please ignore this email.
 

--- a/keycloak/themes/sbomify/email/text/executeActions.ftl
+++ b/keycloak/themes/sbomify/email/text/executeActions.ftl
@@ -14,7 +14,7 @@ Click the link below to complete these actions:
 
 ${link}
 
-This link will expire in ${linkExpiration} minutes.
+This link will expire in ${linkExpirationFormatter(linkExpiration)}.
 
 If you did not expect this email, please contact your administrator.
 

--- a/keycloak/themes/sbomify/email/text/password-reset.ftl
+++ b/keycloak/themes/sbomify/email/text/password-reset.ftl
@@ -6,7 +6,7 @@ We received a request to reset your password for your sbomify account. Click the
 
 ${link}
 
-This link will expire in ${linkExpiration} minutes. If it expires, you can request a new password reset from the login page.
+This link will expire in ${linkExpirationFormatter(linkExpiration)}. If it expires, you can request a new password reset from the login page.
 
 If you did not request a password reset, please ignore this email. Your password will remain unchanged.
 

--- a/keycloak/themes/sbomify/login/components.ftl
+++ b/keycloak/themes/sbomify/login/components.ftl
@@ -212,7 +212,7 @@
                             </svg>
                             <span>
                                 <strong>Didn't receive the email?</strong> 
-                                The verification link will expire in a few minutes. You can request a new one if needed.
+                                The verification link expires after a while. You can request a new one if needed.
                             </span>
                         </div>
                     </div>

--- a/keycloak/themes/sbomify/login/error.ftl
+++ b/keycloak/themes/sbomify/login/error.ftl
@@ -35,7 +35,7 @@
                         </h2>
 
                         <div class="info-message-body">
-                            <p class="instruction">${kcSanitize(message.summary)}</p>
+                            <p class="instruction">${kcSanitize(message.summary)?no_esc}</p>
                         </div>
 
                         <div class="info-footer">

--- a/keycloak/themes/sbomify/login/info.ftl
+++ b/keycloak/themes/sbomify/login/info.ftl
@@ -75,7 +75,7 @@
                                     </svg>
                                     <span>
                                         <strong>Didn't receive the email?</strong> 
-                                        The link will expire in a few minutes. You can request a new verification email if needed.
+                                        The link expires after a while. You can request a new verification email if needed.
                                     </span>
                                 </div>
                             <#elseif message?has_content>

--- a/keycloak/themes/sbomify/login/info.ftl
+++ b/keycloak/themes/sbomify/login/info.ftl
@@ -113,7 +113,7 @@
 
 
                         <div class="info-footer">
-                            <a href="${(client.baseUrl)!url.loginRestartFlowUrl!url.loginUrl}" class="btn-back">
+                            <a href="${(pageRedirectUri)!(actionUri)!(client.baseUrl)!url.loginUrl}" class="btn-back">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <path d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
                                 </svg>

--- a/keycloak/themes/sbomify/login/info.ftl
+++ b/keycloak/themes/sbomify/login/info.ftl
@@ -113,7 +113,7 @@
 
 
                         <div class="info-footer">
-                            <a href="${(pageRedirectUri)!(actionUri)!(client.baseUrl)!url.loginUrl}" class="btn-back">
+                            <a href="${(pageRedirectUri)!(actionUri)!(url.loginRestartFlowUrl)!url.loginUrl}" class="btn-back">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <path d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
                                 </svg>

--- a/keycloak/themes/sbomify/login/info.ftl
+++ b/keycloak/themes/sbomify/login/info.ftl
@@ -32,7 +32,7 @@
 
                         <h2 class="info-message-title">
                             <#if message?has_content>
-                                ${kcSanitize(message.summary)}
+                                ${kcSanitize(message.summary)?no_esc}
                             <#else>
                                 Check Your Email
                             </#if>
@@ -79,7 +79,7 @@
                                     </span>
                                 </div>
                             <#elseif message?has_content>
-                                <p>${kcSanitize(message.summary)}</p>
+                                <p>${kcSanitize(message.summary)?no_esc}</p>
                             <#else>
                                 <p>Check your inbox for further instructions.</p>
                             </#if>
@@ -93,33 +93,24 @@
                                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                             <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012 0m6 0a2 2 0 012 0m-6 4h.01M6 20h12"></path>
                                         </svg>
-                                        <span>${kcSanitize(action)}</span>
+                                        <span>${kcSanitize(action)?no_esc}</span>
                                     </div>
                                 </#list>
                             </div>
                         </#if>
 
-                        <#if skipLink??>
-                            <div class="info-actions">
-                                <a href="${skipLink}" class="btn-skip">
+                        <#-- skipLink is a boolean flag Keycloak sets to suppress the return link -->
+
+                        <#if !(skipLink??)>
+                            <div class="info-footer">
+                                <a href="${(pageRedirectUri)!(actionUri)!(url.loginRestartFlowUrl)!url.loginUrl}" class="btn-back">
                                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                        <path d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+                                        <path d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
                                     </svg>
-                                    <span>Skip</span>
+                                    <span>Back to Login</span>
                                 </a>
                             </div>
                         </#if>
-
-
-
-                        <div class="info-footer">
-                            <a href="${(pageRedirectUri)!(actionUri)!(url.loginRestartFlowUrl)!url.loginUrl}" class="btn-back">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                    <path d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
-                                </svg>
-                                <span>Back to Login</span>
-                            </a>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Part of #1393: the repo-encodable half of the signup fixes. Realm settings live in the bootstrap script as config-as-code; the same kcadm lines are the copy-paste for the prod and stage realms.

Changes:
- Verify-email action tokens live 3 days, reset-credentials 1 hour (realm attribute overrides). The Keycloak default of 5 minutes is what locks out users behind slow corporate mail gateways.
- Update Password is no longer a default required action. The password belongs on the registration form, so nobody gets a second "set new password" step after verifying their email.
- The info page (verification sent / already verified) prefers `pageRedirectUri` and `actionUri` over `client.baseUrl` for its return link, so it continues the login flow instead of jumping to whatever the client base points at. On prod that button currently lands on the marketing site.

Verified end to end on the dev stack (Keycloak 26.4.7, mailpit):
- Register with the password fields on the form, receive the verification mail, decode the JWT: `exp - iat = 259200`. The email copy picks up the new lifespan on its own.
- Click the link: email verified, straight into the app, no second password step.
- Sign out, sign back in with the registration password: works.
- Forgot Password: reset mail arrives, JWT shows 3600, the set-password page renders themed, the new password signs in.
- Re-click the consumed verification link: themed "already verified" page whose return link goes to the app, not a dead end.

Still realm-side for prod/stage (in #1393): enable the Password Validation step in the registration flow (the form renders the fields as soon as the flow sets `passwordRequired` — shipping them without the backing flow step would silently discard the password), apply the same two kcadm updates, fix the sbomify client's Base URL (it points at sbomify.com, which is where the "Back to Login" button currently sends people), deploy the theme, and turn off Mailjet click tracking.
