### PR TITLE
fix: say something when a workspace invitation is accepted for you

### DIFF
--- a/sbomify/apps/teams/notifications.py
+++ b/sbomify/apps/teams/notifications.py
@@ -27,13 +27,10 @@ def get_notifications(request: HttpRequest) -> list[NotificationSchema]:
     try:
         pending = get_pending_invitations_for_email(email)
 
-        # Build action URL pointing to the members tab where accept/reject UI lives
-        current_team = request.session.get("current_team", {})
-        team_key = current_team.get("key")
-        if team_key:
-            action_url = reverse("teams:team_settings", kwargs={"team_key": team_key}) + "#members"
-        else:
-            action_url = reverse("core:settings")
+        # Accepting happens on the user's own settings page. Pointing at the
+        # current workspace's members tab sent someone invited to workspace B
+        # to workspace A's member list, which holds no invitation of theirs.
+        action_url = reverse("core:settings")
 
         notifications: list[NotificationSchema] = []
         for inv in pending:

--- a/sbomify/apps/teams/signals/handlers.py
+++ b/sbomify/apps/teams/signals/handlers.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
     from sbomify.apps.core.models import User
 
 from allauth.socialaccount.models import SocialAccount
+from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save, pre_save
@@ -74,6 +75,16 @@ def _accept_pending_invitations(user: User, request: HttpRequest | None = None) 
         accepted.append(
             {"team_key": invitation.team.key, "invitation_id": invitation.id, "invitation_token": str(invitation.token)}
         )
+
+        if request is not None:
+            # Accepting deletes the invitation, so the pending-invitation
+            # notification has nothing left to show and the user is put in a
+            # workspace without being told. The only other place that says so
+            # is the accept-invite view, which a user who signed up directly
+            # never reaches.
+            # fail_silently: a login that reaches here without the message
+            # middleware (a programmatic force_login, say) must still complete.
+            messages.info(request, f"You have joined {invitation.team.name} as {invitation.role}.", fail_silently=True)
 
         if request is not None:
             # Capture into locals BEFORE invitation.delete() below; the

--- a/sbomify/apps/teams/signals/handlers.py
+++ b/sbomify/apps/teams/signals/handlers.py
@@ -72,19 +72,27 @@ def _accept_pending_invitations(user: User, request: HttpRequest | None = None) 
             is_default_team=not has_default,
         )
         has_default = has_default or membership.is_default_team
-        accepted.append(
-            {"team_key": invitation.team.key, "invitation_id": invitation.id, "invitation_token": str(invitation.token)}
-        )
+        # Accepting deletes the invitation, so the pending-invitation
+        # notification has nothing left to show and the user is put in a
+        # workspace without being told. The accept-invite view announces it
+        # only for someone who arrives through the emailed link.
+        #
+        # Whether it lands is recorded rather than assumed: a login can reach
+        # here with no message storage, and the accept-invite view reads this
+        # flag to decide whether it still has to say so itself.
+        announced = False
+        if request is not None and hasattr(request, "_messages"):
+            messages.info(request, f"You have joined {invitation.team.name} as {invitation.role}")
+            announced = True
 
-        if request is not None:
-            # Accepting deletes the invitation, so the pending-invitation
-            # notification has nothing left to show and the user is put in a
-            # workspace without being told. The only other place that says so
-            # is the accept-invite view, which a user who signed up directly
-            # never reaches.
-            # fail_silently: a login that reaches here without the message
-            # middleware (a programmatic force_login, say) must still complete.
-            messages.info(request, f"You have joined {invitation.team.name} as {invitation.role}.", fail_silently=True)
+        accepted.append(
+            {
+                "team_key": invitation.team.key,
+                "invitation_id": invitation.id,
+                "invitation_token": str(invitation.token),
+                "announced": announced,
+            }
+        )
 
         if request is not None:
             # Capture into locals BEFORE invitation.delete() below; the

--- a/sbomify/apps/teams/tests/test_invite_notifications.py
+++ b/sbomify/apps/teams/tests/test_invite_notifications.py
@@ -1,0 +1,135 @@
+"""Being invited to a workspace has to be visible somewhere.
+
+Two paths, and both were silent. An existing member gets a bell notification
+from the pending invitation, but it linked to whichever workspace happened to
+be active rather than the page that accepts it. A brand-new user never sees
+that notification at all: login auto-accepts and deletes the invitation, so
+there is nothing left to notify about, and the only place that said so was the
+accept-invite view a direct signup never reaches.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import Client, RequestFactory
+from django.urls import reverse
+from django.utils import timezone
+
+from sbomify.apps.core.models import User
+from sbomify.apps.teams.models import Invitation, Member, Team
+from sbomify.apps.teams.notifications import get_notifications
+from sbomify.apps.teams.signals.handlers import _accept_pending_invitations
+
+
+@pytest.fixture
+def invited_user() -> User:
+    return User.objects.create_user(username="invitee", email="invitee@example.test", password="pw")  # nosec B106
+
+
+@pytest.fixture
+def inviting_team() -> Team:
+    return Team.objects.create(name="Lithium Labs")
+
+
+def _invite(team: Team, email: str, role: str = "member") -> Invitation:
+    return Invitation.objects.create(
+        team=team,
+        email=email,
+        role=role,
+        token=uuid.uuid4(),
+        expires_at=timezone.now() + timedelta(days=7),
+    )
+
+
+@pytest.mark.django_db
+def test_a_pending_invitation_raises_a_notification(invited_user: User, inviting_team: Team) -> None:
+    _invite(inviting_team, invited_user.email)
+
+    request = RequestFactory().get("/")
+    request.user = invited_user
+    request.session = SessionStore()
+
+    notifications = get_notifications(request)
+
+    assert [n.type for n in notifications] == ["pending_invitation"]
+    assert inviting_team.display_name in notifications[0].message
+
+
+@pytest.mark.django_db
+def test_the_notification_links_to_where_invitations_are_accepted(invited_user: User, inviting_team: Team) -> None:
+    """Not the active workspace's member list, which holds no invitation of theirs."""
+    other_team = Team.objects.create(name="Somewhere Else")
+    Member.objects.create(team=other_team, user=invited_user, role="owner")
+    _invite(inviting_team, invited_user.email)
+
+    request = RequestFactory().get("/")
+    request.user = invited_user
+    request.session = SessionStore()
+    request.session["current_team"] = {"key": other_team.key, "role": "owner"}
+
+    notifications = get_notifications(request)
+
+    assert notifications[0].action_url == reverse("core:settings")
+
+
+@pytest.mark.django_db
+def test_an_auto_accepted_invitation_tells_the_user(invited_user: User, inviting_team: Team, client: Client) -> None:
+    """A new user is put in the workspace and the invitation is deleted, so
+    nothing downstream can announce it. The acceptance has to say so itself."""
+    _invite(inviting_team, invited_user.email, role="admin")
+
+    request = RequestFactory().get("/")
+    request.user = invited_user
+    request.session = SessionStore()
+    request._messages = FallbackStorageStub()
+
+    accepted = _accept_pending_invitations(invited_user, request)
+
+    assert len(accepted) == 1
+    assert Member.objects.filter(user=invited_user, team=inviting_team).exists()
+    assert not Invitation.objects.filter(email=invited_user.email).exists()
+    assert [str(m) for m in request._messages.stored] == ["You have joined Lithium Labs as admin."]
+
+
+class FallbackStorageStub:
+    """Collects messages without needing MessageMiddleware on a bare request."""
+
+    def __init__(self) -> None:
+        self.stored: list[object] = []
+
+    def add(self, level: int, message: str, extra_tags: str = "") -> None:
+        self.stored.append(message)
+
+
+@pytest.mark.django_db
+def test_an_existing_member_is_not_auto_accepted(invited_user: User, inviting_team: Team) -> None:
+    """The auto-accept is a first-login convenience; anyone else chooses."""
+    other_team = Team.objects.create(name="Already In One")
+    Member.objects.create(team=other_team, user=invited_user, role="owner")
+    _invite(inviting_team, invited_user.email)
+
+    request = RequestFactory().get("/")
+    request.user = invited_user
+    request.session = SessionStore()
+
+    assert _accept_pending_invitations(invited_user, request) == []
+    assert Invitation.objects.filter(email=invited_user.email).exists()
+
+
+@pytest.mark.django_db
+def test_a_login_without_message_storage_still_completes(
+    invited_user: User, inviting_team: Team, client: Client
+) -> None:
+    """force_login builds a request with no message store, and announcing the
+    acceptance must never be the thing that stops someone signing in."""
+    _invite(inviting_team, invited_user.email)
+
+    client.force_login(invited_user)
+    response = client.get(reverse("core:settings"), follow=True)
+
+    assert response.status_code == 200
+    assert Member.objects.filter(user=invited_user, team=inviting_team).exists()

--- a/sbomify/apps/teams/tests/test_invite_notifications.py
+++ b/sbomify/apps/teams/tests/test_invite_notifications.py
@@ -77,7 +77,7 @@ def test_the_notification_links_to_where_invitations_are_accepted(invited_user: 
 
 
 @pytest.mark.django_db
-def test_an_auto_accepted_invitation_tells_the_user(invited_user: User, inviting_team: Team, client: Client) -> None:
+def test_an_auto_accepted_invitation_tells_the_user(invited_user: User, inviting_team: Team) -> None:
     """A new user is put in the workspace and the invitation is deleted, so
     nothing downstream can announce it. The acceptance has to say so itself."""
     _invite(inviting_team, invited_user.email, role="admin")
@@ -92,7 +92,8 @@ def test_an_auto_accepted_invitation_tells_the_user(invited_user: User, inviting
     assert len(accepted) == 1
     assert Member.objects.filter(user=invited_user, team=inviting_team).exists()
     assert not Invitation.objects.filter(email=invited_user.email).exists()
-    assert [str(m) for m in request._messages.stored] == ["You have joined Lithium Labs as admin."]
+    assert accepted[0]["announced"] is True
+    assert [str(m) for m in request._messages.stored] == ["You have joined Lithium Labs as admin"]
 
 
 class FallbackStorageStub:
@@ -133,3 +134,18 @@ def test_a_login_without_message_storage_still_completes(
 
     assert response.status_code == 200
     assert Member.objects.filter(user=invited_user, team=inviting_team).exists()
+
+
+@pytest.mark.django_db
+def test_a_login_with_no_message_storage_records_that_it_said_nothing(invited_user: User, inviting_team: Team) -> None:
+    """The accept-invite view reads this flag to decide whether it still has to
+    announce the join, so a silent acceptance must not claim otherwise."""
+    _invite(inviting_team, invited_user.email)
+
+    request = RequestFactory().get("/")
+    request.user = invited_user
+    request.session = SessionStore()
+
+    accepted = _accept_pending_invitations(invited_user, request)
+
+    assert accepted[0]["announced"] is False

--- a/sbomify/apps/teams/views/__init__.py
+++ b/sbomify/apps/teams/views/__init__.py
@@ -385,12 +385,15 @@ def accept_invite(request: HttpRequest, invite_token: str) -> HttpResponseNotFou
         membership = Member.objects.filter(user=request.user, team__key=matched.get("team_key")).first()
         if membership:
             switch_active_workspace(request, membership.team, membership.role)
-
-            messages.add_message(
-                request,
-                messages.INFO,
-                f"You have joined {membership.team.name} as {membership.role}",
-            )
+            # Login already accepted this one. It says so itself when it can, so
+            # repeating it here would be a second identical toast; the flag tells
+            # us when it could not and this is the only chance to announce it.
+            if not matched.get("announced"):
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    f"You have joined {membership.team.name} as {membership.role}",
+                )
             return redirect("core:dashboard")
 
         return error_response(request, HttpResponseNotFound("Unknown invitation"))


### PR DESCRIPTION
Reported as "no notification when invited to a workspace". The provider and the bell both work, so I reproduced it against the dev database instead of reading:

```
teams provider -> [NotificationSchema(id='pending_invitation_25',
  type='pending_invitation', message="You've been invited to join
  Acme Corporation as member.", ...)]
```

That path is fine. Two others were not.

## A new invitee is never notified, because there is nothing left to notify about

`_accept_pending_invitations` runs on login for users with no existing membership. It creates the `Member` row and **deletes the invitation**, so by the time any page renders, the pending-invitation provider has nothing to report. The user is inside a workspace nobody told them they joined.

The one place that does announce it is the accept-invite view, reached by clicking the emailed link. Someone who signs up directly and then logs in never goes near it.

The acceptance now says so itself, at the moment it happens, which covers every entry path.

`fail_silently=True` is deliberate and the test that drove it is the interesting one: without it, `messages.info` raises `MessageFailure` on any request without message storage, and that request is a login. Announcing a workspace join must never be the thing that stops someone signing in.

## The notification that does fire pointed at the wrong page

```python
action_url = reverse("teams:team_settings", kwargs={"team_key": team_key}) + "#members"
```

`team_key` there is the **current** workspace. Invited to workspace B while working in workspace A, you were sent to workspace A's member list, which contains no invitation of yours. Invitations are accepted on the user's own settings page (`_build_settings_context` → `pending_invitations`), which is where it points now.

## Checked and cleared

Worth recording so nobody re-investigates these: `get_pending_invitations_for_email` matches case-insensitively and filters expired rows correctly; the bell polls `/api/v1/notifications/` on a timer; and `has_pending_invitations` is in the header fragment's cache key, so a new invitation does bust it. Both invitations sitting in the dev database were expired, which produces the reported symptom on its own.
