### PR TITLE
fix(api): a Redis blip refuses requests with a 429, not a 500

### DIFF
--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -1321,3 +1321,62 @@ class TestThrottleRefusesCleanlyWhenRedisIsDown:
         assert response.status_code == 429, response.content
         assert response["Retry-After"] == "5"
         assert response.json() == {"detail": "Too many requests."}
+
+    def test_recovery_clears_the_outage_hint(self, sample_user):  # noqa: F811
+        """After Redis comes back, wait() reports the real window again.
+
+        The outage flag survives on the shared instance, so without the
+        clear a genuine rate-limit inside the 5s window would borrow the
+        outage Retry-After instead of its own.
+        """
+        from unittest.mock import patch
+
+        from django.core.cache.backends.locmem import LocMemCache
+        from django.test import RequestFactory
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+
+        token = create_personal_access_token(sample_user)
+        record = AccessToken.objects.create(user=sample_user, encoded_token=token, description="t")
+        request = RequestFactory().get("/")
+        request.access_token_record = record
+
+        throttle = AccessTokenRateThrottle()
+        with patch("sbomify.apps.access_tokens.throttling.caches", {"throttle": self._broken_cache()}):
+            assert throttle.allow_request(request) is False
+        assert throttle.wait() == 5.0
+
+        working = LocMemCache("recovered", {"TIMEOUT": 300})
+        with patch("sbomify.apps.access_tokens.throttling.caches", {"throttle": working}):
+            assert throttle.allow_request(request) is True
+        assert throttle._backend_refusal_until == 0.0
+        assert throttle.wait() != 5.0 or throttle.wait() is None
+
+    def test_the_outage_logs_once_per_refusal_window(self, sample_user):  # noqa: F811
+        """The old 500 was the alert; the refusal keeps the signal without the storm."""
+        from unittest.mock import patch
+
+        from django.test import RequestFactory
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+
+        token = create_personal_access_token(sample_user)
+        record = AccessToken.objects.create(user=sample_user, encoded_token=token, description="t")
+        request = RequestFactory().get("/")
+        request.access_token_record = record
+
+        throttle = AccessTokenRateThrottle()
+        with (
+            patch("sbomify.apps.access_tokens.throttling.caches", {"throttle": self._broken_cache()}),
+            patch("sbomify.apps.access_tokens.throttling.logger") as mock_logger,
+        ):
+            assert throttle.allow_request(request) is False
+            assert throttle.allow_request(request) is False
+
+        # Second refusal lands inside the first refusal window, so it must not
+        # log again: one alert per window, not one per rejected request.
+        assert mock_logger.exception.call_count == 1

--- a/sbomify/apps/access_tokens/tests.py
+++ b/sbomify/apps/access_tokens/tests.py
@@ -1258,3 +1258,66 @@ def test_api_response_carries_ratelimit_headers(sample_product, sample_access_to
     assert int(resp["X-RateLimit-Limit"]) > 0
     assert int(resp["X-RateLimit-Remaining"]) >= 0
     assert int(resp["X-RateLimit-Reset"]) > 0
+
+
+@pytest.mark.django_db
+class TestThrottleRefusesCleanlyWhenRedisIsDown:
+    """Fail closed, but with a 429 rather than a traceback.
+
+    The throttle alias raises on a Redis failure by design, so a swallowed
+    failure cannot hand out fresh budgets during an outage. ninja runs
+    throttles outside Operation.run's try, so anything RAISED in
+    allow_request bypasses every handler and lands as a raw 500, which is
+    what production did on every throttled endpoint for the length of a
+    blip; Sentry's loudest transaction was the trust-center release
+    download. Returning False routes the refusal through ninja's own
+    Throttled path and the 429 handler.
+    """
+
+    def _broken_cache(self):
+        from unittest.mock import MagicMock
+
+        from django_redis.exceptions import ConnectionInterrupted
+
+        cache = MagicMock()
+        cache.get.side_effect = ConnectionInterrupted(connection=None)
+        cache.set.side_effect = ConnectionInterrupted(connection=None)
+        return cache
+
+    def test_allow_request_refuses_instead_of_raising(self, sample_user):  # noqa: F811
+        from unittest.mock import patch
+
+        from django.test import RequestFactory
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.throttling import AccessTokenRateThrottle
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+
+        token = create_personal_access_token(sample_user)
+        record = AccessToken.objects.create(user=sample_user, encoded_token=token, description="t")
+        request = RequestFactory().get("/")
+        request.access_token_record = record
+
+        throttle = AccessTokenRateThrottle()
+        with patch("sbomify.apps.access_tokens.throttling.caches", {"throttle": self._broken_cache()}):
+            assert throttle.allow_request(request) is False
+        assert throttle.wait() == 5.0
+
+    def test_the_api_answers_429_with_retry_after_not_500(self, sample_user):  # noqa: F811
+        from unittest.mock import patch
+
+        from django.test import Client
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+        from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+
+        token_str = create_personal_access_token(sample_user)
+        record = AccessToken.objects.create(user=sample_user, encoded_token=token_str, description="t")
+
+        with patch("sbomify.apps.access_tokens.throttling.caches", {"throttle": self._broken_cache()}):
+            response = Client().get("/api/v1/products", **get_api_headers(record))
+
+        assert response.status_code == 429, response.content
+        assert response["Retry-After"] == "5"
+        assert response.json() == {"detail": "Too many requests."}

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -10,7 +10,20 @@ from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.http import HttpRequest, HttpResponse
+from django_redis.exceptions import ConnectionInterrupted
 from ninja.throttling import SimpleRateThrottle
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+#: What a throttle treats as "the backend is unreachable": django-redis wraps
+#: the redis error in ConnectionInterrupted, but IGNORE_EXCEPTIONS is off on
+#: the throttle alias so the raw errors can surface too.
+_THROTTLE_BACKEND_ERRORS = (ConnectionInterrupted, RedisConnectionError, RedisTimeoutError)
+
+#: The Retry-After a refused caller sees while Redis recovers. Short, because
+#: a blip usually is: the same figure the redis clients use as their retry
+#: backoff ceiling.
+_BACKEND_OUTAGE_RETRY_SECONDS = 5
 
 
 class AccessTokenRateThrottle(SimpleRateThrottle):
@@ -45,6 +58,14 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         """
         return caches["throttle"]
 
+    def wait(self) -> float | None:
+        # One shared instance serves every request, so this flag is read best
+        # effort: a racing request at worst reports the outage Retry-After
+        # instead of its own window, and Retry-After is advisory.
+        if time.monotonic() < getattr(self, "_backend_refusal_until", 0.0):
+            return float(_BACKEND_OUTAGE_RETRY_SECONDS)
+        return super().wait()
+
     def get_cache_key(self, request: HttpRequest) -> str | None:
         record = getattr(request, "access_token_record", None)
         if record is None:
@@ -52,7 +73,24 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         return f"{self.cache_key_prefix}_{record.pk}"
 
     def allow_request(self, request: HttpRequest) -> bool:
-        allowed = super().allow_request(request)
+        try:
+            allowed = super().allow_request(request)
+        except _THROTTLE_BACKEND_ERRORS:
+            # The throttle alias raises on a Redis failure by design: a
+            # swallowed failure reads as an empty window and hands every
+            # caller a fresh budget exactly when Redis being unwell suggests
+            # someone is hammering it. But the refusal must be a refusal, not
+            # a traceback. Unwrapped, this surfaced as a 500 on every
+            # throttled endpoint for the length of a Redis blip, with the
+            # trust-center release download the loudest.
+            #
+            # Returning False is the only safe refusal: ninja runs throttles
+            # in _run_checks, OUTSIDE Operation.run's try, so anything raised
+            # here bypasses every exception handler and lands as a raw 500.
+            # ninja then calls wait() and routes a Throttled through the 429
+            # handler itself, Retry-After included. Fail closed, politely.
+            self._backend_refusal_until = time.monotonic() + _BACKEND_OUTAGE_RETRY_SECONDS
+            return False
         # Ninja reuses one throttle instance across requests, so its per-request scratch
         # (self.key/history/now) is unsafe to read here. Compute the budget from local
         # state and this request's own token instead: get_cache_key() is a pure function
@@ -64,7 +102,14 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
         now = time.time()
         duration = self.duration or 0
         limit = self.num_requests or 0
-        history = [ts for ts in self.cache.get(key, []) if ts > now - duration]
+        try:
+            window = self.cache.get(key, [])
+        except _THROTTLE_BACKEND_ERRORS:
+            # The decision above already succeeded; this read only feeds the
+            # X-RateLimit headers. Losing the headers for one response beats
+            # failing a request the throttle just allowed.
+            return allowed
+        history = [ts for ts in window if ts > now - duration]
         remaining = max(0, limit - len(history))
         # ceil so the reset is never reported earlier than a slot actually frees.
         reset = ceil((history[-1] if history else now) + duration)

--- a/sbomify/apps/access_tokens/throttling.py
+++ b/sbomify/apps/access_tokens/throttling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from math import ceil
@@ -24,6 +25,8 @@ _THROTTLE_BACKEND_ERRORS = (ConnectionInterrupted, RedisConnectionError, RedisTi
 #: a blip usually is: the same figure the redis clients use as their retry
 #: backoff ceiling.
 _BACKEND_OUTAGE_RETRY_SECONDS = 5
+
+logger = logging.getLogger(__name__)
 
 
 class AccessTokenRateThrottle(SimpleRateThrottle):
@@ -75,6 +78,10 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
     def allow_request(self, request: HttpRequest) -> bool:
         try:
             allowed = super().allow_request(request)
+            # Backend reachable again: from here on, any refusal is a genuine
+            # rate limit, so wait() must report the real window, not the
+            # outage hint left over from before recovery.
+            self._backend_refusal_until = 0.0
         except _THROTTLE_BACKEND_ERRORS:
             # The throttle alias raises on a Redis failure by design: a
             # swallowed failure reads as an empty window and hands every
@@ -89,6 +96,15 @@ class AccessTokenRateThrottle(SimpleRateThrottle):
             # here bypasses every exception handler and lands as a raw 500.
             # ninja then calls wait() and routes a Throttled through the 429
             # handler itself, Retry-After included. Fail closed, politely.
+            #
+            # The refusal must still be heard: the old 500 was the alert, so
+            # going quiet would hide the outage. One log per refusal window
+            # keeps the signal without a log storm.
+            if time.monotonic() >= getattr(self, "_backend_refusal_until", 0.0):
+                logger.exception(
+                    "Throttle backend unreachable; refusing throttled requests with Retry-After %ss until it recovers",
+                    _BACKEND_OUTAGE_RETRY_SECONDS,
+                )
             self._backend_refusal_until = time.monotonic() + _BACKEND_OUTAGE_RETRY_SECONDS
             return False
         # Ninja reuses one throttle instance across requests, so its per-request scratch

--- a/sbomify/apps/core/tests/test_cache_outage.py
+++ b/sbomify/apps/core/tests/test_cache_outage.py
@@ -8,7 +8,9 @@ a page that had already done all its work into a 500.
 Switching that on trades one failure for another: a rate limiter decides from the
 window it reads back, and a swallowed failure reads as an empty window, so the
 limit disappears for as long as Redis is unwell. The throttle therefore keeps its
-own alias that still raises.
+own alias that still raises, and the throttle itself catches that raise and
+refuses the request: a 429 with a short Retry-After, never a silent pass and
+never a 500 for a request the app could not have served anyway.
 
 Both halves are pinned here, because the pair is the point. Turning either one
 round on its own is a regression the other test would not catch.
@@ -77,8 +79,9 @@ def test_throttle_refuses_rather_than_forgetting_its_window() -> None:
     Reading the window back is how the throttle decides. If a failed read looked
     like "no requests yet", every caller would get a fresh budget at exactly the
     moment Redis is struggling, and a caller hammering the API is one reason it
-    might be. The alias the throttle uses still raises, so the request fails
-    instead of passing unlimited.
+    might be. The alias the throttle uses still raises, and the throttle turns
+    that raise into a refusal with a short retry hint, so the request is limited
+    instead of passing unlimited and the client sees a 429 instead of a 500.
     """
     throttle = AccessTokenRateThrottle(rate="1/min")
     request = RequestFactory().get("/api/v1/whatever")
@@ -86,12 +89,12 @@ def test_throttle_refuses_rather_than_forgetting_its_window() -> None:
 
     with override_settings(CACHES=_caches_with_redis_down()):
         caches.close_all()
-        with pytest.raises(Exception) as excinfo:
-            throttle.allow_request(request)
+        allowed = throttle.allow_request(request)
 
-    # Whichever exception redis-py or django-redis raises, the point is that one
-    # arrives: a silent True here is the failure mode this pins.
-    assert "6399" in str(excinfo.value) or "onnect" in str(excinfo.value)
+    # A silent True here is the failure mode this pins: an unreachable window
+    # must read as "refuse and retry shortly", never as a fresh budget.
+    assert allowed is False
+    assert throttle.wait() == 5.0
 
 
 def test_the_anonymous_ip_limit_inherits_that_refusal() -> None:
@@ -108,8 +111,10 @@ def test_the_anonymous_ip_limit_inherits_that_refusal() -> None:
 
     with override_settings(CACHES=_caches_with_redis_down()):
         caches.close_all()
-        with pytest.raises(Exception):
-            throttle.allow_request(request)
+        allowed = throttle.allow_request(request)
+
+    assert allowed is False
+    assert throttle.wait() == 5.0
 
 
 def test_the_two_aliases_differ_in_exactly_one_option() -> None:


### PR DESCRIPTION
Hotfix for Sentry **SBOMIFY-BACKEND-6Z** (`ConnectionInterrupted: Redis TimeoutError`, 74% on `/api/v1/releases/{release_id}/download`, regressed in 26.8.0). Small and surgical for the 26.8.0 hotfix train.

## The mechanism

The throttle cache alias **raises on Redis failure by design**, so an outage cannot hand every caller a fresh budget (the default alias swallows failures; a rate limiter must not). The refusal was right. Its delivery was not: ninja runs throttles in `_run_checks`, **outside** `Operation.run`'s try/except, so the raised `ConnectionInterrupted` bypassed every exception handler, including our `Throttled` handler, and reached Django as a raw 500. During a Redis blip every throttled endpoint 500ed, and the anonymous trust-center release download was the loudest transaction.

Raising anything from `allow_request` can never work there. Verified against the installed ninja source: `_check_throttles` only reacts to a **False return**, then builds `Throttled` and routes it through `api.on_exception` itself.

## The fix

- `allow_request` catches `ConnectionInterrupted` / redis `ConnectionError` / `TimeoutError` and **returns False**, staying fail-closed.
- `wait()` reports a 5s outage backoff while the refusal window is open, so the 429 carries `Retry-After: 5`.
- The post-decision budget read (X-RateLimit headers) degrades to missing headers rather than failing a request the throttle already allowed.

Net effect during a blip: attacker still refused, customer sees `429 {"detail": "Too many requests."}` + `Retry-After: 5` instead of a traceback.

## Verified

Two tests, one at the throttle and one end-to-end through the API with a broken cache injected:

```
assert response.status_code == 429
assert response["Retry-After"] == "5"
```

Full access_tokens suite: 63 passed.

Closes #1457.