### PR TITLE
fix(vulns): show VEX justifications in human wording

### DIFF
--- a/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
@@ -114,7 +114,9 @@
                             VEX
                         {% endif %}
                     </span>
-                    {% if vuln.vex_justification %}<div class="text-xs text-text-muted mt-1">{{ vuln.vex_justification }}</div>{% endif %}
+                    {% if vuln.vex_justification %}
+                        <div class="text-xs text-text-muted mt-1">{{ vuln.vex_justification_label }}</div>
+                    {% endif %}
                 {% elif vuln.vex_state == 'in_triage' %}
                     <span class="text-warning">Under investigation</span>
                 {% elif vuln.vex_state == 'resolved' %}

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -164,7 +164,7 @@
                                 </div>
                                 <p class="text-xs text-text-muted m-0 mt-0.5"
                                    x-show="f.suppressed &amp;&amp; f.justification"
-                                   x-text="'VEX: ' + f.justification.replace(/_/g, ' ')"></p>
+                                   x-text="'VEX: ' + (f.justification_label || f.justification)"></p>
                             </div>
                         </div>
                     </template>

--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -176,7 +176,7 @@
                                                 {% endif %}
                                                 {# VEX analysis state #}
                                                 {% if finding.analysis_state %}
-                                                    <c-badges.info title="{{ finding.analysis_justification|default:'' }} {{ finding.analysis_detail|default:'' }}">
+                                                    <c-badges.info title="{{ finding.analysis_justification|vex_justification_label }} {{ finding.analysis_detail|default:'' }}">
                                                     <i class="fas fa-clipboard-check mr-0.5"></i>{{ finding.analysis_state }}
                                                     </c-badges.info>
                                                 {% endif %}

--- a/sbomify/apps/plugins/templatetags/plugins_extras.py
+++ b/sbomify/apps/plugins/templatetags/plugins_extras.py
@@ -321,3 +321,11 @@ def vulnerability_findings(findings: Any) -> list[Any]:
     if not isinstance(findings, (list, tuple)):
         return []
     return [f for f in findings if isinstance(f, dict) and is_vulnerability(f)]
+
+
+@register.filter
+def vex_justification_label(value: object) -> str:
+    """Human wording for a stored finding's raw VEX justification enum."""
+    from sbomify.apps.vulnerability_scanning.utils import justification_label
+
+    return justification_label(value)

--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -14,7 +14,7 @@ from typing import Any
 from urllib.parse import unquote
 
 from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
-from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
+from sbomify.apps.vulnerability_scanning.utils import is_vulnerability, justification_label
 
 # CycloneDX analysis states that suppress a finding (mirrors vex._SUPPRESSING_STATES).
 _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
@@ -382,6 +382,7 @@ def build_release_vuln_posture(release: Any) -> dict[str, Any]:
                 "suppressed": suppressed,
                 "state": finding.get("analysis_state") or "",
                 "justification": finding.get("analysis_justification") or "",
+                "justification_label": justification_label(finding.get("analysis_justification")),
                 "title": finding.get("title") or finding.get("description") or "",
             }
         )

--- a/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_operational_findings.py
@@ -188,3 +188,41 @@ def test_lifecycle_resolves_the_predicate_at_call_time(monkeypatch: pytest.Monke
     )
 
     assert lifecycle._advisories(result) == {}
+
+
+@pytest.mark.parametrize(
+    ("raw", "label"),
+    [
+        ("code_not_reachable", "Code not reachable"),
+        ("code_not_present", "Code not present"),
+        ("protected_by_mitigating_control", "Protected by mitigating control"),
+        # Unknown enums degrade to sentence case, never snake_case.
+        ("vulnerable_code_cannot_be_controlled_by_adversary", "Vulnerable code cannot be controlled by adversary"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_justification_label(raw: str | None, label: str) -> None:
+    from sbomify.apps.vulnerability_scanning.utils import justification_label
+
+    assert justification_label(raw) == label
+
+
+def test_finding_rows_carry_the_human_justification() -> None:
+    """The card under "Not affected · VEX" read the raw enum straight from the
+    file; rows now carry the display label beside it."""
+    result = {
+        "findings": [
+            {
+                "id": "CVE-2026-1",
+                "severity": "high",
+                "component": {"name": "netty", "version": "4.2.15", "purl": "pkg:maven/io.netty/netty@4.2.15"},
+                "analysis_state": "not_affected",
+                "analysis_justification": "code_not_reachable",
+            }
+        ]
+    }
+    (row,) = extract_finding_rows(result)
+
+    assert row["vex_justification"] == "code_not_reachable"
+    assert row["vex_justification_label"] == "Code not reachable"

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -137,6 +137,33 @@ _SEVERITY_RANK = SEVERITY_RANK
 
 _SUPPRESSING_VEX_STATES = {"not_affected", "false_positive"}
 
+# The CycloneDX impact-analysis justifications, worded exactly as the triage
+# modal offers them, so a decision reads back the way it was made. VEX
+# documents carry the raw enum; every display surface goes through
+# justification_label so "code_not_reachable" never reaches a user.
+VEX_JUSTIFICATION_LABELS: dict[str, str] = {
+    "code_not_present": "Code not present",
+    "code_not_reachable": "Code not reachable",
+    "requires_configuration": "Requires configuration",
+    "requires_dependency": "Requires dependency",
+    "requires_environment": "Requires environment",
+    "protected_by_compiler": "Protected by compiler",
+    "protected_at_runtime": "Protected at runtime",
+    "protected_at_perimeter": "Protected at perimeter",
+    "protected_by_mitigating_control": "Protected by mitigating control",
+}
+
+
+def justification_label(value: object) -> str:
+    """Human wording for a VEX justification enum; '' for none.
+
+    Unknown values (a future CycloneDX enum, an unmapped OpenVEX string)
+    degrade to de-underscored sentence case rather than leaking snake_case.
+    """
+    if not value or not isinstance(value, str):
+        return ""
+    return VEX_JUSTIFICATION_LABELS.get(value, value.replace("_", " ").capitalize())
+
 
 def _fold_finding(dst: dict[str, Any], src: dict[str, Any]) -> None:
     """Fold ``src``'s severity/CVSS/analysis fields into ``dst`` (worst wins)."""
@@ -305,6 +332,7 @@ def extract_finding_rows(
                 "fixed": vuln.get("fixed_version") or vuln.get("fixed") or "",
                 "vex_state": vex_state,
                 "vex_justification": vex_justification,
+                "vex_justification_label": justification_label(vex_justification),
                 "vex_suppressed": vex_state in _SUPPRESSING_VEX_STATES,
                 "vex_manual": vex_manual,
                 "malicious": is_malicious_finding(vuln),

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -793,6 +793,8 @@ def vex_suppression_rows(vex_sbom: Any) -> list[dict[str, Any]]:
     state, justification, and the package (or "All packages" for a
     product-scoped statement).
     """
+    from sbomify.apps.vulnerability_scanning.utils import justification_label
+
     rows: list[dict[str, Any]] = []
     for statement in _statements_from_vex_sbom(vex_sbom):
         names = sorted({name for (_type, name, _version) in statement.get("packages") or set()})
@@ -815,8 +817,7 @@ def vex_suppression_rows(vex_sbom: Any) -> list[dict[str, Any]]:
                 "id": display_id,
                 "aliases": [i for i in display_ids if i != display_id],
                 "state": statement.get("state") or "",
-                # Humanise the CycloneDX enum for display: "code_not_reachable" → "Code not reachable".
-                "justification": justification.replace("_", " ").capitalize(),
+                "justification": justification_label(justification),
                 "detail": statement.get("detail") or "",
                 "package": package,
             }


### PR DESCRIPTION
Viktor's note: `code_not_reachable` renders raw under "Not affected · VEX"; write it out human-readable instead of pulling it straight from the file.

One source of truth: `VEX_JUSTIFICATION_LABELS` + `justification_label()` in `vulnerability_scanning/utils.py`, carrying the nine CycloneDX impact-analysis justifications in the exact wording the triage modal already offers, so a decision reads back the way it was made. Unknown values (a future CycloneDX enum, an unmapped OpenVEX string) degrade to de-underscored sentence case rather than leaking snake_case.

Applied everywhere a justification renders:

- component vulnerabilities card (the screenshot): rows gain `vex_justification_label`, template uses it
- public release posture list: findings JSON gains `justification_label`, replacing the client-side `replace(/_/g, ' ')` which produced lowercase "code not reachable"
- assessment run tooltip: new `vex_justification_label` template filter over stored raw findings
- VEX documents page: `vex_suppression_rows` absorbs its local capitalise-and-replace into the shared helper

Raw enum values still travel alongside the labels, since the triage modal round-trips them as API payloads.

Verified in dev on the customer-repro component: "Not affected · VEX **Code not reachable**" and "**Protected by mitigating control**", no snake_case anywhere on the page. Tests: label mapping (known, unknown-fallback, empty) + a row-level assertion; vulnerability_scanning and plugins suites green (1482 passed).