### PR TITLE
feat(teams): explain how to prepare an NDA where it gets uploaded

### DIFF
--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -562,6 +562,7 @@
                        aria-hidden="true"></i>
                 </button>
                 <div x-show="guideOpen"
+                     x-cloak
                      x-collapse
                      class="px-4 pb-4 text-sm text-text-muted space-y-3">
                     <p class="m-0">

--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -546,6 +546,59 @@
             </div>
         </div>
         <div class="p-6">
+            {# Preparation guidance — the signing flow is click-wrap, and a document drafted for wet signatures reads broken inside it #}
+            <div class="mb-6 border border-border rounded-xl"
+                 x-data="{ guideOpen: false }">
+                <button type="button"
+                        class="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm text-text-muted hover:text-text transition-colors"
+                        @click="guideOpen = !guideOpen"
+                        :aria-expanded="guideOpen">
+                    <span class="flex items-center gap-2 font-medium">
+                        <i class="fas fa-circle-question" aria-hidden="true"></i>
+                        How to prepare your NDA
+                    </span>
+                    <i class="fas fa-chevron-down transition-transform"
+                       :class="guideOpen ? 'rotate-180' : ''"
+                       aria-hidden="true"></i>
+                </button>
+                <div x-show="guideOpen"
+                     x-collapse
+                     class="px-4 pb-4 text-sm text-text-muted space-y-3">
+                    <p class="m-0">
+                        Nobody signs the PDF itself. A requester reads it in the browser, types their
+                        full name, and confirms acceptance — sbomify then records their name, the time,
+                        their IP address, and a cryptographic fingerprint of the exact document version
+                        they accepted. Draft the document for that process:
+                    </p>
+                    <ul class="m-0 pl-5 space-y-1.5 list-disc">
+                        <li>
+                            Write it as a one-way agreement: obligations on the recipient, covering
+                            "information made available through this Trust Center".
+                        </li>
+                        <li>Replace the signature block with an electronic-execution clause, for example:</li>
+                    </ul>
+                    <blockquote class="m-0 ml-5 pl-3 border-l-2 border-border italic">
+                        This Agreement is executed electronically. By typing your name and confirming
+                        acceptance, you agree to be bound by it; your typed name, the date and time,
+                        your IP address, and a fingerprint of this document version are recorded
+                        together and constitute your signature. You represent that you are authorized
+                        to enter into this Agreement on behalf of the organization for which you are
+                        requesting access.
+                    </blockquote>
+                    <ul class="m-0 pl-5 space-y-1.5 list-disc">
+                        <li>Leave no blank name, date, or signature lines — they stay empty forever.</li>
+                        <li>
+                            If your company should appear as a signatory, put its name, title, and date
+                            (or a scanned signature) in the PDF before uploading, so every acceptance is
+                            against an already-countersigned document.
+                        </li>
+                        <li>
+                            Finalize the wording first: uploading a replacement version invalidates every
+                            existing signature and all requesters sign again.
+                        </li>
+                    </ul>
+                </div>
+            </div>
             {% if company_nda_document %}
                 {# Current NDA Display #}
                 <div class="mb-6 p-4 bg-success/5 border border-success/20 rounded-xl">


### PR DESCRIPTION
The Trust Center signing flow is click-wrap: nobody signs the PDF, sbomify records the typed name, timestamp, IP and a SHA-256 fingerprint of the accepted document version. The product said nothing about that, so the natural move — drafting a conventional NDA with two-party signature blocks — produces a document that reads broken inside the flow: blocks nobody can fill and date lines that stay blank forever.

The Company NDA card in Workspace Settings → Trust Center now carries a collapsible **How to prepare your NDA** panel:

- draft it as a one-way agreement covering "information made available through this Trust Center"
- replace the signature block with an electronic-execution clause (example text included, ready to paste)
- leave no blank name/date/signature lines
- optionally pre-countersign in the PDF before uploading
- finalize the wording first — a replacement upload invalidates every existing signature

Uses the same Alpine collapse pattern as the account tab and the danger zone; verified rendered and toggling in the browser. djlint clean.

Pairs with #1415 (signature history) — together they close the gap raised while preparing a real customer NDA.