### PR TITLE
fix(trends): a day without a scan keeps the last known counts

### DIFF
--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -1004,3 +1004,79 @@ class TestVulnerabilityTrendsView:
         response = client.get(self._get_url(product_id=product.id, release_id=foreign_release.id))
         assert response.status_code == 200
         assert response.context["selected_release_id"] == "latest"
+
+
+@pytest.mark.django_db
+class TestTimelineCarriesStateAcrossScanGaps:
+    """Days without a scan hold the last known counts instead of zero. The
+    zero-filled gaps drew sawtooth waves out of a flat vulnerability count
+    whenever the chart's daily resolution exceeded the scan cadence."""
+
+    def _get_url(self, **params: str) -> str:
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"/vulnerability-trends/?{qs}" if qs else "/vulnerability-trends/"
+
+    def _run_on(self, sbom, day_offset: int, *, plugin: str = "grype", critical: int = 0, high: int = 0):
+        run = AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name=plugin,
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+            result=_make_assessment_result(critical=critical, high=high),
+        )
+        AssessmentRun.objects.filter(pk=run.pk).update(created_at=timezone.now() - timedelta(days=day_offset))
+        return run
+
+    def test_gap_days_keep_the_last_scanned_counts(self, team_with_member, component_with_sbom):
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+        self._run_on(sbom, 6, high=45)
+        self._run_on(sbom, 2, high=45)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(days="7"))
+        assert response.status_code == 200
+
+        series = response.context["time_series"]
+        highs = [point["high"] for point in series]
+        first_scan_idx = next(i for i, v in enumerate(highs) if v)
+        # Every day from the first scan onward holds 45 — no zero valleys.
+        assert set(highs[first_scan_idx:]) == {45}
+        assert all(v == 0 for v in highs[:first_scan_idx])
+
+    def test_pairs_scanned_on_different_days_stack_without_dips(self, team_with_member, component_with_sbom):
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+        # Two providers alternating days: each day's point is the sum of both
+        # pairs' carried state once both have reported.
+        self._run_on(sbom, 5, plugin="grype", high=40)
+        self._run_on(sbom, 4, plugin="osv", high=10)
+        self._run_on(sbom, 1, plugin="grype", high=40)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(days="7"))
+
+        highs = [point["high"] for point in response.context["time_series"]]
+        assert 50 in highs
+        idx_50 = highs.index(50)
+        # Once both providers have reported, the line never drops below 50.
+        assert set(highs[idx_50:]) == {50}
+
+    def test_state_scanned_before_the_window_seeds_day_one(self, team_with_member, component_with_sbom):
+        team, user = team_with_member
+        sbom, _ = component_with_sbom
+        self._run_on(sbom, 20, high=45)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+        response = client.get(self._get_url(days="7"))
+
+        highs = [point["high"] for point in response.context["time_series"]]
+        # The pair was last scanned before the window opened; every day in the
+        # window carries that state — the left edge does not climb from zero.
+        assert set(highs) == {45}

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -410,14 +410,26 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # scans rendered as zero and the smoothed chart drew sawtooth waves
         # out of a perfectly flat vulnerability count.
         time_series = []
+        # Running totals over the carried pairs, adjusted only by the pairs
+        # that change on a given day — O(days + scans), not O(days x pairs),
+        # so a workspace with a deep scan history doesn't pay for every pair
+        # on every day of the window.
+        running = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
+        for counts in carried_counts.values():
+            for severity in running:
+                running[severity] += counts[severity]
         current_date = start_date.date()
         while current_date <= end_date.date():
             day_key = current_date.isoformat()
-            carried_counts.update(day_winners.get(day_key, {}))
-            day_data = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
-            for counts in carried_counts.values():
-                for severity in day_data:
-                    day_data[severity] += counts[severity]
+            for pair, counts in day_winners.get(day_key, {}).items():
+                previous = carried_counts.get(pair)
+                if previous is not None:
+                    for severity in running:
+                        running[severity] -= previous[severity]
+                for severity in running:
+                    running[severity] += counts[severity]
+                carried_counts[pair] = counts
+            day_data = dict(running)
             daily_data[day_key] = day_data
             time_series.append(
                 {

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -270,6 +270,11 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # under ASGI, where connection recycling can invalidate named cursors.
         daily_data: dict[str, dict[str, int]] = {}
 
+        # Seed for the carry-forward walk below: the state each (sbom,
+        # provider) pair was already in when the window opens, so day one
+        # shows the real carried counts instead of climbing from zero.
+        carried_counts: dict[tuple[Any, str], dict[str, int]] = {}
+
         # Snapshot: the most recent run per (sbom, provider). Distinct providers
         # and distinct SBOMs each contribute; re-scans collapse to the latest.
         # Without this the cards reported the area under the trend curve — the
@@ -303,14 +308,48 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 if current is None or order > current[0]:
                     timeline_winners[winner_key] = (order, counts)
 
-            for (day_key, _sbom_id, _plugin), (_order, counts) in timeline_winners.items():
-                if day_key not in daily_data:
-                    daily_data[day_key] = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
-                daily_data[day_key]["total"] += counts["total"]
-                daily_data[day_key]["critical"] += counts["critical"]
-                daily_data[day_key]["high"] += counts["high"]
-                daily_data[day_key]["medium"] += counts["medium"]
-                daily_data[day_key]["low"] += counts["low"]
+            # A day's point is the sum of each pair's most recent counts AS OF
+            # that day, not just the runs that happened on it. Group the day's
+            # winners per pair; the walk below carries state across gap days.
+            day_winners: dict[str, dict[tuple[Any, str], dict[str, int]]] = {}
+            for (day_key, sbom_id, plugin), (_order, counts) in timeline_winners.items():
+                day_winners.setdefault(day_key, {})[(sbom_id, plugin)] = counts
+
+            # Pairs whose latest scan predates the window still carry their
+            # state into it. Same latest-per-pair shape as the snapshot below,
+            # bounded to runs before the window opens.
+            seed_scope = scoped_query.filter(created_at__lt=start_date)
+            if connection.vendor == "postgresql":
+                seed_winner_ids = list(
+                    seed_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
+                    .distinct("sbom_id", "plugin_name")
+                    .values_list("id", flat=True)
+                )
+                for seed in (
+                    AssessmentRun.objects.filter(id__in=seed_winner_ids)
+                    .values("plugin_name", "sbom_id", *RESULT_SUMMARY_COLUMNS)
+                    .iterator()
+                ):
+                    key = (seed["sbom_id"], seed["plugin_name"] or "unknown")
+                    carried_counts[key] = extract_severity_counts(reconstruct_result_summary(seed))
+            else:
+                seed_run_key: dict[tuple[Any, str], tuple[Any, Any]] = {}
+                seed_run_id: dict[tuple[Any, str], Any] = {}
+                for run_id, sbom_id, plugin_name, created in seed_scope.values_list(
+                    "id", "sbom_id", "plugin_name", "created_at"
+                ).iterator():
+                    key = (sbom_id, plugin_name or "unknown")
+                    if key not in seed_run_key or (created, run_id) > seed_run_key[key]:
+                        seed_run_key[key] = (created, run_id)
+                        seed_run_id[key] = run_id
+                seeds_by_id = {
+                    row["id"]: row
+                    for row in AssessmentRun.objects.filter(id__in=list(seed_run_id.values())).values(
+                        "id", *RESULT_SUMMARY_COLUMNS
+                    )
+                }
+                for key, run_id in seed_run_id.items():
+                    carried_counts[key] = extract_severity_counts(reconstruct_result_summary(seeds_by_id.get(run_id)))
 
             if connection.vendor == "postgresql":
                 # Postgres resolves the latest run per pair in one indexed pass
@@ -364,15 +403,22 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                         reconstruct_result_summary(annotated_by_id.get(run_id))
                     )
 
-        # Build time series with all days (including zeros)
+        # Build the time series for every day in the window. A pair with no
+        # run on a given day keeps its last known counts (a vulnerability does
+        # not vanish because no scan happened that day); zeros appear only
+        # before anything has ever been scanned. Without this, days between
+        # scans rendered as zero and the smoothed chart drew sawtooth waves
+        # out of a perfectly flat vulnerability count.
         time_series = []
         current_date = start_date.date()
         while current_date <= end_date.date():
             day_key = current_date.isoformat()
-            day_data = daily_data.get(
-                day_key,
-                {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0},
-            )
+            carried_counts.update(day_winners.get(day_key, {}))
+            day_data = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
+            for counts in carried_counts.values():
+                for severity in day_data:
+                    day_data[severity] += counts[severity]
+            daily_data[day_key] = day_data
             time_series.append(
                 {
                     "date": day_key,


### PR DESCRIPTION
## The report

The dashboard vulnerability-trends chart oscillated: counts halved between peaks and climbed back at the next one, in a perfect wave. Viktor's read was right: the chart has higher resolution than the scans.

## Root cause

The timeline builds one point per day and zero-filled any day that had no runs (`daily_data.get(day_key, {all zeros})`). With a scan cadence slower than daily, real-count days alternate with zero days, and the chart's smoothing (`tension: 0.4`) turns that alternation into sine waves. The count never actually changed; the gaps were rendered as if every vulnerability vanished between scans.

## The fix

Each (sbom, provider) pair carries its most recent counts forward across days with no run, and the walk is seeded with each pair's latest run from before the window, so day one starts at the true carried state instead of climbing from zero. A day renders zero only before anything has ever been scanned.

Scan days are unchanged: a day with runs still takes the latest run per (sbom, provider, day), so hourly re-scans still cannot inflate a day's point. Pairs scanned on different days now stack correctly instead of dipping when only one of them ran.

Verified in dev against the dogfood workspace: the chart draws flat plateaus with step changes at real scan events.

## Tests

`TestTimelineCarriesStateAcrossScanGaps` pins three shapes: gap days hold the last counts with no zero valleys; pairs scanned on alternating days stack without dips; state scanned before the window seeds the left edge. Full vulnerability_scanning suite green (411).