### PR TITLE
fix(spdx3): the BOM subject is rootElement, not whichever package came first

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -350,7 +350,11 @@ def _extract_spdx3_primary_package(
         rel_type = rel.get("relationshipType", "")
         if rel_type == "describes":
             target_ids = rel.get("to", [])
-            if target_ids:
+            # JSON-LD compact form: a one-element set may serialise as a bare
+            # string; indexing it would yield one character.
+            if isinstance(target_ids, str):
+                target_ids = [target_ids]
+            if isinstance(target_ids, list) and target_ids:
                 target_id = target_ids[0]
                 for pkg in packages:
                     if pkg.spdx_id == target_id:

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -320,9 +320,12 @@ def _extract_spdx3_primary_package(
     """Extract primary package from SPDX 3.0 document.
 
     Strategy:
-    1. Find a 'describes' relationship and use its target package
-    2. Fall back to matching package name with document name
-    3. Fall back to first software_Package element
+    1. Follow the SpdxDocument's rootElement — how SPDX 3 declares the BOM
+       subject
+    2. Find a 'describes' relationship and use its target package (SPDX 2
+       idiom some producers still write)
+    3. Fall back to matching package name with document name
+    4. Fall back to first software_Package element
     """
     packages = payload.packages
     if not packages:
@@ -330,7 +333,19 @@ def _extract_spdx3_primary_package(
 
     package: SPDX3Package | None = None
 
-    # Strategy 1: Find 'describes' relationship target
+    # Strategy 1: the declared BOM subject. spdx3_document_subjects handles
+    # the JSON-LD compact single-string form and a hostile @graph.
+    from sbomify.apps.plugins.builtins._spdx_shared import spdx3_document_subjects
+
+    _, root_element_ids = spdx3_document_subjects({"@graph": payload.graph})
+    for pkg in packages:
+        if pkg.spdx_id and pkg.spdx_id in root_element_ids:
+            package = pkg
+            break
+    if package:
+        return package, ""
+
+    # Strategy 2: Find 'describes' relationship target
     for rel in payload.relationships:
         rel_type = rel.get("relationshipType", "")
         if rel_type == "describes":
@@ -344,14 +359,14 @@ def _extract_spdx3_primary_package(
             if package:
                 break
 
-    # Strategy 2: Match by document name
+    # Strategy 3: Match by document name
     if not package and payload.name:
         for pkg in packages:
             if pkg.name == payload.name:
                 package = pkg
                 break
 
-    # Strategy 3: Fall back to first package
+    # Strategy 4: Fall back to first package
     if not package:
         package = packages[0]
 

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -106,7 +106,11 @@ def _spdx3_component_info(sbom_data: dict[str, Any]) -> tuple[str, str | None, s
             if isinstance(rel, dict) and rel.get("type") == "Relationship":
                 if rel.get("relationshipType") == "describes":
                     target_ids = rel.get("to", [])
-                    if target_ids:
+                    # JSON-LD compact form: a one-element set may serialise as
+                    # a bare string; indexing it would yield one character.
+                    if isinstance(target_ids, str):
+                        target_ids = [target_ids]
+                    if isinstance(target_ids, list) and target_ids:
                         pkg = next((p for p in packages if p.get("spdxId") == target_ids[0]), None)
                         if pkg:
                             break

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -75,6 +75,47 @@ class SBOMVersion(str, Enum):
     SPDX_3_0 = "3.0"
 
 
+def _spdx3_component_info(sbom_data: dict[str, Any]) -> tuple[str, str | None, str | None] | None:
+    """(name, version, supplier) of an SPDX 3 document's primary package.
+
+    Shared by both release builders, which carried this block in duplicate —
+    and both picked ``packages[0]`` before looking at ``rootElement``, so the
+    aggregate could name the component after whichever package happened to
+    serialise first. Order: the SpdxDocument's rootElement (how SPDX 3
+    declares the BOM subject), then a ``describes`` relationship, then the
+    first package.
+    """
+    elements = sbom_data.get("@graph", sbom_data.get("elements", []))
+    if not isinstance(elements, list):
+        return None
+    packages = [e for e in elements if isinstance(e, dict) and e.get("type") == "software_Package"]
+    if not packages:
+        return None
+
+    from sbomify.apps.plugins.builtins._spdx_shared import spdx3_document_subjects
+
+    pkg = None
+    _, root_element_ids = spdx3_document_subjects({"@graph": elements})
+    for p in packages:
+        if p.get("spdxId") in root_element_ids:
+            pkg = p
+            break
+
+    if pkg is None:
+        for rel in elements:
+            if isinstance(rel, dict) and rel.get("type") == "Relationship":
+                if rel.get("relationshipType") == "describes":
+                    target_ids = rel.get("to", [])
+                    if target_ids:
+                        pkg = next((p for p in packages if p.get("spdxId") == target_ids[0]), None)
+                        if pkg:
+                            break
+
+    if pkg is None:
+        pkg = packages[0]
+    return pkg.get("name", "Unknown"), pkg.get("software_packageVersion"), None
+
+
 class SBOMBuilderProtocol(Protocol):
     """Protocol defining the interface for SBOM builders."""
 
@@ -718,23 +759,9 @@ class ReleaseSPDXBuilder(BaseSPDXBuilder):
         elif "@graph" in sbom_data or (
             sbom_data.get("spdxVersion", "").startswith("SPDX-3.") and "elements" in sbom_data
         ):
-            elements = sbom_data.get("@graph", sbom_data.get("elements", []))
-            packages = [e for e in elements if e.get("type") == "software_Package"]
-            if packages:
-                pkg = packages[0]
-                relationships = [e for e in elements if e.get("type") == "Relationship"]
-                for rel in relationships:
-                    if rel.get("relationshipType") == "describes":
-                        target_ids = rel.get("to", [])
-                        if target_ids:
-                            for p in packages:
-                                if p.get("spdxId") == target_ids[0]:
-                                    pkg = p
-                                    break
-                name = pkg.get("name", "Unknown")
-                version = pkg.get("software_packageVersion")
-                supplier = None
-                return name, version, supplier
+            info = _spdx3_component_info(sbom_data)
+            if info:
+                return info
 
         # Try SPDX 2.x format
         elif sbom_data.get("spdxVersion", "").startswith("SPDX-"):
@@ -1053,24 +1080,9 @@ class ReleaseSPDX3Builder(BaseSPDXBuilder):
         elif "@graph" in sbom_data or (
             sbom_data.get("spdxVersion", "").startswith("SPDX-3.") and "elements" in sbom_data
         ):
-            elements = sbom_data.get("@graph", sbom_data.get("elements", []))
-            packages = [e for e in elements if e.get("type") == "software_Package"]
-            if packages:
-                pkg = packages[0]
-                # Try to find the described package via relationships
-                relationships = [e for e in elements if e.get("type") == "Relationship"]
-                for rel in relationships:
-                    if rel.get("relationshipType") == "describes":
-                        target_ids = rel.get("to", [])
-                        if target_ids:
-                            for p in packages:
-                                if p.get("spdxId") == target_ids[0]:
-                                    pkg = p
-                                    break
-                name = pkg.get("name", "Unknown")
-                version = pkg.get("software_packageVersion")
-                supplier = None
-                return name, version, supplier
+            info = _spdx3_component_info(sbom_data)
+            if info:
+                return info
 
         # SPDX 2.x format
         elif sbom_data.get("spdxVersion", "").startswith("SPDX-"):

--- a/sbomify/apps/sboms/builders.py
+++ b/sbomify/apps/sboms/builders.py
@@ -85,14 +85,14 @@ def _spdx3_component_info(sbom_data: dict[str, Any]) -> tuple[str, str | None, s
     declares the BOM subject), then a ``describes`` relationship, then the
     first package.
     """
-    elements = sbom_data.get("@graph", sbom_data.get("elements", []))
-    if not isinstance(elements, list):
-        return None
-    packages = [e for e in elements if isinstance(e, dict) and e.get("type") == "software_Package"]
+    from sbomify.apps.plugins.builtins._spdx_shared import iter_spdx3_elements, spdx3_document_subjects
+
+    # The shared iterator, not a raw .get: it falls back from a malformed
+    # @graph to a valid elements alias, the same reading every plugin uses.
+    elements = list(iter_spdx3_elements(sbom_data))
+    packages = [e for e in elements if e.get("type") == "software_Package"]
     if not packages:
         return None
-
-    from sbomify.apps.plugins.builtins._spdx_shared import spdx3_document_subjects
 
     pkg = None
     _, root_element_ids = spdx3_document_subjects({"@graph": elements})

--- a/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
@@ -156,3 +156,17 @@ class TestCompactDescribesTarget:
         )
 
         assert info == ("libbar", "2.0.0", None)
+
+
+def test_a_malformed_graph_falls_back_to_the_elements_alias():
+    """The shared iterator's contract, pinned here too: a null @graph must
+    not hide a usable elements container from release aggregation."""
+    from sbomify.apps.sboms.builders import _spdx3_component_info
+
+    document = {
+        "@graph": None,
+        "elements": [
+            {"type": "software_Package", "spdxId": "urn:p1", "name": "board", "software_packageVersion": "2"},
+        ],
+    }
+    assert _spdx3_component_info(document) == ("board", "2", None)

--- a/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
@@ -161,8 +161,6 @@ class TestCompactDescribesTarget:
 def test_a_malformed_graph_falls_back_to_the_elements_alias():
     """The shared iterator's contract, pinned here too: a null @graph must
     not hide a usable elements container from release aggregation."""
-    from sbomify.apps.sboms.builders import _spdx3_component_info
-
     document = {
         "@graph": None,
         "elements": [

--- a/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
@@ -128,3 +128,31 @@ class TestBuilderComponentInfo:
 
     def test_no_packages_is_none(self) -> None:
         assert _spdx3_component_info(_doc({"type": "SpdxDocument", "spdxId": "urn:doc"})) is None
+
+
+class TestCompactDescribesTarget:
+    """JSON-LD compact form on the describes fallback: a bare-string ``to``
+    must resolve as one id, not be indexed into its first character."""
+
+    def test_api_strategy(self) -> None:
+        payload = SPDX3Schema.model_validate(
+            _doc(
+                {"type": "Relationship", "relationshipType": "describes", "from": "urn:doc", "to": "urn:p2"},
+                *_three_packages(),
+            )
+        )
+
+        package, _ = _extract_spdx3_primary_package(payload)
+
+        assert package is not None
+        assert package.name == "libbar"
+
+    def test_builder_helper(self) -> None:
+        info = _spdx3_component_info(
+            _doc(
+                {"type": "Relationship", "relationshipType": "describes", "from": "urn:doc", "to": "urn:p2"},
+                *_three_packages(),
+            )
+        )
+
+        assert info == ("libbar", "2.0.0", None)

--- a/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_primary_package.py
@@ -1,0 +1,130 @@
+"""The BOM subject of an SPDX 3 document is declared by rootElement.
+
+The primary-package pickers looked for a ``describes`` Relationship (an
+SPDX 2 idiom), then a name match, then fell back to ``packages[0]`` — and
+never read ``rootElement``. A three-package document whose SpdxDocument
+declares ``rootElement: ['urn:p3']`` stored the first package's name and
+version, and the release aggregate named the component after the wrong
+package.
+
+The fallbacks stay: a document with no rootElement and a ``describes``
+relationship keeps today's behaviour, and one with neither still resolves to
+the first package without raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sbomify.apps.sboms.apis import _extract_spdx3_primary_package
+from sbomify.apps.sboms.builders import _spdx3_component_info
+from sbomify.apps.sboms.schemas import SPDX3Schema
+
+CONTEXT = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+
+
+def _doc(*graph: dict[str, Any]) -> dict[str, Any]:
+    return {"@context": CONTEXT, "@graph": list(graph)}
+
+
+def _three_packages() -> list[dict[str, Any]]:
+    return [
+        {"type": "software_Package", "spdxId": "urn:p1", "name": "libfoo", "software_packageVersion": "9.9.9"},
+        {"type": "software_Package", "spdxId": "urn:p2", "name": "libbar", "software_packageVersion": "2.0.0"},
+        {"type": "software_Package", "spdxId": "urn:p3", "name": "my-app", "software_packageVersion": "1.2.3"},
+    ]
+
+
+class TestApiPrimaryPackage:
+    def test_root_element_wins(self) -> None:
+        payload = SPDX3Schema.model_validate(
+            _doc(
+                {"type": "SpdxDocument", "spdxId": "urn:doc", "rootElement": ["urn:p3"]},
+                *_three_packages(),
+            )
+        )
+
+        package, error = _extract_spdx3_primary_package(payload)
+
+        assert error == ""
+        assert package is not None
+        assert package.name == "my-app"
+        assert package.version == "1.2.3"
+
+    def test_compact_single_string_root_element(self) -> None:
+        """JSON-LD 1.1 compact form: a one-element set may serialise as a
+        bare string."""
+        payload = SPDX3Schema.model_validate(
+            _doc(
+                {"type": "SpdxDocument", "spdxId": "urn:doc", "rootElement": "urn:p2"},
+                *_three_packages(),
+            )
+        )
+
+        package, _ = _extract_spdx3_primary_package(payload)
+
+        assert package is not None
+        assert package.name == "libbar"
+
+    def test_describes_kept_when_no_root_element(self) -> None:
+        payload = SPDX3Schema.model_validate(
+            _doc(
+                {"type": "Relationship", "relationshipType": "describes", "from": "urn:doc", "to": ["urn:p2"]},
+                *_three_packages(),
+            )
+        )
+
+        package, _ = _extract_spdx3_primary_package(payload)
+
+        assert package is not None
+        assert package.name == "libbar"
+
+    def test_neither_still_falls_back_to_first(self) -> None:
+        payload = SPDX3Schema.model_validate(_doc(*_three_packages()))
+
+        package, _ = _extract_spdx3_primary_package(payload)
+
+        assert package is not None
+        assert package.name == "libfoo"
+
+
+class TestBuilderComponentInfo:
+    """The deduplicated extraction both release builders now share."""
+
+    def test_root_element_wins(self) -> None:
+        info = _spdx3_component_info(
+            _doc(
+                {"type": "SpdxDocument", "spdxId": "urn:doc", "rootElement": ["urn:p3"]},
+                *_three_packages(),
+            )
+        )
+
+        assert info == ("my-app", "1.2.3", None)
+
+    def test_describes_kept_when_no_root_element(self) -> None:
+        info = _spdx3_component_info(
+            _doc(
+                {"type": "Relationship", "relationshipType": "describes", "from": "urn:doc", "to": ["urn:p2"]},
+                *_three_packages(),
+            )
+        )
+
+        assert info == ("libbar", "2.0.0", None)
+
+    def test_neither_still_falls_back_to_first(self) -> None:
+        assert _spdx3_component_info(_doc(*_three_packages())) == ("libfoo", "9.9.9", None)
+
+    def test_legacy_elements_shape(self) -> None:
+        """Legacy spdxVersion/elements documents route through the same reader."""
+        doc = {
+            "spdxVersion": "SPDX-3.0",
+            "elements": [
+                {"type": "SpdxDocument", "spdxId": "urn:doc", "rootElement": ["urn:p2"]},
+                *_three_packages(),
+            ],
+        }
+
+        assert _spdx3_component_info(doc) == ("libbar", "2.0.0", None)
+
+    def test_no_packages_is_none(self) -> None:
+        assert _spdx3_component_info(_doc({"type": "SpdxDocument", "spdxId": "urn:doc"})) is None


### PR DESCRIPTION
Phase 0 of #1324, second PR. `Closes #1328.`

SPDX 3 declares its BOM subject via the SpdxDocument's `rootElement`. Neither primary-package picker read it:

- the upload extractor (`sboms/apis.py`) tried a `describes` relationship (an SPDX 2 idiom), then a name match, then `packages[0]`
- both release builders tried `describes` then `packages[0]` — in two duplicated blocks

Reproduced per the issue: a three-package document with `rootElement: ['urn:p3']` (my-app 1.2.3) stored `libfoo 9.9.9`, and the release aggregate named the component "libfoo". The negative run against unfixed code shows exactly that: `AssertionError: assert 'libfoo' == 'my-app'`.

## The change

- `rootElement` is strategy 1 in the upload extractor, resolved via the existing `spdx3_document_subjects` (handles the JSON-LD compact single-string form and a hostile `@graph`).
- The builders' duplicated blocks collapse into one module-level `_spdx3_component_info` with the same ordering — rootElement → `describes` → first package.
- All fallbacks keep today's behaviour for documents without a `rootElement`; a document with neither still resolves to the first package without raising.

## Tests

9 new (API strategy set + builder helper, including the compact-string form and the legacy `spdxVersion`/`elements` shape), red-first via the probe above. Full sboms suite: 618 passed unchanged — SPDX 2.x extraction untouched.

Independent of #1384; either merges first.


Supersedes #1385.
