### PR TITLE
test(spdx3): a conformant corpus the plugins cannot drift from

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "weasyprint>=69.0,<70",
     "defusedxml>=0.7.1",
     "defusedcsv>=3.0.0",
+    "jsonschema>=4.26,<5",
     "django-cotton>=2.7.2",
 ]
 

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -59,6 +59,7 @@ from typing import Any
 from packaging import version as pkg_version
 
 from sbomify.apps.plugins.builtins._spdx3_helpers import (
+    extract_spdx3_elements,
     get_spdx3_package_fields,
     iter_spdx3_external_identifiers,
     resolve_spdx3_agent,
@@ -885,32 +886,26 @@ class BSICompliancePlugin(AssessmentPlugin):
         """
         findings: list[Finding] = []
 
-        # SPDX 3.x has an "elements" array with different types
+        # SPDX 3.x has an "elements" array with different types. The nested
+        # spdxDocument.elements shape predates the shared helper and is kept.
         elements = data.get("@graph", data.get("spdxDocument", {}).get("elements", []))
         if not elements:
             elements = data.get("elements", [])
 
-        # Extract elements by type
-        creation_info = None
-        packages: list[dict[str, Any]] = []
-        files: list[dict[str, Any]] = []
-        relationships: list[dict[str, Any]] = []
-        persons_orgs: dict[str, dict[str, Any]] = {}
-
-        for element in elements:
-            elem_type = element.get("type", element.get("@type", ""))
-            if "CreationInfo" in elem_type:
-                creation_info = element
-            elif "software_Package" in elem_type or "Package" in elem_type:
-                packages.append(element)
-            elif "software_File" in elem_type or "File" in elem_type:
-                files.append(element)
-            elif "Relationship" in elem_type:
-                relationships.append(element)
-            elif "Person" in elem_type or "Organization" in elem_type:
-                spdx_id = element.get("spdxId", element.get("@id", ""))
-                if spdx_id:
-                    persons_orgs[spdx_id] = element
+        # One extraction, shared with the other plugins — a private routing
+        # copy here is how SoftwareAgent suppliers scored two findings worse
+        # in BSI than everywhere else. Files are BSI-specific, so that pass
+        # stays local.
+        creation_info, packages, relationships, persons_orgs, _ = extract_spdx3_elements({"@graph": elements})
+        # Same normalization as the shared extractor: the bare tail of a
+        # compact or IRI type, matched exactly, so a type merely containing
+        # the word File cannot classify as one.
+        files: list[dict[str, Any]] = [
+            e
+            for e in elements
+            if isinstance(e, dict)
+            and str(e.get("type", e.get("@type", ""))).rsplit("/", 1)[-1] in ("software_File", "File")
+        ]
 
         # === SBOM-level required fields ===
 

--- a/sbomify/apps/plugins/tests/spdx3_corpus.py
+++ b/sbomify/apps/plugins/tests/spdx3_corpus.py
@@ -1,0 +1,301 @@
+"""A conformant SPDX 3.0.1 fixture corpus.
+
+Every earlier SPDX 3 fixture in this suite encoded the non-spec spellings
+(``externalIdentifiers``, ``packageURL``), so the suite stayed green while a
+spec-conformant document scored worse than a malformed one. These builders
+write the spellings the spec defines, and the corpus test validates each
+document against the vendored ``spdx_3.0.1-schema.json`` so the fixtures
+cannot drift from the spec again.
+
+Only the builders listed in ``SCHEMA_VALID_BUILDERS`` claim 3.0.1
+conformance and are schema-validated. The 3.0.0 and 3.1.0 variants (and the
+syft-shaped 3.0.0 document) are deliberately not 3.0.1-conformant; they
+exist for the version-floor and producer-shape tests.
+
+Builders return fresh dicts — tests may mutate freely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CONTEXT = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+CREATED = "2026-08-01T00:00:00Z"
+
+_CI = "_:creationinfo"
+
+
+def _creation_info(created_by: list[Any] | None = None, created_using: list[Any] | None = None) -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "type": "CreationInfo",
+        "@id": _CI,
+        "specVersion": "3.0.1",
+        "created": CREATED,
+        "createdBy": created_by if created_by is not None else ["urn:acme:agent"],
+    }
+    if created_using is not None:
+        info["createdUsing"] = created_using
+    return info
+
+
+def _person(spdx_id: str = "urn:acme:agent", name: str = "Jane Doe", email: str = "jane@acme.test") -> dict[str, Any]:
+    return {
+        "type": "Person",
+        "spdxId": spdx_id,
+        "creationInfo": _CI,
+        "name": name,
+        "externalIdentifier": [{"type": "ExternalIdentifier", "externalIdentifierType": "email", "identifier": email}],
+    }
+
+
+def _tool(spdx_id: str = "urn:acme:tool", name: str = "sbomify-action-1.2.3") -> dict[str, Any]:
+    return {"type": "Tool", "spdxId": spdx_id, "creationInfo": _CI, "name": name}
+
+
+def _document(root: list[str] | str, spdx_id: str = "urn:acme:doc") -> dict[str, Any]:
+    return {
+        "type": "SpdxDocument",
+        "spdxId": spdx_id,
+        "creationInfo": _CI,
+        "rootElement": root,
+        "profileConformance": ["core", "software"],
+    }
+
+
+def _package(
+    spdx_id: str = "urn:acme:pkg1",
+    name: str = "my-app",
+    version: str = "1.2.3",
+    supplier: Any = "urn:acme:agent",
+    **extra: Any,
+) -> dict[str, Any]:
+    package: dict[str, Any] = {
+        "type": "software_Package",
+        "spdxId": spdx_id,
+        "creationInfo": _CI,
+        "name": name,
+        "software_packageVersion": version,
+        "software_downloadLocation": f"https://downloads.acme.test/{name}-{version}.tar.gz",
+        "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "a" * 64}],
+        "externalRef": [
+            {"type": "ExternalRef", "externalRefType": "vcs", "locator": [f"https://github.com/acme/{name}"]}
+        ],
+        "validUntilTime": "2030-01-01T00:00:00Z",
+    }
+    if supplier is not None:
+        package["originatedBy"] = [supplier]
+    package.update(extra)
+    return package
+
+
+def _relationship(rel_type: str, from_id: str, to_ids: list[str], spdx_id: str = "urn:acme:rel1") -> dict[str, Any]:
+    return {
+        "type": "Relationship",
+        "spdxId": spdx_id,
+        "creationInfo": _CI,
+        "relationshipType": rel_type,
+        "from": from_id,
+        "to": to_ids,
+    }
+
+
+def _doc(*graph: dict[str, Any]) -> dict[str, Any]:
+    return {"@context": CONTEXT, "@graph": list(graph)}
+
+
+def minimal_conformant() -> dict[str, Any]:
+    """One package carrying every field the four plugins grade, spec-spelled."""
+    return _doc(
+        _creation_info(created_using=["urn:acme:tool"]),
+        _person(),
+        _tool(),
+        _document(["urn:acme:pkg1"]),
+        _package(software_packageUrl="pkg:pypi/my-app@1.2.3"),
+        _relationship("hasConcludedLicense", "urn:acme:pkg1", ["urn:acme:lic1"]),
+        _relationship("hasDeclaredLicense", "urn:acme:pkg1", ["urn:acme:lic1"], spdx_id="urn:acme:rel2"),
+    )
+
+
+def root_element_non_first() -> dict[str, Any]:
+    """Three packages; the SpdxDocument declares the third as the subject."""
+    return _doc(
+        _creation_info(),
+        _person(),
+        _document(["urn:acme:pkg3"]),
+        _package("urn:acme:pkg1", name="libfoo", version="9.9.9"),
+        _package("urn:acme:pkg2", name="libbar", version="2.0.0"),
+        _package("urn:acme:pkg3", name="my-app", version="1.2.3", software_packageUrl="pkg:pypi/my-app@1.2.3"),
+    )
+
+
+def inline_agents() -> dict[str, Any]:
+    """Inline Agent objects in createdBy and originatedBy — legal per
+    Agent_derived, and the shape that crashed two plugins."""
+    inline_org = {
+        "type": "Organization",
+        "spdxId": "urn:acme:inlineorg",
+        "creationInfo": _CI,
+        "name": "Inline Corp",
+        "externalIdentifier": [
+            {"type": "ExternalIdentifier", "externalIdentifierType": "email", "identifier": "sec@inline.test"}
+        ],
+    }
+    return _doc(
+        _creation_info(created_by=[dict(inline_org)]),
+        _document(["urn:acme:pkg1"]),
+        _package(supplier=dict(inline_org), software_packageUrl="pkg:pypi/my-app@1.2.3"),
+    )
+
+
+def software_agent_supplier() -> dict[str, Any]:
+    """Supplier typed SoftwareAgent — routed to the wrong bucket before."""
+    agent = {
+        "type": "SoftwareAgent",
+        "spdxId": "urn:acme:bot",
+        "creationInfo": _CI,
+        "name": "build-bot",
+        "externalIdentifier": [
+            {"type": "ExternalIdentifier", "externalIdentifierType": "email", "identifier": "bot@acme.test"}
+        ],
+    }
+    return _doc(
+        _creation_info(created_by=["urn:acme:bot"]),
+        agent,
+        _document(["urn:acme:pkg1"]),
+        _package(supplier="urn:acme:bot", software_packageUrl="pkg:pypi/my-app@1.2.3"),
+    )
+
+
+def purl_via_software_package_url_only() -> dict[str, Any]:
+    """The first-class 3.0.1 purl property, and nothing else."""
+    return _doc(
+        _creation_info(),
+        _person(),
+        _document(["urn:acme:pkg1"]),
+        _package(software_packageUrl="pkg:pypi/my-app@1.2.3"),
+    )
+
+
+def purl_via_external_identifier_only() -> dict[str, Any]:
+    """Spec spelling: singular property, packageUrl vocabulary value."""
+    return _doc(
+        _creation_info(),
+        _person(),
+        _document(["urn:acme:pkg1"]),
+        _package(
+            externalIdentifier=[
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "packageUrl",
+                    "identifier": "pkg:pypi/my-app@1.2.3",
+                }
+            ]
+        ),
+    )
+
+
+def legacy_spelling_counterpart() -> dict[str, Any]:
+    """The same package data as purl_via_external_identifier_only, written
+    with the non-spec spellings stored artifacts carry. Deliberately NOT
+    schema-valid — the A/B guard proves it scores no better than the
+    conformant twin."""
+    document = purl_via_external_identifier_only()
+    for element in document["@graph"]:
+        if element["type"] == "software_Package":
+            element["externalIdentifiers"] = [
+                {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/my-app@1.2.3"}
+            ]
+            del element["externalIdentifier"]
+        if element["type"] == "Person":
+            element["externalIdentifiers"] = element.pop("externalIdentifier")
+    return document
+
+
+def yocto_shaped() -> dict[str, Any]:
+    """The shape current Yocto (5.2+/6.0) emits: 3.0.1, purls via
+    software_packageUrl, one de-duplicated CreationInfo shared by reference."""
+    return _doc(
+        _creation_info(created_by=["urn:oe:org"]),
+        {"type": "Organization", "spdxId": "urn:oe:org", "creationInfo": _CI, "name": "OpenEmbedded"},
+        _document(["urn:oe:image"]),
+        _package(
+            "urn:oe:image",
+            name="core-image-minimal",
+            version="6.0",
+            supplier="urn:oe:org",
+            software_packageUrl="pkg:generic/core-image-minimal@6.0",
+        ),
+        _package(
+            "urn:oe:netbase",
+            name="netbase",
+            version="6.4",
+            supplier="urn:oe:org",
+            software_packageUrl="pkg:generic/netbase@6.4?distro=yocto",
+        ),
+    )
+
+
+def syft_shaped() -> dict[str, Any]:
+    """The shape syft v1.46+ writes: SPDX 3.0 converted from its 2.3 model,
+    describes relationship rather than rootElement, purl on externalIdentifier."""
+    document = _doc(
+        _creation_info(created_using=["urn:syft:tool"]),
+        _person("urn:syft:agent", name="Anchore", email="oss@anchore.test"),
+        _tool("urn:syft:tool", name="syft-1.46.0"),
+        {
+            "type": "SpdxDocument",
+            "spdxId": "urn:syft:doc",
+            "creationInfo": _CI,
+            "profileConformance": ["core", "software"],
+        },
+        _package(
+            "urn:syft:pkg1",
+            name="left-pad",
+            version="1.3.0",
+            supplier="urn:syft:agent",
+            externalIdentifier=[
+                {
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "packageUrl",
+                    "identifier": "pkg:npm/left-pad@1.3.0",
+                }
+            ],
+        ),
+        _relationship("describes", "urn:syft:doc", ["urn:syft:pkg1"], spdx_id="urn:syft:rel1"),
+    )
+    document["@context"] = "https://spdx.org/rdf/3.0.0/spdx-context.jsonld"
+    for element in document["@graph"]:
+        if element["type"] == "CreationInfo":
+            element["specVersion"] = "3.0.0"
+    return document
+
+
+def spdx_3_0_0() -> dict[str, Any]:
+    """A 3.0.0 document — inside SPDX 3 detection, below the BSI floor."""
+    document = minimal_conformant()
+    document["@context"] = "https://spdx.org/rdf/3.0.0/spdx-context.jsonld"
+    for element in document["@graph"]:
+        if element["type"] == "CreationInfo":
+            element["specVersion"] = "3.0.0"
+    return document
+
+
+def spdx_3_1() -> dict[str, Any]:
+    """A 3.1 document — prerelease, to be rejected with a clear error."""
+    document = minimal_conformant()
+    document["@context"] = "https://spdx.org/rdf/3.1.0/spdx-context.jsonld"
+    for element in document["@graph"]:
+        if element["type"] == "CreationInfo":
+            element["specVersion"] = "3.1.0"
+    return document
+
+
+SCHEMA_VALID_BUILDERS = [
+    minimal_conformant,
+    root_element_non_first,
+    inline_agents,
+    software_agent_supplier,
+    purl_via_software_package_url_only,
+    purl_via_external_identifier_only,
+    yocto_shaped,
+]

--- a/sbomify/apps/plugins/tests/test_bsi_plugin.py
+++ b/sbomify/apps/plugins/tests/test_bsi_plugin.py
@@ -78,14 +78,14 @@ def create_base_spdx3_sbom() -> dict:
                 "spdxId": "SPDXRef-Creator",
                 "creationInfo": "_:creationInfo",
                 "name": "SBOM Creator Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "sbom@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "sbom@example.com"}],
             },
             {
                 "type": "Organization",
                 "spdxId": "SPDXRef-Maintainer",
                 "creationInfo": "_:creationInfo",
                 "name": "Example Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "maintainer@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "maintainer@example.com"}],
             },
             {
                 "type": "software_Package",
@@ -94,8 +94,8 @@ def create_base_spdx3_sbom() -> dict:
                 "name": "example-package",
                 "software_packageVersion": "1.0.0",
                 "originatedBy": ["SPDXRef-Maintainer"],
-                "externalIdentifiers": [
-                    {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/example@1.0.0"}
+                "externalIdentifier": [
+                    {"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/example@1.0.0"}
                 ],
             },
             {
@@ -900,7 +900,7 @@ class TestAdditionalDataFields:
         sbom = create_base_spdx3_sbom()
         for element in sbom["@graph"]:
             if element.get("type") == "software_Package":
-                element.setdefault("externalIdentifiers", []).append(
+                element.setdefault("externalIdentifier", []).append(
                     {
                         "externalIdentifierType": "vcs",
                         "identifier": "https://github.com/example/repo",

--- a/sbomify/apps/plugins/tests/test_cisa_plugin.py
+++ b/sbomify/apps/plugins/tests/test_cisa_plugin.py
@@ -1218,13 +1218,13 @@ def _create_base_spdx3_sbom() -> dict:
                 "type": "Organization",
                 "spdxId": "SPDXRef-Creator",
                 "name": "SBOM Creator Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
             },
             {
                 "type": "Organization",
                 "spdxId": "SPDXRef-Supplier",
                 "name": "Supplier Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
             },
             {
                 "type": "Tool",
@@ -1237,8 +1237,8 @@ def _create_base_spdx3_sbom() -> dict:
                 "name": "example-package",
                 "software_packageVersion": "1.0.0",
                 "originatedBy": ["SPDXRef-Supplier"],
-                "externalIdentifiers": [
-                    {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/example@1.0.0"}
+                "externalIdentifier": [
+                    {"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/example@1.0.0"}
                 ],
                 "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "abc123"}],
             },

--- a/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
+++ b/sbomify/apps/plugins/tests/test_fda_medical_device_plugin.py
@@ -1698,13 +1698,13 @@ def _create_base_spdx3_sbom() -> dict:
                 "type": "Organization",
                 "spdxId": "SPDXRef-Creator",
                 "name": "SBOM Creator Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
             },
             {
                 "type": "Organization",
                 "spdxId": "SPDXRef-Supplier",
                 "name": "Supplier Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
             },
             {
                 "type": "software_Package",
@@ -1713,8 +1713,8 @@ def _create_base_spdx3_sbom() -> dict:
                 "software_packageVersion": "1.0.0",
                 "originatedBy": ["SPDXRef-Supplier"],
                 "software_validUntilDate": "2025-12-31T00:00:00Z",
-                "externalIdentifiers": [
-                    {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/example@1.0.0"}
+                "externalIdentifier": [
+                    {"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/example@1.0.0"}
                 ],
             },
             {
@@ -1859,8 +1859,8 @@ class TestSPDX3Validation:
                 "name": "dep-package",
                 "software_packageVersion": "2.0.0",
                 "originatedBy": ["SPDXRef-Supplier"],
-                "externalIdentifiers": [
-                    {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/dep@2.0.0"}
+                "externalIdentifier": [
+                    {"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/dep@2.0.0"}
                 ],
             }
         )
@@ -1973,7 +1973,7 @@ class TestSPDX3Validation:
                 "name": "other-package",
                 "software_packageVersion": "2.0.0",
                 "originatedBy": ["SPDXRef-Supplier"],
-                "externalIdentifiers": [{"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/other@2.0.0"}],
+                "externalIdentifier": [{"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/other@2.0.0"}],
             }
         )
         # Declare the document with Package-1 as the only root; an annotation

--- a/sbomify/apps/plugins/tests/test_ntia_plugin.py
+++ b/sbomify/apps/plugins/tests/test_ntia_plugin.py
@@ -845,13 +845,13 @@ def _create_base_spdx3_sbom() -> dict:
                 "type": "Organization",
                 "spdxId": "SPDXRef-Creator",
                 "name": "SBOM Creator Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "creator@example.com"}],
             },
             {
                 "type": "Organization",
                 "spdxId": "SPDXRef-Supplier",
                 "name": "Supplier Corp",
-                "externalIdentifiers": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
+                "externalIdentifier": [{"externalIdentifierType": "email", "identifier": "supplier@example.com"}],
             },
             {
                 "type": "software_Package",
@@ -859,8 +859,8 @@ def _create_base_spdx3_sbom() -> dict:
                 "name": "example-package",
                 "software_packageVersion": "1.0.0",
                 "originatedBy": ["SPDXRef-Supplier"],
-                "externalIdentifiers": [
-                    {"externalIdentifierType": "packageURL", "identifier": "pkg:pypi/example@1.0.0"}
+                "externalIdentifier": [
+                    {"externalIdentifierType": "packageUrl", "identifier": "pkg:pypi/example@1.0.0"}
                 ],
             },
             {
@@ -916,7 +916,7 @@ class TestSPDX3Validation:
     def test_spdx3_missing_unique_identifiers(self) -> None:
         """Test SPDX 3.0 SBOM missing unique identifiers."""
         sbom_data = _create_base_spdx3_sbom()
-        del sbom_data["@graph"][3]["externalIdentifiers"]
+        del sbom_data["@graph"][3]["externalIdentifier"]
 
         result = self._assess_sbom(sbom_data)
 

--- a/sbomify/apps/plugins/tests/test_spdx3_corpus.py
+++ b/sbomify/apps/plugins/tests/test_spdx3_corpus.py
@@ -1,0 +1,113 @@
+"""The corpus guard: conformant documents validate, score, and never lose to
+legacy spellings.
+
+Two properties, each of which failed silently before:
+
+1. Every fixture marked conformant validates against the vendored official
+   ``spdx_3.0.1-schema.json`` — so a fixture that drifts from the spec fails
+   here rather than quietly training the plugins on the wrong shape.
+2. A conformant document scores at least as well as the same data written
+   with the legacy spellings, across all four compliance plugins. Reverting
+   any of the spec-field fixes flips this red.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sbomify.apps.plugins.builtins.bsi import BSICompliancePlugin
+import sbomify.apps.sboms
+from sbomify.apps.plugins.builtins.cisa import CISAMinimumElementsPlugin
+from sbomify.apps.plugins.builtins.fda_medical_device_cybersecurity import FDAMedicalDevicePlugin
+from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+from sbomify.apps.plugins.tests import spdx3_corpus as corpus
+
+# Anchored on the sboms package itself rather than counting parent
+# directories, so a moved test folder cannot silently point at nothing.
+SCHEMA_PATH = Path(sbomify.apps.sboms.__file__).resolve().parent / "schemas" / "spdx_3.0.1-schema.json"
+
+PLUGINS = [NTIAMinimumElementsPlugin, CISAMinimumElementsPlugin, FDAMedicalDevicePlugin, BSICompliancePlugin]
+
+
+@cache
+def _validator() -> Any:
+    from jsonschema import Draft202012Validator
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    # format assertions on: 2020-12 treats format as annotation by default,
+    # and a fixture with a malformed date-time would otherwise pass the guard.
+    return Draft202012Validator(schema, format_checker=Draft202012Validator.FORMAT_CHECKER)
+
+
+def _schema_errors(document: dict[str, Any]) -> list[str]:
+    # Sorted, because jsonschema's iteration order is not stable, and wide
+    # enough (validator name + 300 chars) to debug a failure from the diff.
+    return sorted(
+        f"{'/'.join(str(p) for p in e.absolute_path)} [{e.validator}]: {e.message[:300]}"
+        for e in _validator().iter_errors(document)
+    )
+
+
+class TestCorpusValidatesAgainstTheOfficialSchema:
+    @pytest.mark.parametrize("builder", corpus.SCHEMA_VALID_BUILDERS, ids=lambda b: b.__name__)
+    def test_fixture_is_schema_valid(self, builder) -> None:
+        errors = _schema_errors(builder())
+
+        assert errors == []
+
+    def test_legacy_counterpart_is_deliberately_invalid(self) -> None:
+        """The plural spelling is invalid under unevaluatedProperties: false —
+        which is the whole point: the schema itself refuses the shape the
+        plugins used to require."""
+        assert _schema_errors(corpus.legacy_spelling_counterpart()) != []
+
+
+def _scores(document: dict[str, Any]) -> dict[str, tuple[int, int]]:
+    """{plugin: (pass_count, fail_count)} over the four compliance plugins."""
+    results: dict[str, tuple[int, int]] = {}
+    for plugin_cls in PLUGINS:
+        findings = plugin_cls()._validate_spdx3(document)
+        statuses = [f.status for f in findings]
+        results[plugin_cls.__name__] = (statuses.count("pass"), statuses.count("fail"))
+    return results
+
+
+class TestConformantNeverScoresWorse:
+    def test_spec_spelling_beats_or_ties_legacy_everywhere(self) -> None:
+        conformant = _scores(corpus.purl_via_external_identifier_only())
+        legacy = _scores(corpus.legacy_spelling_counterpart())
+
+        for plugin_name, (spec_pass, spec_fail) in conformant.items():
+            legacy_pass, legacy_fail = legacy[plugin_name]
+            assert spec_pass >= legacy_pass, f"{plugin_name}: conformant passes {spec_pass} < legacy {legacy_pass}"
+            assert spec_fail <= legacy_fail, f"{plugin_name}: conformant fails {spec_fail} > legacy {legacy_fail}"
+
+    def test_first_class_purl_property_scores_like_an_identifier(self) -> None:
+        via_property = _scores(corpus.purl_via_software_package_url_only())
+        via_identifier = _scores(corpus.purl_via_external_identifier_only())
+
+        assert via_property == via_identifier
+
+    @pytest.mark.parametrize(
+        "builder",
+        [corpus.inline_agents, corpus.software_agent_supplier, corpus.yocto_shaped, corpus.syft_shaped],
+        ids=lambda b: b.__name__,
+    )
+    def test_every_producer_shape_completes_without_an_exception(self, builder) -> None:
+        """The inline-Agent shape used to TypeError two plugins into a FAILED
+        run; a corpus document must never take a plugin down."""
+        for plugin_name, (pass_count, fail_count) in _scores(builder()).items():
+            assert pass_count + fail_count > 0, f"{plugin_name} produced no gradeable findings"
+
+    def test_inline_and_referenced_suppliers_score_identically(self) -> None:
+        """Swapping the supplier's shape (reference vs inline) and type
+        (Organization vs SoftwareAgent) must not move the score."""
+        referenced = _scores(corpus.software_agent_supplier())
+        inline = _scores(corpus.inline_agents())
+
+        assert referenced == inline

--- a/uv.lock
+++ b/uv.lock
@@ -1489,6 +1489,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "jwcrypto"
 version = "1.5.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2543,6 +2570,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2025.9.18"
 source = { registry = "https://pypi.org/simple" }
@@ -2679,6 +2719,87 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
 name = "ruamel-yaml"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2762,6 +2883,7 @@ dependencies = [
     { name = "dramatiq-crontab" },
     { name = "email-validator" },
     { name = "gunicorn" },
+    { name = "jsonschema" },
     { name = "libtea" },
     { name = "license-expression" },
     { name = "posthog" },
@@ -2843,6 +2965,7 @@ requires-dist = [
     { name = "dramatiq-crontab", specifier = ">=1.0.12,<2" },
     { name = "email-validator", specifier = ">=2.3.0,<3" },
     { name = "gunicorn", specifier = ">=25.0.3,<27" },
+    { name = "jsonschema", specifier = ">=4.26,<5" },
     { name = "libtea", specifier = "==0.5.1" },
     { name = "license-expression", specifier = ">=30.4.4,<31" },
     { name = "posthog", specifier = ">=3.20.0,<8" },


### PR DESCRIPTION
Phase 0 of #1324, fourth PR. `Closes #1332.`

**Stacked on #1482 (merged) → #1484** — merge those first; this diff shows all three until they land.

Every SPDX 3 fixture in the suite encoded the non-spec spellings, so CI stayed green while a spec-conformant document scored worse than a malformed one. This PR makes that class of bug impossible to reintroduce quietly.

## The corpus

Builders for the shapes producers actually send: minimal conformant, rootElement→non-first package, inline Agents, SoftwareAgent supplier, purl via `software_packageUrl` only, purl via `externalIdentifier` only, **Yocto 6.0-shaped**, **syft-3.0-shaped** (the two mainstream generator paths from the 2026-08-10 scope check), plus 3.0.0 and 3.1 markers for the floor work in #1333/#1334/#1383.

## The guards

- **Schema validation**: every conformant fixture validates against the vendored official `spdx_3.0.1-schema.json` (Draft 2020-12); the legacy counterpart is asserted *invalid* — `unevaluatedProperties: false` refuses the plural spelling, which is the point.
- **A/B scoring**: the conformant spelling scores ≥ the legacy spelling across NTIA, CISA, FDA and BSI; supplier shape (inline vs referenced) and type (Organization vs SoftwareAgent) must not move the score; every producer shape completes without an exception. Sabotaging the spec-key reads flips it red — verified.

## The guard already earned its keep

While being written, the equality guard caught a real residual: **BSI's inline element-routing copy still dropped SoftwareAgent suppliers**, scoring two findings worse than the other plugins on identical data. That private copy is now a call to the shared `extract_spdx3_elements` (the BSI-specific files pass stays local) — one line-item of #1337 pulled forward because #1327's acceptance criteria require it.

## Fixtures

The four plugin base fixtures flip to spec spelling (13 keys, 6 vocabulary values); legacy acceptance is proven centrally by running the A/B counterpart through all four plugins rather than duplicating a legacy fixture per file. Full plugin suite: 1042 passed.


Supersedes #1387.

