### PR TITLE
feat(vex): honour the VEX an SPDX 3 document carries about itself

### DIFF
--- a/sbomify/apps/vulnerability_scanning/posture.py
+++ b/sbomify/apps/vulnerability_scanning/posture.py
@@ -15,9 +15,8 @@ from urllib.parse import unquote
 
 from sbomify.apps.vulnerability_scanning.malicious import is_malicious_finding
 from sbomify.apps.vulnerability_scanning.utils import is_vulnerability, justification_label
+from sbomify.apps.vulnerability_scanning.vex import SUPPRESSED_STATES
 
-# CycloneDX analysis states that suppress a finding (mirrors vex._SUPPRESSING_STATES).
-_SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
 _SEVERITIES = ("critical", "high", "medium", "low", "unknown")
 
 
@@ -27,7 +26,7 @@ def _severity_bucket(finding: dict[str, Any]) -> str:
 
 
 def _is_suppressed(finding: dict[str, Any]) -> bool:
-    return (finding.get("analysis_state") or "") in _SUPPRESSING_STATES
+    return (finding.get("analysis_state") or "") in SUPPRESSED_STATES
 
 
 def _purl_name_version(purl: str) -> tuple[str, str]:

--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -1,0 +1,219 @@
+"""VEX an SPDX 3 document carries about itself.
+
+SPDX 3 keeps the security profile inside the document, so a builder states
+what it knows about a CVE beside the packages it shipped rather than in a
+separate upload. Yocto writes its ``CVE_STATUS`` out exactly this way, which
+is the case this exists for: a backported patch leaves the version string
+untouched, so the scanner reports a CVE the builder already fixed, for ever.
+
+These claims are read from the stored original and applied through the same
+overlay an uploaded VEX goes through, so they annotate and suppress with no
+second mechanism.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from sbomify.apps.vulnerability_scanning.vex import (
+    _default_suppression_detail,
+    _embedded_statements,
+    finding_is_suppressed,
+)
+from sbomify.apps.vulnerability_scanning.vex_formats import (
+    EMBEDDED_SOURCE,
+    derive_spdx3_vex_suppressions,
+)
+
+CVE = "CVE-2023-5678"
+PURL = "pkg:generic/openssl@3.0.11"
+
+
+def _document(*extra: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:ci",
+                "specVersion": "3.0.1",
+                "created": "2026-01-01T00:00:00Z",
+                "createdBy": ["urn:agent"],
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "urn:pkg",
+                "name": "openssl",
+                "software_packageVersion": "3.0.11",
+                "software_packageUrl": PURL,
+            },
+            {"type": "security_Vulnerability", "spdxId": "urn:vuln", "name": CVE},
+            *extra,
+        ],
+    }
+
+
+def _assessment(kind: str, **fields: Any) -> dict[str, Any]:
+    return {"type": kind, "spdxId": "urn:vex", "from": "urn:vuln", "to": ["urn:pkg"], **fields}
+
+
+class TestWhichStatementsClearAFinding:
+    def test_a_fixed_statement_suppresses(self) -> None:
+        """The Yocto case: patched in this build, version string unchanged."""
+        statements = derive_spdx3_vex_suppressions(
+            _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
+        )
+
+        assert len(statements) == 1
+        assert statements[0]["state"] == "resolved"
+        assert statements[0]["ids"] == {CVE.lower()}
+        assert statements[0]["packages"] == {("generic", "openssl", "3.0.11")}
+
+    def test_a_not_affected_statement_suppresses_and_keeps_its_reasoning(self) -> None:
+        statements = derive_spdx3_vex_suppressions(
+            _document(
+                _assessment(
+                    "security_VexNotAffectedVulnAssessmentRelationship",
+                    security_justificationType="security_VexJustificationType_componentNotPresent",
+                    security_impactStatement="not built into this image",
+                )
+            )
+        )
+
+        assert statements[0]["state"] == "not_affected"
+        assert statements[0]["justification"] == "code_not_present"
+        assert "not built into this image" in statements[0]["detail"]
+
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "security_VexAffectedVulnAssessmentRelationship",
+            "security_VexUnderInvestigationVulnAssessmentRelationship",
+        ],
+    )
+    def test_a_statement_saying_the_opposite_clears_nothing(self, kind: str) -> None:
+        assert derive_spdx3_vex_suppressions(_document(_assessment(kind))) == []
+
+
+class TestReadingTheDocumentAsWritten:
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            "security_VexFixedVulnAssessmentRelationship",
+            "security:VexFixedVulnAssessmentRelationship",
+            "https://spdx.org/rdf/3.0.1/terms/Security/VexFixedVulnAssessmentRelationship",
+        ],
+    )
+    def test_every_spelling_of_the_type_is_recognised(self, spelling: str) -> None:
+        """JSON-LD lets the same class arrive three ways."""
+        assert len(derive_spdx3_vex_suppressions(_document(_assessment(spelling)))) == 1
+
+    def test_the_vulnerability_can_be_named_by_external_identifier(self) -> None:
+        document = _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
+        document["@graph"][2] = {
+            "type": "security_Vulnerability",
+            "spdxId": "urn:vuln",
+            "externalIdentifier": [{"externalIdentifierType": "cve", "identifier": CVE}],
+        }
+
+        assert derive_spdx3_vex_suppressions(document)[0]["ids"] == {CVE.lower()}
+
+    def test_an_inline_vulnerability_is_read_too(self) -> None:
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship")
+        assessment["from"] = {"type": "security_Vulnerability", "name": CVE}
+
+        assert derive_spdx3_vex_suppressions(_document(assessment))[0]["ids"] == {CVE.lower()}
+
+    def test_a_document_that_is_not_a_document_yields_nothing(self) -> None:
+        for value in (None, [], "text", {"bomFormat": "CycloneDX"}):
+            assert derive_spdx3_vex_suppressions(value) == []  # type: ignore[arg-type]
+
+
+class TestScopingFailsClosed:
+    def test_a_target_that_names_no_known_package_is_skipped(self) -> None:
+        """Suppressing by id alone would apply it wider than it was written."""
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship", to=["urn:some-other-thing"])
+
+        assert derive_spdx3_vex_suppressions(_document(assessment)) == []
+
+    def test_a_statement_with_no_targets_covers_the_document(self) -> None:
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship")
+        del assessment["to"]
+
+        statements = derive_spdx3_vex_suppressions(_document(assessment))
+
+        assert statements[0]["product_scoped"] is True
+
+
+class TestTheStatementsReachTheOverlay:
+    def _finding(self, purl: str = PURL) -> dict[str, Any]:
+        """The shape a stored scan result carries."""
+        return {"id": CVE, "component": {"purl": purl}}
+
+    def test_a_matching_finding_is_suppressed(self) -> None:
+        statements = derive_spdx3_vex_suppressions(
+            _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
+        )
+
+        assert finding_is_suppressed(self._finding(), statements) is True
+
+    def test_a_different_package_is_not(self) -> None:
+        statements = derive_spdx3_vex_suppressions(
+            _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
+        )
+
+        assert finding_is_suppressed(self._finding("pkg:generic/zlib@1.3"), statements) is False
+
+    def test_an_uploaded_statement_outranks_the_embedded_one(self) -> None:
+        """Most deliberate wins: the list is searched in order."""
+        embedded = derive_spdx3_vex_suppressions(_document(_assessment("security_VexFixedVulnAssessmentRelationship")))
+        uploaded = [dict(embedded[0], state="not_affected", source="uploaded", detail="from the vendor")]
+
+        from sbomify.apps.vulnerability_scanning.vex import find_matching_statement
+
+        match = find_matching_statement(self._finding(), uploaded + embedded)
+
+        assert match is not None
+        assert match["source"] == "uploaded"
+
+    def test_the_reason_names_where_the_claim_came_from(self) -> None:
+        assert _default_suppression_detail({"source": EMBEDDED_SOURCE}) == "Suppressed by a statement in the SBOM"
+
+
+@pytest.mark.django_db
+class TestOnlyTheDocumentsThatCanCarryItAreRead:
+    """An object read per artifact would be a real cost on the reannotate path."""
+
+    def _sbom(self, fmt: str, version: str, mocker: Any, document: dict[str, Any] | None = None) -> Any:
+        from sbomify.apps.core.models import Component
+        from sbomify.apps.sboms.models import SBOM
+        from sbomify.apps.teams.models import Team
+
+        team = Team.objects.create(name="Embedded VEX", key=f"emb{fmt}{version}".replace(".", ""))
+        component = Component.objects.create(name="c", team=team)
+        sbom = SBOM.objects.create(
+            name="s", component=component, format=fmt, format_version=version, sbom_filename="doc.json"
+        )
+        payload = json.dumps(document or _document(_assessment("security_VexFixedVulnAssessmentRelationship")))
+        return sbom, mocker.patch(
+            "sbomify.apps.core.object_store.S3Client.get_sbom_data", return_value=payload.encode()
+        )
+
+    def test_an_spdx3_artifact_is_read(self, mocker: Any) -> None:
+        sbom, fetch = self._sbom("spdx", "3.0.1", mocker)
+
+        statements = _embedded_statements(sbom)
+
+        assert fetch.called
+        assert len(statements) == 1
+        assert statements[0]["source"] == EMBEDDED_SOURCE
+
+    @pytest.mark.parametrize(("fmt", "version"), [("cyclonedx", "1.6"), ("spdx", "2.3")])
+    def test_anything_else_costs_no_object_read(self, mocker: Any, fmt: str, version: str) -> None:
+        sbom, fetch = self._sbom(fmt, version, mocker)
+
+        assert _embedded_statements(sbom) == []
+        fetch.assert_not_called()

--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -25,6 +25,7 @@ from sbomify.apps.vulnerability_scanning.vex import (
 )
 from sbomify.apps.vulnerability_scanning.vex_formats import (
     EMBEDDED_SOURCE,
+    _packages_from_purls,
     derive_spdx3_vex_suppressions,
 )
 
@@ -146,6 +147,31 @@ class TestScopingFailsClosed:
         statements = derive_spdx3_vex_suppressions(_document(assessment))
 
         assert statements[0]["product_scoped"] is True
+
+    def test_a_single_target_written_unwrapped_still_scopes(self) -> None:
+        """JSON-LD writes a lone value without the array, and that is one target, not none."""
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship", to="urn:pkg")
+
+        statements = derive_spdx3_vex_suppressions(_document(assessment))
+
+        assert statements[0]["product_scoped"] is False
+        assert statements[0]["packages"] == _packages_from_purls([PURL])
+
+    def test_an_unwrapped_target_naming_no_known_package_is_skipped(self) -> None:
+        """The widening this must never do: a scoped claim read as a whole-document one."""
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship", to="urn:some-other-thing")
+
+        assert derive_spdx3_vex_suppressions(_document(assessment)) == []
+
+    def test_an_inline_target_object_is_one_target(self) -> None:
+        assessment = _assessment(
+            "security_VexFixedVulnAssessmentRelationship",
+            to={"type": "software_Package", "spdxId": "urn:inline", "software_packageUrl": PURL},
+        )
+
+        statements = derive_spdx3_vex_suppressions(_document(assessment))
+
+        assert statements[0]["product_scoped"] is False
 
 
 class TestTheStatementsReachTheOverlay:

--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -4,7 +4,7 @@ SPDX 3 keeps the security profile inside the document, so a builder states
 what it knows about a CVE beside the packages it shipped rather than in a
 separate upload. Yocto writes its ``CVE_STATUS`` out exactly this way, which
 is the case this exists for: a backported patch leaves the version string
-untouched, so the scanner reports a CVE the builder already fixed, for ever.
+untouched, so the scanner reports a CVE the builder already fixed, forever.
 
 These claims are read from the stored original and applied through the same
 overlay an uploaded VEX goes through, so they annotate and suppress with no

--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -112,6 +112,19 @@ class TestReadingTheDocumentAsWritten:
         """JSON-LD lets the same class arrive three ways."""
         assert len(derive_spdx3_vex_suppressions(_document(_assessment(spelling)))) == 1
 
+    def test_the_plural_spelling_of_external_identifiers_is_read_too(self) -> None:
+        """The plugins already accept it, so a document is not understood two different ways."""
+        vulnerability = {
+            "type": "security_Vulnerability",
+            "spdxId": "urn:vuln2",
+            "externalIdentifiers": [{"externalIdentifierType": "cve", "identifier": CVE}],
+        }
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship", **{"from": "urn:vuln2"})
+
+        statements = derive_spdx3_vex_suppressions(_document(vulnerability, assessment))
+
+        assert statements[0]["ids"] == {CVE.lower()}
+
     def test_the_vulnerability_can_be_named_by_external_identifier(self) -> None:
         document = _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
         document["@graph"][2] = {
@@ -147,6 +160,12 @@ class TestScopingFailsClosed:
         statements = derive_spdx3_vex_suppressions(_document(assessment))
 
         assert statements[0]["product_scoped"] is True
+
+    def test_an_empty_target_list_is_a_scope_its_author_wrote(self) -> None:
+        """Omitting ``to`` says nothing about scope; writing an empty one says it names nothing."""
+        assessment = _assessment("security_VexFixedVulnAssessmentRelationship", to=[])
+
+        assert derive_spdx3_vex_suppressions(_document(assessment)) == []
 
     def test_a_single_target_written_unwrapped_still_scopes(self) -> None:
         """JSON-LD writes a lone value without the array, and that is one target, not none."""

--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -227,6 +227,33 @@ class TestTheStatementsReachTheOverlay:
     def test_the_reason_names_where_the_claim_came_from(self) -> None:
         assert _default_suppression_detail({"source": EMBEDDED_SOURCE}) == "Suppressed by a statement in the SBOM"
 
+    def test_every_reader_agrees_the_finding_is_suppressed(self) -> None:
+        """A Fixed statement stores the state "resolved", which the counts must not read as active."""
+        from sbomify.apps.vulnerability_scanning.posture import _is_suppressed
+        from sbomify.apps.vulnerability_scanning.utils import extract_finding_rows
+        from sbomify.apps.vulnerability_scanning.vex import (
+            finding_dict_is_suppressed,
+            reapply_vex_to_stored_result,
+        )
+
+        statements = derive_spdx3_vex_suppressions(
+            _document(_assessment("security_VexFixedVulnAssessmentRelationship"))
+        )
+        stored = {
+            "findings": [dict(self._finding(), severity="high")],
+            "summary": {"total_findings": 1, "by_severity": {"high": 1}},
+        }
+
+        updated = reapply_vex_to_stored_result(stored, statements)
+        finding = updated["findings"][0]
+
+        assert updated["summary"]["total_findings"] == 0
+        assert updated["summary"]["suppressed_count"] == 1
+        assert finding["analysis_state"] == "resolved"
+        assert finding_dict_is_suppressed(finding) is True
+        assert _is_suppressed(finding) is True
+        assert extract_finding_rows(updated)[0]["vex_suppressed"] is True
+
 
 @pytest.mark.django_db
 class TestOnlyTheDocumentsThatCanCarryItAreRead:

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -135,8 +135,6 @@ SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
 _SEVERITY_RANK = SEVERITY_RANK
 
 
-_SUPPRESSING_VEX_STATES = {"not_affected", "false_positive"}
-
 # The CycloneDX impact-analysis justifications, worded exactly as the triage
 # modal offers them, so a decision reads back the way it was made. VEX
 # documents carry the raw enum; every display surface goes through
@@ -278,6 +276,10 @@ def extract_finding_rows(
     if isinstance(metadata, dict) and metadata.get("skipped"):
         return []
 
+    # Local, as everything reaching into vex from here is: the module imports
+    # this one back.
+    from sbomify.apps.vulnerability_scanning.vex import SUPPRESSED_STATES
+
     match_statement = None
     triage_source = None
     if vex_statements:
@@ -333,7 +335,7 @@ def extract_finding_rows(
                 "vex_state": vex_state,
                 "vex_justification": vex_justification,
                 "vex_justification_label": justification_label(vex_justification),
-                "vex_suppressed": vex_state in _SUPPRESSING_VEX_STATES,
+                "vex_suppressed": vex_state in SUPPRESSED_STATES,
                 "vex_manual": vex_manual,
                 "malicious": is_malicious_finding(vuln),
                 "kev": bool(kev_ids) and finding_in_kev(vuln, kev_ids or frozenset()),

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -748,7 +748,12 @@ def load_vex_suppressions(
 
 
 def _document_from_vex_sbom(vex: Any) -> dict[str, Any] | None:
-    """Load a VEX SBOM row's document from S3. ``None`` when the row is absent or unreadable."""
+    """Load an SBOM row's stored document from S3. ``None`` when the row is absent or unreadable.
+
+    The row is an uploaded VEX artifact on the overlay paths and the artifact
+    being scanned on the embedded one, so the messages name the object rather
+    than assuming which of the two it is.
+    """
     from botocore.exceptions import BotoCoreError, ClientError
 
     from sbomify.apps.core.object_store import S3Client
@@ -763,8 +768,8 @@ def _document_from_vex_sbom(vex: Any) -> dict[str, Any] | None:
         # On the apply paths (strict_vex_reads) skipping would silently drop the
         # intended suppressions, so raise and let the caller retry / flag it.
         if _raise_on_vex_read_error.get():
-            raise VexArtifactUnreadable(f"Could not load VEX artifact {vex.sbom_filename} from S3: {exc}") from exc
-        logger.warning("Could not load VEX artifact %s from S3: %s", vex.sbom_filename, exc)
+            raise VexArtifactUnreadable(f"Could not load {vex.sbom_filename} from S3: {exc}") from exc
+        logger.warning("Could not load %s from S3: %s", vex.sbom_filename, exc)
         return None
     if not raw:
         return None

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -145,11 +145,21 @@ def _statement_ids(vuln: dict[str, Any]) -> set[str]:
     return ids
 
 
-# CycloneDX analysis states that suppress a finding. ``not_affected`` (with a justification) and
-# ``false_positive`` both mean "do not surface this" — Dependency-Track analysts routinely triage
-# with either. ``resolved`` is deliberately excluded: it means remediated, so the next scan should
-# confirm the vulnerable component is gone rather than a VEX statement masking a fix that never shipped.
+# CycloneDX analysis states an uploaded or triaged VEX statement may suppress with.
+# ``not_affected`` (with a justification) and ``false_positive`` both mean "do not surface
+# this" — Dependency-Track analysts routinely triage with either. ``resolved`` is
+# deliberately excluded: from an analyst it means remediated, so the next scan should
+# confirm the vulnerable component is gone rather than a VEX statement masking a fix that
+# never shipped.
 _SUPPRESSING_STATES = frozenset({"not_affected", "false_positive"})
+
+# Every state a finding can be STORED with once something suppressed it, which readers
+# must agree on or a list will count what the summary already dropped. It is the set
+# above plus the states only this system writes: an SPDX 3 document's own "fixed"
+# statement, where the rule above is inverted because a backported patch leaves the
+# version untouched, so no later scan can confirm it and the builder's claim is the only
+# evidence there will ever be.
+SUPPRESSED_STATES = _SUPPRESSING_STATES | {"resolved"}
 
 
 def derive_vex_suppressions(document: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -476,7 +486,7 @@ def finding_is_suppressed(finding: dict[str, Any], statements: list[dict[str, An
 def finding_dict_is_suppressed(finding: dict[str, Any]) -> bool:
     """True when a STORED finding dict already carries a suppressing VEX analysis
     state — for readers that must agree with the re-annotated summary counts."""
-    return finding.get("analysis_state") in _SUPPRESSING_STATES
+    return finding.get("analysis_state") in SUPPRESSED_STATES
 
 
 def _finding_match_dict(finding: Any) -> dict[str, Any]:

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -613,6 +613,9 @@ def reannotate_component_runs(component_id: Any) -> int:
     # Cache by the run's release set: runs sharing releases resolve once. The
     # empty-set key covers runs in no release (component-latest applies).
     context_cache: dict[frozenset[Any], list[dict[str, Any]]] = {}
+    # Several providers scan the same artifact, so a component's runs repeat
+    # its SBOMs. Read each document once rather than once per run.
+    embedded_cache: dict[Any, list[dict[str, Any]]] = {}
 
     def statements_for(run: Any) -> list[dict[str, Any]]:
         release_ids = [release.id for release in run.releases.all()]
@@ -621,7 +624,9 @@ def reannotate_component_runs(component_id: Any) -> int:
             context_cache[key] = _statements_for_release_context(component_id, release_ids)
         # The embedded statements belong to one artifact rather than to the
         # release set, so they sit outside what the cache above keys on.
-        return context_cache[key] + _embedded_statements(run.sbom)
+        if run.sbom_id not in embedded_cache:
+            embedded_cache[run.sbom_id] = _embedded_statements(run.sbom)
+        return context_cache[key] + embedded_cache[run.sbom_id]
 
     runs = (
         AssessmentRun.objects.filter(

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -37,12 +37,14 @@ from typing import Any
 from urllib.parse import quote
 
 from sbomify.apps.vulnerability_scanning.vex_formats import (
+    EMBEDDED_SOURCE,
     MAX_VEX_STATEMENTS,
     VEX_FORMAT_CSAF,
     VEX_FORMAT_CYCLONEDX,
     VEX_FORMAT_OPENVEX,
     derive_csaf_suppressions,
     derive_openvex_suppressions,
+    derive_spdx3_vex_suppressions,
     detect_vex_format,
     parse_vex_bytes,
 )
@@ -126,6 +128,8 @@ def _default_suppression_detail(statement: dict[str, Any]) -> str:
         return "Suppressed via manual triage"
     if source == DEPENDENCY_TRACK_SOURCE:
         return "Suppressed by synced Dependency-Track VEX"
+    if source == EMBEDDED_SOURCE:
+        return "Suppressed by a statement in the SBOM"
     return "Suppressed by uploaded VEX"
 
 
@@ -615,7 +619,9 @@ def reannotate_component_runs(component_id: Any) -> int:
         key = frozenset(release_ids)
         if key not in context_cache:
             context_cache[key] = _statements_for_release_context(component_id, release_ids)
-        return context_cache[key]
+        # The embedded statements belong to one artifact rather than to the
+        # release set, so they sit outside what the cache above keys on.
+        return context_cache[key] + _embedded_statements(run.sbom)
 
     runs = (
         AssessmentRun.objects.filter(
@@ -623,6 +629,7 @@ def reannotate_component_runs(component_id: Any) -> int:
             category=AssessmentCategory.SECURITY.value,
             status=RunStatus.COMPLETED.value,
         )
+        .select_related("sbom")
         .prefetch_related("releases")
         # Newest first: dashboards read the latest run per sbom+provider, so if the
         # task ever hits its time limit the visible runs are already re-annotated.
@@ -653,7 +660,9 @@ def resolve_vex_statements_for_sbom(component_id: Any, sbom_id: Any) -> list[dic
     from sbomify.apps.core.models import ReleaseArtifact
 
     release_ids = list(ReleaseArtifact.objects.filter(sbom_id=sbom_id).values_list("release_id", flat=True))
-    return _statements_for_release_context(component_id, release_ids)
+    # Appended last, so an uploaded document or an analyst's triage decides
+    # first: the list is searched in order and the first match wins.
+    return _statements_for_release_context(component_id, release_ids) + _embedded_statements_for_sbom_id(sbom_id)
 
 
 def _release_pinned_imported_rows(release_ids: list[Any], component_id: Any) -> list[Any]:
@@ -755,6 +764,35 @@ def _document_from_vex_sbom(vex: Any) -> dict[str, Any] | None:
     if not raw:
         return None
     return parse_vex_bytes(raw)
+
+
+def _embedded_statements(sbom: Any) -> list[dict[str, Any]]:
+    """The VEX an artifact asserts about itself.
+
+    SPDX 3 carries the security profile inside the document, so a builder's
+    own assessment travels with the thing it describes instead of arriving as
+    a separate upload. Yocto writes its ``CVE_STATUS`` out this way.
+
+    Read from the stored original, never from a copy derived for a scanner:
+    conversion drops the security profile, which is exactly what this reads.
+    Only SPDX 3 documents are fetched, so nothing else pays for an object read
+    that could only come back empty.
+    """
+    if sbom is None or (sbom.format or "").lower() != "spdx":
+        return []
+    if not str(sbom.format_version or "").startswith("3"):
+        return []
+    document = _document_from_vex_sbom(sbom)
+    if not isinstance(document, dict):
+        return []
+    return derive_spdx3_vex_suppressions(document)
+
+
+def _embedded_statements_for_sbom_id(sbom_id: Any) -> list[dict[str, Any]]:
+    from sbomify.apps.sboms.models import SBOM
+
+    row = SBOM.objects.filter(id=sbom_id).only("id", "format", "format_version", "sbom_filename").first()
+    return _embedded_statements(row)
 
 
 def _statements_from_vex_sbom(vex: Any) -> list[dict[str, Any]]:

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -594,3 +594,147 @@ def parse_vex_bytes(raw: bytes | None) -> dict[str, Any] | None:
     # (e.g. UTF-16 XML) the byte sniff cannot see.
     first, second = (try_xml, try_json) if looks_like_xml(raw) else (try_json, try_xml)
     return first() or second()
+
+
+#: Marks a statement the document makes about itself, so the reason a finding
+#: was cleared can name where the claim came from.
+EMBEDDED_SOURCE = "sbom-embedded"
+
+#: The security-profile relationships that clear a finding, and the CycloneDX
+#: state each one records. ``Affected`` and ``UnderInvestigation`` say the
+#: opposite and never suppress.
+#:
+#: ``Fixed`` suppresses here and does not when it arrives as an uploaded
+#: OpenVEX document. The difference is scope. An uploaded statement speaks
+#: about product versions that may not be the one that was scanned, so
+#: honouring it could clear a finding for a version nobody patched. An
+#: embedded statement speaks about the document it lives in, so the claim and
+#: the scanned artifact are the same object. It is also the status that
+#: carries the value: a backported patch leaves the version string untouched,
+#: which is why the scanner keeps reporting a CVE the builder already fixed.
+_SPDX3_SUPPRESSING_VEX: dict[str, str] = {
+    "VexNotAffectedVulnAssessmentRelationship": "not_affected",
+    "VexFixedVulnAssessmentRelationship": "resolved",
+}
+
+
+def _spdx3_type_tail(value: Any) -> str:
+    """The bare class name, whatever the serialisation.
+
+    A type arrives as a full IRI, as a JSON-LD compact IRI (``security:Vex…``)
+    or in the underscore form (``security_Vex…``), and the profile prefix is
+    not part of the name.
+    """
+    if not isinstance(value, str):
+        return ""
+    tail = value.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+    prefix, _, rest = tail.partition("_")
+    return rest if rest and prefix.islower() else tail
+
+
+def _spdx3_justification_label(value: Any) -> str | None:
+    """An SPDX justification as the snake_case label the shared table is keyed on."""
+    if not isinstance(value, str) or not value:
+        return None
+    leaf = value.rsplit("/", 1)[-1].rsplit(":", 1)[-1].rsplit("_", 1)[-1]
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", leaf).lower() or None
+
+
+def _spdx3_vulnerability_ids(element: dict[str, Any]) -> set[str]:
+    """Every identifier a vulnerability element answers to."""
+    ids: set[str] = set()
+    name = norm_id(element.get("name")) if isinstance(element.get("name"), str) else None
+    if name:
+        ids.add(name)
+    for identifier in _as_list(element.get("externalIdentifier")):
+        if not isinstance(identifier, dict):
+            continue
+        value = norm_id(identifier.get("identifier")) if isinstance(identifier.get("identifier"), str) else None
+        if value:
+            ids.add(value)
+    return ids
+
+
+def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Suppressing statements an SPDX 3 document makes about itself.
+
+    SPDX 3 carries VEX in the document rather than beside it: a
+    ``security_Vulnerability`` element names the CVE, and a Vex relationship
+    points ``from`` it ``to`` the packages it judges. Yocto writes exactly this
+    out of ``CVE_STATUS``, which is the case this exists for.
+
+    Product scoping fails closed the way the other formats do. A statement
+    whose targets resolve to no package is skipped rather than widened to
+    suppress by vulnerability id alone, because over-suppression hides real
+    findings. Only a statement with no targets at all is read as a claim about
+    the whole document.
+    """
+    from sbomify.apps.plugins.builtins._spdx3_helpers import spdx3_package_purl
+    from sbomify.apps.plugins.builtins._spdx_shared import iter_spdx3_elements
+
+    if not isinstance(document, dict):
+        return []
+
+    vulnerabilities: dict[str, set[str]] = {}
+    purls: dict[str, str] = {}
+    assessments: list[tuple[str, dict[str, Any]]] = []
+    for element in iter_spdx3_elements(document):
+        tail = _spdx3_type_tail(element.get("type") or element.get("@type"))
+        spdx_id = element.get("spdxId") or element.get("@id")
+        if tail in _SPDX3_SUPPRESSING_VEX:
+            assessments.append((tail, element))
+        elif tail == "Vulnerability":
+            if isinstance(spdx_id, str) and (ids := _spdx3_vulnerability_ids(element)):
+                vulnerabilities[spdx_id] = ids
+        elif tail == "Package":
+            if isinstance(spdx_id, str) and (purl := spdx3_package_purl(element)):
+                purls[spdx_id] = purl
+
+    statements: list[dict[str, Any]] = []
+    for tail, element in assessments:
+        subject = element.get("from")
+        if isinstance(subject, str):
+            ids = vulnerabilities.get(subject, set())
+        elif isinstance(subject, dict):
+            ids = _spdx3_vulnerability_ids(subject)
+        else:
+            ids = set()
+        if not ids:
+            continue
+        if len(statements) >= MAX_VEX_STATEMENTS:
+            logger.warning(
+                "SPDX 3 document carries more than %d suppressing statements; ignoring the rest.",
+                MAX_VEX_STATEMENTS,
+            )
+            break
+
+        targets = _as_list(element.get("to"))
+        target_purls: list[str] = []
+        for target in targets:
+            if isinstance(target, str) and target in purls:
+                target_purls.append(purls[target])
+            elif isinstance(target, dict) and (purl := spdx3_package_purl(target)):
+                target_purls.append(purl)
+        packages = _packages_from_purls(target_purls)
+        if targets and not packages:
+            # Scoped to something we cannot identify. Suppressing by id alone
+            # would apply it wider than its author wrote it.
+            continue
+
+        justification, detail = _mapped_justification(
+            _spdx3_justification_label(element.get("security_justificationType")),
+            element.get("security_impactStatement") or element.get("security_statusNotes"),
+            "spdx",
+        )
+        statements.append(
+            {
+                "ids": ids,
+                "packages": packages,
+                "product_scoped": not packages,
+                "state": _SPDX3_SUPPRESSING_VEX[tail],
+                "justification": justification,
+                "detail": detail,
+                "source": EMBEDDED_SOURCE,
+            }
+        )
+    return statements

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -654,14 +654,19 @@ def _spdx3_justification_label(value: Any) -> str | None:
 
 
 def _spdx3_vulnerability_ids(element: dict[str, Any]) -> set[str]:
-    """Every identifier a vulnerability element answers to."""
+    """Every identifier a vulnerability element answers to.
+
+    The shared walk is what reads the external identifiers, so a document
+    using the plural spelling is understood here the way the plugins already
+    understand it.
+    """
+    from sbomify.apps.plugins.builtins._spdx3_helpers import iter_spdx3_external_identifiers
+
     ids: set[str] = set()
     name = norm_id(element.get("name")) if isinstance(element.get("name"), str) else None
     if name:
         ids.add(name)
-    for identifier in _as_list(element.get("externalIdentifier")):
-        if not isinstance(identifier, dict):
-            continue
+    for identifier in iter_spdx3_external_identifiers(element):
         value = norm_id(identifier.get("identifier")) if isinstance(identifier.get("identifier"), str) else None
         if value:
             ids.add(value)
@@ -679,8 +684,8 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
     Product scoping fails closed the way the other formats do. A statement
     whose targets resolve to no package is skipped rather than widened to
     suppress by vulnerability id alone, because over-suppression hides real
-    findings. Only a statement with no targets at all is read as a claim about
-    the whole document.
+    findings. Only a statement that omits ``to`` entirely is read as a claim
+    about the whole document.
     """
     from sbomify.apps.plugins.builtins._spdx3_helpers import spdx3_package_purl
     from sbomify.apps.plugins.builtins._spdx_shared import iter_spdx3_elements
@@ -721,17 +726,18 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
             )
             break
 
-        targets = _as_targets(element.get("to"))
+        raw_targets = element.get("to")
         target_purls: list[str] = []
-        for target in targets:
+        for target in _as_targets(raw_targets):
             if isinstance(target, str) and target in purls:
                 target_purls.append(purls[target])
             elif isinstance(target, dict) and (purl := spdx3_package_purl(target)):
                 target_purls.append(purl)
         packages = _packages_from_purls(target_purls)
-        if targets and not packages:
+        if raw_targets is not None and not packages:
             # Scoped to something we cannot identify. Suppressing by id alone
-            # would apply it wider than its author wrote it.
+            # would apply it wider than its author wrote it, and an empty list
+            # is a scope its author wrote rather than a scope they omitted.
             continue
 
         justification, detail = _mapped_justification(

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -129,6 +129,19 @@ def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def _as_targets(value: Any) -> list[Any]:
+    """A relationship's ``to`` as a list, whatever shape it arrives in.
+
+    JSON-LD writes a single-valued property unwrapped, so a bare string or a
+    nested object is one target rather than none. Reading it as none would
+    widen a scoped statement into a claim about the whole document, which is
+    the one direction this must not fail in.
+    """
+    if isinstance(value, list):
+        return value
+    return [] if value is None else [value]
+
+
 def _packages_from_purls(purls: list[str]) -> set[tuple[str | None, str, str | None]]:
     packages: set[tuple[str | None, str, str | None]] = set()
     for purl in purls:
@@ -708,7 +721,7 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
             )
             break
 
-        targets = _as_list(element.get("to"))
+        targets = _as_targets(element.get("to"))
         target_purls: list[str] = []
         for target in targets:
             if isinstance(target, str) and target in purls:


### PR DESCRIPTION
Closes #1499.

## What changed

SPDX 3 keeps VEX inside the document. A `security_Vulnerability` element names the CVE and a Vex relationship points `from` it `to` the packages it judges, so a builder states what it knows beside the packages it shipped rather than publishing a separate file. Yocto writes its `CVE_STATUS` out exactly this way and we read none of it, so a CVE the maintainer already handled still shows as an open finding.

Those statements are now read from the stored original and applied through the overlay an uploaded VEX already goes through. No second mechanism: they annotate and suppress on the same path, and the badge already knows how to say where a suppression came from.

## Precedence falls out of the existing code

They are appended last. `_matches_in_index` sorts by position and the caller takes the first match, so an uploaded document or an analyst's in-app triage decides before a claim the document makes about itself. That is the most-deliberate-wins order the issue asked for, and it needed no new machinery.

## The one decision worth reviewing

**`Fixed` suppresses here. The same status arriving as an uploaded OpenVEX still does not.**

That asymmetry is deliberate, and it is the call to overturn if you disagree. Two reasons for it:

- **Scope.** An uploaded statement speaks about product versions, which may not be the version that was scanned, so honouring it could clear a finding for a version nobody patched. An embedded statement speaks about the document it lives in, so the claim and the scanned artifact are the same object and there is no version to mismatch.
- **It is the status that carries the value.** Yocto maps a patched CVE to `VexFixedVulnAssessmentRelationship` ([oe-core thread](http://www.mail-archive.com/openembedded-core@lists.openembedded.org/msg211973.html)), and a backported patch leaves the version string untouched, so the scanner reports that CVE for ever. Honouring only `NotAffected` would read the smaller half of what Yocto writes.

The existing comment on `_SUPPRESSING_STATES` argues the other way for uploaded VEX, that a real fix should disappear from the next scan by itself. That argument does not survive a backported patch, and it is quoted next to the new mapping so the difference is visible rather than accidental.

`Fixed` records `analysis_state = resolved` rather than borrowing `not_affected`, so the badge stays honest about which claim cleared the finding.

## Kept the habits the other formats have

- **Scoping fails closed.** A statement whose targets resolve to no package is skipped rather than widened to suppress by vulnerability id alone, because over-suppression hides real findings. Only a statement with no targets at all is read as covering the document.
- **Read from the original, never a derived copy.** #1502 converts documents for scanners and conversion drops the security profile, which is precisely what this reads. Convert to scan, overlay to suppress.
- **Only SPDX 3 artifacts are fetched.** The reannotate path walks every run, so an object read per artifact would be a real cost; a CycloneDX or SPDX 2 row is answered from its format alone.

## Tests

19. The extraction half covers which relationship kinds clear a finding and which say the opposite, all three JSON-LD spellings of a type, a vulnerability named by `externalIdentifier` or inlined into the relationship, and scoping failing closed. The overlay half drives `finding_is_suppressed` end to end, pins that an uploaded statement outranks an embedded one, and checks the reason names where the claim came from. Two more prove an SPDX 3 artifact is read and that a CycloneDX or SPDX 2 one costs no object read.

vulnerability_scanning and sboms suites green (1073 passed).

## Sequencing

The value of this depends on #1500, now merged as #1502 and #1503: before it, an SPDX 3 document reached no scanner, so there were no findings for these statements to act on. The code here is independent of that change and does not import from it.


## What a QA pass since found, and it matters for this PR

A Yocto SBOM produces no vulnerability findings today, so these statements currently have nothing to clear. Yocto builds every recipe purl as `pkg:yocto/…` and osv-scanner refuses it ("Invalid PURL", 0 packages), with or without the conversion in #1502. Details and evidence in #1506.

The extraction here was checked against what Yocto actually writes rather than against a fixture invented for it: `from` is the CVE and `to` is the recipe, matching `new_vex_patched_relationship` in `spdx30_tasks.py`, and a real `pkg:yocto/meta/openssl@3.0.11` target resolves to the package tuple the matcher expects. So this is correct and ready for the moment findings exist; it is not observable for Yocto until #1506 is answered.
