### PR TITLE
fix(spdx3): three single-field reads pointed at properties the spec has

### DIFF
--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1793,18 +1793,36 @@ class BSICompliancePlugin(AssessmentPlugin):
         return bool(doc_ids)
 
     def _spdx3_has_source_code_uri(self, package: dict[str, Any]) -> bool:
-        """Per BSI §5.2.4. Accept any non-empty software_sourceInfo or an
-        externalIdentifier referencing a VCS / repository URL.
+        """Per BSI §5.2.4. Accept any non-empty software_sourceInfo, or an
+        externalRef pointing at the source — ``vcs`` and ``sourceArtifact``
+        live in the ExternalRefType vocabulary, not ExternalIdentifierType,
+        so this is the shape a conformant document actually carries.
         """
         source_info = package.get("software_sourceInfo")
         if isinstance(source_info, str) and source_info.strip():
             return True
-        ext_ids = package.get("externalIdentifiers")
-        if not isinstance(ext_ids, list):
-            return False
-        for ext_id in ext_ids:
-            if not isinstance(ext_id, dict):
-                continue
+
+        external_refs = package.get("externalRef")
+        if isinstance(external_refs, list):
+            for ref in external_refs:
+                if not isinstance(ref, dict):
+                    continue
+                # Lowercased like every other externalRefType read here:
+                # producers emit VCS and SourceArtifact casings in the wild.
+                ref_type = str(ref.get("externalRefType") or "").strip().lower()
+                if ref_type not in ("vcs", "sourceartifact"):
+                    continue
+                locators = ref.get("locator") or []
+                # JSON-LD compact form: a one-element set may serialise as a
+                # bare string.
+                if isinstance(locators, str):
+                    locators = [locators]
+                if any(isinstance(loc, str) and loc.strip() for loc in locators):
+                    return True
+
+        # Documents stored before this fix carry a not-in-vocabulary
+        # externalIdentifier of type vcs/url; keep reading it.
+        for ext_id in iter_spdx3_external_identifiers(package):
             id_type = str(ext_id.get("externalIdentifierType") or "").strip().lower()
             ident = ext_id.get("identifier") or ""
             if id_type in ("vcs", "url") and isinstance(ident, str) and ident.strip():

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -49,8 +49,9 @@ CLE Format Support:
           target, per SPDX 2.3 §12). Document-level annotations are only
           applied to the BOM root subject — dependencies must carry their
           own annotations.
-    - SPDX 3.0.1: Native software_validUntilDate field + Annotation elements
-        - Per-package software_validUntilDate for end-of-support.
+    - SPDX 3.0.1: Native validUntilTime field + Annotation elements
+        - Per-package validUntilTime for end-of-support (the legacy
+          software_validUntilDate spelling stays readable).
         - Annotation elements whose statement contains
           cle:supportStatus=<status> / cle:endOfSupport=<date>, scoped
           by the annotation's subject: a non-empty subject matches the
@@ -660,8 +661,14 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
             if not has_support_status:
                 support_status_failures.append(pkg_name)
 
-            # 9. End of support date (software_validUntilDate + root-only doc fallback)
-            has_end_of_support = bool(package.get("software_validUntilDate")) or (is_root and doc_has_end_of_support)
+            # 9. End of support date. The spec property is validUntilTime on
+            # Artifact; software_validUntilDate exists in no 3.0.1 properties
+            # block but is kept readable for documents stored before the fix.
+            has_end_of_support = (
+                bool(package.get("validUntilTime"))
+                or bool(package.get("software_validUntilDate"))
+                or (is_root and doc_has_end_of_support)
+            )
             if not has_end_of_support:
                 end_of_support_failures.append(pkg_name)
 

--- a/sbomify/apps/plugins/tests/test_spdx3_field_fixes.py
+++ b/sbomify/apps/plugins/tests/test_spdx3_field_fixes.py
@@ -1,0 +1,133 @@
+"""Three single-field SPDX 3 reads, each pointed at a property the spec has.
+
+- FDA end-of-support read ``software_validUntilDate``, which exists in no
+  SPDX 3.0.1 properties block. The spec property is ``validUntilTime`` on
+  Artifact. The check could never pass via the package field.
+- BSI's source-code-URI check looked for an ``externalIdentifier`` of type
+  ``vcs`` or ``url`` — neither value exists in the ExternalIdentifierType
+  vocabulary. ``vcs`` lives in ExternalRefType, so it belongs on
+  ``externalRef``.
+- sbomify-action detection read root ``creationInfo.creators[]``, which
+  SPDX 3 does not have — tools live in ``createdUsing`` pointing at Tool
+  elements — so SPDX 3 users who already run the action still saw the
+  "use sbomify-action" CTA.
+
+Legacy spellings stay readable in all three: stored artifacts carry them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sbomify.apps.plugins.builtins.bsi import BSICompliancePlugin
+from sbomify.apps.plugins.builtins.fda_medical_device_cybersecurity import FDAMedicalDevicePlugin
+from sbomify.apps.sboms.utils import _spdx3_metadata_has_sbomify_action
+
+CONTEXT = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+
+END_OF_SUPPORT = "fda-2025:cle:end-of-support"
+
+
+def _fda_doc(package_extra: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "@context": CONTEXT,
+        "@graph": [
+            {"type": "CreationInfo", "spdxId": "urn:ci", "created": "2026-01-01T00:00:00Z"},
+            {"type": "software_Package", "spdxId": "urn:p1", "name": "dev-firmware", **package_extra},
+        ],
+    }
+
+
+def _end_of_support_finding(doc: dict[str, Any]) -> Any:
+    findings = FDAMedicalDevicePlugin()._validate_spdx3(doc)
+    return next(f for f in findings if f.id == END_OF_SUPPORT)
+
+
+class TestFdaEndOfSupport:
+    def test_valid_until_time_passes(self) -> None:
+        finding = _end_of_support_finding(_fda_doc({"validUntilTime": "2030-01-01T00:00:00Z"}))
+
+        assert finding.status == "pass"
+
+    def test_legacy_field_still_passes(self) -> None:
+        finding = _end_of_support_finding(_fda_doc({"software_validUntilDate": "2030-01-01"}))
+
+        assert finding.status == "pass"
+
+    def test_neither_still_fails(self) -> None:
+        finding = _end_of_support_finding(_fda_doc({}))
+
+        assert finding.status == "fail"
+
+
+class TestBsiSourceCodeUri:
+    def _has_uri(self, package_extra: dict[str, Any]) -> bool:
+        package = {"type": "software_Package", "spdxId": "urn:p", "name": "p", **package_extra}
+        return BSICompliancePlugin()._spdx3_has_source_code_uri(package)
+
+    def test_external_ref_vcs_passes(self) -> None:
+        assert (
+            self._has_uri({"externalRef": [{"externalRefType": "vcs", "locator": ["https://github.com/acme/p"]}]})
+            is True
+        )
+
+    def test_external_ref_source_artifact_passes(self) -> None:
+        assert (
+            self._has_uri(
+                {"externalRef": [{"externalRefType": "sourceArtifact", "locator": ["https://acme.test/src.tgz"]}]}
+            )
+            is True
+        )
+
+    def test_locator_as_bare_string(self) -> None:
+        """JSON-LD compact form: a one-element set may serialise unwrapped."""
+        assert (
+            self._has_uri({"externalRef": [{"externalRefType": "vcs", "locator": "https://github.com/acme/p"}]}) is True
+        )
+
+    def test_source_info_fallback_unchanged(self) -> None:
+        assert self._has_uri({"software_sourceInfo": "built from https://github.com/acme/p"}) is True
+
+    def test_legacy_invalid_identifier_shape_still_accepted(self) -> None:
+        """Documents stored before the fix carry the not-in-vocabulary shape."""
+        assert (
+            self._has_uri(
+                {"externalIdentifiers": [{"externalIdentifierType": "vcs", "identifier": "https://github.com/acme/p"}]}
+            )
+            is True
+        )
+
+    def test_nothing_still_fails(self) -> None:
+        assert self._has_uri({}) is False
+        assert self._has_uri({"externalRef": [{"externalRefType": "binaryArtifact", "locator": ["x"]}]}) is False
+
+
+class TestSpdx3ActionDetection:
+    def _doc(self, tool_name: str) -> dict[str, Any]:
+        return {
+            "@context": CONTEXT,
+            "@graph": [
+                {"type": "Tool", "spdxId": "urn:tool", "name": tool_name},
+                {"type": "CreationInfo", "spdxId": "urn:ci", "createdUsing": ["urn:tool"]},
+            ],
+        }
+
+    def test_tool_element_named_sbomify_action(self) -> None:
+        assert _spdx3_metadata_has_sbomify_action(self._doc("sbomify-action")) is True
+
+    def test_versioned_tool_name(self) -> None:
+        """augmentation.py writes f"{name}-{version}"."""
+        assert _spdx3_metadata_has_sbomify_action(self._doc("sbomify-action-1.2.3")) is True
+
+    def test_other_tool_keeps_the_cta(self) -> None:
+        assert _spdx3_metadata_has_sbomify_action(self._doc("syft-1.46.0")) is False
+
+    def test_lookalike_wrapper_is_not_the_action(self) -> None:
+        """Same rule as the SPDX 2 creator parser: only a trailing version
+        segment is stripped, so a different generator wrapping the name does
+        not hide the CTA."""
+        assert _spdx3_metadata_has_sbomify_action(self._doc("sbomify-action-v2-wrapper")) is False
+
+    def test_malformed_document_is_false(self) -> None:
+        assert _spdx3_metadata_has_sbomify_action({"@graph": "not a list"}) is False
+        assert _spdx3_metadata_has_sbomify_action(None) is False

--- a/sbomify/apps/sboms/tests/test_utils.py
+++ b/sbomify/apps/sboms/tests/test_utils.py
@@ -1208,6 +1208,29 @@ class TestSbomWasGeneratedBySbomifyAction:
         ttl_used = cache_set.call_args.args[2]
         assert ttl_used == _SBOMIFY_ACTION_CHECK_CACHE_TTL
 
+    def test_non_object_json_is_a_durable_clean_negative(
+        self, mocker, sample_sbom: SBOM, clear_sbomify_action_cache
+    ):  # noqa: F811
+        """A top-level JSON array decodes fine but is no SBOM; that is a fact
+        about the document, so it caches at the long TTL instead of retrying
+        on every page load through the transient path."""
+        from sbomify.apps.sboms.utils import (
+            _SBOMIFY_ACTION_CHECK_CACHE_TTL,
+            sbom_was_generated_by_sbomify_action,
+        )
+
+        sample_sbom.format = "spdx"
+        sample_sbom.save(update_fields=["format"])
+        cache_set = mocker.patch("django.core.cache.cache.set")
+        mocker.patch("django.core.cache.cache.get", return_value=None)
+        mock_client = mocker.MagicMock()
+        mock_client.get_sbom_data.return_value = b"[1, 2, 3]"
+        mocker.patch("sbomify.apps.core.object_store.S3Client", return_value=mock_client)
+
+        assert sbom_was_generated_by_sbomify_action(sample_sbom) is False
+
+        assert cache_set.call_args.args[2] == _SBOMIFY_ACTION_CHECK_CACHE_TTL
+
     def test_cache_get_failure_treated_as_miss(self, mocker, sample_sbom: SBOM, clear_sbomify_action_cache):  # noqa: F811
         """django-redis without IGNORE_EXCEPTIONS raises on Redis outage.
         cache.get() failure must NOT propagate — Step 2 must keep rendering."""

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -219,7 +219,13 @@ def _spdx_creator_names_sbomify_action(creator: str) -> bool:
     """
     if not creator.lower().startswith("tool:"):
         return False
-    tool_name = creator.split(":", 1)[1].strip()
+    return _tool_name_is_sbomify_action(creator.split(":", 1)[1].strip())
+
+
+def _tool_name_is_sbomify_action(tool_name: str) -> bool:
+    """The version-stripping half of the creator match, shared with the
+    SPDX 3 detector — Tool element names carry the same ``<name>-<version>``
+    composite without the ``Tool:`` prefix."""
     # No version segment: the entire payload IS the name.
     if _matches_sbomify_action_name(tool_name):
         return True
@@ -253,6 +259,29 @@ def _spdx_metadata_has_sbomify_action(sbom_data: Any) -> bool:
         if isinstance(creator, str) and _spdx_creator_names_sbomify_action(creator):
             return True
     return False
+
+
+def _spdx3_metadata_has_sbomify_action(sbom_data: Any) -> bool:
+    """Detect sbomify-action in a parsed SPDX 3.x SBOM.
+
+    SPDX 3 has no root ``creationInfo.creators`` — tools live in
+    ``createdUsing`` on the CreationInfo element, pointing at Tool elements
+    in the graph. Same fail-safe shape guards as the other detectors.
+    """
+    if not isinstance(sbom_data, dict):
+        return False
+    from sbomify.apps.plugins.builtins._spdx3_helpers import (
+        extract_spdx3_elements,
+        get_spdx3_creation_info_fields,
+    )
+
+    try:
+        creation_info, _, _, agents, tools = extract_spdx3_elements(sbom_data)
+        fields = get_spdx3_creation_info_fields(creation_info, agents, tools)
+    except Exception:
+        return False
+    entries = fields.get("tool_entries", [])
+    return any(isinstance(entry, str) and _tool_name_is_sbomify_action(entry) for entry in entries)
 
 
 def sbom_was_generated_by_sbomify_action(sbom: SBOM) -> bool:
@@ -309,9 +338,23 @@ def sbom_was_generated_by_sbomify_action(sbom: SBOM) -> bool:
             _cache_set(False, _SBOMIFY_ACTION_NEGATIVE_CACHE_TTL)
             return False
         sbom_data = json.loads(sbom_bytes.decode("utf-8"))
+        if not isinstance(sbom_data, dict):
+            # Valid JSON that is not an object (a top-level list, a string)
+            # is a durable fact about the document, not a transient failure:
+            # fall through to the long-TTL cache with a clean negative.
+            _cache_set(False, _SBOMIFY_ACTION_CHECK_CACHE_TTL)
+            return False
         fmt = (sbom.format or "").lower()
         if fmt == "spdx":
-            result = _spdx_metadata_has_sbomify_action(sbom_data)
+            # SPDX 3 keeps its tools in the graph, not in creators[] — the
+            # 2.x detector reads a field 3.x does not have, so every SPDX 3
+            # document from the action still showed the enrichment CTA.
+            from sbomify.apps.plugins.builtins._spdx3_helpers import is_spdx3
+
+            if is_spdx3(sbom_data):
+                result = _spdx3_metadata_has_sbomify_action(sbom_data)
+            else:
+                result = _spdx_metadata_has_sbomify_action(sbom_data)
         else:
             # Default to CycloneDX detection — covers ``cyclonedx`` and any
             # future variant (sbom.format defaults to "spdx" but most uploads


### PR DESCRIPTION
Phase 0 of #1324, third PR. `Closes #1329, closes #1330, closes #1331.`

Was stacked on #1482 (shared `bsi.py` and helpers); that and #1483 are merged, so this diff now shows only this PR's own changes.

| Issue | Wrong read | Spec property |
|---|---|---|
| #1329 | FDA end-of-support read `software_validUntilDate` — in no 3.0.1 properties block; the check could never pass via the package field | `validUntilTime` on Artifact |
| #1330 | BSI source-code URI matched `externalIdentifier` types `vcs`/`url` — neither exists in ExternalIdentifierType; only `software_sourceInfo` could pass | `vcs` lives in ExternalRefType → `externalRef` |
| #1331 | sbomify-action detection read root `creationInfo.creators[]`, which SPDX 3 does not have — action users still saw the enrichment CTA | tools live in `createdUsing` → Tool elements |

## The change

- `validUntilTime` read first; the legacy spelling stays readable for stored documents.
- BSI iterates `externalRef` for `vcs` and `sourceArtifact`, handles the JSON-LD compact bare-string locator, keeps the `software_sourceInfo` fallback, and still reads the stored not-in-vocabulary identifier shape.
- The detector dispatcher branches on `is_spdx3` to a new `_spdx3_metadata_has_sbomify_action` that walks `createdUsing` to Tool elements — reusing the SPDX 2 creator parser's version-stripping (factored out as `_tool_name_names_sbomify_action`), so `sbomify-action-1.2.3` matches and `sbomify-action-v2-wrapper` does not.

## Evidence

Red-first against the unfixed tree: `validUntilTime` scores **fail**, the `externalRef` vcs package reads **False**. 14 new tests; 1081 plugin + utils tests pass unchanged (SPDX 2.x detection untouched, legacy spellings pinned by dedicated tests).


Supersedes #1386.


