### PR TITLE
fix: close out the staging QA findings

### DIFF
--- a/sbomify/apps/documents/templates/documents/request_access.html.j2
+++ b/sbomify/apps/documents/templates/documents/request_access.html.j2
@@ -40,6 +40,13 @@
                         </span>
                     {% endif %}
                 </p>
+                {% if was_rejected %}
+                    <div class="mb-4 px-4 py-3 rounded-xl border border-border text-sm"
+                         style="background: var(--bg-secondary);
+                                color: var(--text-primary)">
+                        Your earlier request was not approved. You can submit a new one.
+                    </div>
+                {% endif %}
                 <form method="post" action="{% url 'documents:request_access' team.key %}">
                     {% csrf_token %}
                     {% if not user %}

--- a/sbomify/apps/documents/views/access_requests.py
+++ b/sbomify/apps/documents/views/access_requests.py
@@ -276,6 +276,12 @@ class AccessRequestView(View):
                 messages.info(request, "Your access request is pending approval.")
                 return redirect("core:workspace_public", workspace_key=team_key)
 
+        # A requester whose last request was rejected otherwise lands on a blank
+        # form with no sign anything happened; say so, and let them re-request.
+        was_rejected = AccessRequest.objects.filter(
+            team=team, user=request.user, status=AccessRequest.Status.REJECTED
+        ).exists()
+
         # Always check for company-wide NDA - if it exists, always require signing
         company_nda = team.get_company_nda_document()
         requires_nda = company_nda is not None
@@ -291,6 +297,7 @@ class AccessRequestView(View):
                 "brand": brand,
                 "company_nda": company_nda,
                 "requires_nda": requires_nda,
+                "was_rejected": was_rejected,
                 "user": request.user if request.user.is_authenticated else None,
             },
         )

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -55,7 +55,7 @@ from sbomify.apps.teams.services.suppliers import (
     list_suppliers,
     update_supplier,
 )
-from sbomify.apps.teams.utils import on_demand_tls_cache_key
+from sbomify.apps.teams.utils import on_demand_tls_cache_key, refresh_current_team_session
 from sbomify.logging import getLogger
 
 logger = getLogger(__name__)
@@ -1041,6 +1041,10 @@ def update_team(request: HttpRequest, team_key: str, payload: TeamUpdateSchema) 
                 team.is_public = payload.is_public
             team.save()
 
+        # The navbar reads the session's current_team; without this the old
+        # name survives every reload until the session cache expires.
+        refresh_current_team_session(request, team)
+
         return 200, _build_team_response(request, team)
 
     except IntegrityError:
@@ -1085,6 +1089,8 @@ def patch_team(request: HttpRequest, team_key: str, payload: TeamPatchSchema) ->
             for field, value in update_data.items():
                 setattr(team, field, value)
             team.save()
+
+        refresh_current_team_session(request, team)
 
         return 200, _build_team_response(request, team)
 

--- a/sbomify/apps/teams/views/team_branding.py
+++ b/sbomify/apps/teams/views/team_branding.py
@@ -67,4 +67,12 @@ class TeamBrandingView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         # rollback would otherwise produce a ghost event.
         transaction.on_commit(lambda: capture_for_request(request, "team:branding_updated", team_key=team_key))
 
+        # A color saved while custom branding is off changes nothing anyone can
+        # see; without the hint the toast reads as "done" and the trust center
+        # quietly keeps the platform look.
+        if not form.cleaned_data.get("branding_enabled"):
+            return htmx_success_response(
+                "Branding saved. Turn on custom branding to show it on your public pages.",
+                triggers={"refreshTeamBranding": True},
+            )
         return htmx_success_response("Branding updated successfully", triggers={"refreshTeamBranding": True})

--- a/sbomify/apps/vulnerability_scanning/tests/test_views.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_views.py
@@ -986,6 +986,66 @@ class TestVulnerabilityTrendsView:
         filtered = client.get(self._get_url(product_id=product.id, release_id=release.id))
         assert filtered.context["summary"]["critical"] == 3
 
+    def test_release_summary_counts_a_component_once_across_format_twins(self, team_with_member, component_with_sbom):
+        """A release pins the SPDX and CycloneDX twins of one component (and its
+        CBOM); the snapshot must report that component once — the newest real
+        SBOM's counts — not the same packages summed once per pinned format.
+        The dashboard defaults to the latest release, so this double-count read
+        roughly twice the component page's numbers."""
+        from sbomify.apps.core.models import Release, ReleaseArtifact
+
+        team, user = team_with_member
+        spdx_sbom, component = component_with_sbom
+        product = Product.objects.get(team=team, name="Test Product")
+        SBOM.objects.filter(pk=spdx_sbom.pk).update(created_at=timezone.now() - timedelta(days=2))
+
+        cdx_twin = SBOM.objects.create(
+            name="twin-cdx",
+            version="1.0.0",
+            format="cyclonedx",
+            sbom_filename="twin.cdx.json",
+            component=component,
+            source="test",
+            format_version="1.6",
+        )
+        SBOM.objects.filter(pk=cdx_twin.pk).update(created_at=timezone.now() - timedelta(days=1))
+        cbom = SBOM.objects.create(
+            name="twin-cbom",
+            version="1.0.0",
+            format="cyclonedx",
+            bom_type="cbom",
+            sbom_filename="twin.cbom.json",
+            component=component,
+            source="test",
+            format_version="1.6",
+        )
+
+        release = Release.objects.create(product=product, name="v1.0", version="1.0")
+        for sbom in (spdx_sbom, cdx_twin, cbom):
+            ReleaseArtifact.objects.create(release=release, sbom=sbom)
+
+        common = dict(
+            plugin_name="grype",
+            plugin_version="1.0",
+            category="security",
+            status="completed",
+            plugin_config_hash="a" * 64,
+            run_reason="manual",
+        )
+        AssessmentRun.objects.create(sbom=spdx_sbom, result=_make_assessment_result(critical=3), **common)
+        AssessmentRun.objects.create(sbom=cdx_twin, result=_make_assessment_result(critical=4), **common)
+        # The CBOM's newest-of-all skip run must not win the component slot and
+        # zero the count — bom_type filtering keeps it out entirely.
+        AssessmentRun.objects.create(sbom=cbom, result=_make_assessment_result(), **common)
+
+        client = Client()
+        setup_authenticated_client_session(client, team, user)
+
+        response = client.get(self._get_url(product_id=product.id, release_id=release.id))
+        assert response.status_code == 200
+        assert response.context["summary"]["critical"] == 4
+        assert response.context["summary"]["total"] == 4
+
     def test_stale_release_id_falls_back_to_latest_not_403(self, team_with_member, component_with_sbom):
         """A release_id that doesn't belong to the selected product falls back to
         the LATEST sentinel (so switching products mid-flight doesn't error),

--- a/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
+++ b/sbomify/apps/vulnerability_scanning/views/vulnerability_trends.py
@@ -262,6 +262,15 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         snapshot_scope = scoped_query.filter(created_at__lte=end_date)
         if not release_id:
             snapshot_scope = snapshot_scope.filter(sbom_id__in=self._latest_sbom_ids(team, component_id, product_id))
+        else:
+            # A release legitimately pins several BOMs of one component — the
+            # CycloneDX and SPDX twins of the same content, plus CBOM/VEX rows.
+            # Counting each pinned SBOM separately reported the same packages
+            # once per format (the dashboard defaults to the latest release, so
+            # its cards read roughly double the component pages). Restrict to
+            # real SBOMs here; the per-component winner pick below keeps one
+            # BOM per component, matching what the component page reports.
+            snapshot_scope = snapshot_scope.filter(sbom__bom_type=SBOM.BomType.SBOM)
 
         # Compute daily data in Python since severity counts are in JSON.
         # Use .iterator() to stream rows instead of materializing all result
@@ -364,17 +373,23 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # ORDER BY returns an arbitrary row per group instead of the
                 # latest. Row order of the second query doesn't matter — rows
                 # land in a dict.
+                # Winner per (component, provider), not per (sbom, provider):
+                # the newest SBOM's newest run speaks for the component, so a
+                # release pinning format twins or a scope holding superseded
+                # uploads never counts one component twice.
                 snapshot_winner_ids = list(
-                    snapshot_scope.order_by("sbom_id", "plugin_name", "-created_at", "-id")
-                    .distinct("sbom_id", "plugin_name")
+                    snapshot_scope.order_by(
+                        "sbom__component_id", "plugin_name", "-sbom__created_at", "-sbom_id", "-created_at", "-id"
+                    )
+                    .distinct("sbom__component_id", "plugin_name")
                     .values_list("id", flat=True)
                 )
                 for snap in (
                     AssessmentRun.objects.filter(id__in=snapshot_winner_ids)
-                    .values("plugin_name", "sbom_id", *RESULT_SUMMARY_COLUMNS)
+                    .values("plugin_name", "sbom__component_id", *RESULT_SUMMARY_COLUMNS)
                     .iterator()
                 ):
-                    key = (snap["sbom_id"], snap["plugin_name"] or "unknown")
+                    key = (snap["sbom__component_id"], snap["plugin_name"] or "unknown")
                     latest_run_counts[key] = extract_severity_counts(reconstruct_result_summary(snap))
             else:
                 # Portable fallback (the SQLite test backend has no DISTINCT ON):
@@ -382,14 +397,15 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # result blobs for the winning runs only. Test-scale data, so the
                 # full scan is cheap. Compare (created_at, id) so equal timestamps
                 # break deterministically, matching the Postgres -id tiebreak.
-                latest_run_key: dict[tuple[Any, str], tuple[Any, Any]] = {}
+                latest_run_key: dict[tuple[Any, str], tuple[Any, Any, Any, Any]] = {}
                 latest_run_id: dict[tuple[Any, str], Any] = {}
-                for run_id, sbom_id, plugin_name, created in snapshot_scope.values_list(
-                    "id", "sbom_id", "plugin_name", "created_at"
+                for run_id, comp_id, sbom_id, sbom_created, plugin_name, created in snapshot_scope.values_list(
+                    "id", "sbom__component_id", "sbom_id", "sbom__created_at", "plugin_name", "created_at"
                 ).iterator():
-                    key = (sbom_id, plugin_name or "unknown")
-                    if key not in latest_run_key or (created, run_id) > latest_run_key[key]:
-                        latest_run_key[key] = (created, run_id)
+                    key = (comp_id, plugin_name or "unknown")
+                    value = (sbom_created, sbom_id, created, run_id)
+                    if key not in latest_run_key or value > latest_run_key[key]:
+                        latest_run_key[key] = value
                         latest_run_id[key] = run_id
                 annotated_by_id = {
                     row["id"]: row
@@ -446,7 +462,7 @@ class VulnerabilityTrendsView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
         # reshapes the timeline chart — it never changes these current counts.
         summary = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
         provider_data: dict[str, dict[str, int]] = {}
-        for (_sbom_id, provider), counts in latest_run_counts.items():
+        for (_component_id, provider), counts in latest_run_counts.items():
             for severity in summary:
                 summary[severity] += counts[severity]
             stats = provider_data.setdefault(provider, {"scans": 0, "vulnerabilities": 0})


### PR DESCRIPTION
Closes the findings from the staging QA follow-up pass (results in the QA log; the dashboard one is #1445).

**Dashboard severity cards double-count format twins** (closes #1445). The dashboard defaults to the latest release, and the release-scoped snapshot in `vulnerability_trends` counted every pinned BOM separately, so a component pinning its CycloneDX and SPDX twins reported the same packages once per format: the cards read 11 Critical / 167 High where the component page reads 6 / 47. The snapshot winner is now the newest real SBOM per (component, provider), with CBOM/VEX rows filtered out of the pool so a fresher CBOM skip-run can never zero a component's slot. Regression test pins a release with an SPDX twin plus a CBOM and asserts the component counts once. The timeline chart keeps per-SBOM carry-forward semantics; only the point-in-time snapshot changes.

**Workspace rename left the navbar stale** (QA DEFECT-7). Neither rename API handler refreshed the session-cached team name, so the navbar showed the old name until the 300s cache expired. Both `update_team` and `patch_team` now call `refresh_current_team_session`.

**Branding saved into the void** (QA OBS-10). Saving colors while Use custom branding is off toasted success and publicly changed nothing. The toast now says the colors wait for the toggle.

**Rejected access requesters saw a blank form** (QA OBS-9). The request page handled pending and approved states but said nothing after a rejection. It now shows a neutral notice that the earlier request was not approved, and still allows a new request.

One QA observation was dropped as not-a-bug after code reading: the release artifact list does refresh itself after pinning (`addSelectedArtifacts` awaits `loadArtifacts`); the stale view during QA was the automation sampling mid-flight between sequential add requests.

Tests: vulnerability_scanning trends suite (35), teams + documents suites (775) all green; djlint/ruff/mypy clean.