### PR TITLE
fix(plugins): a warning suppresses the public "All checks passed" badge

### DIFF
--- a/sbomify/apps/plugins/orchestrator.py
+++ b/sbomify/apps/plugins/orchestrator.py
@@ -22,6 +22,7 @@ from .models import AssessmentRun, RegisteredPlugin
 from .sdk.base import AssessmentPlugin, RetryLaterError, SBOMContext
 from .sdk.enums import AssessmentCategory, RunReason, RunStatus, ScanMode
 from .utils import compute_config_hash, compute_content_digest
+from .verdict import compliance_summary_passing
 
 if TYPE_CHECKING:
     from sbomify.apps.access_tokens.models import AccessToken
@@ -737,6 +738,11 @@ class PluginOrchestrator:
         to assert; treating it as passing would let BSI/FDA/etc. dependency
         gates pass on no evidence.
 
+        Warnings alongside a real pass do NOT block the gate — unlike the
+        public badge, which shares this implementation but is strict about
+        them. See ``verdict.compliance_summary_passing`` for why the two
+        consumers differ on exactly that axis.
+
         Args:
             run: The AssessmentRun to check.
 
@@ -761,18 +767,7 @@ class PluginOrchestrator:
             )
             return total_from_severity == 0
 
-        fail_count: int = summary.get("fail_count", 0)
-        error_count: int = summary.get("error_count", 0)
-        # ``pass_count`` was added to summary payloads at the same time as
-        # this stricter check. Older runs predating that may not carry the
-        # key at all — distinguish "key absent" (legacy schema) from "key
-        # present and zero" (modern run with no positive findings) so we
-        # don't retroactively un-pass historical runs that satisfied the
-        # gate under the old contract.
-        pass_count = summary.get("pass_count")
-        if pass_count is None:
-            return fail_count == 0 and error_count == 0
-        return fail_count == 0 and error_count == 0 and pass_count > 0
+        return compliance_summary_passing(summary, warnings_block=False)
 
     def get_plugin_instance(
         self,

--- a/sbomify/apps/plugins/public_assessment_utils.py
+++ b/sbomify/apps/plugins/public_assessment_utils.py
@@ -15,6 +15,7 @@ from django.db.utils import NotSupportedError
 
 from .models import AssessmentRun, RegisteredPlugin
 from .sdk.enums import AssessmentCategory, RunStatus
+from .verdict import compliance_summary_passing
 
 if TYPE_CHECKING:
     from sbomify.apps.core.models import Component, Product
@@ -144,8 +145,14 @@ def _is_run_passing(run: AssessmentRun) -> bool:
     with open criticals would earn a green shield. Mirrors the orchestrator's
     dependency-gate predicate.
 
-    Compliance-style runs additionally require at least one actual pass:
-    a warnings-only result (``pass_count == 0``) asserts nothing worth a badge.
+    Compliance-style runs additionally require at least one actual pass and no
+    warnings. The badge literally claims every check passed; a run whose
+    per-component elements all warn (everything exempt) still passes its
+    document-level checks, and rendering "All checks passed" over live
+    warnings asserts something the run did not establish. The dependency gate
+    in ``orchestrator._is_passing`` shares the same implementation but
+    tolerates warnings — see ``verdict.compliance_summary_passing`` for why
+    the two consumers differ on exactly that axis.
     """
     if run.status != RunStatus.COMPLETED.value:
         return False
@@ -154,25 +161,15 @@ def _is_run_passing(run: AssessmentRun) -> bool:
 
     result = run.result or {}
     summary = result.get("summary", {})
-    fail_count: int = summary.get("fail_count", 0)
-    error_count: int = summary.get("error_count", 0)
-    if fail_count != 0 or error_count != 0:
-        return False
 
     if run.category == AssessmentCategory.SECURITY.value:
+        if summary.get("fail_count", 0) != 0 or summary.get("error_count", 0) != 0:
+            return False
         by_severity = summary.get("by_severity") or {}
         findings_total = sum(v for v in by_severity.values() if isinstance(v, int))
         return findings_total == 0 and not summary.get("malicious_count")
 
-    # ``pass_count`` was added to summary payloads later, so a run predating it
-    # carries no key at all. ``orchestrator._is_passing`` distinguishes that from
-    # a present-and-zero count and lets the legacy run pass; reading a default of
-    # 0 here did not, so the same run satisfied a dependency gate and showed no
-    # public badge. The two encode one judgement and now answer alike.
-    pass_count = summary.get("pass_count")
-    if pass_count is None:
-        return True
-    return bool(pass_count)
+    return compliance_summary_passing(summary, warnings_block=True)
 
 
 def _passing_assessment_from_run(run: AssessmentRun, plugin_info: dict[str, tuple[str, str]]) -> PassingAssessment:

--- a/sbomify/apps/plugins/tests/test_orchestrator.py
+++ b/sbomify/apps/plugins/tests/test_orchestrator.py
@@ -560,6 +560,29 @@ class TestDependencyChecking:
         orchestrator = PluginOrchestrator()
         assert orchestrator._is_passing(run) is True
 
+    def test_is_passing_tolerates_warnings_when_a_pass_exists(self, test_sbom, db) -> None:
+        """The dependency gate must NOT treat warnings as blocking.
+
+        The verification plugin deliberately emits per-source warnings instead
+        of failures so that one verified source (say, provenance) satisfies
+        the attestation requirement even while another source (a detached
+        signature) is absent; its aggregating summary is the designed fail
+        signal. A gate that blocked on warnings would fail BSI attestation
+        for every provenance-verified unsigned SBOM.
+        """
+        orchestrator = PluginOrchestrator()
+        run = AssessmentRun.objects.create(
+            sbom=test_sbom,
+            plugin_name="sbom-verification",
+            plugin_version="1.0.0",
+            plugin_config_hash="",
+            category="attestation",
+            run_reason="on_upload",
+            status="completed",
+            result={"summary": {"pass_count": 3, "fail_count": 0, "error_count": 0, "warning_count": 4}},
+        )
+        assert orchestrator._is_passing(run) is True
+
     def test_is_passing_with_failures(self, test_sbom, db) -> None:
         """Test _is_passing returns False when there are failures."""
         run = AssessmentRun.objects.create(

--- a/sbomify/apps/plugins/tests/test_public_assessment_utils.py
+++ b/sbomify/apps/plugins/tests/test_public_assessment_utils.py
@@ -300,6 +300,41 @@ class TestGetSbomPassingAssessments:
 
         assert get_sbom_passing_assessments(str(sbom.id)) == []
 
+    def test_mixed_pass_and_warning_run_is_not_passing(self, sbom, ntia_plugin):
+        """Warnings must suppress the public "All checks passed" badge.
+
+        A document whose per-component elements all warn (everything exempt)
+        still has document-level checks that pass, so pass_count > 0 — but a
+        public badge claiming every check passed over live warnings is false.
+        """
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="ntia-minimum-elements-2021",
+            plugin_version="1.0.0",
+            plugin_config_hash="abc123",
+            category=AssessmentCategory.COMPLIANCE.value,
+            run_reason=RunReason.ON_UPLOAD.value,
+            status=RunStatus.COMPLETED.value,
+            result={
+                "summary": {
+                    "total_findings": 7,
+                    "pass_count": 3,
+                    "fail_count": 0,
+                    "warning_count": 4,
+                    "error_count": 0,
+                }
+            },
+        )
+
+        assert get_sbom_passing_assessments(str(sbom.id)) == []
+
+    def test_public_badge_and_dependency_gate_share_one_judgement(self):
+        """The two predicates must not drift: same function, explicit axis."""
+        from sbomify.apps.plugins import orchestrator, public_assessment_utils, verdict
+
+        assert public_assessment_utils.compliance_summary_passing is verdict.compliance_summary_passing
+        assert orchestrator.compliance_summary_passing is verdict.compliance_summary_passing
+
     def test_passing_run_carries_citable_facts(self, sbom, ntia_plugin):
         """The standard identity, check counts and verified date reach the badge."""
         from django.utils import timezone

--- a/sbomify/apps/plugins/verdict.py
+++ b/sbomify/apps/plugins/verdict.py
@@ -1,0 +1,46 @@
+"""The single implementation of "is this compliance-style summary passing?".
+
+Two consumers encode this judgement, and they must not drift:
+
+* ``public_assessment_utils._is_run_passing`` — decides whether a public
+  component or product page renders the "All checks passed" badge.
+* ``orchestrator._is_passing`` — decides whether a run satisfies another
+  plugin's ``requires_one_of`` dependency gate.
+
+They share this function; the one axis they differ on is explicit.
+
+``warnings_block`` exists because the two consumers make different claims. A
+public badge says every check passed, which is false the moment any check
+warned — a document whose per-component elements are all exempt still passes
+its document-level checks, and without this the reader is told "All checks
+passed" about a run that graded nothing. The dependency gate asks a weaker
+question — "did this plugin positively verify anything?" — and must tolerate
+warnings: the verification plugin deliberately reports unverified *sources* as
+warnings rather than failures so that one verified source (provenance, say)
+satisfies the attestation requirement while another (a detached signature) is
+merely absent. Its aggregating summary finding is the designed fail signal for
+"no source verified"; a gate that blocked on warnings would fail attestation
+for every provenance-verified unsigned SBOM.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compliance_summary_passing(summary: dict[str, Any], *, warnings_block: bool) -> bool:
+    """Judge a non-security run's summary counts.
+
+    ``pass_count`` was added to summary payloads later than the other counts,
+    so a run predating it carries no key at all. Key-absent (legacy schema) is
+    distinguished from present-and-zero (a modern run with nothing positive to
+    assert) so historical runs that satisfied the old contract keep passing.
+    """
+    if summary.get("fail_count", 0) != 0 or summary.get("error_count", 0) != 0:
+        return False
+    if warnings_block and summary.get("warning_count", 0):
+        return False
+    pass_count = summary.get("pass_count")
+    if pass_count is None:
+        return True
+    return bool(pass_count)


### PR DESCRIPTION
Closes #1356. Follows #1348.

A document whose per-component elements all warn — everything exempt, so nothing was graded — still passes its document-level checks, so `pass_count` lands above zero and the public badge renders **"All checks passed"**. The badge's claim is false the moment any check warned.

## Measured first, per the issue

Across 6,208 completed non-security runs in the dev corpus:

- **11 currently-passing runs carry warnings** — the set whose badge changes. All are `sbom-verification`, and each is a run whose signature checks warned because nothing was signed ("No Signature Attached", "Signature Validation Skipped"). Suppressing the "All checks passed" claim over those is truthful.
- 41 all-warning runs were already suppressed by the existing `pass_count` requirement.
- 400 legacy runs carry no `warning_count` key at all and are unaffected.

## One judgement, one implementation, one explicit axis

The same judgement lived in `public_assessment_utils._is_run_passing` and `orchestrator._is_passing`. Both now call `verdict.compliance_summary_passing`, and a test pins that they resolve to the same function — the agreement the issue asks for is structural, not coincidental.

The one axis they differ on is deliberate and documented: **the badge blocks on warnings, the dependency gate does not.** The verification plugin deliberately reports unverified *sources* as warnings rather than failures, so one verified source (provenance) satisfies `requires_one_of: attestation` while another (a detached signature) is merely absent; its aggregating summary finding is the designed fail signal. A gate that blocked on warnings would fail BSI attestation for every provenance-verified unsigned SBOM. A regression test pins that contract too.

## Acceptance criteria

- [x] Measured the badge-flip set before changing the rule (11 runs, one plugin, shapes listed above)
- [x] A run whose per-component elements all warn renders no public "All checks passed" badge
- [x] A run with no warnings is unaffected (existing tests still green; legacy no-key summaries unaffected)
- [x] The two predicates share one implementation; a test asserts both modules resolve to it

Suites: plugins 1,016, compliance+controls 808, core 2,649 — all green.