### PR TITLE
fix(auth): the authorize URL stops relying on + meaning a space

### DIFF
--- a/sbomify/apps/core/adapters.py
+++ b/sbomify/apps/core/adapters.py
@@ -2,15 +2,47 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import parse_qsl, quote, urlencode
 
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
+
+
+class SpaceEncodedOAuth2Client(OAuth2Client):  # type: ignore[misc]
+    """An authorize URL whose spaces are ``%20``, not ``+``.
+
+    ``urlencode`` writes a space as ``+``, which reads back as a space only
+    under form-urlencoding rules. A generic URI reader follows RFC 3986,
+    where ``+`` is a literal character, so any hop that decodes this query
+    and re-encodes it conservatively escapes the scope separators to
+    ``%2B``. Keycloak then reads all three scopes as one unknown scope
+    named ``openid+email+profile`` and refuses the login.
+
+    That is the shape of the failures: the value is correct when it leaves
+    here, most logins work, and a minority arrive escaped. ``%20`` means a
+    space to both readers and comes back unchanged from a decode/encode
+    round trip, so the ambiguity the mangling relies on is gone.
+
+    Nothing else about the URL moves. A literal ``+``, which a PKCE
+    challenge can contain, is ``%2B`` either way.
+    """
+
+    def get_redirect_url(self, authorization_url: str, scope: Any, extra_params: dict[str, Any]) -> str:
+        url: str = super().get_redirect_url(authorization_url, scope, extra_params)
+        base, separator, query = url.partition("?")
+        if not separator:
+            return url
+        # Re-encode what the base class built rather than rebuilding the
+        # parameters here, so a parameter allauth adds later still travels.
+        pairs = parse_qsl(query, keep_blank_values=True)
+        return f"{base}?{urlencode(pairs, quote_via=quote)}"
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):  # type: ignore[misc]

--- a/sbomify/apps/core/apps.py
+++ b/sbomify/apps/core/apps.py
@@ -20,3 +20,14 @@ class CoreConfig(AppConfig):
         from sbomify.apps.core.posthog_service import shutdown
 
         atexit.register(shutdown)
+
+        # allauth builds the OpenID Connect provider's URLs from a fixed
+        # adapter class, so client_class is the seam it leaves for choosing a
+        # client. Pointing it at ours is what stops the authorize URL spelling
+        # its scope separators with a character that only means a space under
+        # form-urlencoding rules.
+        from allauth.socialaccount.providers.openid_connect.views import OpenIDConnectOAuth2Adapter
+
+        from sbomify.apps.core.adapters import SpaceEncodedOAuth2Client
+
+        OpenIDConnectOAuth2Adapter.client_class = SpaceEncodedOAuth2Client

--- a/sbomify/apps/core/tests/test_oidc_scope_encoding.py
+++ b/sbomify/apps/core/tests/test_oidc_scope_encoding.py
@@ -1,0 +1,79 @@
+"""The authorize URL must not depend on ``+`` meaning a space.
+
+Keycloak rejected a minority of logins with ``Invalid scopes:
+openid+email+profile``: the separators reached it escaped, so all three
+scopes arrived as one token and the user landed back on the login page.
+The value is correct when it leaves us, which is why most logins work, so
+these pin the property that removes the ambiguity rather than the hop that
+exploits it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qsl, urlparse
+
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
+from allauth.socialaccount.providers.openid_connect.views import OpenIDConnectOAuth2Adapter
+
+from sbomify.apps.core.adapters import SpaceEncodedOAuth2Client
+
+AUTHORIZE = "https://kc.example.test/realms/sbomify/protocol/openid-connect/auth"
+SCOPE = ["openid", "email", "profile"]
+
+
+def _client(cls: type) -> Any:
+    return cls(
+        None,
+        "sbomify",
+        "secret",
+        "POST",
+        "https://kc.example.test/realms/sbomify/protocol/openid-connect/token",
+        "https://app.example.test/accounts/oidc/keycloak/login/callback/",
+    )
+
+
+def _query(url: str) -> dict[str, str]:
+    return dict(parse_qsl(urlparse(url).query, keep_blank_values=True))
+
+
+class TestScopeSeparatorsSurviveAReEncode:
+    def test_the_separator_is_percent_encoded(self) -> None:
+        url = _client(SpaceEncodedOAuth2Client).get_redirect_url(AUTHORIZE, SCOPE, {})
+
+        query = urlparse(url).query
+        assert "%20" in query
+        # A bare + is the ambiguity: a reader following RFC 3986 sees a
+        # literal character and re-encodes it to %2B, which is the failure.
+        assert "+" not in query
+        assert set(_query(url)["scope"].split()) == set(SCOPE)
+
+    def test_the_scopes_still_arrive_as_three(self) -> None:
+        """What a strict reader and a form reader each make of the value."""
+        url = _client(SpaceEncodedOAuth2Client).get_redirect_url(AUTHORIZE, SCOPE, {})
+        raw = _query(url)["scope"]
+
+        assert len(raw.split()) == 3
+        assert "+" not in raw
+
+    def test_nothing_else_about_the_url_moves(self) -> None:
+        extra = {"prompt": "login", "code_challenge_method": "S256"}
+        ours = _client(SpaceEncodedOAuth2Client).get_redirect_url(AUTHORIZE, SCOPE, extra)
+        theirs = _client(OAuth2Client).get_redirect_url(AUTHORIZE, SCOPE, extra)
+
+        assert urlparse(ours)._replace(query="") == urlparse(theirs)._replace(query="")
+        ours_params, theirs_params = _query(ours), _query(theirs)
+        # Scope order comes from a set, so compare it as one.
+        assert set(ours_params.pop("scope").split()) == set(theirs_params.pop("scope").split())
+        assert ours_params == theirs_params
+
+    def test_a_literal_plus_is_still_a_plus(self) -> None:
+        """A PKCE challenge is base64 and can carry a real +."""
+        url = _client(SpaceEncodedOAuth2Client).get_redirect_url(
+            AUTHORIZE, SCOPE, {"code_challenge": "E9Melhoa2Ow_iaL3Ph1O+Cg"}
+        )
+
+        assert _query(url)["code_challenge"] == "E9Melhoa2Ow_iaL3Ph1O+Cg"
+
+    def test_the_keycloak_provider_uses_this_client(self) -> None:
+        assert OpenIDConnectOAuth2Adapter.client_class is SpaceEncodedOAuth2Client


### PR DESCRIPTION
Closes #1458.

## What was happening

Keycloak logged `error="invalid_request", reason="Invalid scopes: openid+email+profile"` on a minority of logins, and the affected user landed back on the login page with nothing to act on.

The `+` is the whole story, but not in the direction the issue first read it. Our value leaves correct: allauth builds the authorize URL with a single `urlencode`, so the scopes go out as `scope=openid+email+profile`. Keycloak decodes that fine, which is exactly why most logins succeed and why this was never reproducible on demand.

`+` means a space only under form-urlencoding rules. A reader following RFC 3986 sees a literal plus in a query string, and a hop that decodes this URL and re-encodes it conservatively has to escape that plus to `%2B`. Keycloak then decodes one scope named `openid+email+profile`, does not recognise it, and refuses the request. The scope order drifting between failures fits the same reading: allauth joins `set(scope)`, so the order is per-process, meaning the mangled URLs were ours and were correct when generated.

## The fix

The authorize URL writes its spaces as `%20`. Every reader agrees on what that means, and unlike `+` it survives a decode and re-encode unchanged, so the ambiguity the mangling depends on is no longer in the URL.

The change is one hop away from allauth's own output. Verified in a shell, the two query strings differ in exactly one respect:

```
allauth: scope=openid+email+profile&code_challenge=E9Melhoa2Ow_iaL3Ph1O%2BCg&redirect_uri=https%3A%2F%2F...
ours   : scope=openid%20email%20profile&code_challenge=E9Melhoa2Ow_iaL3Ph1O%2BCg&redirect_uri=https%3A%2F%2F...
```

A literal `+`, which a PKCE challenge can contain, is `%2B` on both sides.

## How it is wired

`OAuth2Adapter.client_class` is the seam allauth leaves for choosing a client, and the OpenID Connect provider builds its URLs from a fixed adapter class, so `CoreConfig.ready()` points that attribute at ours. `SpaceEncodedOAuth2Client` calls the base implementation and re-encodes the query it produced, rather than rebuilding the parameters, so a parameter allauth adds in a later release still travels.

## Tests

Five, in `test_oidc_scope_encoding.py`: the separator is percent-encoded and no bare `+` remains, the scopes still read as three, the URL is parameter-for-parameter equal to allauth's, a literal `+` stays a plus, and the Keycloak provider is actually using this client. Full core suite green (3567 passed).

## What this does not settle

The hop doing the re-encoding is still unidentified, and this closes the failure without naming it. That is deliberate: the ambiguity is ours to remove and costs six lines, while reproducing a minority-path rewrite that happens outside our infrastructure is open-ended. If `Invalid scopes` entries continue after this deploys, the remaining candidate is a hop that escapes `%` as well, and the Keycloak log line will say so.
