### PR TITLE
feat(scanning): Dependency Track reads SPDX through a derived CycloneDX copy

### DIFF
--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -34,7 +34,6 @@ from sbomify.apps.sboms.conversion import (
     ConversionFailed,
     ConversionUnavailable,
     convert_sbom,
-    converter_path,
 )
 from sbomify.logging import getLogger
 
@@ -150,11 +149,12 @@ class DependencyTrackPlugin(AssessmentPlugin):
         # against it (ADR-004). The conversion itself happens at the upload
         # below, not here: this runs again on every poll, and converting each
         # time would spend a subprocess to learn what it already knew.
+        # Whether a converter exists is deliberately not asked here. This runs
+        # again on every poll of a scan already in flight, and a worker without
+        # the binary would answer a poll with a skip instead of the findings the
+        # upload is waiting for. Availability is settled where it is acted on,
+        # at the upload below, which runs once.
         needs_conversion = not self._validate_cyclonedx(sbom_bytes)
-        if needs_conversion and converter_path() is None:
-            return self._create_unconvertible_result(
-                "this deployment has no converter installed to derive a CycloneDX copy"
-            )
 
         # Look up SBOM → Component → Team
         try:

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -488,7 +488,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
             return declared
         # SPDX 3 moved the version into CreationInfo, so the context is what
         # identifies the document without walking the graph.
-        if "spdx.org/rdf/3" in str(content.get("@context", "")):
+        if "spdx.org/rdf/3.0" in str(content.get("@context", "")):
             return "SPDX-3.0"
         return "unknown"
 

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -466,6 +466,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
         """
         try:
             content = json.loads(sbom_bytes.decode("utf-8"))
+            if not isinstance(content, dict):
+                # Valid JSON that is not an object, an array say, is not
+                # CycloneDX and must not raise on the way to saying so.
+                return False
             is_cyclonedx: bool = content.get("bomFormat") == "CycloneDX"
             return is_cyclonedx
         except (json.JSONDecodeError, UnicodeDecodeError):

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -14,6 +14,7 @@ Reference:
 """
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -486,11 +487,18 @@ class DependencyTrackPlugin(AssessmentPlugin):
         declared = content.get("spdxVersion")
         if isinstance(declared, str) and declared:
             return declared
-        # SPDX 3 moved the version into CreationInfo, so the context is what
-        # identifies the document without walking the graph.
-        if "spdx.org/rdf/3.0" in str(content.get("@context", "")):
-            return "SPDX-3.0"
-        return "unknown"
+        # SPDX 3 moved the version into CreationInfo, so the document is
+        # recognised by the shared detector rather than a string test here.
+        # Matching "3.0" alone sent a 3.1 document to the unconvertible skip
+        # at the gate above, though the converter would have read it.
+        from sbomify.apps.plugins.builtins._spdx3_helpers import is_spdx3
+
+        if not is_spdx3(content):
+            return "unknown"
+        # The context carries the line, so a 3.1 document is labelled 3.1
+        # rather than flattened onto 3.0 in the provenance we record.
+        match = re.search(r"spdx\.org/rdf/(3\.\d+)", str(content.get("@context", "")))
+        return f"SPDX-{match.group(1)}" if match else "SPDX-3.0"
 
     def _create_unconvertible_result(self, reason: str) -> AssessmentResult:
         """A document Dependency Track cannot read and we cannot convert either.

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -155,6 +155,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
         # upload is waiting for. Availability is settled where it is acted on,
         # at the upload below, which runs once.
         needs_conversion = not self._validate_cyclonedx(sbom_bytes)
+        if needs_conversion and self._source_format_label(sbom_bytes) == "unknown":
+            # Neither CycloneDX nor SPDX, so there is nothing to convert from,
+            # and that is knowable without a database round trip.
+            return self._create_unconvertible_result("the document is neither CycloneDX nor SPDX")
 
         # Look up SBOM → Component → Team
         try:

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -29,6 +29,13 @@ from sbomify.apps.plugins.sdk.results import (
     Finding,
     PluginMetadata,
 )
+from sbomify.apps.sboms.conversion import (
+    CYCLONEDX_1_6_JSON,
+    ConversionFailed,
+    ConversionUnavailable,
+    convert_sbom,
+    converter_path,
+)
 from sbomify.logging import getLogger
 
 logger = getLogger(__name__)
@@ -137,19 +144,16 @@ class DependencyTrackPlugin(AssessmentPlugin):
             logger.error(f"[DT] Failed to read SBOM file: {e}")
             return self._create_error_result(f"Failed to read SBOM: {e}")
 
-        # Validate CycloneDX format (DT does not support SPDX).
-        # Non-CycloneDX SBOMs aren't an error — DT simply can't process them.
-        # Return a skipped result so the UI shows "not applicable" rather than
-        # a hard error finding for a format choice the user made deliberately.
-        if not self._validate_cyclonedx(sbom_bytes):
-            return self.create_skipped_result(
-                finding_id="dependency-track:unsupported-format",
-                title="Format Not Supported",
-                description=(
-                    "Dependency Track only supports CycloneDX format. "
-                    "This SBOM appears to be SPDX or an unrecognized format — "
-                    "vulnerability scanning was skipped."
-                ),
+        # Dependency Track reads CycloneDX only, so a document in any other
+        # format is uploaded as a derived CycloneDX copy rather than skipped.
+        # The stored artifact is never modified and the findings come back
+        # against it (ADR-004). The conversion itself happens at the upload
+        # below, not here: this runs again on every poll, and converting each
+        # time would spend a subprocess to learn what it already knew.
+        needs_conversion = not self._validate_cyclonedx(sbom_bytes)
+        if needs_conversion and converter_path() is None:
+            return self._create_unconvertible_result(
+                "this deployment has no converter installed to derive a CycloneDX copy"
             )
 
         # Look up SBOM → Component → Team
@@ -216,6 +220,14 @@ class DependencyTrackPlugin(AssessmentPlugin):
             # First scan for this SBOM against this DT server. Upload bytes,
             # discover the new DT project version UUID, persist the row, set
             # the initial tag set, then raise RetryLater to poll for results.
+            if needs_conversion:
+                try:
+                    sbom_bytes = convert_sbom(sbom_bytes, CYCLONEDX_1_6_JSON)
+                except (ConversionUnavailable, ConversionFailed) as exc:
+                    logger.warning(f"[DT] SBOM {sbom_id} could not be converted to CycloneDX: {exc}")
+                    return self._create_unconvertible_result(str(exc))
+                logger.info(f"[DT] Uploading SBOM {sbom_id} as a derived CycloneDX copy")
+
             try:
                 version_row = self._upload_new_sbom_version(
                     sbom=sbom,
@@ -283,6 +295,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 sbom_id=sbom_id,
                 project_name=project_name,
                 current_release_names=current_release_names,
+                converted_from=self._source_format_label(sbom_bytes) if needs_conversion else None,
             )
         except RetryLaterError:
             raise
@@ -454,6 +467,40 @@ class DependencyTrackPlugin(AssessmentPlugin):
         except (json.JSONDecodeError, UnicodeDecodeError):
             return False
 
+    def _source_format_label(self, sbom_bytes: bytes) -> str:
+        """What the stored document calls itself, recorded on a converted scan."""
+        try:
+            content = json.loads(sbom_bytes.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return "unknown"
+        if not isinstance(content, dict):
+            return "unknown"
+        declared = content.get("spdxVersion")
+        if isinstance(declared, str) and declared:
+            return declared
+        # SPDX 3 moved the version into CreationInfo, so the context is what
+        # identifies the document without walking the graph.
+        if "spdx.org/rdf/3" in str(content.get("@context", "")):
+            return "SPDX-3.0"
+        return "unknown"
+
+    def _create_unconvertible_result(self, reason: str) -> AssessmentResult:
+        """A document Dependency Track cannot read and we cannot convert either.
+
+        Still not an error. The format is a choice the uploader made and the
+        artifact may be perfectly valid, so this stays the skip it has always
+        been, now carrying why no conversion happened.
+        """
+        return self.create_skipped_result(
+            finding_id="dependency-track:unsupported-format",
+            title="Format Not Supported",
+            description=(
+                "Dependency Track only supports CycloneDX format, and this SBOM could not be "
+                "converted to CycloneDX, so vulnerability scanning was skipped."
+            ),
+            extra_metadata={"conversion_error": reason[:500]},
+        )
+
     def _team_has_dt_enabled(self, team: Any) -> bool:
         """Check if team has the dependency-track plugin enabled.
 
@@ -523,6 +570,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
         sbom_id: str,
         project_name: str,
         current_release_names: list[str],
+        converted_from: str | None = None,
     ) -> AssessmentResult:
         """Poll DT for vulnerability results using the stored per-SBOM version UUID.
 
@@ -615,6 +663,9 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 "dt_project_version": version_row.dt_project_version,
                 "dt_project_release_tags": sorted(set(current_release_names)),
                 "metrics": metrics,
+                # Says the scan read a derived copy, so a surprising result is
+                # traceable to the conversion rather than to the scanner.
+                **({"converted_from": converted_from, "converted_to": "CycloneDX-1.6"} if converted_from else {}),
             },
         )
 

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -490,6 +490,12 @@ class DependencyTrackPlugin(AssessmentPlugin):
         Still not an error. The format is a choice the uploader made and the
         artifact may be perfectly valid, so this stays the skip it has always
         been, now carrying why no conversion happened.
+
+        ``unsupported_input`` puts it on the longer backoff the scheduled sweep
+        keeps for capability gaps. That matters more than it did before this
+        plugin could convert: without it, every sweep would re-attempt a
+        conversion that has no reason to succeed until the document or the
+        deployment changes.
         """
         return self.create_skipped_result(
             finding_id="dependency-track:unsupported-format",
@@ -498,6 +504,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 "Dependency Track only supports CycloneDX format, and this SBOM could not be "
                 "converted to CycloneDX, so vulnerability scanning was skipped."
             ),
+            unsupported_input=True,
             extra_metadata={"conversion_error": reason[:500]},
         )
 

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -145,14 +145,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
         # Dependency Track reads CycloneDX only, so a document in any other
         # format is uploaded as a derived CycloneDX copy rather than skipped.
         # The stored artifact is never modified and the findings come back
-        # against it (ADR-004). The conversion itself happens at the upload
-        # below, not here: this runs again on every poll, and converting each
-        # time would spend a subprocess to learn what it already knew.
-        # Whether a converter exists is deliberately not asked here. This runs
-        # again on every poll of a scan already in flight, and a worker without
-        # the binary would answer a poll with a skip instead of the findings the
-        # upload is waiting for. Availability is settled where it is acted on,
-        # at the upload below, which runs once.
+        # against it (ADR-004). The conversion itself happens in-process at the
+        # upload below, not here: this runs again on every poll of a scan
+        # already in flight, and deriving the copy each time would redo work
+        # whose outcome the upload already recorded.
         needs_conversion = not self._validate_cyclonedx(sbom_bytes)
         if needs_conversion and self._source_format_label(sbom_bytes) == "unknown":
             # Neither CycloneDX nor SPDX, so there is nothing to convert from,

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -31,6 +31,7 @@ from sbomify.apps.plugins.sdk.results import (
     PluginMetadata,
 )
 from sbomify.apps.sboms.conversion import (
+    CYCLONEDX_1_6,
     ConversionFailed,
     to_cyclonedx,
 )
@@ -511,8 +512,8 @@ class DependencyTrackPlugin(AssessmentPlugin):
             finding_id="dependency-track:unsupported-format",
             title="Format Not Supported",
             description=(
-                "Dependency Track only supports CycloneDX format, and this SBOM could not be "
-                "converted to CycloneDX, so vulnerability scanning was skipped."
+                "Dependency Track reads CycloneDX only. This SBOM is not CycloneDX, and only "
+                "SPDX documents can be converted into it, so vulnerability scanning was skipped."
             ),
             unsupported_input=True,
             extra_metadata={"conversion_error": reason[:500]},
@@ -682,7 +683,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 "metrics": metrics,
                 # Says the scan read a derived copy, so a surprising result is
                 # traceable to the conversion rather than to the scanner.
-                **({"converted_from": converted_from, "converted_to": "CycloneDX-1.6"} if converted_from else {}),
+                **({"converted_from": converted_from, "converted_to": CYCLONEDX_1_6} if converted_from else {}),
             },
         )
 

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -151,7 +151,12 @@ class DependencyTrackPlugin(AssessmentPlugin):
         # already in flight, and deriving the copy each time would redo work
         # whose outcome the upload already recorded.
         needs_conversion = not self._validate_cyclonedx(sbom_bytes)
-        if needs_conversion and self._source_format_label(sbom_bytes) == "unknown":
+        # Labelled once. assess() runs again on every poll of a scan already in
+        # flight, and the label is read twice per call, so deriving it here
+        # keeps the JSON decoding for provenance to one pass over the bytes
+        # rather than one per read.
+        source_label = self._source_format_label(sbom_bytes) if needs_conversion else None
+        if source_label == "unknown":
             # Neither CycloneDX nor SPDX, so there is nothing to convert from,
             # and that is knowable without a database round trip.
             return self._create_unconvertible_result("the document is neither CycloneDX nor SPDX")
@@ -295,7 +300,7 @@ class DependencyTrackPlugin(AssessmentPlugin):
                 sbom_id=sbom_id,
                 project_name=project_name,
                 current_release_names=current_release_names,
-                converted_from=self._source_format_label(sbom_bytes) if needs_conversion else None,
+                converted_from=source_label,
             )
         except RetryLaterError:
             raise
@@ -512,8 +517,10 @@ class DependencyTrackPlugin(AssessmentPlugin):
             finding_id="dependency-track:unsupported-format",
             title="Format Not Supported",
             description=(
-                "Dependency Track reads CycloneDX only. This SBOM is not CycloneDX, and only "
-                "SPDX documents can be converted into it, so vulnerability scanning was skipped."
+                "Dependency Track reads CycloneDX only, and this SBOM could not be turned into "
+                "CycloneDX, so vulnerability scanning was skipped. Either the document is not a "
+                "format we can convert from, or it is SPDX and the conversion did not produce "
+                "anything to scan."
             ),
             unsupported_input=True,
             extra_metadata={"conversion_error": reason[:500]},

--- a/sbomify/apps/plugins/builtins/dependency_track.py
+++ b/sbomify/apps/plugins/builtins/dependency_track.py
@@ -31,10 +31,8 @@ from sbomify.apps.plugins.sdk.results import (
     PluginMetadata,
 )
 from sbomify.apps.sboms.conversion import (
-    CYCLONEDX_1_6_JSON,
     ConversionFailed,
-    ConversionUnavailable,
-    convert_sbom,
+    to_cyclonedx,
 )
 from sbomify.logging import getLogger
 
@@ -227,8 +225,8 @@ class DependencyTrackPlugin(AssessmentPlugin):
             # the initial tag set, then raise RetryLater to poll for results.
             if needs_conversion:
                 try:
-                    sbom_bytes = convert_sbom(sbom_bytes, CYCLONEDX_1_6_JSON)
-                except (ConversionUnavailable, ConversionFailed) as exc:
+                    sbom_bytes = to_cyclonedx(sbom_bytes)
+                except ConversionFailed as exc:
                     logger.warning(f"[DT] SBOM {sbom_id} could not be converted to CycloneDX: {exc}")
                     return self._create_unconvertible_result(str(exc))
                 logger.info(f"[DT] Uploading SBOM {sbom_id} as a derived CycloneDX copy")

--- a/sbomify/apps/plugins/tests/test_dt_scan_count.py
+++ b/sbomify/apps/plugins/tests/test_dt_scan_count.py
@@ -98,40 +98,14 @@ class TestTrackedObjectCount:
 
 
 class TestUnsupportedFormatSkipped:
-    """DT should return a skipped (not error) result when given a non-CycloneDX SBOM.
+    """A document DT cannot read is a skip, not an error, and costs no database.
 
-    SPDX is a deliberate format choice, not an error condition — DT simply doesn't
-    support it. The UI/reporting layer should surface this as "not applicable"
-    rather than a hard error finding.
+    SPDX is no longer in this category: it is converted to CycloneDX and
+    scanned, which test_dt_spdx_conversion.py covers through the real upload
+    path. What remains here is input that is neither CycloneDX nor SPDX, so
+    there is nothing to convert from and the answer is reachable before any
+    lookup happens.
     """
-
-    def test_spdx_input_returns_skipped_not_error(self, tmp_path) -> None:
-        """Passing an SPDX 2.3 SBOM to DT should yield a skipped result."""
-        import json
-
-        spdx_sbom = {
-            "spdxVersion": "SPDX-2.3",
-            "SPDXID": "SPDXRef-DOCUMENT",
-            "name": "test",
-            "dataLicense": "CC0-1.0",
-            "documentNamespace": "https://example.com/test",
-            "creationInfo": {"created": "2026-01-01T00:00:00Z", "creators": ["Tool: test"]},
-            "packages": [],
-        }
-        sbom_path = tmp_path / "test.spdx.json"
-        sbom_path.write_text(json.dumps(spdx_sbom))
-
-        plugin = DependencyTrackPlugin(config={})
-        result = plugin.assess("sbom-id-does-not-matter", sbom_path)
-
-        assert result.summary.error_count == 0, f"SPDX input should not produce errors, got {result.summary}"
-        assert result.summary.warning_count == 1
-        assert result.metadata.get("skipped") is True
-        assert len(result.findings) == 1
-        finding = result.findings[0]
-        assert finding.id == "dependency-track:unsupported-format"
-        assert finding.status == "warning"
-        assert "skipped" in (finding.description or "").lower()
 
     def test_unrecognized_format_also_returns_skipped(self, tmp_path) -> None:
         """Anything that isn't valid CycloneDX (random JSON, truncated file, etc.)

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import uuid
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
-from sbomify.apps.sboms.conversion import ConversionFailed
+from sbomify.apps.sboms.conversion import ConversionFailed, ConversionUnavailable
 
 SPDX_2_3 = json.dumps({"spdxVersion": "SPDX-2.3", "name": "image", "packages": []})
 SPDX_3 = json.dumps({"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": []})
@@ -51,23 +52,6 @@ class TestNamingTheSourceFormat:
         self, plugin: DependencyTrackPlugin, document: str, expected: str
     ) -> None:
         assert plugin._source_format_label(document.encode()) == expected
-
-
-class TestWithoutAConverter:
-    def test_spdx_still_skips_and_says_why(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
-        """A deployment with no converter behaves as it always did."""
-        path = tmp_path / "sbom.json"
-        path.write_text(SPDX_2_3)
-
-        with patch("sbomify.apps.plugins.builtins.dependency_track.converter_path", return_value=None):
-            result = _as_dict(plugin.assess("sbom-1", path))
-
-        assert result["metadata"].get("skipped") is True
-        assert result["findings"][0]["id"] == "dependency-track:unsupported-format"
-        assert "no converter installed" in result["metadata"]["conversion_error"]
-        # Puts it on the longer sweep backoff, so a converter that is not there
-        # is not re-attempted on every pass.
-        assert result["metadata"]["unsupported_input"] is True
 
 
 @pytest.mark.django_db
@@ -105,12 +89,6 @@ class TestTheUploadCarriesTheConversion:
             raise RuntimeError("stop after the upload was handed its bytes")
 
         with (
-            # The gate checks a converter exists before letting the run
-            # continue; the tests container has no binary installed.
-            patch(
-                "sbomify.apps.plugins.builtins.dependency_track.converter_path",
-                return_value="/usr/local/bin/syft",
-            ),
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
             patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
             patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
@@ -139,6 +117,51 @@ class TestTheUploadCarriesTheConversion:
         self._assess_capturing_upload(plugin, scannable, convert)
 
         assert path.read_text() == SPDX_2_3
+
+    def test_no_converter_installed_is_a_skip_that_says_so(self, plugin: DependencyTrackPlugin, scannable) -> None:
+        """A deployment without the binary behaves as it always did."""
+        convert = patch(
+            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            side_effect=ConversionUnavailable("no SBOM converter is installed"),
+        )
+        _, result = self._assess_capturing_upload(plugin, scannable, convert)
+
+        assert result["metadata"].get("skipped") is True
+        assert "no SBOM converter is installed" in result["metadata"]["conversion_error"]
+        # The longer sweep backoff, so a converter that is not there is not
+        # re-attempted on every pass.
+        assert result["metadata"]["unsupported_input"] is True
+
+    def test_a_poll_neither_converts_nor_needs_a_converter(self, plugin: DependencyTrackPlugin, scannable) -> None:
+        """The upload already happened, and a poll must return its findings.
+
+        Workers are not guaranteed to be identical, so one without the binary
+        has to be able to poll a scan another worker uploaded. It also records
+        the provenance, which is only known from the stored document.
+        """
+        from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
+
+        sbom, path, server = scannable
+        SbomDependencyTrackProjectVersion.objects.create(
+            sbom=sbom, dt_server=server, dt_project_version="1.0", dt_project_version_uuid=uuid.uuid4()
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_poll(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return MagicMock()
+
+        with (
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
+            patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
+            patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
+            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch.object(DependencyTrackPlugin, "_poll_results", side_effect=fake_poll),
+        ):
+            plugin.assess(str(sbom.id), path)
+
+        convert.assert_not_called()
+        assert captured["converted_from"] == "SPDX-2.3"
 
     def test_a_document_no_converter_reads_is_a_skip(self, plugin: DependencyTrackPlugin, scannable) -> None:
         convert = patch(
@@ -178,10 +201,6 @@ class TestWhatIsNotConverted:
 
         with (
             patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
-            patch(
-                "sbomify.apps.plugins.builtins.dependency_track.converter_path",
-                return_value="/usr/local/bin/syft",
-            ),
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
         ):
             plugin.assess("sbom-1", path)

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -1,0 +1,185 @@
+"""Dependency Track reads SPDX through a derived CycloneDX copy.
+
+DT takes CycloneDX only, so every SPDX document used to come back as a skip.
+The upload now carries a converted copy instead. The stored artifact is never
+modified and the findings come back against it (ADR-004).
+
+The conversion is deliberately not done at the format gate. That gate runs on
+every poll of an in-flight scan, so converting there would spend a subprocess
+each time to learn what the previous pass already knew.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
+from sbomify.apps.sboms.conversion import ConversionFailed
+
+SPDX_2_3 = json.dumps({"spdxVersion": "SPDX-2.3", "name": "image", "packages": []})
+SPDX_3 = json.dumps({"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": []})
+CYCLONEDX = json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1})
+CONVERTED = b'{"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}'
+
+
+def _as_dict(result: Any) -> dict[str, Any]:
+    return result.model_dump() if hasattr(result, "model_dump") else dataclasses.asdict(result)
+
+
+@pytest.fixture
+def plugin() -> DependencyTrackPlugin:
+    return DependencyTrackPlugin()
+
+
+class TestNamingTheSourceFormat:
+    @pytest.mark.parametrize(
+        ("document", "expected"),
+        [
+            (SPDX_2_3, "SPDX-2.3"),
+            (SPDX_3, "SPDX-3.0"),
+            ('{"nothing": "familiar"}', "unknown"),
+            ("not json at all", "unknown"),
+            ("[1, 2, 3]", "unknown"),
+        ],
+    )
+    def test_the_label_recorded_on_a_converted_scan(
+        self, plugin: DependencyTrackPlugin, document: str, expected: str
+    ) -> None:
+        assert plugin._source_format_label(document.encode()) == expected
+
+
+class TestWithoutAConverter:
+    def test_spdx_still_skips_and_says_why(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
+        """A deployment with no converter behaves as it always did."""
+        path = tmp_path / "sbom.json"
+        path.write_text(SPDX_2_3)
+
+        with patch("sbomify.apps.plugins.builtins.dependency_track.converter_path", return_value=None):
+            result = _as_dict(plugin.assess("sbom-1", path))
+
+        assert result["metadata"].get("skipped") is True
+        assert result["findings"][0]["id"] == "dependency-track:unsupported-format"
+        assert "no converter installed" in result["metadata"]["conversion_error"]
+
+
+@pytest.mark.django_db
+class TestTheUploadCarriesTheConversion:
+    @pytest.fixture
+    def scannable(self, tmp_path):
+        from sbomify.apps.core.models import Component, Product
+        from sbomify.apps.sboms.models import SBOM
+        from sbomify.apps.teams.models import Team
+        from sbomify.apps.vulnerability_scanning.models import DependencyTrackServer
+
+        team = Team.objects.create(name="DT Conv Team", key="dtconvteam", billing_plan="business")
+        server = DependencyTrackServer.objects.create(
+            name="DT Conv Server",
+            url="https://dt-conv.example.com",
+            api_key="key",
+            health_status="healthy",
+            max_concurrent_scans=10,
+        )
+        component = Component.objects.create(name="DT Conv Component", team=team)
+        product = Product.objects.create(name="DT Conv Product", team=team)
+        product.components.add(component)
+        sbom = SBOM.objects.create(name="s", component=component, format="spdx", format_version="2.3")
+
+        path = tmp_path / "sbom.json"
+        path.write_text(SPDX_2_3)
+        return sbom, path, server
+
+    def _assess_capturing_upload(self, plugin, scannable, convert_patch):
+        sbom, path, server = scannable
+        captured: dict[str, Any] = {}
+
+        def capture(**kwargs: Any) -> None:
+            captured["bytes"] = kwargs["sbom_bytes"]
+            raise RuntimeError("stop after the upload was handed its bytes")
+
+        with (
+            # The gate checks a converter exists before letting the run
+            # continue; the tests container has no binary installed.
+            patch(
+                "sbomify.apps.plugins.builtins.dependency_track.converter_path",
+                return_value="/usr/local/bin/syft",
+            ),
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
+            patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
+            patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
+            patch.object(DependencyTrackPlugin, "_upload_new_sbom_version", side_effect=capture),
+            convert_patch,
+        ):
+            result = _as_dict(plugin.assess(str(sbom.id), path))
+        return captured, result
+
+    def test_the_upload_gets_cyclonedx_not_the_spdx(self, plugin: DependencyTrackPlugin, scannable) -> None:
+        convert = patch(
+            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            return_value=CONVERTED,
+        )
+        captured, _ = self._assess_capturing_upload(plugin, scannable, convert)
+
+        assert captured["bytes"] == CONVERTED
+        assert json.loads(captured["bytes"])["bomFormat"] == "CycloneDX"
+
+    def test_the_stored_document_is_left_alone(self, plugin: DependencyTrackPlugin, scannable) -> None:
+        _, path, _ = scannable
+        convert = patch(
+            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            return_value=CONVERTED,
+        )
+        self._assess_capturing_upload(plugin, scannable, convert)
+
+        assert path.read_text() == SPDX_2_3
+
+    def test_a_document_no_converter_reads_is_a_skip(self, plugin: DependencyTrackPlugin, scannable) -> None:
+        convert = patch(
+            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            side_effect=ConversionFailed("no SPDX document found"),
+        )
+        _, result = self._assess_capturing_upload(plugin, scannable, convert)
+
+        assert result["metadata"].get("skipped") is True
+        assert result["findings"][0]["id"] == "dependency-track:unsupported-format"
+        assert "no SPDX document found" in result["metadata"]["conversion_error"]
+
+
+@pytest.mark.django_db
+class TestWhatIsNotConverted:
+    def test_cyclonedx_never_reaches_the_converter(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
+        path = tmp_path / "sbom.cdx.json"
+        path.write_text(CYCLONEDX)
+
+        with (
+            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
+        ):
+            plugin.assess("sbom-1", path)
+
+        convert.assert_not_called()
+
+    def test_conversion_waits_for_the_upload(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
+        """The gate runs on every poll, so it must not convert.
+
+        Stopping the run before the upload (the workspace has DT switched off)
+        proves the conversion is not done on the way past the gate.
+        """
+        path = tmp_path / "sbom.json"
+        path.write_text(SPDX_2_3)
+
+        with (
+            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch(
+                "sbomify.apps.plugins.builtins.dependency_track.converter_path",
+                return_value="/usr/local/bin/syft",
+            ),
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
+        ):
+            plugin.assess("sbom-1", path)
+
+        convert.assert_not_called()

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -32,6 +32,31 @@ def _as_dict(result: Any) -> dict[str, Any]:
     return result.model_dump() if hasattr(result, "model_dump") else dataclasses.asdict(result)
 
 
+def _records(tmp_path, document: str, fmt: str, key: str, filename: str):
+    """Real rows, so assess() gets past the lookup and reaches the upload."""
+    from sbomify.apps.core.models import Component, Product
+    from sbomify.apps.sboms.models import SBOM
+    from sbomify.apps.teams.models import Team
+    from sbomify.apps.vulnerability_scanning.models import DependencyTrackServer
+
+    team = Team.objects.create(name=f"Team {key}", key=key, billing_plan="business")
+    server = DependencyTrackServer.objects.create(
+        name=f"Server {key}",
+        url=f"https://{key}.example.com",
+        api_key="key",
+        health_status="healthy",
+        max_concurrent_scans=10,
+    )
+    component = Component.objects.create(name=f"Component {key}", team=team)
+    product = Product.objects.create(name=f"Product {key}", team=team)
+    product.components.add(component)
+    sbom = SBOM.objects.create(name="s", component=component, format=fmt, format_version="1.6")
+
+    path = tmp_path / filename
+    path.write_text(document)
+    return sbom, path, server
+
+
 @pytest.fixture
 def plugin() -> DependencyTrackPlugin:
     return DependencyTrackPlugin()
@@ -178,31 +203,49 @@ class TestTheUploadCarriesTheConversion:
 
 @pytest.mark.django_db
 class TestWhatIsNotConverted:
-    def test_cyclonedx_never_reaches_the_converter(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
-        path = tmp_path / "sbom.cdx.json"
-        path.write_text(CYCLONEDX)
+    def test_cyclonedx_reaches_the_upload_unconverted(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
+        """Driven all the way to the upload, so this says more than "not yet"."""
+        sbom, path, server = _records(tmp_path, CYCLONEDX, "cyclonedx", "dtcdxteam", "sbom.cdx.json")
+        captured: dict[str, Any] = {}
+
+        def capture(**kwargs: Any) -> None:
+            captured["bytes"] = kwargs["sbom_bytes"]
+            raise RuntimeError("stop after the upload was handed its bytes")
 
         with (
             patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
-            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
+            patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
+            patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
+            patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
+            patch.object(DependencyTrackPlugin, "_upload_new_sbom_version", side_effect=capture),
         ):
-            plugin.assess("sbom-1", path)
+            plugin.assess(str(sbom.id), path)
 
         convert.assert_not_called()
+        assert captured["bytes"] == CYCLONEDX.encode()
 
     def test_conversion_waits_for_the_upload(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
         """The gate runs on every poll, so it must not convert.
 
-        Stopping the run before the upload (the workspace has DT switched off)
-        proves the conversion is not done on the way past the gate.
+        The run stops after the lookup, on the workspace having Dependency
+        Track switched off, which is past the gate and short of the upload.
         """
-        path = tmp_path / "sbom.json"
-        path.write_text(SPDX_2_3)
+        sbom, path, _ = _records(tmp_path, SPDX_2_3, "spdx", "dtgateteam", "sbom.json")
 
         with (
             patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
         ):
-            plugin.assess("sbom-1", path)
+            plugin.assess(str(sbom.id), path)
 
         convert.assert_not_called()
+
+    def test_a_json_array_is_a_skip_rather_than_a_crash(self, plugin: DependencyTrackPlugin, tmp_path) -> None:
+        """Valid JSON that is not an object must not raise on the way to the skip."""
+        path = tmp_path / "sbom.json"
+        path.write_text("[1, 2, 3]")
+
+        result = _as_dict(plugin.assess("sbom-1", path))
+
+        assert result["metadata"].get("skipped") is True
+        assert result["findings"][0]["id"] == "dependency-track:unsupported-format"

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -65,6 +65,9 @@ class TestWithoutAConverter:
         assert result["metadata"].get("skipped") is True
         assert result["findings"][0]["id"] == "dependency-track:unsupported-format"
         assert "no converter installed" in result["metadata"]["conversion_error"]
+        # Puts it on the longer sweep backoff, so a converter that is not there
+        # is not re-attempted on every pass.
+        assert result["metadata"]["unsupported_input"] is True
 
 
 @pytest.mark.django_db
@@ -147,6 +150,7 @@ class TestTheUploadCarriesTheConversion:
         assert result["metadata"].get("skipped") is True
         assert result["findings"][0]["id"] == "dependency-track:unsupported-format"
         assert "no SPDX document found" in result["metadata"]["conversion_error"]
+        assert result["metadata"]["unsupported_input"] is True
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -32,6 +32,22 @@ def _as_dict(result: Any) -> dict[str, Any]:
     return result.model_dump() if hasattr(result, "model_dump") else dataclasses.asdict(result)
 
 
+def _document_version(document: str) -> str:
+    """The version the document declares, so the row matches its own bytes.
+
+    A hardcoded "1.6" put a CycloneDX spec version on SPDX rows, which is
+    data no upload could produce and would mask a bug the day anything
+    branches on ``sbom.format_version``.
+    """
+    data = json.loads(document)
+    if spdx2 := data.get("spdxVersion"):
+        return str(spdx2).removeprefix("SPDX-")
+    context = data.get("@context")
+    if isinstance(context, str) and "spdx-context" in context:
+        return context.rsplit("/spdx-context", 1)[0].rsplit("/", 1)[-1]
+    return str(data.get("specVersion", ""))
+
+
 def _records(tmp_path, document: str, fmt: str, key: str, filename: str):
     """Real rows, so assess() gets past the lookup and reaches the upload."""
     from sbomify.apps.core.models import Component, Product
@@ -50,7 +66,7 @@ def _records(tmp_path, document: str, fmt: str, key: str, filename: str):
     component = Component.objects.create(name=f"Component {key}", team=team)
     product = Product.objects.create(name=f"Product {key}", team=team)
     product.components.add(component)
-    sbom = SBOM.objects.create(name="s", component=component, format=fmt, format_version="1.6")
+    sbom = SBOM.objects.create(name="s", component=component, format=fmt, format_version=_document_version(document))
 
     path = tmp_path / filename
     path.write_text(document)

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -78,6 +78,30 @@ def plugin() -> DependencyTrackPlugin:
     return DependencyTrackPlugin()
 
 
+class TestRecognisingSpdx3Lines:
+    """A 3.1 document is convertible, and the label says which line it came from."""
+
+    @pytest.mark.parametrize(
+        ("context", "expected"),
+        [
+            ("https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "SPDX-3.0"),
+            ("https://spdx.org/rdf/3.1.0/spdx-context.jsonld", "SPDX-3.1"),
+            ("https://spdx.org/rdf/3.2/spdx-context.jsonld", "SPDX-3.2"),
+        ],
+    )
+    def test_any_3x_line_is_spdx3(self, plugin: DependencyTrackPlugin, context: str, expected: str) -> None:
+        document = json.dumps({"@context": context, "@graph": []}).encode()
+
+        assert plugin._source_format_label(document) == expected
+
+    def test_a_bare_graph_is_still_spdx3(self, plugin: DependencyTrackPlugin) -> None:
+        """No context, so the graph is the only signal, and the label falls back to 3.0."""
+        assert plugin._source_format_label(json.dumps({"@graph": []}).encode()) == "SPDX-3.0"
+
+    def test_something_that_is_neither_is_unknown(self, plugin: DependencyTrackPlugin) -> None:
+        assert plugin._source_format_label(json.dumps({"hello": "world"}).encode()) == "unknown"
+
+
 class TestNamingTheSourceFormat:
     @pytest.mark.parametrize(
         ("document", "expected"),

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -5,8 +5,8 @@ The upload now carries a converted copy instead. The stored artifact is never
 modified and the findings come back against it (ADR-004).
 
 The conversion is deliberately not done at the format gate. That gate runs on
-every poll of an in-flight scan, so converting there would spend a subprocess
-each time to learn what the previous pass already knew.
+every poll of an in-flight scan, so converting there would derive the same
+copy each time to learn what the previous pass already knew.
 """
 
 from __future__ import annotations
@@ -203,9 +203,9 @@ class TestTheUploadCarriesTheConversion:
     def test_a_poll_neither_converts_nor_needs_a_converter(self, plugin: DependencyTrackPlugin, scannable) -> None:
         """The upload already happened, and a poll must return its findings.
 
-        Workers are not guaranteed to be identical, so one without the binary
-        has to be able to poll a scan another worker uploaded. It also records
-        the provenance, which is only known from the stored document.
+        A poll answers from what the upload already settled, so it never
+        derives another CycloneDX copy. It also records the provenance,
+        which is only known from the stored document.
         """
         from sbomify.apps.vulnerability_scanning.models import SbomDependencyTrackProjectVersion
 

--- a/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
+++ b/sbomify/apps/plugins/tests/test_dt_spdx_conversion.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sbomify.apps.plugins.builtins.dependency_track import DependencyTrackPlugin
-from sbomify.apps.sboms.conversion import ConversionFailed, ConversionUnavailable
+from sbomify.apps.sboms.conversion import ConversionFailed
 
 SPDX_2_3 = json.dumps({"spdxVersion": "SPDX-2.3", "name": "image", "packages": []})
 SPDX_3 = json.dumps({"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": []})
@@ -165,7 +165,7 @@ class TestTheUploadCarriesTheConversion:
 
     def test_the_upload_gets_cyclonedx_not_the_spdx(self, plugin: DependencyTrackPlugin, scannable) -> None:
         convert = patch(
-            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            "sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx",
             return_value=CONVERTED,
         )
         captured, _ = self._assess_capturing_upload(plugin, scannable, convert)
@@ -176,25 +176,28 @@ class TestTheUploadCarriesTheConversion:
     def test_the_stored_document_is_left_alone(self, plugin: DependencyTrackPlugin, scannable) -> None:
         _, path, _ = scannable
         convert = patch(
-            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            "sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx",
             return_value=CONVERTED,
         )
         self._assess_capturing_upload(plugin, scannable, convert)
 
         assert path.read_text() == SPDX_2_3
 
-    def test_no_converter_installed_is_a_skip_that_says_so(self, plugin: DependencyTrackPlugin, scannable) -> None:
-        """A deployment without the binary behaves as it always did."""
+    def test_a_document_that_cannot_be_expressed_is_a_skip_that_says_so(
+        self, plugin: DependencyTrackPlugin, scannable
+    ) -> None:
+        """No binary to be missing any more, so the only skip left is a document
+        the emitter cannot express as CycloneDX."""
         convert = patch(
-            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
-            side_effect=ConversionUnavailable("no SBOM converter is installed"),
+            "sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx",
+            side_effect=ConversionFailed("SPDX-3.0 document names no package to scan"),
         )
         _, result = self._assess_capturing_upload(plugin, scannable, convert)
 
         assert result["metadata"].get("skipped") is True
-        assert "no SBOM converter is installed" in result["metadata"]["conversion_error"]
-        # The longer sweep backoff, so a converter that is not there is not
-        # re-attempted on every pass.
+        assert "names no package to scan" in result["metadata"]["conversion_error"]
+        # The longer sweep backoff, so a document nothing can do anything with
+        # is not re-attempted on every pass.
         assert result["metadata"]["unsupported_input"] is True
 
     def test_a_poll_neither_converts_nor_needs_a_converter(self, plugin: DependencyTrackPlugin, scannable) -> None:
@@ -220,7 +223,7 @@ class TestTheUploadCarriesTheConversion:
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
             patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
             patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
-            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch("sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx") as convert,
             patch.object(DependencyTrackPlugin, "_poll_results", side_effect=fake_poll),
         ):
             plugin.assess(str(sbom.id), path)
@@ -230,7 +233,7 @@ class TestTheUploadCarriesTheConversion:
 
     def test_a_document_no_converter_reads_is_a_skip(self, plugin: DependencyTrackPlugin, scannable) -> None:
         convert = patch(
-            "sbomify.apps.plugins.builtins.dependency_track.convert_sbom",
+            "sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx",
             side_effect=ConversionFailed("no SPDX document found"),
         )
         _, result = self._assess_capturing_upload(plugin, scannable, convert)
@@ -253,7 +256,7 @@ class TestWhatIsNotConverted:
             raise RuntimeError("stop after the upload was handed its bytes")
 
         with (
-            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch("sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx") as convert,
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=True),
             patch.object(DependencyTrackPlugin, "_select_dt_server", return_value=server),
             patch.object(DependencyTrackPlugin, "_resolve_release_context", return_value=[]),
@@ -273,7 +276,7 @@ class TestWhatIsNotConverted:
         sbom, path, _ = _records(tmp_path, SPDX_2_3, "spdx", "dtgateteam", "sbom.json")
 
         with (
-            patch("sbomify.apps.plugins.builtins.dependency_track.convert_sbom") as convert,
+            patch("sbomify.apps.plugins.builtins.dependency_track.to_cyclonedx") as convert,
             patch.object(DependencyTrackPlugin, "_team_has_dt_enabled", return_value=False),
         ):
             plugin.assess(str(sbom.id), path)


### PR DESCRIPTION
Closes #1500. Stacked on #1502, which adds the conversion service this uses; review that one first.

## What changed

Dependency Track takes CycloneDX only, so an SPDX upload came back as "Format Not Supported" and nothing was scanned. The upload now carries a derived CycloneDX 1.6 copy. The stored artifact is never modified and the findings come back against it (ADR-004).

Both SPDX generations are covered, since the converter reads 2.x and 3.x alike. Verified against syft 1.51.1 with purls surviving in both directions, which is the property that lets findings line up with the stored document.

## Where the conversion happens, and why it matters

At the upload, not at the format gate.

The gate runs on every pass through `assess`, including each poll of a scan already in flight. Converting there would spend a subprocess on every poll to re-derive what the first pass already uploaded. So the gate only asks the cheap question, "is a converter installed at all", and the conversion itself sits immediately before `_upload_new_sbom_version`, which runs once per SBOM.

`test_conversion_waits_for_the_upload` pins this by stopping a run before the upload and asserting nothing was converted. Without it the deferral would be an easy thing to undo while tidying.

## The client still refuses SPDX

Deliberately. `DependencyTrackClient.upload_sbom` raising on a non-CycloneDX body is a true statement about what the server accepts, and with the plugin converting first it stops being the thing users hit and becomes an invariant that would catch a future caller skipping the conversion. Moving the conversion down into the client would have made the API wrapper own a policy decision that belongs to the plugin, which is where the skip results are built.

## What still skips

Two paths, both carrying their reason in the result metadata:

- **No converter installed.** Behaves exactly as before, so the feature degrades rather than breaking.
- **A document no converter will read.** Reports the converter's own message.

Neither presents as an error on an artifact that may be perfectly valid, which is the behaviour the format gate already had and this keeps.

A converted scan records `converted_from` and `converted_to` in its metadata, so a surprising result is traceable to the derivation rather than looking like a Dependency Track fault.

## Tests

11 new. Five cover the source-format label the record uses, including the shapes that are not SBOMs at all. The rest drive the real `assess()`: the upload receives CycloneDX rather than the SPDX it started with, the stored document is unchanged afterwards, a refused conversion becomes a skip carrying the message, CycloneDX never reaches the converter, and the deferral above.

Plugins and vulnerability_scanning suites green (1565 passed).
