### PR TITLE
Keep OIDC publish tokens off the expiry bell

### DIFF
--- a/sbomify/apps/access_tokens/notifications.py
+++ b/sbomify/apps/access_tokens/notifications.py
@@ -91,6 +91,14 @@ def get_notifications(request: HttpRequest) -> list[NotificationSchema]:
         if token.expires_at is None:
             continue
         days = days_until(token.expires_at, now)
+        lifetime = lifetime_days(token)
+        # A token that lives under a day is born inside its final day, so the
+        # final-day carve-out below would keep it on the bell for its whole
+        # life. The OIDC publish exchange mints a 15-minute token per CI run,
+        # which piled up one "expires tomorrow" badge per publish. Expiring
+        # that soon is the token's design, not an event.
+        if lifetime is not None and lifetime <= 1:
+            continue
         # Keep the final day for short-lived tokens: silence for the whole life
         # would let a pipeline start failing with no notice at all.
         if days > 1 and is_short_lived(token):

--- a/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
+++ b/sbomify/apps/access_tokens/tests/test_expiry_warnings.py
@@ -208,6 +208,45 @@ class TestShortLivedTokensAreNotNagged:
         assert warn_expiring_tokens.fn() == 0
         assert mail.outbox == []
 
+    def test_an_oidc_publish_token_never_reaches_the_bell(
+        self, rf: Any, sample_team_with_owner_member: Any, guest_user: Any
+    ) -> None:
+        """From staging: the OIDC exchange mints a 15-minute token per CI
+        publish, and each one sat on the owner's bell as "expires tomorrow"
+        for its whole life, one badge per publish. A token born inside its
+        final day has no final-day news to break.
+        """
+        member = sample_team_with_owner_member
+        _bot_member(guest_user, member.team)
+        for i in range(3):
+            AccessToken.objects.create(
+                user=guest_user,
+                team=member.team,
+                description="oidc:github:bind1234abcd",
+                encoded_token=f"tok-oidc-{i}",
+                expires_at=timezone.now() + timedelta(minutes=15),
+            )
+
+        assert get_notifications(self._request(rf, member.user, member.team)) == []
+
+    def test_the_sweep_never_mails_about_a_publish_token(
+        self, sample_team_with_owner_member: Any, guest_user: Any
+    ) -> None:
+        """The email side already agrees through its threshold arithmetic; pin
+        the agreement so the two paths cannot drift apart at this boundary."""
+        member = sample_team_with_owner_member
+        _bot_member(guest_user, member.team)
+        AccessToken.objects.create(
+            user=guest_user,
+            team=member.team,
+            description="oidc:github:bind1234abcd",
+            encoded_token="tok-oidc-sweep",
+            expires_at=timezone.now() + timedelta(minutes=15),
+        )
+
+        assert warn_expiring_tokens.fn() == 0
+        assert mail.outbox == []
+
     def test_the_tighter_thresholds_fire_once_it_has_aged(self, sample_team_with_owner_member: Any) -> None:
         """The same 14-day token a week on, expressed as a second fixture
         rather than by moving ``expires_at``: shifting it also moves the


### PR DESCRIPTION
Stage report: the notification bell filled with identical badges, one "Access token \"oidc:github:...\" expires tomorrow." per CI publish.

## Why

The OIDC exchange mints a 15-minute token for every publish. The bell provider ceils remaining time to whole days, so 15 minutes reads as 1 day. The short-lived guard skips tokens whose whole life fits inside the 14-day warning window, but deliberately keeps their final day so a pipeline never breaks unannounced. A 15-minute token is born inside its final day, so that carve-out kept every publish token on the bell for its entire life. Workspace owners see bot tokens, so each CI run parked another "expires tomorrow" badge on the owner's bell until that token aged out and the next publish minted a fresh one.

## Fix

A token that lives under a day has no final-day news to break: expiring that soon is its design. The bell now skips any token whose lifetime is a day or less. The 7-day CI dialog token still warns on its real final day, and a long-lived token aging into the window is untouched.

The email sweep never mailed about these, its thresholds only fire when they are strictly inside the token's lifetime. A test now pins that agreement so the bell and the sweep cannot drift apart at this boundary.

Repro test creates three 15-minute publish tokens and asserts the owner's bell stays empty.