### PR TITLE
feat(spdx3): resolve licence relationships to expressions, not booleans

### DIFF
--- a/sbomify/apps/plugins/builtins/_spdx3_helpers.py
+++ b/sbomify/apps/plugins/builtins/_spdx3_helpers.py
@@ -326,3 +326,230 @@ def get_spdx3_package_fields(
         "external_refs": external_refs,
         "external_identifiers": external_identifiers,
     }
+
+
+# Licensing element types from the SimpleLicensing and ExpandedLicensing
+# profiles, matched on the unprefixed tail like every other type here. The
+# NoAssertion/None singletons are collected too so a reference to them
+# resolves deliberately to "no licence" rather than falling through as an
+# unknown target.
+# Spec spelling first (lowercase profile prefixes, per the 3.0.1 schema:
+# simplelicensing_, expandedlicensing_), with the camelCase variants this
+# module's reading rules extend to every other profile-prefixed name.
+def _license_type_tail(elem_type: str) -> str:
+    """The bare type name, whatever the serialization: full IRI (.../Simple
+    Licensing/LicenseExpression), JSON-LD compact IRI (simplelicensing:
+    LicenseExpression) or the underscore compact form, which is already bare.
+    """
+    return elem_type.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+
+
+def _with_vocabulary_prefixes(bases: frozenset[str], *prefixes: str) -> frozenset[str]:
+    """The bare names plus each prefixed spelling, so the sets cannot drift
+    from the casing variants by hand-maintenance."""
+    return bases | frozenset(f"{prefix}{base}" for base in bases for prefix in prefixes)
+
+
+_SIMPLE_LICENSING_BASES = frozenset({"LicenseExpression", "SimpleLicensingText"})
+_EXPANDED_LICENSING_BASES = frozenset(
+    {
+        "ListedLicense",
+        "CustomLicense",
+        "NoAssertionLicense",
+        "NoneLicense",
+        "ConjunctiveLicenseSet",
+        "DisjunctiveLicenseSet",
+        "OrLaterOperator",
+        "WithAdditionOperator",
+        "ListedLicenseException",
+        "CustomLicenseAddition",
+    }
+)
+
+_LICENSE_TYPE_TAILS = _with_vocabulary_prefixes(
+    _SIMPLE_LICENSING_BASES, "simplelicensing_", "simpleLicensing_"
+) | _with_vocabulary_prefixes(_EXPANDED_LICENSING_BASES, "expandedlicensing_", "expandedLicensing_")
+
+_NO_LICENSE_TAILS = _with_vocabulary_prefixes(
+    frozenset({"NoAssertionLicense", "NoneLicense"}), "expandedlicensing_", "expandedLicensing_"
+)
+
+
+def extract_spdx3_licenses(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Licensing elements from @graph, keyed by spdxId.
+
+    Kept separate from ``extract_spdx3_elements`` so its five-tuple contract
+    (and every existing unpack site) stays untouched; the licence checks are
+    the only consumers of this map.
+    """
+    elements = data.get("@graph", data.get("elements", []))
+    if not isinstance(elements, list):
+        return {}
+    licenses: dict[str, dict[str, Any]] = {}
+    for element in elements:
+        if not isinstance(element, dict):
+            continue
+        elem_type = element.get("type", element.get("@type", "")) or ""
+        if not isinstance(elem_type, str):
+            continue
+        if _license_type_tail(elem_type) not in _LICENSE_TYPE_TAILS:
+            continue
+        spdx_id = element.get("spdxId", element.get("@id", ""))
+        if isinstance(spdx_id, str) and spdx_id:
+            licenses[spdx_id] = element
+    return licenses
+
+
+def _spdx_listed_license_tail(reference: str) -> str | None:
+    """The licence id from a real SPDX licence-list URL, else ``None``.
+
+    Parsed, not substring-matched: an untrusted document could otherwise
+    smuggle ``spdx.org/licenses/`` inside a hostile URL's path and have a
+    crafted string score as a listed licence.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(reference)
+    if parsed.scheme not in ("http", "https") or parsed.netloc not in ("spdx.org", "www.spdx.org"):
+        return None
+    if not parsed.path.startswith("/licenses/"):
+        return None
+    tail = parsed.path[len("/licenses/") :].rstrip("/")
+    return tail if tail and "/" not in tail else None
+
+
+def resolve_spdx3_license_expression(
+    target: Any, licenses: dict[str, dict[str, Any]], _seen: frozenset[str] = frozenset()
+) -> str | None:
+    """The licence string a relationship target denotes, or ``None``.
+
+    Resolution order: a LicenseExpression's expression string, then the
+    ExpandedLicensing compound shapes (AND/OR sets, or-later, with-addition)
+    composed recursively, then a Listed/Custom licence's name, then the SPDX
+    licence-list id tail for a ``spdx.org/licenses/…`` reference that carries
+    no element (the conventional way documents cite listed licences).
+    NoAssertion/None singletons and anything unresolvable are ``None`` — a
+    reference to nothing must not score as a licence.
+    """
+    element: dict[str, Any] | None
+    if isinstance(target, dict):
+        element = target
+    elif isinstance(target, str):
+        if target in _seen:
+            return None  # a licence set citing itself must not recurse forever
+        _seen = _seen | {target}
+        element = licenses.get(target)
+    else:
+        return None
+
+    if element is None:
+        if isinstance(target, str):
+            return _spdx_listed_license_tail(target)
+        return None
+
+    elem_type = element.get("type", element.get("@type", "")) or ""
+    if isinstance(elem_type, str) and _license_type_tail(elem_type) in _NO_LICENSE_TAILS:
+        return None
+
+    bare_type = _license_type_tail(elem_type) if isinstance(elem_type, str) else ""
+    compound = _resolve_compound_license(bare_type, element, licenses, _seen)
+    if compound is not None:
+        return compound
+
+    expression = element.get("simplelicensing_licenseExpression", element.get("simpleLicensing_licenseExpression"))
+    if isinstance(expression, str) and expression.strip():
+        return expression.strip()
+    name = element.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    spdx_id = element.get("spdxId", element.get("@id", ""))
+    if bare_type.endswith("SimpleLicensingText"):
+        # A nameless free-text licence still IS a licence; its id is the only
+        # string that identifies it without dumping the text into a report.
+        text = element.get("simplelicensing_licenseText", element.get("simpleLicensing_licenseText"))
+        if isinstance(text, str) and text.strip() and isinstance(spdx_id, str) and spdx_id:
+            return spdx_id
+    if isinstance(spdx_id, str):
+        return _spdx_listed_license_tail(spdx_id)
+    return None
+
+
+def _field(element: dict[str, Any], name: str) -> Any:
+    """Both vocabulary casings, like every ExpandedLicensing read here."""
+    lower = "expandedlicensing_" + name
+    camel = "expandedLicensing_" + name
+    return element.get(lower, element.get(camel))
+
+
+def _resolve_compound_license(
+    bare_type: str, element: dict[str, Any], licenses: dict[str, dict[str, Any]], seen: frozenset[str]
+) -> str | None:
+    """Compose an SPDX expression from the ExpandedLicensing compound shapes.
+
+    A member that is itself compound is parenthesized, so AND/OR nesting
+    survives the round trip through a flat string.
+    """
+
+    def _operand(target: Any) -> str | None:
+        resolved = resolve_spdx3_license_expression(target, licenses, seen)
+        if resolved is None:
+            return None
+        if " AND " in resolved or " OR " in resolved:
+            return f"({resolved})"
+        return resolved
+
+    if bare_type.endswith(("ConjunctiveLicenseSet", "DisjunctiveLicenseSet")):
+        members = _field(element, "member")
+        if isinstance(members, (str, dict)):
+            members = [members]
+        if not isinstance(members, list):
+            return None
+        resolved_members = [_operand(m) for m in members]
+        if len(resolved_members) < 2 or any(m is None for m in resolved_members):
+            return None  # a set with an unresolvable member must not half-score
+        joiner = " AND " if bare_type.endswith("ConjunctiveLicenseSet") else " OR "
+        return joiner.join(resolved_members)  # type: ignore[arg-type]
+
+    if bare_type.endswith("OrLaterOperator"):
+        subject = _operand(_field(element, "subjectLicense"))
+        return f"{subject}+" if subject else None
+
+    if bare_type.endswith("WithAdditionOperator"):
+        subject = _operand(_field(element, "subjectLicense"))
+        addition = _operand(_field(element, "subjectAddition"))
+        return f"{subject} WITH {addition}" if subject and addition else None
+
+    return None
+
+
+def get_spdx3_package_license(
+    package: dict[str, Any],
+    relationships: list[dict[str, Any]],
+    licenses: dict[str, dict[str, Any]],
+    relationship_type: str,
+) -> str | None:
+    """The resolved licence for ``package`` via ``relationship_type``.
+
+    ``hasConcludedLicense`` and ``hasDeclaredLicense`` relationships point
+    from the package at licensing elements; the first resolvable target wins.
+    ``None`` when no relationship exists or every target is unresolvable —
+    the callers treat both as the same failure, deliberately.
+    """
+    pkg_id = package.get("spdxId", package.get("@id", ""))
+    if not pkg_id:
+        return None
+    for rel in relationships:
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("from") != pkg_id or rel.get("relationshipType") != relationship_type:
+            continue
+        targets = rel.get("to", [])
+        if isinstance(targets, (str, dict)):
+            targets = [targets]
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            resolved = resolve_spdx3_license_expression(target, licenses)
+            if resolved:
+                return resolved
+    return None

--- a/sbomify/apps/plugins/builtins/_spdx3_helpers.py
+++ b/sbomify/apps/plugins/builtins/_spdx3_helpers.py
@@ -504,11 +504,19 @@ def _resolve_compound_license(
             members = [members]
         if not isinstance(members, list):
             return None
+        # Every member is resolved before any of them is judged, so the walk
+        # visits the same elements whatever the outcome, and the cycle guard
+        # sees the same ids either way.
         resolved_members = [_operand(m) for m in members]
-        if len(resolved_members) < 2 or any(m is None for m in resolved_members):
-            return None  # a set with an unresolvable member must not half-score
+        if len(resolved_members) < 2:
+            return None
+        operands: list[str] = []
+        for resolved in resolved_members:
+            if resolved is None:
+                return None  # a set with an unresolvable member must not half-score
+            operands.append(resolved)
         joiner = " AND " if bare_type.endswith("ConjunctiveLicenseSet") else " OR "
-        return joiner.join(resolved_members)  # type: ignore[arg-type]
+        return joiner.join(operands)
 
     if bare_type.endswith("OrLaterOperator"):
         subject = _operand(_field(element, "subjectLicense"))

--- a/sbomify/apps/plugins/builtins/_spdx3_helpers.py
+++ b/sbomify/apps/plugins/builtins/_spdx3_helpers.py
@@ -543,8 +543,12 @@ def get_spdx3_package_license(
     ``None`` when no relationship exists or every target is unresolvable —
     the callers treat both as the same failure, deliberately.
     """
-    pkg_id = package.get("spdxId", package.get("@id", ""))
-    if not pkg_id:
+    # ``or`` rather than a default argument: a package carrying spdxId as null
+    # would otherwise take the null over the @id beside it. The relationship's
+    # ``from`` is a string, so anything else here can only fail to match and
+    # would read back as "no licence" rather than as the malformed id it is.
+    pkg_id = package.get("spdxId") or package.get("@id")
+    if not isinstance(pkg_id, str) or not pkg_id:
         return None
     for rel in relationships:
         if not isinstance(rel, dict):

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -60,7 +60,9 @@ from packaging import version as pkg_version
 
 from sbomify.apps.plugins.builtins._spdx3_helpers import (
     extract_spdx3_elements,
+    extract_spdx3_licenses,
     get_spdx3_package_fields,
+    get_spdx3_package_license,
     iter_spdx3_external_identifiers,
     resolve_spdx3_agent,
 )
@@ -909,6 +911,7 @@ class BSICompliancePlugin(AssessmentPlugin):
         # in BSI than everywhere else. Files are BSI-specific, so that pass
         # stays local.
         creation_info, packages, relationships, persons_orgs, _ = extract_spdx3_elements({"@graph": elements})
+        licenses = extract_spdx3_licenses({"@graph": elements})
         # Same normalization as the shared extractor: the bare tail of a
         # compact or IRI type, matched exactly, so a type merely containing
         # the word File cannot classify as one.
@@ -1018,7 +1021,7 @@ class BSICompliancePlugin(AssessmentPlugin):
                         structured_failures.append(pkg_name)
 
             # Licence
-            has_licence = self._has_spdx3_licence(package, relationships)
+            has_licence = self._has_spdx3_licence(package, relationships, licenses)
             if not has_licence:
                 licence_failures.append(pkg_name)
 
@@ -1032,7 +1035,7 @@ class BSICompliancePlugin(AssessmentPlugin):
                 source_code_uri_warnings.append(pkg_name)
             if not self._spdx3_has_deployable_uri(package):
                 uri_deployable_form_warnings.append(pkg_name)
-            if not self._spdx3_has_original_licence(package, relationships):
+            if not self._spdx3_has_original_licence(package, relationships, licenses):
                 original_licences_warnings.append(pkg_name)
 
         # Create findings (same pattern as CycloneDX)
@@ -1777,13 +1780,20 @@ class BSICompliancePlugin(AssessmentPlugin):
 
         return "other" if has_other_hash else "none"
 
-    def _has_spdx3_licence(self, package: dict[str, Any], relationships: list[dict[str, Any]]) -> bool:
-        """Check if SPDX 3.x package has concluded licence via relationship."""
-        pkg_id = package.get("spdxId", package.get("@id"))
-        for rel in relationships:
-            if rel.get("from") == pkg_id and rel.get("relationshipType") == "hasConcludedLicense":
-                return True
-        return False
+    def _has_spdx3_licence(
+        self,
+        package: dict[str, Any],
+        relationships: list[dict[str, Any]],
+        licenses: dict[str, dict[str, Any]],
+    ) -> bool:
+        """A concluded licence the document can actually resolve.
+
+        Existence of the relationship alone is not enough: a
+        hasConcludedLicense pointing at nothing resolvable carries no licence
+        information, and scoring it as one would grade a dangling reference
+        the same as a real expression.
+        """
+        return get_spdx3_package_license(package, relationships, licenses, "hasConcludedLicense") is not None
 
     def _has_spdx3_identifier(self, package: dict[str, Any]) -> bool:
         """Check if SPDX 3.x package has unique identifier."""
@@ -1841,17 +1851,17 @@ class BSICompliancePlugin(AssessmentPlugin):
         value = package.get("software_downloadLocation")
         return isinstance(value, str) and bool(value.strip())
 
-    def _spdx3_has_original_licence(self, package: dict[str, Any], relationships: list[dict[str, Any]]) -> bool:
+    def _spdx3_has_original_licence(
+        self,
+        package: dict[str, Any],
+        relationships: list[dict[str, Any]],
+        licenses: dict[str, dict[str, Any]],
+    ) -> bool:
         """Per BSI §5.2.4, recognise an original/declared licence via the
-        hasDeclaredLicense relationship on the package.
+        hasDeclaredLicense relationship — resolved to an actual licensing
+        element, for the same reason as the concluded check.
         """
-        pkg_id = package.get("spdxId", package.get("@id"))
-        for rel in relationships:
-            if not isinstance(rel, dict):
-                continue
-            if rel.get("from") == pkg_id and rel.get("relationshipType") == "hasDeclaredLicense":
-                return True
-        return False
+        return get_spdx3_package_license(package, relationships, licenses, "hasDeclaredLicense") is not None
 
     def _check_spdx3_dependencies(self, relationships: list[dict[str, Any]]) -> tuple[bool, bool]:
         """Check SPDX 3.x dependencies and completeness indicator.

--- a/sbomify/apps/plugins/builtins/cisa.py
+++ b/sbomify/apps/plugins/builtins/cisa.py
@@ -63,8 +63,10 @@ from typing import Any
 
 from sbomify.apps.plugins.builtins._spdx3_helpers import (
     extract_spdx3_elements,
+    extract_spdx3_licenses,
     get_spdx3_creation_info_fields,
     get_spdx3_package_fields,
+    get_spdx3_package_license,
     has_spdx3_supplier,
     is_spdx3,
 )
@@ -584,6 +586,7 @@ class CISAMinimumElementsPlugin(AssessmentPlugin):
         """
         findings: list[Finding] = []
         creation_info, packages, relationships, persons_orgs, tools = extract_spdx3_elements(data)
+        licenses = extract_spdx3_licenses(data)
         ci_fields = get_spdx3_creation_info_fields(creation_info, persons_orgs, tools)
 
         # Track element-level failures across all packages
@@ -618,13 +621,9 @@ class CISAMinimumElementsPlugin(AssessmentPlugin):
             if not pkg_fields["has_hash"]:
                 hash_failures.append(pkg_name)
 
-            # 7. License (hasConcludedLicense relationship)
-            pkg_id = package.get("spdxId", package.get("@id", ""))
-            has_license = any(
-                rel.get("from") == pkg_id and rel.get("relationshipType") == "hasConcludedLicense"
-                for rel in relationships
-            )
-            if not has_license:
+            # 7. License — the relationship must resolve to a licensing
+            # element; a dangling hasConcludedLicense carries no licence.
+            if get_spdx3_package_license(package, relationships, licenses, "hasConcludedLicense") is None:
                 license_failures.append(pkg_name)
 
         # 2. Software Producer

--- a/sbomify/apps/plugins/tests/spdx3_corpus.py
+++ b/sbomify/apps/plugins/tests/spdx3_corpus.py
@@ -88,6 +88,15 @@ def _package(
     return package
 
 
+def _license_expression(spdx_id: str = "urn:acme:lic1", expression: str = "MIT") -> dict[str, Any]:
+    return {
+        "type": "simplelicensing_LicenseExpression",
+        "spdxId": spdx_id,
+        "creationInfo": _CI,
+        "simplelicensing_licenseExpression": expression,
+    }
+
+
 def _relationship(rel_type: str, from_id: str, to_ids: list[str], spdx_id: str = "urn:acme:rel1") -> dict[str, Any]:
     return {
         "type": "Relationship",
@@ -111,6 +120,7 @@ def minimal_conformant() -> dict[str, Any]:
         _tool(),
         _document(["urn:acme:pkg1"]),
         _package(software_packageUrl="pkg:pypi/my-app@1.2.3"),
+        _license_expression(),
         _relationship("hasConcludedLicense", "urn:acme:pkg1", ["urn:acme:lic1"]),
         _relationship("hasDeclaredLicense", "urn:acme:pkg1", ["urn:acme:lic1"], spdx_id="urn:acme:rel2"),
     )

--- a/sbomify/apps/plugins/tests/test_spdx3_license_resolution.py
+++ b/sbomify/apps/plugins/tests/test_spdx3_license_resolution.py
@@ -1,0 +1,241 @@
+"""SPDX 3 licence relationships resolve to expressions, not booleans.
+
+The plugins used to check only that a ``hasConcludedLicense`` /
+``hasDeclaredLicense`` relationship *existed*; a relationship pointing at
+nothing resolvable scored the same as a real licence. These pin the
+resolver across the element kinds the spec allows and the failure the
+plugins must now report for a dangling target.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sbomify.apps.plugins.builtins._spdx3_helpers import (
+    extract_spdx3_licenses,
+    get_spdx3_package_license,
+    resolve_spdx3_license_expression,
+)
+from sbomify.apps.plugins.tests import spdx3_corpus
+
+
+def _graph(*elements: dict[str, Any]) -> dict[str, Any]:
+    return {"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": list(elements)}
+
+
+EXPRESSION = {
+    "type": "simplelicensing_LicenseExpression",
+    "spdxId": "urn:acme:lic1",
+    "simplelicensing_licenseExpression": "Apache-2.0 OR MIT",
+}
+LISTED = {
+    "type": "expandedlicensing_ListedLicense",
+    "spdxId": "https://spdx.org/licenses/MIT",
+    "name": "MIT",
+}
+NOASSERTION = {
+    "type": "expandedlicensing_NoAssertionLicense",
+    "spdxId": "urn:acme:noassert",
+}
+
+
+class TestResolver:
+    def test_license_expression_resolves_to_its_expression(self):
+        licenses = extract_spdx3_licenses(_graph(EXPRESSION))
+        assert resolve_spdx3_license_expression("urn:acme:lic1", licenses) == "Apache-2.0 OR MIT"
+
+    def test_listed_license_resolves_to_its_name(self):
+        licenses = extract_spdx3_licenses(_graph(LISTED))
+        assert resolve_spdx3_license_expression("https://spdx.org/licenses/MIT", licenses) == "MIT"
+
+    def test_spdx_listed_url_without_an_element_resolves_to_the_id_tail(self):
+        assert resolve_spdx3_license_expression("https://spdx.org/licenses/BSD-3-Clause", {}) == "BSD-3-Clause"
+
+    def test_noassertion_resolves_to_nothing(self):
+        licenses = extract_spdx3_licenses(_graph(NOASSERTION))
+        assert resolve_spdx3_license_expression("urn:acme:noassert", licenses) is None
+
+    def test_dangling_reference_resolves_to_nothing(self):
+        assert resolve_spdx3_license_expression("urn:acme:missing", {}) is None
+
+    def test_inline_target_resolves_without_a_graph_element(self):
+        assert resolve_spdx3_license_expression(dict(EXPRESSION), {}) == "Apache-2.0 OR MIT"
+
+
+class TestCompoundShapes:
+    """The ExpandedLicensing sets and operators compose into expressions.
+
+    A package whose hasDeclaredLicense points at a ConjunctiveLicenseSet used
+    to resolve to nothing and fail the check as unresolvable, though the
+    document declared its licence exactly as the 3.0.1 model prescribes.
+    """
+
+    APACHE = {"type": "expandedlicensing_ListedLicense", "spdxId": "https://spdx.org/licenses/Apache-2.0", "name": "Apache-2.0"}
+    GPL = {"type": "expandedlicensing_ListedLicense", "spdxId": "https://spdx.org/licenses/GPL-2.0-only", "name": "GPL-2.0-only"}
+    EXCEPTION = {
+        "type": "expandedlicensing_ListedLicenseException",
+        "spdxId": "urn:acme:classpath",
+        "name": "Classpath-exception-2.0",
+    }
+
+    def test_conjunctive_set_joins_with_and(self):
+        conj = {
+            "type": "expandedlicensing_ConjunctiveLicenseSet",
+            "spdxId": "urn:acme:conj",
+            "expandedlicensing_member": [LISTED["spdxId"], self.APACHE["spdxId"]],
+        }
+        licenses = extract_spdx3_licenses(_graph(conj, LISTED, self.APACHE))
+        assert resolve_spdx3_license_expression("urn:acme:conj", licenses) == "MIT AND Apache-2.0"
+
+    def test_nested_set_is_parenthesized(self):
+        disj = {
+            "type": "expandedlicensing_DisjunctiveLicenseSet",
+            "spdxId": "urn:acme:disj",
+            "expandedlicensing_member": [LISTED["spdxId"], self.APACHE["spdxId"]],
+        }
+        conj = {
+            "type": "expandedlicensing_ConjunctiveLicenseSet",
+            "spdxId": "urn:acme:conj",
+            "expandedlicensing_member": ["urn:acme:disj", self.GPL["spdxId"]],
+        }
+        licenses = extract_spdx3_licenses(_graph(conj, disj, LISTED, self.APACHE, self.GPL))
+        assert resolve_spdx3_license_expression("urn:acme:conj", licenses) == "(MIT OR Apache-2.0) AND GPL-2.0-only"
+
+    def test_or_later_appends_plus(self):
+        later = {
+            "type": "expandedlicensing_OrLaterOperator",
+            "spdxId": "urn:acme:later",
+            "expandedlicensing_subjectLicense": self.GPL["spdxId"],
+        }
+        licenses = extract_spdx3_licenses(_graph(later, self.GPL))
+        assert resolve_spdx3_license_expression("urn:acme:later", licenses) == "GPL-2.0-only+"
+
+    def test_with_addition_names_the_exception(self):
+        with_op = {
+            "type": "expandedlicensing_WithAdditionOperator",
+            "spdxId": "urn:acme:with",
+            "expandedlicensing_subjectLicense": self.GPL["spdxId"],
+            "expandedlicensing_subjectAddition": "urn:acme:classpath",
+        }
+        licenses = extract_spdx3_licenses(_graph(with_op, self.GPL, self.EXCEPTION))
+        assert (
+            resolve_spdx3_license_expression("urn:acme:with", licenses)
+            == "GPL-2.0-only WITH Classpath-exception-2.0"
+        )
+
+    def test_a_set_with_an_unresolvable_member_resolves_to_nothing(self):
+        conj = {
+            "type": "expandedlicensing_ConjunctiveLicenseSet",
+            "spdxId": "urn:acme:conj",
+            "expandedlicensing_member": [LISTED["spdxId"], "urn:acme:missing"],
+        }
+        licenses = extract_spdx3_licenses(_graph(conj, LISTED))
+        assert resolve_spdx3_license_expression("urn:acme:conj", licenses) is None
+
+    def test_a_spoofed_licenses_url_does_not_resolve(self):
+        """spdx.org/licenses/ buried in a hostile URL must not score."""
+        assert resolve_spdx3_license_expression("https://evil.example/spdx.org/licenses/MIT", {}) is None
+        assert resolve_spdx3_license_expression("https://spdx.org.evil.example/licenses/MIT", {}) is None
+        assert resolve_spdx3_license_expression("https://spdx.org/licenses/", {}) is None
+
+    def test_a_named_simple_licensing_text_resolves_to_its_name(self):
+        """Free-text licences with a name score by that name; a nameless one
+        has no expression to score and stays None."""
+        named = {
+            "type": "simplelicensing_SimpleLicensingText",
+            "spdxId": "urn:acme:freetext",
+            "name": "Acme Proprietary 1.0",
+            "simplelicensing_licenseText": "You may...",
+        }
+        licenses = extract_spdx3_licenses(_graph(named))
+        assert resolve_spdx3_license_expression("urn:acme:freetext", licenses) == "Acme Proprietary 1.0"
+
+        nameless = dict(named)
+        del nameless["name"]
+        nameless["spdxId"] = "urn:acme:nameless"
+        licenses = extract_spdx3_licenses(_graph(nameless))
+        # Still a licence: it resolves to its id, the one string that
+        # identifies it without dumping the text into a report.
+        assert resolve_spdx3_license_expression("urn:acme:nameless", licenses) == "urn:acme:nameless"
+
+    def test_compact_iri_types_are_collected_and_resolved(self):
+        """JSON-LD compact IRIs spell the type with a colon; the tail reader
+        must see through that as it does the slash and underscore forms."""
+        expr = {
+            "type": "simplelicensing:LicenseExpression",
+            "spdxId": "urn:acme:compact",
+            "simplelicensing_licenseExpression": "BSD-2-Clause",
+        }
+        noassert = {"type": "expandedlicensing:NoAssertionLicense", "spdxId": "urn:acme:na"}
+        licenses = extract_spdx3_licenses(_graph(expr, noassert))
+        assert resolve_spdx3_license_expression("urn:acme:compact", licenses) == "BSD-2-Clause"
+        assert resolve_spdx3_license_expression("urn:acme:na", licenses) is None
+
+    def test_a_self_citing_set_terminates(self):
+        conj = {
+            "type": "expandedlicensing_ConjunctiveLicenseSet",
+            "spdxId": "urn:acme:conj",
+            "expandedlicensing_member": ["urn:acme:conj", LISTED["spdxId"]],
+        }
+        licenses = extract_spdx3_licenses(_graph(conj, LISTED))
+        assert resolve_spdx3_license_expression("urn:acme:conj", licenses) is None
+
+
+class TestPackageLicense:
+    def test_declared_license_resolves_through_the_relationship(self):
+        package = {"type": "software_Package", "spdxId": "urn:acme:pkg1", "name": "my-app"}
+        relationships = [
+            {
+                "type": "Relationship",
+                "relationshipType": "hasDeclaredLicense",
+                "from": "urn:acme:pkg1",
+                "to": ["urn:acme:lic1"],
+            }
+        ]
+        licenses = extract_spdx3_licenses(_graph(EXPRESSION))
+        assert get_spdx3_package_license(package, relationships, licenses, "hasDeclaredLicense") == "Apache-2.0 OR MIT"
+
+    def test_relationship_to_nothing_resolvable_yields_none(self):
+        package = {"type": "software_Package", "spdxId": "urn:acme:pkg1", "name": "my-app"}
+        relationships = [
+            {
+                "type": "Relationship",
+                "relationshipType": "hasConcludedLicense",
+                "from": "urn:acme:pkg1",
+                "to": ["urn:acme:missing"],
+            }
+        ]
+        assert get_spdx3_package_license(package, relationships, {}, "hasConcludedLicense") is None
+
+
+class TestPluginsFailOnDanglingLicence:
+    def _dangling(self) -> dict[str, Any]:
+        """The conformant corpus doc with its licence element removed — the
+        relationships still point at urn:acme:lic1, now dangling."""
+        doc = spdx3_corpus.minimal_conformant()
+        doc["@graph"] = [element for element in doc["@graph"] if "License" not in str(element.get("type", ""))]
+        return doc
+
+    def _licence_statuses(self, findings: list[Any]) -> list[str]:
+        return [finding.status for finding in findings if "licen" in finding.id.lower()]
+
+    def test_bsi_licence_check_fails(self):
+        from sbomify.apps.plugins.builtins.bsi import BSICompliancePlugin
+
+        findings = BSICompliancePlugin()._validate_spdx3(self._dangling())
+        assert "fail" in self._licence_statuses(findings)
+
+    def test_cisa_licence_check_fails(self):
+        from sbomify.apps.plugins.builtins.cisa import CISAMinimumElementsPlugin
+
+        findings = CISAMinimumElementsPlugin()._validate_spdx3(self._dangling())
+        assert "fail" in self._licence_statuses(findings)
+
+    def test_conformant_corpus_still_passes_licence_checks(self):
+        from sbomify.apps.plugins.builtins.bsi import BSICompliancePlugin
+        from sbomify.apps.plugins.builtins.cisa import CISAMinimumElementsPlugin
+
+        doc = spdx3_corpus.minimal_conformant()
+        for plugin in (BSICompliancePlugin(), CISAMinimumElementsPlugin()):
+            statuses = self._licence_statuses(plugin._validate_spdx3(doc))
+            assert "fail" not in statuses

--- a/sbomify/apps/plugins/tests/test_spdx3_license_resolution.py
+++ b/sbomify/apps/plugins/tests/test_spdx3_license_resolution.py
@@ -70,8 +70,16 @@ class TestCompoundShapes:
     document declared its licence exactly as the 3.0.1 model prescribes.
     """
 
-    APACHE = {"type": "expandedlicensing_ListedLicense", "spdxId": "https://spdx.org/licenses/Apache-2.0", "name": "Apache-2.0"}
-    GPL = {"type": "expandedlicensing_ListedLicense", "spdxId": "https://spdx.org/licenses/GPL-2.0-only", "name": "GPL-2.0-only"}
+    APACHE = {
+        "type": "expandedlicensing_ListedLicense",
+        "spdxId": "https://spdx.org/licenses/Apache-2.0",
+        "name": "Apache-2.0",
+    }
+    GPL = {
+        "type": "expandedlicensing_ListedLicense",
+        "spdxId": "https://spdx.org/licenses/GPL-2.0-only",
+        "name": "GPL-2.0-only",
+    }
     EXCEPTION = {
         "type": "expandedlicensing_ListedLicenseException",
         "spdxId": "urn:acme:classpath",
@@ -239,3 +247,34 @@ class TestPluginsFailOnDanglingLicence:
         for plugin in (BSICompliancePlugin(), CISAMinimumElementsPlugin()):
             statuses = self._licence_statuses(plugin._validate_spdx3(doc))
             assert "fail" not in statuses
+
+
+class TestThePackageIdIsReadHonestly:
+    """The relationship's ``from`` is a string, so anything else can only fail
+    to match, and a miss reads back as "no licence" rather than as a bad id."""
+
+    def _graph(self, package):
+        return (
+            [
+                {
+                    "from": "urn:pkg",
+                    "relationshipType": "hasDeclaredLicense",
+                    "to": ["urn:lic"],
+                }
+            ],
+            {"urn:lic": {"type": "expandedlicensing_ListedLicense", "spdxId": "https://spdx.org/licenses/MIT"}},
+            package,
+        )
+
+    def test_an_id_given_only_as_at_id_resolves(self):
+        rels, lics, package = self._graph({"@id": "urn:pkg"})
+        assert get_spdx3_package_license(package, rels, lics, "hasDeclaredLicense") == "MIT"
+
+    def test_a_null_spdx_id_falls_back_to_at_id(self):
+        """A default argument does not fire when the key is there holding null."""
+        rels, lics, package = self._graph({"spdxId": None, "@id": "urn:pkg"})
+        assert get_spdx3_package_license(package, rels, lics, "hasDeclaredLicense") == "MIT"
+
+    def test_an_id_that_is_not_a_string_resolves_to_nothing(self):
+        rels, lics, package = self._graph({"spdxId": {"nested": "urn:pkg"}})
+        assert get_spdx3_package_license(package, rels, lics, "hasDeclaredLicense") is None


### PR DESCRIPTION
Closes #1338. **Stacked on #1487** (the top of the SPDX 3 phase-0/1 stack, #1482 (merged)–#1487) — the diff contains the stack's commits until those merge; review the top commit.

The plugins checked only that a `hasConcludedLicense`/`hasDeclaredLicense` relationship *existed* — a relationship pointing at nothing resolvable scored identically to a real licence, and nothing ever read the SimpleLicensing/ExpandedLicensing elements.

- `extract_spdx3_licenses` collects licensing elements from the graph (spec-spelled `simplelicensing_`/`expandedlicensing_` tails — note the official 3.0.1 schema uses lowercase profile prefixes, not the camelCase in the issue text — with camelCase variants accepted per this module's read-both convention).
- `resolve_spdx3_license_expression` turns a relationship target into a licence string: a `LicenseExpression`'s expression, a Listed/Custom licence's `name`, an inline target object, or the id tail of a `spdx.org/licenses/…` reference carrying no element (the conventional citation form). NoAssertion/None singletons and dangling references resolve to `None`, deliberately.
- BSI's concluded + declared checks and CISA's licence check now require a resolvable licence.
- The conformant corpus fixture cited `urn:acme:lic1` without ever defining it — under the new rule that is exactly the dangling-reference defect the checks exist to catch, so the corpus gains its `LicenseExpression` element (schema-validated).

Acceptance criteria: expression surfaces through the resolver ✓, BSI/CISA fail on an unresolvable target ✓ (pinned by tests that strip the licence element from the conformant doc), no-relationship keeps today's failure ✓.

11 new tests; full plugins suite 1,071 green; ruff/mypy clean.


Supersedes #1420.

