### PR TITLE
style(teams): give the security.txt section its proper title

### DIFF
--- a/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_settings_tabs/trust_center.html.j2
@@ -168,18 +168,19 @@
             {% endif %}
         </section>
     {% endif %}
-    {# Security.txt (RFC 9116) #}
+    {# security.txt (RFC 9116) #}
     {% if team.is_public %}
         <section class="mt-8 pt-8 border-t border-border"
                  x-data="{ securityTxtEnabled: {{ security_txt_config.enabled|default:False|yesno:'true,false' }} }">
             <div class="flex flex-wrap items-center justify-between gap-3">
+                {# The filename is the name: RFC 9116 writes security.txt lowercase everywhere. #}
                 <h3 class="text-sm font-semibold text-text m-0">
-                    Security.txt
+                    security.txt
                     <span class="text-text-muted font-normal">(RFC 9116)</span>
                 </h3>
-                <span class="text-xs font-medium"
-                      :class="securityTxtEnabled ? 'text-success' : 'text-text-muted'"
-                      x-text="securityTxtEnabled ? 'Enabled' : 'Disabled'"></span>
+                {# TEA-style status badges; x-show keeps them live since this toggle saves via the form's Save. #}
+                <c-badges.success x-show="securityTxtEnabled" x-cloak>Enabled</c-badges.success>
+                <c-badges.secondary x-show="!securityTxtEnabled">Disabled</c-badges.secondary>
             </div>
             <p class="text-sm text-text-muted mt-1 m-0">
                 Help security researchers report vulnerabilities via a standard contact file.


### PR DESCRIPTION
Viktor's review note on the Trust Center settings tab: the security.txt section needs a proper title.

Two changes, mirroring the TEA section directly above it:

- The heading now reads **security.txt** (RFC 9116). The filename is the name, and RFC 9116 writes it lowercase everywhere; the capitalized "Security.txt" was the only place in the product that cased it.
- The Enabled/Disabled status becomes the same badge chip the TEA section renders, instead of a bare text snippet. Since this section's toggle saves via the form's Save button rather than on change, the badges are bound with x-show so the chip tracks the unsaved toggle state, the same pattern the release tables already use.

Verified in dev on both themes; the badge flips live with the toggle. No e2e baseline covers this tab.