### PR TITLE
fix(core): mark CSV exports private and uncacheable

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -4979,6 +4979,10 @@ def _export_team(request: HttpRequest) -> tuple[Any, tuple[int, ErrorResponse] |
 def _csv_response(csv_text: str, filename: str) -> HttpResponse:
     response = HttpResponse(csv_text, content_type="text/csv; charset=utf-8")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    # Workspace-scoped data behind session/token auth. Without an explicit
+    # Cache-Control, CDNs cache .csv by extension and ignore Vary: Cookie, so
+    # one user's export could be served stale — or to another user.
+    response["Cache-Control"] = "private, no-store"
     return response
 
 

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -244,7 +244,26 @@ class TestEndpoints:
         assert response.status_code == 200
         assert response["Content-Type"].startswith("text/csv")
         assert "attachment" in response["Content-Disposition"]
-        assert response["Cache-Control"] == "private, no-store"
+
+    def test_every_export_is_private_and_uncacheable(self, authenticated_api_client, inventory, stub_sbom_bytes):
+        """CDNs cache .csv by extension and ignore Vary: Cookie, so any export
+        endpoint that drops the header leaks a workspace-scoped response into
+        a shared cache. Asserted per endpoint so one switching off
+        _csv_response() fails here, not in production."""
+        client, token = authenticated_api_client
+        from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+        _, _, docs = inventory
+        sbom_id = next(iter(docs))
+        for url in (
+            "/api/v1/exports/inventory.csv",
+            "/api/v1/exports/licenses.csv",
+            f"/api/v1/exports/findings.csv?sbom_id={sbom_id}",
+            "/api/v1/exports/vulnerabilities.csv",
+        ):
+            response = client.get(url, **get_api_headers(token))
+            assert response.status_code == 200, url
+            assert response["Cache-Control"] == "private, no-store", url
 
     def test_another_user_sees_none_of_this_workspaces_data(self, inventory, stub_sbom_bytes, guest_user, client):
         """Signup gives every user their own workspace, so the export succeeds —

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -244,6 +244,7 @@ class TestEndpoints:
         assert response.status_code == 200
         assert response["Content-Type"].startswith("text/csv")
         assert "attachment" in response["Content-Disposition"]
+        assert response["Cache-Control"] == "private, no-store"
 
     def test_another_user_sees_none_of_this_workspaces_data(self, inventory, stub_sbom_bytes, guest_user, client):
         """Signup gives every user their own workspace, so the export succeeds —


### PR DESCRIPTION
The CSV export endpoints send no Cache-Control header. Cloudflare caches `.csv` URLs by file extension and ignores `Vary: Cookie`, which makes an authenticated, workspace-scoped export cacheable at the shared edge.

Observed live on staging while verifying a VEX upload: `/api/v1/exports/vulnerabilities.csv` kept returning findings as active for hours after the VEX had suppressed them. A cache-busted request returned the correct rows, and the response carried `cache-control: max-age=14400` with `cf-cache-status` flipping between HIT and MISS. Beyond staleness, a shared-cache copy of a per-workspace export is a potential cross-user data leak, since the edge keys on the URL, not the session.

The fix sets `Cache-Control: private, no-store` in `_csv_response`, which covers all four export endpoints (inventory, licenses, findings, vulnerabilities). The endpoint test now pins the header.