### PR TITLE
fix: close the gaps the QA follow-up pass left open

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3261,11 +3261,7 @@ def update_release(request: HttpRequest, release_id: str, payload: ReleaseUpdate
 
         # Broadcast to workspace for real-time UI updates (after transaction commits)
         if release.product.team.key:
-            schedule_broadcast(
-                release.product.team.key,
-                "release_updated",
-                {"release_id": str(release.id), "product_id": str(release.product.id), "name": release.name},
-            )
+            _broadcast_release_artifacts_changed(release)
 
         return 200, _build_release_response(request, release, include_artifacts=True)
 
@@ -3343,11 +3339,7 @@ def patch_release(request: HttpRequest, release_id: str, payload: ReleasePatchSc
 
         # Broadcast to workspace for real-time UI updates (only if something changed, after transaction commits)
         if changed and release.product.team.key:
-            schedule_broadcast(
-                release.product.team.key,
-                "release_updated",
-                {"release_id": str(release.id), "product_id": str(release.product.id), "name": release.name},
-            )
+            _broadcast_release_artifacts_changed(release)
 
         return 200, _build_release_response(request, release, include_artifacts=True)
 
@@ -3716,7 +3708,11 @@ def list_release_artifacts(
     if mode == "existing":
         # Return artifacts that are already in this release
         existing_artifacts_queryset = (
-            ReleaseArtifact.objects.filter(release=release).select_related("sbom", "document").order_by("-created_at")
+            # component is read for every row below, so it belongs in the join:
+            # page_size=-1 turns a missing one into a query per artifact.
+            ReleaseArtifact.objects.filter(release=release)
+            .select_related("sbom__component", "document__component")
+            .order_by("-created_at")
         )
 
         # Extract pagination parameters properly
@@ -3937,9 +3933,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
                     }
                 return 400, {"detail": result["error"], "error_code": ErrorCode.INTERNAL_ERROR}
             artifact = result["artifact"]
-            _broadcast_release_artifacts_changed(release)
-
-            return 201, {
+            created = {
                 "id": str(artifact.id),
                 "artifact_type": "sbom",
                 "artifact_name": artifact.sbom.name,
@@ -3956,6 +3950,12 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
         except Exception as e:
             log.error(f"Error processing SBOM: {e}")
             return 400, {"detail": "Error processing SBOM", "error_code": ErrorCode.INTERNAL_ERROR}
+
+        # Outside the try on purpose: the row is committed by here, and letting a
+        # broadcast failure fall into the handler above would report a successful
+        # pin as a 400.
+        _broadcast_release_artifacts_changed(release)
+        return 201, created
 
     # Handle Document
     if payload.document_id:
@@ -3981,9 +3981,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
                     }
                 return 400, {"detail": result["error"], "error_code": ErrorCode.INTERNAL_ERROR}
             artifact = result["artifact"]
-            _broadcast_release_artifacts_changed(release)
-
-            return 201, {
+            created = {
                 "id": str(artifact.id),
                 "artifact_type": "document",
                 "artifact_name": artifact.document.name,
@@ -3999,6 +3997,12 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
         except Exception as e:
             log.error(f"Error processing document: {e}")
             return 400, {"detail": "Error processing document", "error_code": ErrorCode.INTERNAL_ERROR}
+
+        # Outside the try on purpose: the row is committed by here, and letting a
+        # broadcast failure fall into the handler above would report a successful
+        # pin as a 400.
+        _broadcast_release_artifacts_changed(release)
+        return 201, created
 
     return 400, {"detail": "Either sbom_id or document_id must be provided", "error_code": ErrorCode.BAD_REQUEST}
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3849,11 +3849,17 @@ def list_release_artifacts(
         page_size_num = page_size if isinstance(page_size, int) else int(request.GET.get("page_size", 15))
 
         page_num = max(1, page_num)  # Ensure page is at least 1
-        page_size_num = min(max(1, page_size_num), 100)  # Ensure page_size is between 1 and 100
-
-        start_index = (page_num - 1) * page_size_num
-        end_index = start_index + page_size_num
-        paginated_artifacts = available_artifacts[start_index:end_index]
+        if page_size_num == -1:
+            # Same contract as _paginate_queryset, which the existing-mode branch
+            # uses: -1 means every row. Clamping it to 1 here would hand the
+            # caller a single artifact and call it the whole list.
+            page_size_num = max(1, total_items)
+            paginated_artifacts = available_artifacts
+        else:
+            page_size_num = min(max(1, page_size_num), 100)  # Ensure page_size is between 1 and 100
+            start_index = (page_num - 1) * page_size_num
+            end_index = start_index + page_size_num
+            paginated_artifacts = available_artifacts[start_index:end_index]
 
         # Create pagination metadata
         from sbomify.apps.core.schemas import PaginationMeta

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -115,6 +115,23 @@ def schedule_broadcast(workspace_key: str, message_type: str, data: dict[str, An
     )
 
 
+def _broadcast_release_artifacts_changed(release: Release) -> None:
+    """Tell the workspace a release's artifact set moved.
+
+    Reuses the ``release_updated`` message the release tables already listen
+    for, so a pin or an unpin repaints every open view instead of waiting for
+    someone to reload.
+    """
+    workspace_key = release.product.team.key
+    if not workspace_key:
+        return
+    schedule_broadcast(
+        workspace_key,
+        "release_updated",
+        {"release_id": str(release.id), "product_id": str(release.product.id), "name": release.name},
+    )
+
+
 @dataclass(frozen=True)
 class ProductLookupResult:
     """Container for a product API payload plus the ORM instance."""
@@ -3914,6 +3931,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
                     }
                 return 400, {"detail": result["error"], "error_code": ErrorCode.INTERNAL_ERROR}
             artifact = result["artifact"]
+            _broadcast_release_artifacts_changed(release)
 
             return 201, {
                 "id": str(artifact.id),
@@ -3957,6 +3975,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
                     }
                 return 400, {"detail": result["error"], "error_code": ErrorCode.INTERNAL_ERROR}
             artifact = result["artifact"]
+            _broadcast_release_artifacts_changed(release)
 
             return 201, {
                 "id": str(artifact.id),
@@ -4011,6 +4030,7 @@ def remove_artifact_from_release(request: HttpRequest, release_id: str, artifact
         }
 
     artifact.delete()
+    _broadcast_release_artifacts_changed(release)
     return 204, None
 
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -115,12 +115,12 @@ def schedule_broadcast(workspace_key: str, message_type: str, data: dict[str, An
     )
 
 
-def _broadcast_release_artifacts_changed(release: Release) -> None:
-    """Tell the workspace a release's artifact set moved.
+def _broadcast_release_updated(release: Release) -> None:
+    """Tell the workspace a release moved: its fields or its artifact set.
 
-    Reuses the ``release_updated`` message the release tables already listen
-    for, so a pin or an unpin repaints every open view instead of waiting for
-    someone to reload.
+    Sends the ``release_updated`` message the release tables already listen
+    for, so an edit, a pin or an unpin repaints every open view instead of
+    waiting for someone to reload.
     """
     workspace_key = release.product.team.key
     if not workspace_key:
@@ -3261,7 +3261,7 @@ def update_release(request: HttpRequest, release_id: str, payload: ReleaseUpdate
 
         # Broadcast to workspace for real-time UI updates (after transaction commits)
         if release.product.team.key:
-            _broadcast_release_artifacts_changed(release)
+            _broadcast_release_updated(release)
 
         return 200, _build_release_response(request, release, include_artifacts=True)
 
@@ -3339,7 +3339,7 @@ def patch_release(request: HttpRequest, release_id: str, payload: ReleasePatchSc
 
         # Broadcast to workspace for real-time UI updates (only if something changed, after transaction commits)
         if changed and release.product.team.key:
-            _broadcast_release_artifacts_changed(release)
+            _broadcast_release_updated(release)
 
         return 200, _build_release_response(request, release, include_artifacts=True)
 
@@ -3958,7 +3958,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
         # Outside the try on purpose: the row is committed by here, and letting a
         # broadcast failure fall into the handler above would report a successful
         # pin as a 400.
-        _broadcast_release_artifacts_changed(release)
+        _broadcast_release_updated(release)
         return 201, created
 
     # Handle Document
@@ -4005,7 +4005,7 @@ def add_artifacts_to_release(request: HttpRequest, release_id: str, payload: Rel
         # Outside the try on purpose: the row is committed by here, and letting a
         # broadcast failure fall into the handler above would report a successful
         # pin as a 400.
-        _broadcast_release_artifacts_changed(release)
+        _broadcast_release_updated(release)
         return 201, created
 
     return 400, {"detail": "Either sbom_id or document_id must be provided", "error_code": ErrorCode.BAD_REQUEST}
@@ -4044,7 +4044,7 @@ def remove_artifact_from_release(request: HttpRequest, release_id: str, artifact
         }
 
     artifact.delete()
-    _broadcast_release_artifacts_changed(release)
+    _broadcast_release_updated(release)
     return 204, None
 
 

--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3847,9 +3847,11 @@ def list_release_artifacts(
         page_num = max(1, page_num)  # Ensure page is at least 1
         if page_size_num == -1:
             # Same contract as _paginate_queryset, which the existing-mode branch
-            # uses: -1 means every row. Clamping it to 1 here would hand the
-            # caller a single artifact and call it the whole list.
-            page_size_num = max(1, total_items)
+            # uses: -1 means every row, on page 1, in one page. Clamping it to 1
+            # here would hand the caller a single artifact and call it the whole
+            # list, and leaving page_num alone would report page 2 of 1.
+            page_num = 1
+            page_size_num = total_items
             paginated_artifacts = available_artifacts
         else:
             page_size_num = min(max(1, page_size_num), 100)  # Ensure page_size is between 1 and 100
@@ -3860,7 +3862,9 @@ def list_release_artifacts(
         # Create pagination metadata
         from sbomify.apps.core.schemas import PaginationMeta
 
-        total_pages = (total_items + page_size_num - 1) // page_size_num  # Ceiling division
+        # page_size_num is 0 only when -1 met an empty list, and _paginate_queryset
+        # calls that one page, not zero.
+        total_pages = (total_items + page_size_num - 1) // page_size_num if page_size_num else 1
 
         pagination_meta = PaginationMeta(
             total=total_items,

--- a/sbomify/apps/core/js/components/release-artifacts.ts
+++ b/sbomify/apps/core/js/components/release-artifacts.ts
@@ -128,8 +128,11 @@ export function registerReleaseArtifacts() {
             async loadArtifacts() {
                 this.isLoading = true;
                 try {
+                    // page_size=-1 returns every row. The table filters, sorts
+                    // and paginates client-side, so a server page would silently
+                    // hide artifacts and make the pager report wrong totals.
                     const response = await $axios.get(
-                        `/api/v1/releases/${this.releaseId}/artifacts?mode=existing`
+                        `/api/v1/releases/${this.releaseId}/artifacts?mode=existing&page_size=-1`
                     );
                     const artifactsData = Array.isArray(response.data) ? response.data : response.data.items || [];
                     this.artifacts = artifactsData;
@@ -144,7 +147,7 @@ export function registerReleaseArtifacts() {
             async loadAvailableArtifacts() {
                 this.isLoadingAvailable = true;
                 try {
-                    const response = await $axios.get(`/api/v1/releases/${this.releaseId}/artifacts?mode=available`);
+                    const response = await $axios.get(`/api/v1/releases/${this.releaseId}/artifacts?mode=available&page_size=-1`);
                     const data = Array.isArray(response.data) ? response.data : response.data.items || [];
                     this.availableArtifacts = data;
                 } catch (error) {

--- a/sbomify/apps/core/templates/core/components/release_artifacts.html.j2
+++ b/sbomify/apps/core/templates/core/components/release_artifacts.html.j2
@@ -1,8 +1,7 @@
 {% load static %}
 {# The @ws:message handler repaints when someone pins or unpins in another tab or session. #}
 <div x-data="releaseArtifacts({ releaseId: '{{ release_id }}', productId: '{{ product_id }}', initialArtifacts: [], totalCount: 0, canEdit: {{ can_edit|yesno:'true,false' }}, isLatest: {{ is_latest|default:False|yesno:'true,false' }} })"
-     x-init="loadArtifacts()"
-     @ws:message.window="if ($event.detail.type === 'release_updated' && $event.detail.release_id === '{{ release_id }}') { loadArtifacts(); }">
+     @ws:message.window="if ($event.detail.type === 'release_updated' && $event.detail.release_id === '{{ release_id }}') { clearTimeout($el._wsDebounce); $el._wsDebounce = setTimeout(() => loadArtifacts(), 500); }">
     {# The shell draws the frame itself, so the table needs no card around it. #}
     <c-tables.shell>
     <c-tables.toolbar>

--- a/sbomify/apps/core/templates/core/components/release_artifacts.html.j2
+++ b/sbomify/apps/core/templates/core/components/release_artifacts.html.j2
@@ -1,6 +1,8 @@
 {% load static %}
+{# The @ws:message handler repaints when someone pins or unpins in another tab or session. #}
 <div x-data="releaseArtifacts({ releaseId: '{{ release_id }}', productId: '{{ product_id }}', initialArtifacts: [], totalCount: 0, canEdit: {{ can_edit|yesno:'true,false' }}, isLatest: {{ is_latest|default:False|yesno:'true,false' }} })"
-     x-init="loadArtifacts()">
+     x-init="loadArtifacts()"
+     @ws:message.window="if ($event.detail.type === 'release_updated' && $event.detail.release_id === '{{ release_id }}') { loadArtifacts(); }">
     {# The shell draws the frame itself, so the table needs no card around it. #}
     <c-tables.shell>
     <c-tables.toolbar>

--- a/sbomify/apps/core/tests/test_release_artifacts_api.py
+++ b/sbomify/apps/core/tests/test_release_artifacts_api.py
@@ -85,6 +85,11 @@ class TestReleaseArtifactsAPI(TestCase):
             assert payload["pagination"]["total"] > 1, f"{mode} fixture proves nothing"
             assert payload["pagination"]["page_size"] >= payload["pagination"]["total"], mode
             assert len(payload["items"]) == payload["pagination"]["total"], mode
+            # Both modes have to report the same shape, or a client walking
+            # pages gets a different contract depending on what it asked for.
+            assert payload["pagination"]["page"] == 1, mode
+            assert payload["pagination"]["total_pages"] == 1, mode
+            assert payload["pagination"]["has_previous"] is False, mode
 
     def test_bom_type_survives_response_serialisation(self):
         """bom_type must reach the client through the response schema.
@@ -225,7 +230,9 @@ class TestAddArtifactsToReleaseAPI:
         self.release = Release.objects.create(name="v1.0.0", product=self.product, is_latest=False, is_prerelease=False)
 
         # Create component
-        self.component = Component.objects.create(name="Test Component", team=self.team, visibility=Component.Visibility.PRIVATE)
+        self.component = Component.objects.create(
+            name="Test Component", team=self.team, visibility=Component.Visibility.PRIVATE
+        )
 
         # Create SBOM
         self.sbom = SBOM.objects.create(name="Test SBOM", component=self.component, format="cyclonedx", version="1.0.0")

--- a/sbomify/apps/core/tests/test_release_artifacts_api.py
+++ b/sbomify/apps/core/tests/test_release_artifacts_api.py
@@ -55,6 +55,37 @@ class TestReleaseArtifactsAPI(TestCase):
         # Add SBOM to release as artifact
         self.release_artifact = ReleaseArtifact.objects.create(release=self.release, sbom=self.sbom)
 
+    def test_page_size_minus_one_returns_every_artifact_in_both_modes(self):
+        """The table paginates client-side, so a clamped -1 would hide rows.
+
+        The available branch does its own clamping rather than going through
+        _paginate_queryset, so the two modes have to be checked separately.
+        """
+        # Available artifacts are drawn from the product's components, so the
+        # component has to be attached or that list stays empty.
+        self.product.components.add(self.component)
+        extras = [
+            SBOM.objects.create(
+                name=f"extra-sbom-{index}",
+                version=f"1.0.{index}",
+                format="cyclonedx",
+                format_version="1.6",
+                component=self.component,
+            )
+            for index in range(4)
+        ]
+        # Two pinned, two not, so neither mode is trivially satisfied.
+        for sbom in extras[:2]:
+            ReleaseArtifact.objects.get_or_create(release=self.release, sbom=sbom)
+
+        for mode in ("existing", "available"):
+            response = Client().get(f"/api/v1/releases/{self.release.id}/artifacts?mode={mode}&page_size=-1")
+            assert response.status_code == 200, mode
+            payload = json.loads(response.content)
+            assert payload["pagination"]["total"] > 1, f"{mode} fixture proves nothing"
+            assert payload["pagination"]["page_size"] >= payload["pagination"]["total"], mode
+            assert len(payload["items"]) == payload["pagination"]["total"], mode
+
     def test_bom_type_survives_response_serialisation(self):
         """bom_type must reach the client through the response schema.
 

--- a/sbomify/apps/core/tests/test_release_artifacts_api.py
+++ b/sbomify/apps/core/tests/test_release_artifacts_api.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -223,6 +224,49 @@ class TestAddArtifactsToReleaseAPI:
 
         # Verify artifact was created
         assert ReleaseArtifact.objects.filter(release=self.release, sbom=self.sbom).exists()
+
+    def test_pinning_an_artifact_broadcasts_to_the_workspace(
+        self, authenticated_api_client: tuple[Client, Any], django_capture_on_commit_callbacks: Any
+    ) -> None:
+        """Open release views repaint on the broadcast instead of waiting for a reload."""
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+
+        with (
+            patch("sbomify.apps.core.apis.broadcast_to_workspace") as mock_broadcast,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            response = client.post(
+                f"/api/v1/releases/{self.release.id}/artifacts",
+                data=json.dumps({"sbom_id": str(self.sbom.id)}),
+                content_type="application/json",
+                **headers,
+            )
+
+        assert response.status_code == 201
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.kwargs["message_type"] == "release_updated"
+        assert mock_broadcast.call_args.kwargs["data"]["release_id"] == str(self.release.id)
+
+    def test_unpinning_an_artifact_broadcasts_to_the_workspace(
+        self, authenticated_api_client: tuple[Client, Any], django_capture_on_commit_callbacks: Any
+    ) -> None:
+        client, access_token = authenticated_api_client
+        headers = get_api_headers(access_token)
+        artifact = ReleaseArtifact.objects.create(release=self.release, sbom=self.sbom)
+
+        with (
+            patch("sbomify.apps.core.apis.broadcast_to_workspace") as mock_broadcast,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            response = client.delete(
+                f"/api/v1/releases/{self.release.id}/artifacts/{artifact.id}",
+                **headers,
+            )
+
+        assert response.status_code == 204
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.kwargs["message_type"] == "release_updated"
 
     def test_add_duplicate_artifact_returns_409_conflict(self, authenticated_api_client: tuple[Client, Any]) -> None:
         """Test that adding a duplicate artifact returns 409 Conflict.

--- a/sbomify/apps/documents/templates/documents/request_access.html.j2
+++ b/sbomify/apps/documents/templates/documents/request_access.html.j2
@@ -41,9 +41,11 @@
                     {% endif %}
                 </p>
                 {% if was_rejected %}
-                    <c-feedback.alert variant="warning" icon="fas fa-circle-info" class="mb-4">
-                    Your earlier request was not approved. You can submit a new one.
-                    </c-feedback.alert>
+                    <div class="mb-4 px-4 py-3 rounded-xl border border-border text-sm"
+                         style="background: var(--bg-secondary);
+                                color: var(--text-primary)">
+                        Your earlier request was not approved. You can submit a new one.
+                    </div>
                 {% endif %}
                 <form method="post" action="{% url 'documents:request_access' team.key %}">
                     {% csrf_token %}

--- a/sbomify/apps/documents/templates/documents/request_access.html.j2
+++ b/sbomify/apps/documents/templates/documents/request_access.html.j2
@@ -41,11 +41,9 @@
                     {% endif %}
                 </p>
                 {% if was_rejected %}
-                    <div class="mb-4 px-4 py-3 rounded-xl border border-border text-sm"
-                         style="background: var(--bg-secondary);
-                                color: var(--text-primary)">
-                        Your earlier request was not approved. You can submit a new one.
-                    </div>
+                    <c-feedback.alert variant="warning" icon="fas fa-circle-info" class="mb-4">
+                    Your earlier request was not approved. You can submit a new one.
+                    </c-feedback.alert>
                 {% endif %}
                 <form method="post" action="{% url 'documents:request_access' team.key %}">
                     {% csrf_token %}

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -275,18 +275,23 @@ def delete_from_s3(
 def _refresh_workspace_list_session(request: HttpRequest) -> None:
     """Recompute the cached workspace list after a rename.
 
-    Only for callers that already carry a session. SessionMiddleware hands
-    every request a lazy SessionStore, so writing to it unconditionally would
-    mint a session row and a Set-Cookie for token clients that never asked for
-    one. An unsaved store has no ``session_key``, which is the tell.
+    Only for callers that already carry one. SessionMiddleware hands every
+    request a lazy SessionStore, so writing to it unconditionally would mint a
+    session row and a Set-Cookie for token clients that never asked for one.
     """
     session = getattr(request, "session", None)
-    if session is None or session.session_key is None:
+    user = getattr(request, "user", None)
+    if session is None or user is None or not user.is_authenticated:
         return
 
-    user = getattr(request, "user", None)
-    if user is not None and user.is_authenticated:
-        update_user_teams_session(request, user)
+    # Refresh a workspace list only where one already exists. session_key alone
+    # is the unloaded cookie value, so a token client sending a stale sessionid
+    # would pass that check and then get a fresh session minted on write. Reading
+    # a key loads the store, and a dead key loads as empty.
+    if "user_teams" not in session:
+        return
+
+    update_user_teams_session(request, user)
 
 
 @router.put(

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -275,11 +275,17 @@ def delete_from_s3(
 def _refresh_workspace_list_session(request: HttpRequest) -> None:
     """Recompute the cached workspace list after a rename.
 
-    Token-authenticated callers have no session to update, so this is a no-op
-    for them.
+    Only for callers that already carry a session. SessionMiddleware hands
+    every request a lazy SessionStore, so writing to it unconditionally would
+    mint a session row and a Set-Cookie for token clients that never asked for
+    one. An unsaved store has no ``session_key``, which is the tell.
     """
+    session = getattr(request, "session", None)
+    if session is None or session.session_key is None:
+        return
+
     user = getattr(request, "user", None)
-    if user is not None and user.is_authenticated and hasattr(request, "session"):
+    if user is not None and user.is_authenticated:
         update_user_teams_session(request, user)
 
 

--- a/sbomify/apps/teams/apis.py
+++ b/sbomify/apps/teams/apis.py
@@ -55,7 +55,11 @@ from sbomify.apps.teams.services.suppliers import (
     list_suppliers,
     update_supplier,
 )
-from sbomify.apps.teams.utils import on_demand_tls_cache_key, refresh_current_team_session
+from sbomify.apps.teams.utils import (
+    on_demand_tls_cache_key,
+    refresh_current_team_session,
+    update_user_teams_session,
+)
 from sbomify.logging import getLogger
 
 logger = getLogger(__name__)
@@ -266,6 +270,17 @@ def delete_from_s3(
 ) -> None:
     s3_client = S3Client("MEDIA")
     s3_client.delete_object(settings.AWS_MEDIA_STORAGE_BUCKET_NAME, filename)
+
+
+def _refresh_workspace_list_session(request: HttpRequest) -> None:
+    """Recompute the cached workspace list after a rename.
+
+    Token-authenticated callers have no session to update, so this is a no-op
+    for them.
+    """
+    user = getattr(request, "user", None)
+    if user is not None and user.is_authenticated and hasattr(request, "session"):
+        update_user_teams_session(request, user)
 
 
 @router.put(
@@ -1042,8 +1057,12 @@ def update_team(request: HttpRequest, team_key: str, payload: TeamUpdateSchema) 
             team.save()
 
         # The navbar reads the session's current_team; without this the old
-        # name survives every reload until the session cache expires.
+        # name survives every reload until the session cache expires. The
+        # sidebar and header are also cached fragments keyed on
+        # ``user_teams_version``, so the workspace list has to be recomputed
+        # too or the switcher keeps the old name regardless.
         refresh_current_team_session(request, team)
+        _refresh_workspace_list_session(request)
 
         return 200, _build_team_response(request, team)
 
@@ -1091,6 +1110,7 @@ def patch_team(request: HttpRequest, team_key: str, payload: TeamPatchSchema) ->
             team.save()
 
         refresh_current_team_session(request, team)
+        _refresh_workspace_list_session(request)
 
         return 200, _build_team_response(request, team)
 

--- a/sbomify/apps/teams/templates/teams/team_branding.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_branding.html.j2
@@ -34,8 +34,11 @@
                 <h2 class="text-lg font-semibold text-text m-0">Branding</h2>
                 <p class="text-sm text-text-muted mt-1 m-0">Your colors and logo, on every page you share with customers.</p>
             </div>
-            {# Saving while the toggle is off changes nothing publicly, which reads as a
-               broken save. Say so next to the fields, not only beside the toggle. #}
+            {% comment %}
+                Saving while the toggle is off changes nothing publicly, which
+                reads as a broken save. Say so next to the fields, not only
+                beside the toggle.
+            {% endcomment %}
             <c-feedback.alert variant="warning" icon="fas fa-triangle-exclamation" class="mt-6" x-show="!localBrandingInfo.branding_enabled">
             Custom branding is off, so public pages show the default sbomify look. Your colors and logo are saved. Turn it on under Display to use them.
             </c-feedback.alert>

--- a/sbomify/apps/teams/templates/teams/team_branding.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_branding.html.j2
@@ -39,7 +39,7 @@
                 reads as a broken save. Say so next to the fields, not only
                 beside the toggle.
             {% endcomment %}
-            <c-feedback.alert variant="warning" icon="fas fa-triangle-exclamation" class="mt-6" x-show="!localBrandingInfo.branding_enabled">
+            <c-feedback.alert variant="warning" icon="fas fa-triangle-exclamation" class="mt-6" x-show="!branding_info.branding_enabled">
             Custom branding is off, so public pages show the default sbomify look. Your colors and logo are saved. Turn it on under Display to use them.
             </c-feedback.alert>
             {# Colors #}

--- a/sbomify/apps/teams/templates/teams/team_branding.html.j2
+++ b/sbomify/apps/teams/templates/teams/team_branding.html.j2
@@ -34,6 +34,11 @@
                 <h2 class="text-lg font-semibold text-text m-0">Branding</h2>
                 <p class="text-sm text-text-muted mt-1 m-0">Your colors and logo, on every page you share with customers.</p>
             </div>
+            {# Saving while the toggle is off changes nothing publicly, which reads as a
+               broken save. Say so next to the fields, not only beside the toggle. #}
+            <c-feedback.alert variant="warning" icon="fas fa-triangle-exclamation" class="mt-6" x-show="!localBrandingInfo.branding_enabled">
+            Custom branding is off, so public pages show the default sbomify look. Your colors and logo are saved. Turn it on under Display to use them.
+            </c-feedback.alert>
             {# Colors #}
             <section class="mt-8">
                 <div class="flex items-center justify-between">

--- a/sbomify/apps/teams/tests/test_team_general.py
+++ b/sbomify/apps/teams/tests/test_team_general.py
@@ -13,6 +13,34 @@ from sbomify.apps.teams.models import Member, Team
 class TestTeamGeneralView:
     """Test cases for TeamGeneralView."""
 
+    def test_rename_refreshes_the_cached_workspace_list(
+        self, client: Client, sample_team_with_owner_member
+    ):
+        """A rename has to bust the sidebar and header fragment caches.
+
+        Those fragments are keyed on ``user_teams_version``, so a rename that
+        only refreshes ``current_team`` leaves the switcher showing the old
+        name until the cache expires.
+        """
+        team = sample_team_with_owner_member.team
+        user = sample_team_with_owner_member.user
+        setup_authenticated_client_session(client, team, user)
+
+        stale_version = client.session.get("user_teams_version")
+
+        response = client.post(
+            reverse("teams:team_general", kwargs={"team_key": team.key}),
+            {"action": "update_name", "name": "Renamed Workspace"},
+        )
+
+        assert response.status_code == 200
+        assert Team.objects.get(pk=team.pk).name == "Renamed Workspace"
+
+        session = client.session
+        assert session["current_team"]["name"] == "Renamed Workspace"
+        assert session["user_teams"][team.key]["name"] == "Renamed Workspace"
+        assert session["user_teams_version"] != stale_version
+
     def test_set_default_workspace(
         self, client: Client, sample_team_with_owner_member
     ):

--- a/sbomify/apps/teams/views/team_general.py
+++ b/sbomify/apps/teams/views/team_general.py
@@ -94,6 +94,11 @@ class TeamGeneralView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                 team_obj.save(update_fields=["name", "sbom_freshness_days"])
 
             refresh_current_team_session(request, team_obj)
+            # The sidebar and header are cached fragments keyed on
+            # ``user_teams_version``, and only this call recomputes that
+            # checksum. Without it the switcher keeps showing the old name
+            # until the cache expires on its own.
+            update_user_teams_session(request, cast(User, request.user))
 
             return htmx_success_response(
                 "Workspace settings updated successfully", triggers={"refreshTeamGeneral": True}


### PR DESCRIPTION
The follow-up QA pass on stage left four observations open. Two turned out to be real bugs with a different cause than the notes recorded, one was a second defect hiding on the same code path, and one was already closed.

### The rename fix did not reach the navbar

An earlier commit called `refresh_current_team_session` on the two rename API handlers. That updates `session["current_team"]`, which the navbar chip does not read. The sidebar and header render inside `{% cache 300 'sidebar' … request.session.user_teams_version %}`, and only `update_user_teams_session` recomputes that checksum. The cache key also carries `current_team.id`, which a rename leaves alone, so the stale name survived.

The web view (`teams/views/team_general.py::_update_general`) never refreshed anything at all. `_set_default`, thirty lines below it, already did.

All three rename paths now refresh both halves. The regression test fails on master.

### Pinning an artifact broadcast nothing

`add_artifacts_to_release` and `remove_artifact_from_release` never called `schedule_broadcast`, while seven other mutations in the same file do. A second tab or a colleague's browser waited for a manual reload. Both now send `release_updated`, the message the release tables already listen for, and the release artifacts table gained a listener.

### The same table only ever saw 15 artifacts

`loadArtifacts()` requested `?mode=existing` with no page size, so the server applied its default of 15. The table then filtered, sorted and paginated client-side as though it held the whole set, so a release with more artifacts showed a subset and reported wrong page totals. The available-artifacts modal had the same bug, which made artifacts unpinnable if they fell outside the first 15.

Both lists now pass `page_size=-1`, which the paginator already supports.

### Branding said it only once

Saving colours with custom branding off produced a toast explaining the colours were waiting for the toggle. The toast is gone by the next edit. The form now carries that state whenever the toggle is off.

### Reverted after review

The rejected re-request notice landed on 21 Aug. Its markup moves to `c-feedback.alert`, which is what the public-page rules call for.

## Changed after review

Swapping that notice to `c-feedback.alert` was a mistake and is reverted. `public_base` redefines `--color-text` as a bare RGB triplet (`248 250 252`), not a colour, so the alert's `color-mix` is invalid at computed-value time and its text falls back to inherit. Its icon is brand amber on a 10% tint of the same amber. The original markup uses the tokens public pages actually define. That bare-triplet redefinition breaks any `color-mix` consumer on a public page and wants its own fix.

Also from review:

- The websocket handler had no debounce, unlike every other listener in the repo. Pinning fifty artifacts posts fifty times, so every open tab fired fifty unsequenced refetches and the table settled on whichever reply landed last. Debounced at 500ms.
- The broadcast sat inside the try whose `except` returns 400, so a failure reading the team reported a committed pin as "Failed to add". Both branches now build the response, leave the try, then broadcast.
- `page_size=-1` on a queryset that joined `sbom` and `document` but not `component`, which the loop reads per row, meant a query per artifact. Widened the join.
- The session guard tested `session_key`, which is the unloaded cookie value, so a token client with a stale `sessionid` passed it and got a session minted anyway. It now checks the store actually holds a workspace list.
- The helper was a third copy of a block that existed twice already; both now call it.
- The branding notice tracked the unsaved checkbox, so it claimed colours were saved before anything was submitted.
- The artifacts table loaded twice on every page open, because `x-init` duplicated `init()`.
