### PR TITLE
feat(core): NOTICE attribution document per release, product or workspace

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4948,3 +4948,48 @@ def export_vulnerabilities(
     if not result.ok:
         return 403, ErrorResponse(detail=result.error or "Export failed")
     return _csv_response(result.value or "", "vulnerabilities.csv")
+
+
+@router.get(
+    "/exports/notice",
+    response={403: ErrorResponse, 404: ErrorResponse},
+    summary="Export a third-party NOTICE document",
+    tags=["Exports"],
+)
+def export_notice(
+    request: HttpRequest,
+    product_id: str | None = None,
+    release_id: str | None = None,
+    format: str = "text",
+) -> HttpResponse | tuple[int, ErrorResponse]:
+    """Attribution document derived from stored artifacts — name, version,
+    licenses and copyright, with license-less components in their own section.
+    `format` is "text" or "html"."""
+    from sbomify.apps.core.services import csv_exports
+
+    team, err = _export_team(request)
+    if err:
+        return err
+
+    product = None
+    release = None
+    if release_id:
+        release = Release.objects.filter(id=release_id, product__team=team).select_related("product").first()
+        if release is None:
+            return 404, ErrorResponse(detail="Release not found")
+    elif product_id:
+        product = Product.objects.filter(id=product_id, team=team).first()
+        if product is None:
+            return 404, ErrorResponse(detail="Product not found")
+
+    if format == "html":
+        result = csv_exports.export_notice_html(team, product=product, release=release)
+        content_type, filename = "text/html; charset=utf-8", "NOTICE.html"
+    else:
+        result = csv_exports.export_notice_text(team, product=product, release=release)
+        content_type, filename = "text/plain; charset=utf-8", "NOTICE.txt"
+    if not result.ok:
+        return 403, ErrorResponse(detail=result.error or "Export failed")
+    response = HttpResponse(result.value, content_type=content_type)
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4830,7 +4830,7 @@ def _csv_response(csv_text: str, filename: str) -> HttpResponse:
 
 @router.get(
     "/exports/inventory.csv",
-    response={403: ErrorResponse, 404: ErrorResponse},
+    response={400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
     summary="Export the package inventory as CSV",
     tags=["Exports"],
 )
@@ -4851,7 +4851,7 @@ def export_inventory(request: HttpRequest, product_id: str | None = None) -> Htt
 
     result = csv_exports.export_inventory_csv(team, product=product)
     if not result.ok:
-        return 403, ErrorResponse(detail=result.error or "Export failed")
+        return result.status_code or 400, ErrorResponse(detail=result.error or "Export failed")
     scope = product.name if product else team.name
     safe = re.sub(r"[^a-zA-Z0-9\-]+", "-", scope.lower()).strip("-")
     return _csv_response(result.value or "", f"{safe}-inventory.csv")
@@ -4859,7 +4859,7 @@ def export_inventory(request: HttpRequest, product_id: str | None = None) -> Htt
 
 @router.get(
     "/exports/licenses.csv",
-    response={403: ErrorResponse, 404: ErrorResponse},
+    response={400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
     summary="Export the license list as CSV",
     tags=["Exports"],
 )
@@ -4887,13 +4887,13 @@ def export_licenses(
 
     result = csv_exports.export_licenses_csv(team, product=product, release=release)
     if not result.ok:
-        return 403, ErrorResponse(detail=result.error or "Export failed")
+        return result.status_code or 400, ErrorResponse(detail=result.error or "Export failed")
     return _csv_response(result.value or "", "licenses.csv")
 
 
 @router.get(
     "/exports/findings.csv",
-    response={403: ErrorResponse, 404: ErrorResponse},
+    response={400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
     summary="Export assessment findings as CSV",
     tags=["Exports"],
 )
@@ -4912,13 +4912,13 @@ def export_findings(request: HttpRequest, sbom_id: str) -> HttpResponse | tuple[
 
     result = csv_exports.export_findings_csv(sbom)
     if not result.ok:
-        return 403, ErrorResponse(detail=result.error or "Export failed")
+        return result.status_code or 400, ErrorResponse(detail=result.error or "Export failed")
     return _csv_response(result.value or "", f"{sbom_id}-findings.csv")
 
 
 @router.get(
     "/exports/vulnerabilities.csv",
-    response={403: ErrorResponse, 404: ErrorResponse},
+    response={400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
     summary="Export vulnerability findings as CSV",
     tags=["Exports"],
 )
@@ -4946,5 +4946,5 @@ def export_vulnerabilities(
 
     result = csv_exports.export_vulnerabilities_csv(team, component=component, release=release)
     if not result.ok:
-        return 403, ErrorResponse(detail=result.error or "Export failed")
+        return result.status_code or 400, ErrorResponse(detail=result.error or "Export failed")
     return _csv_response(result.value or "", "vulnerabilities.csv")

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4952,7 +4952,7 @@ def export_vulnerabilities(
 
 @router.get(
     "/exports/notice",
-    response={403: ErrorResponse, 404: ErrorResponse},
+    response={400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},
     summary="Export a third-party NOTICE document",
     tags=["Exports"],
 )
@@ -4985,9 +4985,13 @@ def export_notice(
     if format == "html":
         result = csv_exports.export_notice_html(team, product=product, release=release)
         content_type, filename = "text/html; charset=utf-8", "NOTICE.html"
-    else:
+    elif format == "text":
         result = csv_exports.export_notice_text(team, product=product, release=release)
         content_type, filename = "text/plain; charset=utf-8", "NOTICE.txt"
+    else:
+        # A typo must not silently produce the default format — automation
+        # would never notice it asked for something else.
+        return 400, ErrorResponse(detail='Unknown format; expected "text" or "html".')
     if not result.ok:
         return 403, ErrorResponse(detail=result.error or "Export failed")
     response = HttpResponse(result.value, content_type=content_type)

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4800,3 +4800,151 @@ def export_user_data_endpoint(request: HttpRequest) -> Any:
             "detail": "Failed to export user data. Please try again later.",
             "error_code": ErrorCode.INTERNAL_ERROR,
         }
+
+
+# ---------------------------------------------------------------------------
+# CSV exports — auditor-facing tabular downloads
+# ---------------------------------------------------------------------------
+
+
+def _export_team(request: HttpRequest) -> tuple[Any, tuple[int, ErrorResponse] | None]:
+    """The caller's workspace for an export, or an error pair."""
+    from sbomify.apps.teams.models import Team
+
+    team_id = _get_user_team_id(request)
+    if not team_id:
+        return None, (403, ErrorResponse(detail="No workspace context"))
+    team = Team.objects.filter(id=team_id).first()
+    if team is None:
+        return None, (403, ErrorResponse(detail="No workspace context"))
+    if not can(request, "workspace:read", team):
+        return None, (403, ErrorResponse(detail="Forbidden"))
+    return team, None
+
+
+def _csv_response(csv_text: str, filename: str) -> HttpResponse:
+    response = HttpResponse(csv_text, content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
+
+
+@router.get(
+    "/exports/inventory.csv",
+    response={403: ErrorResponse, 404: ErrorResponse},
+    summary="Export the package inventory as CSV",
+    tags=["Exports"],
+)
+def export_inventory(request: HttpRequest, product_id: str | None = None) -> HttpResponse | tuple[int, ErrorResponse]:
+    """Package inventory across the newest SBOM per component: name, version,
+    supplier, licenses and PURL — workspace-wide, or one product."""
+    from sbomify.apps.core.services import csv_exports
+
+    team, err = _export_team(request)
+    if err:
+        return err
+
+    product = None
+    if product_id:
+        product = Product.objects.filter(id=product_id, team=team).first()
+        if product is None:
+            return 404, ErrorResponse(detail="Product not found")
+
+    result = csv_exports.export_inventory_csv(team, product=product)
+    if not result.ok:
+        return 403, ErrorResponse(detail=result.error or "Export failed")
+    scope = product.name if product else team.name
+    safe = re.sub(r"[^a-zA-Z0-9\-]+", "-", scope.lower()).strip("-")
+    return _csv_response(result.value or "", f"{safe}-inventory.csv")
+
+
+@router.get(
+    "/exports/licenses.csv",
+    response={403: ErrorResponse, 404: ErrorResponse},
+    summary="Export the license list as CSV",
+    tags=["Exports"],
+)
+def export_licenses(
+    request: HttpRequest, product_id: str | None = None, release_id: str | None = None
+) -> HttpResponse | tuple[int, ErrorResponse]:
+    """Distinct licenses in scope with package and component counts —
+    workspace-wide, one product, or one release."""
+    from sbomify.apps.core.services import csv_exports
+
+    team, err = _export_team(request)
+    if err:
+        return err
+
+    product = None
+    release = None
+    if release_id:
+        release = Release.objects.filter(id=release_id, product__team=team).first()
+        if release is None:
+            return 404, ErrorResponse(detail="Release not found")
+    elif product_id:
+        product = Product.objects.filter(id=product_id, team=team).first()
+        if product is None:
+            return 404, ErrorResponse(detail="Product not found")
+
+    result = csv_exports.export_licenses_csv(team, product=product, release=release)
+    if not result.ok:
+        return 403, ErrorResponse(detail=result.error or "Export failed")
+    return _csv_response(result.value or "", "licenses.csv")
+
+
+@router.get(
+    "/exports/findings.csv",
+    response={403: ErrorResponse, 404: ErrorResponse},
+    summary="Export assessment findings as CSV",
+    tags=["Exports"],
+)
+def export_findings(request: HttpRequest, sbom_id: str) -> HttpResponse | tuple[int, ErrorResponse]:
+    """Latest compliance findings per plugin for one SBOM (NTIA, BSI, FDA...)."""
+    from sbomify.apps.core.services import csv_exports
+    from sbomify.apps.sboms.models import SBOM as SBOMModel
+
+    team, err = _export_team(request)
+    if err:
+        return err
+
+    sbom = SBOMModel.objects.filter(id=sbom_id, component__team=team).select_related("component").first()
+    if sbom is None:
+        return 404, ErrorResponse(detail="SBOM not found")
+
+    result = csv_exports.export_findings_csv(sbom)
+    if not result.ok:
+        return 403, ErrorResponse(detail=result.error or "Export failed")
+    return _csv_response(result.value or "", f"{sbom_id}-findings.csv")
+
+
+@router.get(
+    "/exports/vulnerabilities.csv",
+    response={403: ErrorResponse, 404: ErrorResponse},
+    summary="Export vulnerability findings as CSV",
+    tags=["Exports"],
+)
+def export_vulnerabilities(
+    request: HttpRequest, component_id: str | None = None, release_id: str | None = None
+) -> HttpResponse | tuple[int, ErrorResponse]:
+    """Vulnerability findings with the post-VEX analysis state — the same
+    alias-merged numbers the dashboards show."""
+    from sbomify.apps.core.services import csv_exports
+
+    team, err = _export_team(request)
+    if err:
+        return err
+
+    component = None
+    release = None
+    if release_id:
+        release = Release.objects.filter(id=release_id, product__team=team).first()
+        if release is None:
+            return 404, ErrorResponse(detail="Release not found")
+    elif component_id:
+        component = Component.objects.filter(id=component_id, team=team).first()
+        if component is None:
+            return 404, ErrorResponse(detail="Component not found")
+
+    result = csv_exports.export_vulnerabilities_csv(team, component=component, release=release)
+    if not result.ok:
+        return 403, ErrorResponse(detail=result.error or "Export failed")
+    return _csv_response(result.value or "", "vulnerabilities.csv")

--- a/sbomify/apps/core/services/csv_exports.py
+++ b/sbomify/apps/core/services/csv_exports.py
@@ -103,6 +103,7 @@ def _packages(payload: dict[str, Any], sbom_format: str) -> list[dict[str, Any]]
                     "supplier": (supplier or {}).get("name", "") if isinstance(supplier, dict) else "",
                     "licenses": _cyclonedx_licenses(entry),
                     "purl": entry.get("purl") or "",
+                    "copyright": entry.get("copyright") if isinstance(entry.get("copyright"), str) else "",
                 }
             )
     else:
@@ -126,6 +127,11 @@ def _packages(payload: dict[str, Any], sbom_format: str) -> list[dict[str, Any]]
                         [declared] if isinstance(declared, str) and declared and declared != "NOASSERTION" else []
                     ),
                     "purl": purl,
+                    "copyright": (
+                        entry.get("copyrightText")
+                        if isinstance(entry.get("copyrightText"), str) and entry.get("copyrightText") != "NOASSERTION"
+                        else ""
+                    ),
                 }
             )
     return rows
@@ -313,3 +319,112 @@ def export_vulnerabilities_csv(
             rows,
         )
     )
+
+
+def _notice_entries(
+    team: Team,
+    product: Product | None = None,
+    release: Release | None = None,
+) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
+    """``(scope_name, attributed, unknown)`` — the one structure both notice
+    renderers consume, so text and HTML can never list different components."""
+    if release is not None:
+        sboms = [
+            artifact.sbom
+            for artifact in release.artifacts.select_related("sbom__component").all()
+            if artifact.sbom is not None and artifact.sbom.bom_type == SBOM.BomType.SBOM.value
+        ]
+        scope_name = f"{release.product.name} {release.name}"
+    else:
+        sboms = _latest_sboms(team, product)
+        scope_name = product.name if product is not None else team.name
+
+    seen: dict[tuple[str, str], dict[str, Any]] = {}
+    for sbom in sboms:
+        payload = _load_payload(sbom)
+        if payload is None:
+            continue
+        for package in _packages(payload, sbom.format):
+            if not package["name"]:
+                continue
+            key = (package["name"], package["version"])
+            entry = seen.setdefault(
+                key,
+                {"name": package["name"], "version": package["version"], "licenses": [], "copyright": ""},
+            )
+            for label in package["licenses"]:
+                if label not in entry["licenses"]:
+                    entry["licenses"].append(label)
+            if package["copyright"] and not entry["copyright"]:
+                entry["copyright"] = package["copyright"]
+
+    entries = sorted(seen.values(), key=lambda e: (e["name"].lower(), e["version"]))
+    attributed = [e for e in entries if e["licenses"]]
+    unknown = [e for e in entries if not e["licenses"]]
+    return scope_name, attributed, unknown
+
+
+def export_notice_text(
+    team: Team,
+    product: Product | None = None,
+    release: Release | None = None,
+) -> ServiceResult[str]:
+    """A NOTICE document as plain text.
+
+    Components the artifacts carry no licence for are listed in their own
+    section rather than dropped — an attribution file that silently omits them
+    reads as complete when it is not.
+    """
+    scope_name, attributed, unknown = _notice_entries(team, product=product, release=release)
+    lines = [f"Third-Party Notices for {scope_name}", "=" * 40, ""]
+    for entry in attributed:
+        lines.append(f"{entry['name']} {entry['version']}".rstrip())
+        lines.append(f"  License: {'; '.join(entry['licenses'])}")
+        if entry["copyright"]:
+            lines.append(f"  {entry['copyright']}")
+        lines.append("")
+    if unknown:
+        lines += ["Components without license data", "-" * 40, ""]
+        for entry in unknown:
+            lines.append(f"{entry['name']} {entry['version']}".rstrip())
+        lines.append("")
+    return ServiceResult.success("\n".join(lines))
+
+
+def export_notice_html(
+    team: Team,
+    product: Product | None = None,
+    release: Release | None = None,
+) -> ServiceResult[str]:
+    """The same NOTICE document as a standalone HTML page.
+
+    Every value is artifact-derived, so everything renders through
+    ``django.utils.html.escape``.
+    """
+    from django.utils.html import escape
+
+    scope_name, attributed, unknown = _notice_entries(team, product=product, release=release)
+    parts = [
+        "<!doctype html><html><head><meta charset='utf-8'>",
+        f"<title>Third-Party Notices for {escape(scope_name)}</title>",
+        "<style>body{font-family:sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#1a1a2e}"
+        "h1{font-size:1.4rem}h2{font-size:1.1rem;margin-top:2rem}"
+        "li{margin-bottom:.6rem}.c{color:#555;font-size:.9rem}</style></head><body>",
+        f"<h1>Third-Party Notices for {escape(scope_name)}</h1><ul>",
+    ]
+    for entry in attributed:
+        parts.append(
+            f"<li><strong>{escape(entry['name'])} {escape(entry['version'])}</strong>"
+            f" — {escape('; '.join(entry['licenses']))}"
+        )
+        if entry["copyright"]:
+            parts.append(f"<div class='c'>{escape(entry['copyright'])}</div>")
+        parts.append("</li>")
+    parts.append("</ul>")
+    if unknown:
+        parts.append("<h2>Components without license data</h2><ul>")
+        for entry in unknown:
+            parts.append(f"<li>{escape(entry['name'])} {escape(entry['version'])}</li>")
+        parts.append("</ul>")
+    parts.append("</body></html>")
+    return ServiceResult.success("".join(parts))

--- a/sbomify/apps/core/services/csv_exports.py
+++ b/sbomify/apps/core/services/csv_exports.py
@@ -1,0 +1,315 @@
+"""Auditor-facing CSV exports: inventory, licences, findings, vulnerabilities.
+
+Procurement and auditors ask for tabular data; before this the answer was
+scripting against the API. Four generators, one shape: a ``ServiceResult[str]``
+of CSV text the endpoint serves as an attachment.
+
+Two rules every generator follows:
+
+* **The writer is defusedcsv.** Every cell that matters — package names,
+  licence ids, vulnerability titles — originates in uploaded artifacts or
+  scanner output, and a value like ``=cmd|...`` must open in a spreadsheet as
+  text, not as a formula.
+* **Unreadable artifacts surface as explicit rows.** A parts list that
+  silently omits the SBOMs it could not read looks complete while it is not,
+  which for an auditor is worse than an error.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from defusedcsv import csv
+
+from sbomify.apps.core.services.results import ServiceResult
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.sboms.utils import SBOMDataError, get_sbom_data_bytes
+
+if TYPE_CHECKING:
+    from sbomify.apps.core.models import Component, Product, Release
+    from sbomify.apps.teams.models import Team
+
+MAX_PARSE_BYTES = 50 * 1024 * 1024
+"""Largest stored artifact an export will pull into memory; larger ones get
+the explicit unreadable row instead of an OOM."""
+
+UNREADABLE = "(unreadable artifact)"
+
+
+def _latest_sboms(team: Team, product: Product | None = None) -> list[SBOM]:
+    """The newest ``bom_type=sbom`` per component in scope — the dashboards'
+    counting rule, so an export never stacks superseded uploads."""
+    queryset = SBOM.objects.filter(component__team=team, bom_type=SBOM.BomType.SBOM)
+    if product is not None:
+        queryset = queryset.filter(component__products=product)
+    return list(queryset.select_related("component").order_by("component_id", "-created_at").distinct("component_id"))
+
+
+def _load_payload(sbom: SBOM) -> dict[str, Any] | None:
+    """The parsed document, or ``None`` for anything unreadable."""
+    try:
+        _, raw = get_sbom_data_bytes(sbom.id)
+    except (SBOMDataError, Exception):
+        return None
+    if raw is None or len(raw) > MAX_PARSE_BYTES:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _cyclonedx_licenses(entry: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for lic in entry.get("licenses") or []:
+        if not isinstance(lic, dict):
+            continue
+        nested = lic.get("license")
+        if isinstance(nested, dict):
+            label = nested.get("id") or nested.get("name")
+        elif isinstance(nested, str):
+            label = nested
+        else:
+            label = lic.get("expression")
+        if isinstance(label, str) and label:
+            labels.append(label)
+    return labels
+
+
+def _spdx_supplier(value: Any) -> str:
+    """``Organization: npm`` / ``Person: Jane`` → the bare name."""
+    if not isinstance(value, str):
+        return ""
+    _, _, name = value.partition(":")
+    return (name or value).strip()
+
+
+def _packages(payload: dict[str, Any], sbom_format: str) -> list[dict[str, Any]]:
+    """Normalise CycloneDX components / SPDX packages into one row shape."""
+    rows: list[dict[str, Any]] = []
+    if sbom_format.lower() == "cyclonedx":
+        for entry in payload.get("components") or []:
+            if not isinstance(entry, dict):
+                continue
+            supplier = entry.get("supplier")
+            rows.append(
+                {
+                    "name": entry.get("name") or "",
+                    "version": entry.get("version") or "",
+                    "supplier": (supplier or {}).get("name", "") if isinstance(supplier, dict) else "",
+                    "licenses": _cyclonedx_licenses(entry),
+                    "purl": entry.get("purl") or "",
+                }
+            )
+    else:
+        for entry in payload.get("packages") or []:
+            if not isinstance(entry, dict):
+                continue
+            declared = entry.get("licenseDeclared")
+            if not isinstance(declared, str) or not declared or declared == "NOASSERTION":
+                declared = entry.get("licenseConcluded")
+            purl = ""
+            for ref in entry.get("externalRefs") or []:
+                if isinstance(ref, dict) and ref.get("referenceType") == "purl":
+                    purl = ref.get("referenceLocator") or ""
+                    break
+            rows.append(
+                {
+                    "name": entry.get("name") or "",
+                    "version": entry.get("versionInfo") or "",
+                    "supplier": _spdx_supplier(entry.get("supplier")),
+                    "licenses": (
+                        [declared] if isinstance(declared, str) and declared and declared != "NOASSERTION" else []
+                    ),
+                    "purl": purl,
+                }
+            )
+    return rows
+
+
+def _csv(header: list[str], rows: list[list[Any]]) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output)  # type: ignore[no-untyped-call]
+    writer.writerow(header)
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def export_inventory_csv(team: Team, product: Product | None = None) -> ServiceResult[str]:
+    """Package inventory across the newest SBOM per component."""
+    rows: list[list[Any]] = []
+    for sbom in _latest_sboms(team, product):
+        payload = _load_payload(sbom)
+        if payload is None:
+            rows.append([sbom.component.name, sbom.version or "", UNREADABLE, "", "", "", ""])
+            continue
+        for package in _packages(payload, sbom.format):
+            rows.append(
+                [
+                    sbom.component.name,
+                    sbom.version or "",
+                    package["name"],
+                    package["version"],
+                    package["supplier"],
+                    "; ".join(package["licenses"]),
+                    package["purl"],
+                ]
+            )
+    return ServiceResult.success(
+        _csv(["Component", "SBOM Version", "Package", "Version", "Supplier", "Licenses", "PURL"], rows)
+    )
+
+
+def export_licenses_csv(
+    team: Team,
+    product: Product | None = None,
+    release: Release | None = None,
+) -> ServiceResult[str]:
+    """Distinct licences in scope, with how many packages and components carry each."""
+    if release is not None:
+        sboms = [
+            artifact.sbom
+            for artifact in release.artifacts.select_related("sbom__component").all()
+            if artifact.sbom is not None and artifact.sbom.bom_type == SBOM.BomType.SBOM.value
+        ]
+    else:
+        sboms = _latest_sboms(team, product)
+
+    packages_by_license: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    components_by_license: dict[str, set[str]] = defaultdict(set)
+    for sbom in sboms:
+        payload = _load_payload(sbom)
+        if payload is None:
+            continue
+        for package in _packages(payload, sbom.format):
+            for label in package["licenses"]:
+                packages_by_license[label].add((package["name"], package["version"]))
+                components_by_license[label].add(sbom.component_id)
+
+    rows = [
+        [label, len(packages_by_license[label]), len(components_by_license[label])]
+        for label in sorted(packages_by_license)
+    ]
+    return ServiceResult.success(_csv(["License", "Packages", "Components"], rows))
+
+
+def export_findings_csv(sbom: SBOM) -> ServiceResult[str]:
+    """Latest compliance-style findings per plugin for one SBOM."""
+    from sbomify.apps.plugins.models import AssessmentRun
+    from sbomify.apps.plugins.sdk.enums import AssessmentCategory, RunStatus
+
+    runs = (
+        AssessmentRun.objects.filter(sbom=sbom, status=RunStatus.COMPLETED.value)
+        .exclude(category=AssessmentCategory.SECURITY.value)
+        .order_by("plugin_name", "-created_at", "-id")
+        .distinct("plugin_name")
+    )
+    rows: list[list[Any]] = []
+    for run in runs:
+        result = run.result if isinstance(run.result, dict) else {}
+        for finding in result.get("findings") or []:
+            if not isinstance(finding, dict):
+                continue
+            rows.append(
+                [
+                    run.plugin_name,
+                    finding.get("id") or "",
+                    finding.get("title") or "",
+                    finding.get("status") or "",
+                    finding.get("description") or finding.get("details") or "",
+                ]
+            )
+    return ServiceResult.success(_csv(["Plugin", "Check", "Title", "Status", "Description"], rows))
+
+
+def export_vulnerabilities_csv(
+    team: Team,
+    component: Component | None = None,
+    release: Release | None = None,
+) -> ServiceResult[str]:
+    """Vulnerability findings with the post-VEX analysis state, like the dashboards.
+
+    Same helpers the UI uses — alias-merged across providers, bookkeeping rows
+    dropped, VEX statements resolved live — so the export never disagrees with
+    the page beside it.
+    """
+    from sbomify.apps.plugins.models import AssessmentRun
+    from sbomify.apps.plugins.sdk.enums import AssessmentCategory, RunStatus
+    from sbomify.apps.vulnerability_scanning.utils import (
+        extract_finding_rows,
+        is_vulnerability,
+        merge_findings_by_alias,
+    )
+    from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
+
+    if release is not None:
+        sbom_ids = [
+            artifact.sbom_id
+            for artifact in release.artifacts.select_related("sbom").all()
+            if artifact.sbom is not None and artifact.sbom.bom_type == SBOM.BomType.SBOM.value
+        ]
+        runs = AssessmentRun.objects.filter(sbom_id__in=sbom_ids)
+    elif component is not None:
+        runs = AssessmentRun.objects.filter(sbom__component=component)
+    else:
+        latest_ids = [sbom.id for sbom in _latest_sboms(team)]
+        runs = AssessmentRun.objects.filter(sbom_id__in=latest_ids)
+
+    runs = (
+        runs.filter(sbom__component__team=team, category=AssessmentCategory.SECURITY.value)
+        .filter(status=RunStatus.COMPLETED.value)
+        .select_related("sbom", "sbom__component")
+        .order_by("sbom_id", "plugin_name", "-created_at", "-id")
+        .distinct("sbom_id", "plugin_name")
+    )
+
+    by_sbom: dict[str, list[AssessmentRun]] = defaultdict(list)
+    for run in runs:
+        by_sbom[run.sbom_id].append(run)
+
+    vex_cache: dict[Any, list[dict[str, Any]]] = {}
+    rows: list[list[Any]] = []
+    for sbom_id, sbom_runs in by_sbom.items():
+        merged = merge_findings_by_alias([run.result for run in sbom_runs])
+        merged["findings"] = [
+            finding
+            for finding in merged.get("findings") or []
+            if isinstance(finding, dict) and is_vulnerability(finding)
+        ]
+        sbom = sbom_runs[0].sbom
+        providers = "; ".join(sorted({run.plugin_name for run in sbom_runs}))
+        statements = load_vex_suppressions(sbom.component_id, cache=vex_cache)
+        for row in extract_finding_rows(merged, statements):
+            rows.append(
+                [
+                    row.get("id") or "",
+                    row.get("severity") or "",
+                    row.get("cvss_score") if row.get("cvss_score") is not None else "",
+                    row.get("package") or "",
+                    row.get("version") or "",
+                    sbom.component.name,
+                    row.get("vex_state") or "",
+                    "yes" if row.get("vex_suppressed") else "",
+                    providers,
+                ]
+            )
+    return ServiceResult.success(
+        _csv(
+            [
+                "Vulnerability",
+                "Severity",
+                "CVSS",
+                "Package",
+                "Version",
+                "Component",
+                "Analysis State",
+                "Suppressed",
+                "Providers",
+            ],
+            rows,
+        )
+    )

--- a/sbomify/apps/core/services/csv_exports.py
+++ b/sbomify/apps/core/services/csv_exports.py
@@ -193,19 +193,25 @@ def export_licenses_csv(
 
     packages_by_license: dict[str, set[tuple[str, str]]] = defaultdict(set)
     components_by_license: dict[str, set[str]] = defaultdict(set)
+    unreadable_components: set[str] = set()
     for sbom in sboms:
         payload = _load_payload(sbom)
         if payload is None:
+            unreadable_components.add(sbom.component_id)
             continue
         for package in _packages(payload, sbom.format):
             for label in package["licenses"]:
                 packages_by_license[label].add((package["name"], package["version"]))
                 components_by_license[label].add(sbom.component_id)
 
-    rows = [
+    rows: list[list[Any]] = [
         [label, len(packages_by_license[label]), len(components_by_license[label])]
         for label in sorted(packages_by_license)
     ]
+    if unreadable_components:
+        # The same rule as the inventory export: an aggregation that silently
+        # dropped what it could not read looks complete while it is not.
+        rows.append([UNREADABLE, "", len(unreadable_components)])
     return ServiceResult.success(_csv(["License", "Packages", "Components"], rows))
 
 
@@ -331,9 +337,10 @@ def _notice_entries(
     team: Team,
     product: Product | None = None,
     release: Release | None = None,
-) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
-    """``(scope_name, attributed, unknown)`` — the one structure both notice
-    renderers consume, so text and HTML can never list different components."""
+) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    """``(scope_name, attributed, unknown, unreadable)`` — the one structure
+    both notice renderers consume, so text and HTML can never list different
+    components; ``unreadable`` names the artifacts the notice could not cover."""
     if release is not None:
         sboms = [
             artifact.sbom
@@ -346,9 +353,11 @@ def _notice_entries(
         scope_name = product.name if product is not None else team.name
 
     seen: dict[tuple[str, str], dict[str, Any]] = {}
+    unreadable: list[str] = []
     for sbom in sboms:
         payload = _load_payload(sbom)
         if payload is None:
+            unreadable.append(f"{sbom.component.name} ({sbom.name} {sbom.version or ''})".strip())
             continue
         for package in _packages(payload, sbom.format):
             if not package["name"]:
@@ -367,7 +376,7 @@ def _notice_entries(
     entries = sorted(seen.values(), key=lambda e: (e["name"].lower(), e["version"]))
     attributed = [e for e in entries if e["licenses"]]
     unknown = [e for e in entries if not e["licenses"]]
-    return scope_name, attributed, unknown
+    return scope_name, attributed, unknown, sorted(unreadable)
 
 
 def export_notice_text(
@@ -381,7 +390,7 @@ def export_notice_text(
     section rather than dropped — an attribution file that silently omits them
     reads as complete when it is not.
     """
-    scope_name, attributed, unknown = _notice_entries(team, product=product, release=release)
+    scope_name, attributed, unknown, unreadable = _notice_entries(team, product=product, release=release)
     lines = [f"Third-Party Notices for {scope_name}", "=" * 40, ""]
     for entry in attributed:
         lines.append(f"{entry['name']} {entry['version']}".rstrip())
@@ -393,6 +402,10 @@ def export_notice_text(
         lines += ["Components without license data", "-" * 40, ""]
         for entry in unknown:
             lines.append(f"{entry['name']} {entry['version']}".rstrip())
+        lines.append("")
+    if unreadable:
+        lines += ["Artifacts that could not be read", "-" * 40, ""]
+        lines += unreadable
         lines.append("")
     return ServiceResult.success("\n".join(lines))
 
@@ -409,7 +422,7 @@ def export_notice_html(
     """
     from django.utils.html import escape
 
-    scope_name, attributed, unknown = _notice_entries(team, product=product, release=release)
+    scope_name, attributed, unknown, unreadable = _notice_entries(team, product=product, release=release)
     parts = [
         "<!doctype html><html><head><meta charset='utf-8'>",
         f"<title>Third-Party Notices for {escape(scope_name)}</title>",
@@ -431,6 +444,11 @@ def export_notice_html(
         parts.append("<h2>Components without license data</h2><ul>")
         for entry in unknown:
             parts.append(f"<li>{escape(entry['name'])} {escape(entry['version'])}</li>")
+        parts.append("</ul>")
+    if unreadable:
+        parts.append("<h2>Artifacts that could not be read</h2><ul>")
+        for label in unreadable:
+            parts.append(f"<li>{escape(label)}</li>")
         parts.append("</ul>")
     parts.append("</body></html>")
     return ServiceResult.success("".join(parts))

--- a/sbomify/apps/core/services/csv_exports.py
+++ b/sbomify/apps/core/services/csv_exports.py
@@ -22,6 +22,7 @@ import json
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from botocore.exceptions import BotoCoreError, ClientError
 from defusedcsv import csv
 
 from sbomify.apps.core.services.results import ServiceResult
@@ -45,14 +46,19 @@ def _latest_sboms(team: Team, product: Product | None = None) -> list[SBOM]:
     queryset = SBOM.objects.filter(component__team=team, bom_type=SBOM.BomType.SBOM)
     if product is not None:
         queryset = queryset.filter(component__products=product)
-    return list(queryset.select_related("component").order_by("component_id", "-created_at").distinct("component_id"))
+    return list(
+        queryset.select_related("component").order_by("component_id", "-created_at", "-id").distinct("component_id")
+    )
 
 
 def _load_payload(sbom: SBOM) -> dict[str, Any] | None:
     """The parsed document, or ``None`` for anything unreadable."""
     try:
         _, raw = get_sbom_data_bytes(sbom.id)
-    except (SBOMDataError, Exception):
+    except (SBOMDataError, ClientError, BotoCoreError):
+        # get_sbom_data_bytes normalises most failures into SBOMDataError, but
+        # the S3 fetch itself re-raises botocore errors; anything else is a
+        # programming error that must surface, not an unreadable artifact.
         return None
     if raw is None or len(raw) > MAX_PARSE_BYTES:
         return None

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -1,0 +1,253 @@
+"""The four auditor-facing CSV exports: inventory, licenses, findings, vulnerabilities.
+
+Everything a row carries — package names, licence ids, vulnerability titles —
+originates in uploaded artifacts or scanner output, so the writer must be the
+CSV-injection-safe one and unreadable artifacts must surface as explicit rows
+rather than silently shrinking the export.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sbomify.apps.core.models import Component, Product, Release
+from sbomify.apps.core.services import csv_exports
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+
+CYCLONEDX = {
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "version": 1,
+    "components": [
+        {
+            "type": "library",
+            "name": "requests",
+            "version": "2.32.3",
+            "purl": "pkg:pypi/requests@2.32.3",
+            "supplier": {"name": "PSF"},
+            "licenses": [{"license": {"id": "Apache-2.0"}}],
+        },
+        {
+            "type": "library",
+            "name": "=cmd|calc",
+            "version": "1.0",
+            "licenses": [{"expression": "MIT"}],
+        },
+    ],
+}
+
+SPDX = {
+    "spdxVersion": "SPDX-2.3",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "spdx-doc",
+    "packages": [
+        {
+            "name": "left-pad",
+            "versionInfo": "1.3.0",
+            "supplier": "Organization: npm",
+            "licenseDeclared": "MIT",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:npm/left-pad@1.3.0",
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def inventory(sample_team_with_owner_member):
+    team = sample_team_with_owner_member.team
+    product = Product.objects.create(name="Prod", team=team)
+    c1 = Component.objects.create(name="frontend", team=team)
+    c2 = Component.objects.create(name="backend", team=team)
+    c1.products.add(product)
+    c2.products.add(product)
+    s1 = SBOM.objects.create(
+        name="frontend",
+        version="1.0",
+        format="cyclonedx",
+        format_version="1.6",
+        sbom_filename="f.json",
+        component=c1,
+    )
+    s2 = SBOM.objects.create(
+        name="backend",
+        version="2.0",
+        format="spdx",
+        format_version="2.3",
+        sbom_filename="b.json",
+        component=c2,
+    )
+    return team, product, {s1.id: CYCLONEDX, s2.id: SPDX}
+
+
+@pytest.fixture
+def stub_sbom_bytes(inventory, monkeypatch):
+    _, _, docs = inventory
+
+    def fake(sbom_id):
+        sbom = SBOM.objects.get(id=sbom_id)
+        return sbom, json.dumps(docs[sbom_id]).encode()
+
+    monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", fake)
+    return docs
+
+
+@pytest.mark.django_db
+class TestInventoryCsv:
+    def test_packages_across_both_formats(self, inventory, stub_sbom_bytes):
+        team, product, _ = inventory
+        result = csv_exports.export_inventory_csv(team, product=product)
+        assert result.ok
+        body = result.value
+        assert "requests,2.32.3,PSF,Apache-2.0,pkg:pypi/requests@2.32.3" in body
+        assert "left-pad,1.3.0,npm,MIT,pkg:npm/left-pad@1.3.0" in body
+
+    def test_formula_injection_is_neutralised(self, inventory, stub_sbom_bytes):
+        team, _, _ = inventory
+        result = csv_exports.export_inventory_csv(team)
+        assert "'=cmd" in result.value
+        assert not any(cell.startswith("=") for line in result.value.splitlines() for cell in line.split(","))
+
+    def test_unreadable_sbom_gets_an_explicit_row(self, inventory, monkeypatch):
+        team, _, docs = inventory
+
+        def broken(sbom_id):
+            raise csv_exports.SBOMDataError("gone")
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", broken)
+        result = csv_exports.export_inventory_csv(team)
+        assert result.ok
+        assert result.value.count("(unreadable artifact)") == 2
+
+    def test_only_latest_sbom_per_component(self, inventory, monkeypatch):
+        team, _, docs = inventory
+        component = Component.objects.get(name="frontend", team=team)
+        newer = SBOM.objects.create(
+            name="frontend",
+            version="1.1",
+            format="cyclonedx",
+            format_version="1.6",
+            sbom_filename="f2.json",
+            component=component,
+        )
+        docs[newer.id] = {"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}
+
+        def fake(sbom_id):
+            return SBOM.objects.get(id=sbom_id), json.dumps(docs[sbom_id]).encode()
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", fake)
+        result = csv_exports.export_inventory_csv(team)
+        assert "requests" not in result.value
+
+
+@pytest.mark.django_db
+class TestLicensesCsv:
+    def test_licences_aggregate_with_counts(self, inventory, stub_sbom_bytes):
+        team, product, _ = inventory
+        result = csv_exports.export_licenses_csv(team, product=product)
+        assert result.ok
+        lines = result.value.splitlines()
+        assert lines[0] == "License,Packages,Components"
+        assert "Apache-2.0,1,1" in lines
+        assert "MIT,2,2" in lines
+
+
+@pytest.mark.django_db
+class TestFindingsCsv:
+    def test_latest_compliance_run_rows(self, inventory):
+        team, _, docs = inventory
+        sbom = SBOM.objects.filter(component__team=team).first()
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="ntia",
+            plugin_version="1",
+            plugin_config_hash="",
+            category="compliance",
+            run_reason="on_upload",
+            status="completed",
+            result={
+                "findings": [
+                    {"id": "ntia:supplier", "title": "Supplier", "status": "fail", "description": "missing"},
+                ]
+            },
+        )
+        result = csv_exports.export_findings_csv(sbom)
+        assert result.ok
+        assert "ntia,ntia:supplier,Supplier,fail,missing" in result.value
+
+
+@pytest.mark.django_db
+class TestVulnerabilitiesCsv:
+    def test_rows_carry_analysis_state(self, inventory):
+        team, product, docs = inventory
+        sbom = SBOM.objects.filter(component__team=team, format="cyclonedx").first()
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1",
+            plugin_config_hash="",
+            category="security",
+            run_reason="on_upload",
+            status="completed",
+            result={
+                "findings": [
+                    {
+                        "id": "CVE-2025-1",
+                        "severity": "high",
+                        "cvss_score": 8.1,
+                        "component": {"name": "requests", "version": "2.32.3"},
+                        "analysis_state": "not_affected",
+                    },
+                    {
+                        "id": "CVE-2025-2",
+                        "severity": "critical",
+                        "component": {"name": "requests", "version": "2.32.3"},
+                    },
+                ]
+            },
+        )
+        result = csv_exports.export_vulnerabilities_csv(team, component=sbom.component)
+        assert result.ok
+        assert "CVE-2025-2,critical" in result.value
+        suppressed_line = next(line for line in result.value.splitlines() if line.startswith("CVE-2025-1"))
+        assert "not_affected" in suppressed_line
+
+    def test_release_scope_uses_pinned_sboms(self, inventory):
+        team, product, docs = inventory
+        release = Release.objects.create(product=product, name="v1")
+        result = csv_exports.export_vulnerabilities_csv(team, release=release)
+        assert result.ok
+        assert result.value.splitlines()[0].startswith("Vulnerability")
+
+
+@pytest.mark.django_db
+class TestEndpoints:
+    def test_inventory_endpoint_returns_csv(self, authenticated_api_client, inventory, stub_sbom_bytes):
+        client, token = authenticated_api_client
+        from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+        team, _, _ = inventory
+        response = client.get("/api/v1/exports/inventory.csv", **get_api_headers(token))
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("text/csv")
+        assert "attachment" in response["Content-Disposition"]
+
+    def test_another_user_sees_none_of_this_workspaces_data(self, inventory, stub_sbom_bytes, guest_user, client):
+        """Signup gives every user their own workspace, so the export succeeds —
+        against their workspace, never this one."""
+        client.force_login(guest_user)
+        response = client.get("/api/v1/exports/inventory.csv")
+        if response.status_code == 200:
+            body = response.content.decode()
+            assert "requests" not in body
+            assert "frontend" not in body
+        else:
+            assert response.status_code in (401, 403)

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -333,3 +333,33 @@ class TestNoticeReport:
         html = client.get("/api/v1/exports/notice?format=html", **get_api_headers(token))
         assert html.status_code == 200
         assert html["Content-Type"].startswith("text/html")
+
+
+@pytest.mark.django_db
+class TestUnreadableSurfacing:
+    def test_licenses_csv_counts_unreadable_artifacts(self, inventory, monkeypatch):
+        team, _, _ = inventory
+
+        def broken(sbom_id):
+            raise csv_exports.SBOMDataError("gone")
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", broken)
+        result = csv_exports.export_licenses_csv(team)
+        assert "(unreadable artifact)" in result.value
+
+    def test_notice_lists_unreadable_artifacts(self, inventory, monkeypatch):
+        team, _, _ = inventory
+
+        def broken(sbom_id):
+            raise csv_exports.SBOMDataError("gone")
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", broken)
+        result = csv_exports.export_notice_text(team)
+        assert "Artifacts that could not be read" in result.value
+
+    def test_unknown_notice_format_is_rejected(self, authenticated_api_client, inventory, stub_sbom_bytes):
+        client, token = authenticated_api_client
+        from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+        response = client.get("/api/v1/exports/notice?format=pdf", **get_api_headers(token))
+        assert response.status_code == 400

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -112,9 +112,14 @@ class TestInventoryCsv:
 
     def test_formula_injection_is_neutralised(self, inventory, stub_sbom_bytes):
         team, _, _ = inventory
+        import csv as stdlib_csv
+        import io
+
         result = csv_exports.export_inventory_csv(team)
         assert "'=cmd" in result.value
-        assert not any(cell.startswith("=") for line in result.value.splitlines() for cell in line.split(","))
+        for record in stdlib_csv.reader(io.StringIO(result.value)):
+            for cell in record:
+                assert not cell.startswith(("=", "+", "@", "\t"))
 
     def test_unreadable_sbom_gets_an_explicit_row(self, inventory, monkeypatch):
         team, _, docs = inventory

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -251,3 +251,80 @@ class TestEndpoints:
             assert "frontend" not in body
         else:
             assert response.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+class TestNoticeReport:
+    def test_text_notice_groups_and_flags_unknown(self, inventory, stub_sbom_bytes):
+        team, product, docs = inventory
+        result = csv_exports.export_notice_text(team, product=product)
+        assert result.ok
+        body = result.value
+        assert "Third-Party Notices" in body
+        assert "requests 2.32.3" in body
+        assert "Apache-2.0" in body
+        # the =cmd|calc package has a licence (MIT); nothing lands in unknown here
+        assert "left-pad 1.3.0" in body
+
+    def test_packages_without_licence_land_in_unknown_section(self, inventory, monkeypatch):
+        team, _, docs = inventory
+        bare = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [{"type": "library", "name": "mystery", "version": "0.1"}],
+        }
+
+        def fake(sbom_id):
+            return SBOM.objects.get(id=sbom_id), json.dumps(bare).encode()
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", fake)
+        result = csv_exports.export_notice_text(team)
+        assert "Components without license data" in result.value
+        assert "mystery 0.1" in result.value
+
+    def test_html_notice_escapes_supplier_controlled_strings(self, inventory, monkeypatch):
+        team, _, docs = inventory
+        hostile = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "components": [
+                {
+                    "type": "library",
+                    "name": "<script>alert(1)</script>",
+                    "version": "1.0",
+                    "licenses": [{"expression": "MIT"}],
+                    "copyright": "(c) <b>Evil</b>",
+                }
+            ],
+        }
+
+        def fake(sbom_id):
+            return SBOM.objects.get(id=sbom_id), json.dumps(hostile).encode()
+
+        monkeypatch.setattr(csv_exports, "get_sbom_data_bytes", fake)
+        result = csv_exports.export_notice_html(team)
+        assert result.ok
+        assert "<script>alert(1)</script>" not in result.value
+        assert "&lt;script&gt;" in result.value
+
+    def test_release_aggregate_covers_pinned_sboms(self, inventory, stub_sbom_bytes):
+        team, product, docs = inventory
+        from sbomify.apps.core.models import ReleaseArtifact
+
+        release = Release.objects.create(product=product, name="v1")
+        for sbom in SBOM.objects.filter(component__team=team):
+            ReleaseArtifact.objects.create(release=release, sbom=sbom)
+        result = csv_exports.export_notice_text(team, release=release)
+        assert "requests 2.32.3" in result.value
+        assert "left-pad 1.3.0" in result.value
+
+    def test_notice_endpoint_serves_both_formats(self, authenticated_api_client, inventory, stub_sbom_bytes):
+        client, token = authenticated_api_client
+        from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+        text = client.get("/api/v1/exports/notice?format=text", **get_api_headers(token))
+        assert text.status_code == 200
+        assert text["Content-Type"].startswith("text/plain")
+        html = client.get("/api/v1/exports/notice?format=html", **get_api_headers(token))
+        assert html.status_code == 200
+        assert html["Content-Type"].startswith("text/html")


### PR DESCRIPTION
Closes #1183. **Stacked on #1417** — reuses its artifact-extraction layer, so the diff contains that PR's commit until it merges; review the top commit.

Every shipped release owes a third-party attribution document; customers produce them by hand today. This derives one on read from the stored artifacts:

- `GET /api/v1/exports/notice?release_id=…&format=text|html` → `NOTICE.txt` / `NOTICE.html` (also `product_id`, or workspace-wide with no filter)
- Component name, version, licenses, and copyright where the artifact carries one (`copyright` in CycloneDX, `copyrightText` minus `NOASSERTION` in SPDX), de-duplicated per package across the release's pinned SBOMs
- **Components without license data land in their own section rather than being dropped** — an attribution file that silently omits them reads as complete when it is not
- Both renderers consume one entry structure, so text and HTML can never disagree; every HTML value renders through `escape()` (test pins a `<script>` package name)

Acceptance criteria from the issue: NOTICE per release in text + HTML ✓, unknown section ✓, release aggregates ✓.

Five tests: grouping, the unknown section, HTML escaping of hostile artifact strings, release aggregation across multiple pinned SBOMs, and both endpoint content types.