### PR TITLE
feat(teams): security.txt in the shape BSI TR-03183-3 mandates

### DIFF
--- a/sbomify/apps/compliance/services/wizard_service.py
+++ b/sbomify/apps/compliance/services/wizard_service.py
@@ -132,6 +132,16 @@ def _auto_fill_from_contacts(assessment: CRAAssessment) -> None:
     """Populate security contact and CSIRT email from existing contact profiles."""
     team = assessment.team
 
+    # The trust center's security.txt collects the same three answers
+    # (TR-03183-3 4.2.3/4.2.7); whichever side was filled first wins.
+    security_txt_config = team.security_txt_config or {}
+    if not assessment.csirt_contact_email and security_txt_config.get("csirt_email"):
+        assessment.csirt_contact_email = security_txt_config["csirt_email"]
+    if not assessment.vdp_url and security_txt_config.get("policy_url"):
+        assessment.vdp_url = security_txt_config["policy_url"]
+    if not assessment.security_contact_url and security_txt_config.get("report_url"):
+        assessment.security_contact_url = security_txt_config["report_url"]
+
     security_contact = get_security_contact(team)
     if security_contact:
         if not assessment.csirt_contact_email:
@@ -1246,8 +1256,32 @@ def _save_step_3(
                 "updated_at",
             ]
         )
+        _fill_security_txt_from_assessment(assessment)
 
     return ServiceResult.success(assessment)
+
+
+def _fill_security_txt_from_assessment(assessment: CRAAssessment) -> None:
+    """Fill empty security.txt slots from the vulnerability-handling answers.
+
+    The trust center file and the wizard collect the same three values
+    (TR-03183-3 4.2.3/4.2.7); syncing on save spares the operator entering
+    them twice. Slots the operator already set are never overwritten.
+    """
+    team = assessment.team
+    config = dict(team.security_txt_config or {})
+    filled = False
+    for config_key, value in (
+        ("csirt_email", assessment.csirt_contact_email),
+        ("policy_url", assessment.vdp_url),
+        ("report_url", assessment.security_contact_url),
+    ):
+        if value and not str(config.get(config_key, "")).strip():
+            config[config_key] = value
+            filled = True
+    if filled:
+        team.security_txt_config = config
+        team.save(update_fields=["security_txt_config"])
 
 
 def _save_step_4(

--- a/sbomify/apps/compliance/services/wizard_service.py
+++ b/sbomify/apps/compliance/services/wizard_service.py
@@ -1268,15 +1268,17 @@ def _fill_security_txt_from_assessment(assessment: CRAAssessment) -> None:
     (TR-03183-3 4.2.3/4.2.7); syncing on save spares the operator entering
     them twice. Slots the operator already set are never overwritten.
     """
+    from sbomify.apps.teams.services.security_txt import validate_security_email, validate_security_txt_url
+
     team = assessment.team
     config = dict(team.security_txt_config or {})
     filled = False
-    for config_key, value in (
-        ("csirt_email", assessment.csirt_contact_email),
-        ("policy_url", assessment.vdp_url),
-        ("report_url", assessment.security_contact_url),
+    for config_key, value, validate in (
+        ("csirt_email", assessment.csirt_contact_email, validate_security_email),
+        ("policy_url", assessment.vdp_url, validate_security_txt_url),
+        ("report_url", assessment.security_contact_url, validate_security_txt_url),
     ):
-        if value and not str(config.get(config_key, "")).strip():
+        if value and not str(config.get(config_key, "")).strip() and validate(value) is None:
             config[config_key] = value
             filled = True
     if filled:

--- a/sbomify/apps/compliance/tests/test_wizard_service.py
+++ b/sbomify/apps/compliance/tests/test_wizard_service.py
@@ -653,6 +653,23 @@ class TestSaveStepData:
         # An explicit setting is never overwritten
         assert config["policy_url"] == "https://example.com/existing-policy"
 
+    def test_step_3_sync_skips_values_the_settings_view_would_reject(self, assessment, sample_user):
+        """The sync path validates like the settings form, so a value the
+        Trust Center would refuse never lands in the config sideways."""
+        data = {
+            "vulnerability_handling": {
+                "csirt_contact_email": "not-an-email",
+                "security_contact_url": "ftp://example.com/report",
+            },
+        }
+        result = save_step_data(assessment, 3, data, sample_user)
+
+        assert result.ok
+        assessment.team.refresh_from_db()
+        config = assessment.team.security_txt_config or {}
+        assert "csirt_email" not in config
+        assert "report_url" not in config
+
     def test_step_3_updates_article_14(self, assessment, sample_user):
         data = {
             "article_14": {

--- a/sbomify/apps/compliance/tests/test_wizard_service.py
+++ b/sbomify/apps/compliance/tests/test_wizard_service.py
@@ -570,11 +570,7 @@ class TestSaveStepData:
         Attempting to waive an operator_action finding (e.g. missing
         SBOM creator) returns 400 — the gap would represent a genuine
         Annex I Part II(1) deficiency that must be fixed."""
-        data = {
-            "waivers": {
-                "bsi-tr03183:sbom-creator": {"justification": "we don't feel like it"}
-            }
-        }
+        data = {"waivers": {"bsi-tr03183:sbom-creator": {"justification": "we don't feel like it"}}}
         result = save_step_data(assessment, 2, data, sample_user)
         assert not result.ok
         assert result.status_code == 400
@@ -633,6 +629,30 @@ class TestSaveStepData:
         assert a.vdp_url == "https://example.com/vdp"
         assert a.acknowledgment_timeline_days == 5
 
+    def test_step_3_fills_empty_security_txt_slots(self, assessment, sample_user):
+        """The wizard answers and the trust center security.txt are the same
+        three values; saving step 3 fills the slots the operator left empty."""
+        team = assessment.team
+        team.security_txt_config = {"enabled": True, "policy_url": "https://example.com/existing-policy"}
+        team.save(update_fields=["security_txt_config"])
+
+        data = {
+            "vulnerability_handling": {
+                "vdp_url": "https://example.com/vdp",
+                "csirt_contact_email": "csirt@example.com",
+                "security_contact_url": "https://example.com/report",
+            },
+        }
+        result = save_step_data(assessment, 3, data, sample_user)
+
+        assert result.ok
+        team.refresh_from_db()
+        config = team.security_txt_config
+        assert config["csirt_email"] == "csirt@example.com"
+        assert config["report_url"] == "https://example.com/report"
+        # An explicit setting is never overwritten
+        assert config["policy_url"] == "https://example.com/existing-policy"
+
     def test_step_3_updates_article_14(self, assessment, sample_user):
         data = {
             "article_14": {
@@ -673,15 +693,11 @@ class TestSaveStepData:
         or wrong-type inner value previously skipped the write without
         any signal. An SDK/curl client would see a 200 while the DB
         retained the old value. Return 400 to match Step 1's strictness."""
-        result = save_step_data(
-            assessment, 3, {"vulnerability_handling": "not-a-dict"}, sample_user
-        )
+        result = save_step_data(assessment, 3, {"vulnerability_handling": "not-a-dict"}, sample_user)
         assert not result.ok and result.status_code == 400
 
     def test_step_3_article_14_not_dict_rejected(self, assessment, sample_user):
-        result = save_step_data(
-            assessment, 3, {"article_14": ["not-a-dict"]}, sample_user
-        )
+        result = save_step_data(assessment, 3, {"article_14": ["not-a-dict"]}, sample_user)
         assert not result.ok and result.status_code == 400
 
     def test_step_3_vh_wrong_type_rejected(self, assessment, sample_user):

--- a/sbomify/apps/teams/services/security_txt.py
+++ b/sbomify/apps/teams/services/security_txt.py
@@ -1,7 +1,10 @@
 """RFC 9116 security.txt generation service.
 
-Generates a security.txt file from a team's security contact and configuration.
-Spec: https://www.rfc-editor.org/rfc/rfc9116
+Generates a security.txt file from a team's security contact and configuration,
+laid out the way BSI TR-03183-3 section 4.2 expects it: the contact lines in
+the mandated order (PSIRT mailbox, CSIRT mailbox, report page), a comment line
+above each block, and an Expires no more than a year out.
+Specs: https://www.rfc-editor.org/rfc/rfc9116 and BSI TR-03183-3.
 """
 
 from __future__ import annotations
@@ -20,6 +23,9 @@ MAX_FIELD_LENGTH = 2048
 MAX_PREFERRED_LANGUAGES_LENGTH = 200
 PREFERRED_LANGUAGES_PATTERN = r"[a-zA-Z0-9, \-]+"
 
+# TR-03183-3 4.2.9: Expires must not be more than a year ahead.
+MAX_EXPIRES_AHEAD = timedelta(days=365)
+
 
 def validate_preferred_languages(value: str) -> str | None:
     """Validate preferred_languages. Returns error message or None if valid."""
@@ -35,6 +41,19 @@ def validate_preferred_languages(value: str) -> str | None:
 def _sanitize_value(value: str) -> str:
     """Strip control characters (newlines, carriage returns, null bytes) to prevent field injection."""
     return re.sub(r"[\r\n\x00]", "", value).strip()
+
+
+def validate_security_email(value: str) -> str | None:
+    """Validate an email for a Contact: mailto line. Returns error message or None if valid."""
+    if not value:
+        return None
+    if len(value) > MAX_FIELD_LENGTH:
+        return f"Email exceeds maximum length of {MAX_FIELD_LENGTH} characters"
+    if re.search(r"[\x00-\x1f\x7f\s]", value):
+        return "Email contains invalid characters (whitespace or control characters)"
+    if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", value):
+        return "Enter a valid email address"
+    return None
 
 
 def _get_security_contact_email(team: Team, config: dict[str, Any]) -> str | None:
@@ -91,8 +110,34 @@ def validate_security_txt_url(url: str) -> str | None:
     return None
 
 
+def clean_expires(raw: str) -> str:
+    """A valid Expires value: in the future, at most a year out, whole seconds.
+
+    Falls back to a year from now when the stored value is missing, past,
+    unparseable, or further out than TR-03183-3 4.2.9 allows.
+    """
+    now = datetime.now(timezone.utc)
+    cap = now + MAX_EXPIRES_AHEAD
+    try:
+        expires_dt = datetime.fromisoformat(raw) if raw else None
+        if expires_dt and expires_dt.tzinfo is None:
+            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        expires_dt = None
+    if not expires_dt or expires_dt <= now or expires_dt > cap:
+        expires_dt = cap
+    return expires_dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _valid_url(config: dict[str, Any], key: str) -> str:
+    raw = str(config.get(key, "")).strip()
+    if raw and validate_security_txt_url(raw) is None:
+        return _sanitize_value(raw)
+    return ""
+
+
 def generate_security_txt(team: Team) -> str:
-    """Generate RFC 9116 security.txt content for a team.
+    """Generate RFC 9116 / TR-03183-3 security.txt content for a team.
 
     Returns empty string if security.txt is disabled or no security contact
     is configured. All values are sanitized to prevent newline/field injection.
@@ -114,51 +159,58 @@ def generate_security_txt(team: Team) -> str:
 
     lines: list[str] = []
 
-    # Required: Contact (mailto URI) — sanitize email to prevent injection
+    # TR-03183-3 4.2.3 mandates the contact order: the PSIRT mailbox first,
+    # the CSIRT mailbox second, the report page URI third.
+    lines.append("# Our security addresses")
     lines.append(f"Contact: mailto:{_sanitize_value(email)}")
-
-    # Optional URL fields — validated first (reject invalid), then sanitized for output
-    url_fields = [
-        ("Policy", "policy_url"),
-        ("Acknowledgments", "acknowledgments_url"),
-        ("Canonical", "canonical_url"),
-        ("Hiring", "hiring_url"),
-    ]
-    for field_name, config_key in url_fields:
-        raw_value = str(config.get(config_key, "")).strip()
-        if raw_value and validate_security_txt_url(raw_value) is None:
-            value = _sanitize_value(raw_value)
-            if value:
-                lines.append(f"{field_name}: {value}")
+    csirt_email = str(config.get("csirt_email", "")).strip()
+    if csirt_email and validate_security_email(csirt_email) is None:
+        lines.append(f"Contact: mailto:{_sanitize_value(csirt_email)}")
+    if report_url := _valid_url(config, "report_url"):
+        lines.append(f"Contact: {report_url}")
 
     # Encryption: multiple URLs supported (RFC 9116 allows repeated Encryption fields)
+    encryption_lines: list[str] = []
     if "encryption_urls" in config and isinstance(config["encryption_urls"], list):
         for raw_url in config["encryption_urls"]:
             raw_url = str(raw_url).strip()
             if raw_url and validate_security_txt_url(raw_url) is None:
                 value = _sanitize_value(raw_url)
                 if value:
-                    lines.append(f"Encryption: {value}")
+                    encryption_lines.append(f"Encryption: {value}")
     # Backward compat: single encryption_url (legacy configs)
     elif encryption_url := str(config.get("encryption_url", "")).strip():
         if validate_security_txt_url(encryption_url) is None:
-            lines.append(f"Encryption: {_sanitize_value(encryption_url)}")
+            encryption_lines.append(f"Encryption: {_sanitize_value(encryption_url)}")
+    if encryption_lines:
+        lines.append("# Our OpenPGP keys")
+        lines.extend(encryption_lines)
+
+    if policy_url := _valid_url(config, "policy_url"):
+        lines.append("# Our security policy")
+        lines.append(f"Policy: {policy_url}")
+
+    if acknowledgments_url := _valid_url(config, "acknowledgments_url"):
+        lines.append("# Our acknowledgments page")
+        lines.append(f"Acknowledgments: {acknowledgments_url}")
+
+    # CSAF 2.0 section 7.1.8: points at the provider-metadata.json.
+    if csaf_url := _valid_url(config, "csaf_url"):
+        lines.append("# Our CSAF provider metadata")
+        lines.append(f"CSAF: {csaf_url}")
+
+    if hiring_url := _valid_url(config, "hiring_url"):
+        lines.append(f"Hiring: {hiring_url}")
+
+    if canonical_url := _valid_url(config, "canonical_url"):
+        lines.append(f"Canonical: {canonical_url}")
 
     # Optional non-URL fields — reuse centralized validation
     if preferred_languages := _sanitize_value(str(config.get("preferred_languages", ""))):
         if validate_preferred_languages(preferred_languages) is None:
             lines.append(f"Preferred-Languages: {preferred_languages}")
 
-    # Required: Expires — use stored value if valid and not past, else generate fresh
-    expires_str = str(config.get("expires", ""))
-    try:
-        expires_dt = datetime.fromisoformat(expires_str) if expires_str else None
-        if expires_dt and expires_dt.tzinfo is None:
-            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
-    except (ValueError, TypeError):
-        expires_dt = None
-    if not expires_dt or expires_dt <= datetime.now(timezone.utc):
-        expires_str = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
-    lines.append(f"Expires: {_sanitize_value(expires_str)}")
+    # Required: Expires — stored value if usable, clamped to a year out either way
+    lines.append(f"Expires: {clean_expires(str(config.get('expires', '')))}")
 
     return "\n".join(lines) + "\n"

--- a/sbomify/apps/teams/services/security_txt.py
+++ b/sbomify/apps/teams/services/security_txt.py
@@ -45,13 +45,18 @@ def _sanitize_value(value: str) -> str:
 
 def validate_security_email(value: str) -> str | None:
     """Validate an email for a Contact: mailto line. Returns error message or None if valid."""
+    from django.core.exceptions import ValidationError
+    from django.core.validators import validate_email
+
     if not value:
         return None
     if len(value) > MAX_FIELD_LENGTH:
         return f"Email exceeds maximum length of {MAX_FIELD_LENGTH} characters"
     if re.search(r"[\x00-\x1f\x7f\s]", value):
         return "Email contains invalid characters (whitespace or control characters)"
-    if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", value):
+    try:
+        validate_email(value)
+    except ValidationError:
         return "Enter a valid email address"
     return None
 

--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -226,6 +226,18 @@
                                class="text-primary hover:underline">Contact Profiles</a>.
                             </c-forms.hint>
                         </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                            <div>
+                                <c-forms.label for="security_txt_csirt_email">CSIRT email</c-forms.label>
+                                <c-forms.input type="email" id="security_txt_csirt_email" name="security_txt_csirt_email" value="{{ security_txt_config.csirt_email|default:'' }}" placeholder="csirt@example.com" disabled="{{ can_administer|yesno:',1' }}" />
+                                <c-forms.hint class="mt-1">Second contact line. BSI TR-03183-3 lists the CSIRT mailbox after the security contact.</c-forms.hint>
+                            </div>
+                            <div>
+                                <c-forms.label for="security_txt_report_url">Report page URL</c-forms.label>
+                                <c-forms.input type="url" id="security_txt_report_url" name="security_txt_report_url" value="{{ security_txt_config.report_url|default:'' }}" placeholder="https://example.com/report-vulnerability" disabled="{{ can_administer|yesno:',1' }}" />
+                                <c-forms.hint class="mt-1">Where researchers submit reports. Third contact line.</c-forms.hint>
+                            </div>
+                        </div>
                     </div>
                     {# Optional: Links #}
                     <div class="mb-6 pb-6 border-b border-border/50">
@@ -259,6 +271,11 @@
                                        name="security_txt_encryption_urls"
                                        :value="JSON.stringify(urls)">
                                 <c-forms.hint class="mt-1">PGP public keys for encrypted reports (multiple allowed per RFC 9116)</c-forms.hint>
+                            </div>
+                            <div>
+                                <c-forms.label for="security_txt_csaf_url">CSAF provider metadata URL</c-forms.label>
+                                <c-forms.input type="url" id="security_txt_csaf_url" name="security_txt_csaf_url" value="{{ security_txt_config.csaf_url|default:'' }}" placeholder="https://example.com/.well-known/csaf/provider-metadata.json" disabled="{{ can_administer|yesno:',1' }}" />
+                                <c-forms.hint class="mt-1">Link to your provider-metadata.json if you publish CSAF advisories.</c-forms.hint>
                             </div>
                             <div>
                                 <c-forms.label for="security_txt_acknowledgments_url">Acknowledgments URL</c-forms.label>

--- a/sbomify/apps/teams/tests/test_security_txt.py
+++ b/sbomify/apps/teams/tests/test_security_txt.py
@@ -214,18 +214,40 @@ class TestGenerateSecurityTxtOptionalFields:
     def test_custom_expires_override(self, sample_team_with_owner_member) -> None:
         from datetime import timedelta
 
-        future_expires = (datetime.now(timezone.utc) + timedelta(days=180)).isoformat()
+        stored = datetime.now(timezone.utc) + timedelta(days=180)
         team = sample_team_with_owner_member.team
         team.security_txt_config = {
             "enabled": True,
-            "expires": future_expires,
+            "expires": stored.isoformat(),
         }
         team.save(update_fields=["security_txt_config"])
         _create_security_contact(team, "sec@example.com")
 
         result = generate_security_txt(team)
 
-        assert f"Expires: {future_expires}" in result
+        # Same instant, normalized to whole seconds in UTC (TR-03183-3 keeps
+        # the field auditor-friendly; microseconds leaked before).
+        assert f"Expires: {stored.strftime('%Y-%m-%dT%H:%M:%SZ')}" in result
+
+    def test_expires_beyond_a_year_is_clamped(self, sample_team_with_owner_member) -> None:
+        from datetime import timedelta
+
+        team = sample_team_with_owner_member.team
+        team.security_txt_config = {
+            "enabled": True,
+            "expires": (datetime.now(timezone.utc) + timedelta(days=900)).isoformat(),
+        }
+        team.save(update_fields=["security_txt_config"])
+        _create_security_contact(team, "sec@example.com")
+
+        result = generate_security_txt(team)
+
+        expires_line = next(line for line in result.splitlines() if line.startswith("Expires: "))
+        emitted = datetime.strptime(expires_line.removeprefix("Expires: "), "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+        assert emitted <= datetime.now(timezone.utc) + timedelta(days=365, minutes=1)
+        assert emitted > datetime.now(timezone.utc)
 
 
 @pytest.mark.django_db
@@ -528,3 +550,75 @@ class TestSecurityTxtSettingsPost:
         msgs = list(response.context["messages"]) if hasattr(response, "context") and response.context else []
         if msgs:
             assert "settings saved" in str(msgs[0]).lower() or "enabled" not in str(msgs[0]).lower()
+
+
+@pytest.mark.django_db
+class TestBsiTr03183Layout:
+    """TR-03183-3 4.2: contact ordering, comment lines, CSAF pointer."""
+
+    def _team(self, sample_team_with_owner_member, **config):
+        team = sample_team_with_owner_member.team
+        team.security_txt_config = {"enabled": True, **config}
+        team.save(update_fields=["security_txt_config"])
+        _create_security_contact(team, "psirt@example.com")
+        return team
+
+    def test_contacts_emit_in_mandated_order(self, sample_team_with_owner_member) -> None:
+        team = self._team(
+            sample_team_with_owner_member,
+            csirt_email="csirt@example.com",
+            report_url="https://example.com/report",
+        )
+
+        lines = generate_security_txt(team).splitlines()
+
+        assert lines[0] == "# Our security addresses"
+        assert lines[1] == "Contact: mailto:psirt@example.com"
+        assert lines[2] == "Contact: mailto:csirt@example.com"
+        assert lines[3] == "Contact: https://example.com/report"
+
+    def test_each_block_carries_its_comment(self, sample_team_with_owner_member) -> None:
+        team = self._team(
+            sample_team_with_owner_member,
+            encryption_urls=["https://example.com/key.asc"],
+            policy_url="https://example.com/vdp",
+            acknowledgments_url="https://example.com/thanks",
+            csaf_url="https://example.com/.well-known/csaf/provider-metadata.json",
+        )
+
+        result = generate_security_txt(team)
+
+        for comment, field in (
+            ("# Our OpenPGP keys", "Encryption: https://example.com/key.asc"),
+            ("# Our security policy", "Policy: https://example.com/vdp"),
+            ("# Our acknowledgments page", "Acknowledgments: https://example.com/thanks"),
+            ("# Our CSAF provider metadata", "CSAF: https://example.com/.well-known/csaf/provider-metadata.json"),
+        ):
+            lines = result.splitlines()
+            assert field in lines
+            assert lines[lines.index(field) - 1] == comment
+
+    def test_comments_absent_for_empty_blocks(self, sample_team_with_owner_member) -> None:
+        team = self._team(sample_team_with_owner_member)
+
+        result = generate_security_txt(team)
+
+        assert "# Our OpenPGP keys" not in result
+        assert "# Our security policy" not in result
+        assert "# Our CSAF provider metadata" not in result
+
+    def test_invalid_csirt_email_is_dropped(self, sample_team_with_owner_member) -> None:
+        team = self._team(sample_team_with_owner_member, csirt_email="not-an-email")
+
+        result = generate_security_txt(team)
+
+        assert result.count("Contact:") == 1
+
+    def test_still_valid_with_single_contact(self, sample_team_with_owner_member) -> None:
+        """An existing single-contact config keeps producing a valid file."""
+        team = self._team(sample_team_with_owner_member)
+
+        result = generate_security_txt(team)
+
+        assert "Contact: mailto:psirt@example.com" in result
+        assert result.splitlines()[-1].startswith("Expires: ")

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -753,6 +753,17 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                 return self._redirect_with_tab(request, team_key)
         config["contact_id"] = contact_id
 
+        # CSIRT mailbox — the second contact line TR-03183-3 4.2.3 expects
+        from sbomify.apps.teams.services.security_txt import validate_security_email
+
+        csirt_email = request.POST.get("security_txt_csirt_email", "").strip()
+        if csirt_email:
+            email_error = validate_security_email(csirt_email)
+            if email_error:
+                messages.error(request, f"Invalid CSIRT email: {email_error}")
+                return self._redirect_with_tab(request, team_key)
+        config["csirt_email"] = csirt_email
+
         # Validate and store URL fields
         # Note: validation is intentionally duplicated here and in the service layer
         # (generate_security_txt) for defense-in-depth — the view rejects bad input early,
@@ -762,6 +773,8 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             "acknowledgments_url": "security_txt_acknowledgments_url",
             "hiring_url": "security_txt_hiring_url",
             "canonical_url": "security_txt_canonical_url",
+            "report_url": "security_txt_report_url",
+            "csaf_url": "security_txt_csaf_url",
         }
         for config_key, post_key in url_fields.items():
             value = request.POST.get(post_key, "").strip()
@@ -803,8 +816,11 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             return self._redirect_with_tab(request, team_key)
         config["preferred_languages"] = preferred_languages
 
-        # Refresh Expires on every save per RFC 9116 semantics
-        config["expires"] = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+        # Refresh Expires on every save per RFC 9116 semantics; clean_expires
+        # keeps it at most a year out and drops sub-second precision.
+        from sbomify.apps.teams.services.security_txt import clean_expires
+
+        config["expires"] = clean_expires((datetime.now(timezone.utc) + timedelta(days=365)).isoformat())
 
         team.security_txt_config = config
         team.save(update_fields=["security_txt_config"])


### PR DESCRIPTION
Phase 1 of the TR-03183-3 section 4.2 gap Viktor mapped: everything except the OpenPGP signature, which needs a key-custody decision first.

**What the file gains** (all emitted only when configured, so no existing config regresses):

- **4.2.3 contact ordering**: two new slots, CSIRT email and report page URL, emitted as the second and third `Contact:` lines after the PSIRT mailbox. Existing single-contact configs keep producing exactly one valid contact line.
- **4.2.8 CSAF pointer**: optional `CSAF:` field for the provider-metadata.json.
- **BSI comment lines**: `# Our security addresses`, `# Our OpenPGP keys`, `# Our security policy`, `# Our acknowledgments page`, `# Our CSAF provider metadata`, each only above a block that has content.
- **4.2.9 Expires**: whole-second UTC (`2027-08-20T06:55:52Z`), clamped to at most a year out. The live file leaked `datetime.isoformat()` microseconds. Serving already regenerates a past Expires on the fly, so the file can't go stale between saves.
- **4.2.5** Acknowledgments already existed and stays optional.

**One dataset with the CRA wizard.** Step 3b already collects the same three answers (`vdp_url`, `csirt_contact_email`, `security_contact_url`). Saving the wizard now fills empty security.txt slots, and creating an assessment prefills from security.txt, in both directions only into empty fields, never overwriting.

**Settings UI**: CSIRT email + report page URL under Contact, CSAF URL under Links, same field pattern as the neighbours. No e2e baseline covers this tab.

**Verified**: 42 security.txt unit tests including contact ordering, per-block comments, the one-year clamp, invalid-CSIRT rejection and single-contact back-compat; wizard sync test; teams + compliance suites green (1296 passed). Live checks against trust.sbomify.com: transport and crawler reachability (200 for Googlebot, findsecuritycontacts, curl, python-requests UAs) already conform, so 4.2.11 needed no change.

**Still open after this PR** (tracked in the ticket): 4.2.10 OpenPGP signing needs the key-custody design call (sbomify-managed vs customer-supplied; cosign does not satisfy the OpenPGP requirement), and 4.2.4 key coverage for the expanded contact list is the operator's content, not code.