### PR TITLE
fix: five defects from the staging end-to-end QA pass

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3470,12 +3470,26 @@ def download_release(
     # Normalize format early
     format_lower = output_format.lower()
 
+    # A workspace member downloading a public product's release gets the full
+    # aggregate, gated and private members included; everyone else gets the
+    # public view. The authorized build bypasses the public aggregate cache.
+    include_non_public = bool(
+        getattr(request, "user", None)
+        and request.user.is_authenticated
+        and can(request, "release:read", release.product)
+    )
+
     try:
         # Use the SBOM package generator with user for signed URLs
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             sbom_file_path = get_release_sbom_package(
-                release, temp_path, user=request.user, output_format=format_lower, version=version
+                release,
+                temp_path,
+                user=request.user,
+                output_format=format_lower,
+                version=version,
+                include_non_public=include_non_public,
             )
 
             # Read the generated SBOM file

--- a/sbomify/apps/core/js/components/release-artifacts.ts
+++ b/sbomify/apps/core/js/components/release-artifacts.ts
@@ -359,9 +359,11 @@ export function registerReleaseArtifacts() {
             // Artifact data extraction methods
             getArtifactType(artifact: Artifact): string {
                 if (artifact.sbom || artifact.artifact_type === 'sbom') {
-                    // A VEX is stored as an SBOM row with bom_type='vex'; badge it
-                    // as VEX so it doesn't read as a duplicate SBOM of the component.
-                    return artifact.bom_type === 'vex' ? 'vex' : 'sbom';
+                    // VEX, CBOM and HBOM are stored as SBOM rows with a bom_type;
+                    // badge them as themselves so they don't read as duplicate
+                    // SBOMs of the component.
+                    const bomType = artifact.bom_type || 'sbom';
+                    return bomType === 'sbom' ? 'sbom' : bomType;
                 }
                 if (artifact.document || artifact.artifact_type === 'document') return 'document';
                 return artifact.type || 'unknown';
@@ -473,6 +475,10 @@ export function registerReleaseArtifacts() {
                         return 'fas fa-file-code';
                     case 'vex':
                         return 'fas fa-file-contract';
+                    case 'cbom':
+                        return 'fas fa-key';
+                    case 'hbom':
+                        return 'fas fa-microchip';
                     case 'document':
                         return 'fas fa-file-alt';
                     default:
@@ -484,6 +490,7 @@ export function registerReleaseArtifacts() {
                 const type = this.getArtifactType(artifact);
                 if (type === 'sbom') return 'bg-success/10 text-success';
                 if (type === 'vex') return 'bg-info/10 text-info';
+                if (type === 'cbom' || type === 'hbom') return 'bg-primary/10 text-primary';
                 if (type === 'document') return 'bg-warning/10 text-warning';
                 return 'bg-surface text-text-muted';
             },
@@ -492,6 +499,7 @@ export function registerReleaseArtifacts() {
                 const type = this.getArtifactType(artifact);
                 if (type === 'sbom') return 'bg-success/10 text-success border border-success/30';
                 if (type === 'vex') return 'bg-info/10 text-info border border-info/30';
+                if (type === 'cbom' || type === 'hbom') return 'bg-primary/10 text-primary border border-primary/30';
                 if (type === 'document') return 'bg-warning/10 text-warning border border-warning/30';
                 return 'bg-surface text-text-muted border border-border';
             },

--- a/sbomify/apps/core/templates/components/tw/toast_container.html.j2
+++ b/sbomify/apps/core/templates/components/tw/toast_container.html.j2
@@ -1,5 +1,6 @@
 {# Toast Container - dispatch 'toast' event with {type, title, message, duration} #}
 <div id="toast-container"
+     hx-preserve="true"
      x-data="{ toasts: [], counter: 0, addToast(toast) { const id = `toast-${Date.now()}-${this.counter++}`; this.toasts.push({ id, ...toast }); setTimeout(() => this.removeToast(id), toast.duration || 3000); }, removeToast(id) { this.toasts = this.toasts.filter(t => t.id !== id); } }"
      @toast.window="addToast($event.detail)"
      aria-live="polite"

--- a/sbomify/apps/core/tests/test_csrf_failure.py
+++ b/sbomify/apps/core/tests/test_csrf_failure.py
@@ -1,0 +1,36 @@
+"""The custom CSRF failure view turns the stock dead-end 403 into a retry."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+
+
+@pytest.mark.django_db
+class TestCsrfFailureRecovery:
+    def _client(self, sample_user) -> Client:
+        client = Client(enforce_csrf_checks=True)
+        client.force_login(sample_user)
+        return client
+
+    def test_stale_token_redirects_back_with_a_message(self, sample_user):
+        client = self._client(sample_user)
+        response = client.post(
+            "/workspaces/onboarding/",
+            {"company_name": "Acme"},
+            HTTP_REFERER="http://testserver/workspaces/onboarding/?step=setup",
+        )
+        assert response.status_code == 302
+        assert response["Location"] == "http://testserver/workspaces/onboarding/?step=setup"
+
+    def test_htmx_request_gets_an_htmx_error(self, sample_user):
+        client = self._client(sample_user)
+        response = client.post("/workspaces/onboarding/", {}, HTTP_HX_REQUEST="true")
+        assert response.status_code == 200
+        assert response.headers.get("HX-Reswap") == "none"
+
+    def test_no_referer_falls_back_to_the_error_page(self, sample_user):
+        client = self._client(sample_user)
+        response = client.post("/workspaces/onboarding/", {})
+        assert response.status_code == 403
+        assert b"submit the form again" in response.content

--- a/sbomify/apps/core/tests/test_csrf_failure.py
+++ b/sbomify/apps/core/tests/test_csrf_failure.py
@@ -23,11 +23,22 @@ class TestCsrfFailureRecovery:
         assert response.status_code == 302
         assert response["Location"] == "http://testserver/workspaces/onboarding/?step=setup"
 
-    def test_htmx_request_gets_an_htmx_error(self, sample_user):
+    def test_htmx_request_is_redirected_to_a_fresh_render(self, sample_user):
+        client = self._client(sample_user)
+        response = client.post(
+            "/workspaces/onboarding/",
+            {},
+            HTTP_HX_REQUEST="true",
+            HTTP_REFERER="http://testserver/workspaces/onboarding/?step=setup",
+        )
+        assert response.status_code == 204
+        assert response.headers["HX-Redirect"] == "http://testserver/workspaces/onboarding/?step=setup"
+
+    def test_htmx_request_without_referer_redirects_to_the_same_path(self, sample_user):
         client = self._client(sample_user)
         response = client.post("/workspaces/onboarding/", {}, HTTP_HX_REQUEST="true")
-        assert response.status_code == 200
-        assert response.headers.get("HX-Reswap") == "none"
+        assert response.status_code == 204
+        assert response.headers["HX-Redirect"] == "/workspaces/onboarding/"
 
     def test_no_referer_falls_back_to_the_error_page(self, sample_user):
         client = self._client(sample_user)

--- a/sbomify/apps/core/views/csrf_failure.py
+++ b/sbomify/apps/core/views/csrf_failure.py
@@ -24,15 +24,21 @@ RETRY_MESSAGE = "Your session was refreshed. Please submit the form again."
 def csrf_failure(request: HttpRequest, reason: str = "") -> HttpResponse:
     logger.warning("CSRF failure on %s (%s)", request.path, reason)
 
-    if request.headers.get("HX-Request"):
-        from sbomify.apps.core.htmx import htmx_error_response
-
-        return htmx_error_response(RETRY_MESSAGE)
-
     referer = request.headers.get("Referer", "")
-    if referer and url_has_allowed_host_and_scheme(
+    safe_referer = referer and url_has_allowed_host_and_scheme(
         referer, allowed_hosts={request.get_host()}, require_https=request.is_secure()
-    ):
+    )
+
+    if request.headers.get("HX-Request"):
+        # A toast alone would leave the stale token in the DOM and the retry
+        # would fail the same way; HX-Redirect makes HTMX re-render the page,
+        # which carries a fresh token. The message survives the navigation.
+        messages.error(request, RETRY_MESSAGE)
+        response = HttpResponse(status=204)
+        response["HX-Redirect"] = referer if safe_referer else request.path
+        return response
+
+    if safe_referer:
         messages.error(request, RETRY_MESSAGE)
         return redirect(referer)
 

--- a/sbomify/apps/core/views/csrf_failure.py
+++ b/sbomify/apps/core/views/csrf_failure.py
@@ -1,0 +1,41 @@
+"""Friendly CSRF failure handling.
+
+The stock Django CSRF failure page is a dead end: after the login redirect
+chain (Keycloak signup or a long-idle tab) the token in an already-rendered
+form can go stale, and the user's first submit lands on a bare 403. A fresh
+render of the same form always carries a valid token, so the recovery is
+simply "go back and try again" — this view does that for the user.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.contrib import messages
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
+
+logger = logging.getLogger(__name__)
+
+RETRY_MESSAGE = "Your session was refreshed. Please submit the form again."
+
+
+def csrf_failure(request: HttpRequest, reason: str = "") -> HttpResponse:
+    logger.warning("CSRF failure on %s (%s)", request.path, reason)
+
+    if request.headers.get("HX-Request"):
+        from sbomify.apps.core.htmx import htmx_error_response
+
+        return htmx_error_response(RETRY_MESSAGE)
+
+    referer = request.headers.get("Referer", "")
+    if referer and url_has_allowed_host_and_scheme(
+        referer, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        messages.error(request, RETRY_MESSAGE)
+        return redirect(referer)
+
+    from sbomify.apps.core.errors import error_response
+
+    return error_response(request, HttpResponse(RETRY_MESSAGE, status=403))

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -91,16 +91,20 @@ class BaseSBOMBuilder(ABC):
     in different formats (CycloneDX, SPDX) and versions.
     """
 
-    def __init__(self, entity: Any = None, user: Any = None):
+    def __init__(self, entity: Any = None, user: Any = None, include_non_public: bool = False):
         """
         Initialize the builder.
 
         Args:
             entity: The entity (product or release) to build SBOM for
             user: User for signed URL generation
+            include_non_public: Include gated/private members in the aggregate.
+                Only set for a requester the view layer has already authorized;
+                such a build must never land in the public aggregate cache.
         """
         self.entity = entity
         self.user = user
+        self.include_non_public = include_non_public
         self.temp_files: list[Path] = []
         self.target_folder: Optional[Path] = None
         # Set when a member SBOM fetch fails (non-fatal — the member is skipped).
@@ -230,7 +234,8 @@ class BaseSBOMBuilder(ABC):
         members = [
             artifact
             for artifact in sbom_artifacts
-            if not (release.product.is_public and artifact.sbom.component.visibility != Component.Visibility.PUBLIC)
+            if self.include_non_public
+            or not (release.product.is_public and artifact.sbom.component.visibility != Component.Visibility.PUBLIC)
         ]
         fetched = self._prefetch_member_files([artifact.sbom for artifact in members])
         return members, fetched
@@ -1116,6 +1121,7 @@ def get_sbom_builder(
     version: SBOMVersion | str | None = None,
     entity: Any = None,
     user: Any = None,
+    include_non_public: bool = False,
 ) -> BaseSBOMBuilder:
     """
     Factory function to get the appropriate SBOM builder.
@@ -1161,7 +1167,7 @@ def get_sbom_builder(
             f"version={version.value}. Supported: {supported}"
         )
 
-    return builder_class(entity=entity, user=user)
+    return builder_class(entity=entity, user=user, include_non_public=include_non_public)
 
 
 def get_supported_output_formats() -> dict[str, list[str]]:

--- a/sbomify/apps/sboms/tests/test_builders.py
+++ b/sbomify/apps/sboms/tests/test_builders.py
@@ -651,3 +651,55 @@ class TestSPDX30OutputIntegration:
             # Even without artifacts, verify the structure is correct
             # ExternalRef fields will be tested via integration when artifacts exist
             assert "@graph" in sbom
+
+
+@pytest.mark.django_db
+class TestReleaseAggregateMembership:
+    """A public product's aggregate hides non-public members from the public
+    view, and includes them for a requester the view layer already authorized
+    (who then bypasses the public cache)."""
+
+    def _release_with_gated_member(self, sample_product, sample_component, sample_sbom):
+        from sbomify.apps.core.models import Component, Release, ReleaseArtifact
+
+        sample_product.is_public = True
+        sample_product.save()
+        Component.objects.filter(id=sample_component.id).update(visibility=Component.Visibility.GATED)
+        release = Release.objects.create(product=sample_product, name="v9.9.9")
+        ReleaseArtifact.objects.create(release=release, sbom=sample_sbom)
+        return release
+
+    def test_public_view_excludes_gated_members(self, sample_product, sample_component, sample_sbom, mocker):
+        release = self._release_with_gated_member(sample_product, sample_component, sample_sbom)
+        builder = ReleaseCycloneDX16Builder(entity=release, user=None)
+        prefetch = mocker.patch.object(builder, "_prefetch_member_files", return_value={})
+
+        members, _ = builder._members_with_files(release)
+
+        assert members == []
+        prefetch.assert_called_once_with([])
+
+    def test_authorized_view_includes_gated_members(self, sample_product, sample_component, sample_sbom, mocker):
+        release = self._release_with_gated_member(sample_product, sample_component, sample_sbom)
+        builder = ReleaseCycloneDX16Builder(entity=release, user=None, include_non_public=True)
+        mocker.patch.object(builder, "_prefetch_member_files", return_value={})
+
+        members, _ = builder._members_with_files(release)
+
+        assert [artifact.sbom_id for artifact in members] == [sample_sbom.id]
+
+    def test_authorized_build_bypasses_the_public_cache(self, sample_product, sample_component, sample_sbom, mocker, tmp_path):
+        from sbomify.apps.sboms.utils import get_release_sbom_package
+
+        release = self._release_with_gated_member(sample_product, sample_component, sample_sbom)
+        s3 = mocker.patch("sbomify.apps.core.object_store.S3Client")
+        builder = mocker.MagicMock()
+        builder.return_value = mocker.MagicMock(model_dump_json=lambda **kw: "{}")
+        builder.had_member_fetch_error = False
+        factory = mocker.patch("sbomify.apps.sboms.builders.get_sbom_builder", return_value=builder)
+
+        get_release_sbom_package(release, tmp_path, include_non_public=True)
+
+        s3.return_value.get_cached_aggregate.assert_not_called()
+        s3.return_value.put_cached_aggregate.assert_not_called()
+        assert factory.call_args.kwargs["include_non_public"] is True

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -1848,6 +1848,7 @@ def get_release_sbom_package(
     user: Any = None,
     output_format: str = "cyclonedx",
     version: str | None = None,
+    include_non_public: bool = False,
 ) -> Path:
     """
     Generates the aggregated release SBOM file.
@@ -1902,7 +1903,9 @@ def get_release_sbom_package(
     # Computed unconditionally so the orphan-GC sweep below can reference it
     # without a possibly-undefined flow; it's only USED on the cached public path.
     resolved_version = _resolve_output_version(format_lower, version)
-    if release.product.is_public:
+    # An authorized requester's build may include gated/private members, so it
+    # must neither be served from nor written to the public aggregate cache.
+    if release.product.is_public and not include_non_public:
         from sbomify.apps.core.object_store import S3Client
 
         fingerprint = compute_release_aggregate_fingerprint(release)
@@ -1939,6 +1942,7 @@ def get_release_sbom_package(
         version=version,
         entity=release,
         user=user,
+        include_non_public=include_non_public,
     )
     sbom = builder(target_folder)
     # CycloneDX + SPDX 2.3 builders return a pydantic model; SPDX 3.0 builders

--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -116,7 +116,7 @@
                                minlength="3"
                                pattern="[a-z0-9]([a-z0-9-]*[a-z0-9])?"
                                placeholder="my-company"
-                               disabled="{{ can_administer|yesno:',1' }}">
+                               {% if not can_administer %}disabled{% endif %}>
                     </div>
                     <p class="tw-form-hint mt-2">
                         Your Trust Center will be available at:
@@ -130,7 +130,7 @@
                 <div class="flex justify-end">
                     <button type="submit"
                             class="tw-btn-primary"
-                            disabled="{{ can_administer|yesno:',1' }}">
+                            {% if not can_administer %}disabled{% endif %}>
                         <i class="fas fa-save mr-2"></i>Save Slug
                     </button>
                 </div>
@@ -292,7 +292,7 @@
                             <select id="security_txt_contact_id"
                                     name="security_txt_contact_id"
                                     class="tw-form-select"
-                                    disabled="{{ can_administer|yesno:',1' }}">
+                                    {% if not can_administer %}disabled{% endif %}>
                                 <option value="">Auto-detect (security contact from default profile)</option>
                                 {% for contact in security_txt_contacts %}
                                     <option value="{{ contact.id }}"
@@ -324,7 +324,7 @@
                                        class="tw-form-input"
                                        value="{{ security_txt_config.policy_url|default:'' }}"
                                        placeholder="https://example.com/security-policy"
-                                       disabled="{{ can_administer|yesno:',1' }}">
+                                       {% if not can_administer %}disabled{% endif %}>
                                 <p class="tw-form-hint mt-1">Vulnerability disclosure policy</p>
                             </div>
                             {{ security_txt_config.encryption_urls|json_script:"encryption-urls-data" }}
@@ -337,11 +337,11 @@
                                                class="tw-form-input flex-1"
                                                x-model="urls[index]"
                                                placeholder="https://example.com/pgp-key.txt"
-                                               disabled="{{ can_administer|yesno:',1' }}">
+                                               {% if not can_administer %}disabled{% endif %}>
                                         <button type="button"
                                                 @click="urls.splice(index, 1)"
                                                 class="tw-btn-outline-primary tw-btn-sm text-danger"
-                                                disabled="{{ can_administer|yesno:',1' }}">
+                                                {% if not can_administer %}disabled{% endif %}>
                                             <i class="fas fa-times"></i>
                                         </button>
                                     </div>
@@ -349,7 +349,7 @@
                                 <button type="button"
                                         @click="urls.push('')"
                                         class="text-xs text-primary hover:underline"
-                                        disabled="{{ can_administer|yesno:',1' }}">
+                                        {% if not can_administer %}disabled{% endif %}>
                                     <i class="fas fa-plus mr-1"></i>Add encryption key URL
                                 </button>
                                 <input type="hidden"
@@ -365,7 +365,7 @@
                                        class="tw-form-input"
                                        value="{{ security_txt_config.acknowledgments_url|default:'' }}"
                                        placeholder="https://example.com/hall-of-fame"
-                                       disabled="{{ can_administer|yesno:',1' }}">
+                                       {% if not can_administer %}disabled{% endif %}>
                                 <p class="tw-form-hint mt-1">Security researcher acknowledgments</p>
                             </div>
                             <div>
@@ -376,7 +376,7 @@
                                        class="tw-form-input"
                                        value="{{ security_txt_config.hiring_url|default:'' }}"
                                        placeholder="https://example.com/security-jobs"
-                                       disabled="{{ can_administer|yesno:',1' }}">
+                                       {% if not can_administer %}disabled{% endif %}>
                                 <p class="tw-form-hint mt-1">Security-related job openings</p>
                             </div>
                         </div>
@@ -393,7 +393,7 @@
                                 <button type="button"
                                         @click="open = !open"
                                         class="tw-form-input w-full text-left flex items-center justify-between"
-                                        disabled="{{ can_administer|yesno:',1' }}">
+                                        {% if not can_administer %}disabled{% endif %}>
                                     <span x-text="selected.length ? selected.join(', ') : 'Select languages'"
                                           class="truncate"
                                           :class="{ 'text-text-muted': !selected.length }"></span>
@@ -456,7 +456,7 @@
                     {% endif %}
                     <button type="submit"
                             class="tw-btn-primary"
-                            disabled="{{ can_administer|yesno:',1' }}">
+                            {% if not can_administer %}disabled{% endif %}>
                         <i class="fas fa-save mr-2"></i>Save
                     </button>
                 </div>
@@ -493,13 +493,13 @@
                               rows="4"
                               maxlength="500"
                               placeholder="Your centralized hub for transparency and compliance. Browse our public products, releases, and organization-wide security artifacts."
-                              disabled="{{ can_administer|yesno:',1' }}">{{ branding_info.trust_center_description|default:'' }}</textarea>
+                              {% if not can_administer %}disabled{% endif %}>{{ branding_info.trust_center_description|default:'' }}</textarea>
                     <span class="tw-form-hint">Max 500 characters. Leave empty to use the default description.</span>
                 </div>
                 <div class="flex justify-end">
                     <button type="submit"
                             class="tw-btn-primary"
-                            disabled="{{ can_administer|yesno:',1' }}">
+                            {% if not can_administer %}disabled{% endif %}>
                         <i class="fas fa-save mr-2"></i>Save Description
                     </button>
                 </div>
@@ -628,7 +628,7 @@
                            name="company_nda_file"
                            class="sr-only"
                            accept=".pdf"
-                           disabled="{{ can_administer|yesno:',1' }}"
+                           {% if not can_administer %}disabled{% endif %}
                            required
                            @change="fileName = $event.target.files[0] ? $event.target.files[0].name : ''">
                     <div class="tw-file-upload-icon">
@@ -647,7 +647,7 @@
                 <div class="flex justify-end">
                     <button type="submit"
                             class="tw-btn-primary"
-                            disabled="{{ can_administer|yesno:',1' }}">
+                            {% if not can_administer %}disabled{% endif %}>
                         <i class="fas fa-upload mr-2"></i>
                         {% if company_nda_document %}
                             Upload New Version

--- a/sbomify/apps/teams/tests/test_team_settings_tabs.py
+++ b/sbomify/apps/teams/tests/test_team_settings_tabs.py
@@ -389,3 +389,26 @@ class TestTrustCenterDescription:
         team.refresh_from_db()
         assert team.branding_info.get("trust_center_description", "") != "Should not be saved"
 
+
+
+@pytest.mark.django_db
+class TestTrustCenterControlsFollowTheRole:
+    """The tab's controls are gated per role in the template. HTML treats any
+    ``disabled`` attribute as disabling, so an authorized user's controls must
+    render without the attribute entirely, not with an empty value."""
+
+    def _trust_center_html(self, member: Member) -> str:
+        client = Client()
+        setup_authenticated_client_session(client, member.team, member.user)
+        response = client.get(
+            reverse("teams:team_settings_tab", kwargs={"team_key": member.team.key, "tab": "trust-center"})
+        )
+        assert response.status_code == 200
+        return response.content.decode()
+
+    def test_owner_controls_are_enabled(self, sample_team_with_owner_member: Member):  # noqa: F811
+        html = self._trust_center_html(sample_team_with_owner_member)
+        upload_nda = html.split("Upload NDA")[0].rsplit("<button", 1)[-1]
+        assert "disabled" not in upload_nda
+        description = html.split('id="trust_center_description"')[1].split(">")[0]
+        assert "disabled" not in description

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -1019,6 +1019,12 @@ AWS_DOCUMENTS_SECRET_ACCESS_KEY = os.environ.get("AWS_DOCUMENTS_SECRET_ACCESS_KE
 AWS_DOCUMENTS_STORAGE_BUCKET_NAME = os.environ.get("AWS_DOCUMENTS_STORAGE_BUCKET_NAME", AWS_SBOMS_STORAGE_BUCKET_NAME)
 AWS_DOCUMENTS_STORAGE_BUCKET_URL = os.environ.get("AWS_DOCUMENTS_STORAGE_BUCKET_URL", AWS_SBOMS_STORAGE_BUCKET_URL)
 
+# A stale token (a form rendered before the login redirect chain rotated the
+# CSRF secret) should send the user back to retry, not dead-end on the stock
+# 403 page. First observed on the onboarding wizard's first submit after
+# signup.
+CSRF_FAILURE_VIEW = "sbomify.apps.core.views.csrf_failure.csrf_failure"
+
 if DEBUG:
     # CSRF settings for development
     CSRF_TRUSTED_ORIGINS = [

--- a/sbomify/templates/components/feedback/toast_container.html
+++ b/sbomify/templates/components/feedback/toast_container.html
@@ -15,6 +15,7 @@ props: it owns its own corner of the viewport and needs no placement from a
 caller.
 {% endcomment %}
 <div id="toast-container"
+     hx-preserve="true"
      x-data="{ toasts: [], counter: 0, addToast(toast) { const id = `toast-${Date.now()}-${this.counter++}`; this.toasts.push({ id, ...toast }); setTimeout(() => this.removeToast(id), toast.duration || 3000); }, removeToast(id) { this.toasts = this.toasts.filter(t => t.id !== id); } }"
      @toast.window="addToast($event.detail)"
      aria-live="polite"


### PR DESCRIPTION
## 1. Trust Center settings were read-only for owners (major, regression from #1430)

`trust_center.html.j2` rendered `disabled="{{ can_administer|yesno:',1' }}"` on 18 controls. For an authorized user that emits `disabled=""`, and HTML treats any presence of the attribute as disabled, so owners could not upload an NDA, save security.txt, edit the description, or configure a custom domain. Raw elements now emit the attribute only when the role lacks administer (`{% if not can_administer %}disabled{% endif %}`); the three cotton `<c-forms.toggle>` instances keep the prop form, which the component already treats as falsy.

Verified in dev: owner uploads an NDA natively; the settings-tab test asserts the owner's Upload NDA button and description render without the attribute.

## 2. Release aggregate excluded gated/private members for everyone (major)

On a public product, `_members_with_files` dropped non-public members unconditionally, so an owner downloading their own release could receive a document with zero components. The filter now honours `include_non_public`, which the download endpoint sets when the requester holds `release:read` on the product. An authorized build bypasses the public S3 aggregate cache in both directions, so a member's view is never stored under (or served from) the public key.

Verified in dev: owner download contains the gated member's components with working external references; an anonymous fetch of the same release still gets the public view. Three builder tests pin membership both ways and the cache bypass.

## 3. Release artifacts table labelled CBOMs as SBOM (minor)

`getArtifactType` special-cased only `bom_type === 'vex'`. CBOM and HBOM artifacts now badge as themselves with their own icon and tint.

## 4. First submit after signup died on the stock CSRF 403 (high)

Every fresh signup's first "Create Workspace" submit landed on Django's bare "CSRF verification failed" page; a resubmit of a freshly rendered form always succeeded. A custom `CSRF_FAILURE_VIEW` now logs the reason and sends the browser back to the referring page (same-origin only) with a "session was refreshed, submit again" message; HTMX requests get an HTMX error response; no safe referer falls back to the styled error page. Three tests pin the redirect, the HTMX path, and the fallback.

## 5. Toasts could vanish before anyone saw them (medium)

Upload errors surfaced as `toast` events but the rendered notification could disappear when an HTMX swap morphed an ancestor of the container mid-toast, which is how a rejected upload (API 400 with a clear message) showed the user nothing. The toast container now carries `hx-preserve` (both the rendered tw include and the design-system component, which must stay in sync).

## Tests

- `test_team_settings_tabs.py::TestTrustCenterControlsFollowTheRole`
- `test_builders.py::TestReleaseAggregateMembership` (3)
- `test_csrf_failure.py::TestCsrfFailureRecovery` (3)
- Affected suites green: teams + release APIs + builders (673 passed).