### PR TITLE
fix(billing): deleting a workspace cancels its subscription

### DIFF
--- a/sbomify/apps/billing/apps.py
+++ b/sbomify/apps/billing/apps.py
@@ -13,4 +13,13 @@ class BillingConfig(AppConfig):
         # Import signals, tasks, and cron to register them with Django and Dramatiq.
         # Without importing cron here the `daily_stale_trial_check` actor is
         # never registered with the dramatiq worker.
+        import stripe
+        from django.conf import settings
+
         from . import cron, signals, tasks  # noqa: F401
+
+        # Pin here rather than per call: every request the library makes then
+        # states the version it was written against, so upgrading the library
+        # cannot change request or response shapes underneath us.
+        if getattr(settings, "STRIPE_API_VERSION", ""):
+            stripe.api_version = settings.STRIPE_API_VERSION

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -455,7 +455,7 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
 
     # Definitively unresolved after every strategy → the workspace is gone. Keep the
     # message free of the Stripe subscription id (re-logged by the webhook view).
-    raise Team.DoesNotExist("No team found for the subscription in this webhook event")
+    raise Team.DoesNotExist("No workspace holds the subscription in this webhook event")
 
 
 def _update_billing_from_subscription(team: Team, subscription: Any, webhook_id: str) -> dict[str, Any]:

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -268,6 +268,12 @@ def handle_trial_period(subscription: Any, team: Team) -> bool:
             logger.warning(f"Could not convert trial_end to datetime: {e}")
             return False
 
+        # Whether the trial is over is read from the timestamp, not from the day
+        # count. timedelta.days floors, so anything under 24 hours counts as 0,
+        # and expiring on that published every private component in the
+        # workspace up to a day before the trial actually ended.
+        trial_has_ended = trial_end <= timezone.now()
+
         with transaction.atomic():
             team = Team.objects.select_for_update().get(pk=team.pk)
             billing_limits = (team.billing_plan_limits or {}).copy()
@@ -281,7 +287,7 @@ def handle_trial_period(subscription: Any, team: Team) -> bool:
             notify_billing_managers(team, email_notifications.notify_trial_ending, days_remaining)
             logger.info("Trial ending notification sent")
 
-        if days_remaining <= 0:
+        if trial_has_ended:
             # See ``TrialExpiryEmissionGuard`` for the two-marker state machine
             # that makes the side effects below crash-tolerant and idempotent
             # across concurrent / redelivered webhooks.

--- a/sbomify/apps/billing/billing_processing.py
+++ b/sbomify/apps/billing/billing_processing.py
@@ -29,7 +29,13 @@ from .billing_helpers import (
 from .config import get_unlimited_plan_limits, is_billing_enabled
 from .models import BillingPlan
 from .stripe_cache import get_subscription_cancel_at_period_end, invalidate_subscription_cache
-from .stripe_client import BillingRetryableError, StripeError, get_stripe_client, handle_stripe_errors
+from .stripe_client import (
+    BillingRetryableError,
+    StripeError,
+    WorkspaceGoneError,
+    get_stripe_client,
+    handle_stripe_errors,
+)
 
 logger = getLogger(__name__)
 
@@ -61,17 +67,20 @@ def _raise_classified_webhook_error(exc: Exception) -> NoReturn:
     * ``BillingRetryableError`` (incl. transient Stripe failures surfaced by the
       ``handle_stripe_errors`` decorator) -> propagate so the view returns 5xx and
       Stripe retries.
-    * ``Team.DoesNotExist`` / an explicit terminal ``StripeError`` (e.g. an invalid
-      subscription status, or a terminal Stripe failure such as a missing customer)
-      -> terminal: the view acknowledges with 200.
+    * ``Team.DoesNotExist`` -> ``WorkspaceGoneError``, terminal: the view
+      acknowledges with 200 and reports it as an event with nowhere to land
+      rather than as a fault.
+    * An explicit terminal ``StripeError`` (e.g. an invalid subscription status,
+      or a terminal Stripe failure such as a missing customer) -> terminal: the
+      view acknowledges with 200.
     * Anything else (unexpected) -> retryable, so a transient bug/outage is not
       silently dropped.
     """
     if isinstance(exc, BillingRetryableError):
         raise exc
     if isinstance(exc, Team.DoesNotExist):
-        # Terminal: a genuinely nonexistent team cannot be conjured by a retry.
-        raise StripeError(str(exc) or "No team found for webhook event") from exc
+        # Terminal: a genuinely nonexistent workspace cannot be conjured by a retry.
+        raise WorkspaceGoneError(str(exc) or "No workspace found for webhook event") from exc
     if isinstance(exc, StripeError):
         # Explicit terminal business error or a terminal Stripe failure — preserve it.
         raise exc
@@ -416,6 +425,7 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
     # Stripe outage here must be retried (BillingRetryableError); a *permanent* failure
     # (e.g. no such customer) cannot be resolved by retrying, so fall through to the
     # terminal "no team" path rather than amplifying futile retries.
+    customer_unreadable = False
     try:
         customer = stripe_client.get_customer(subscription.customer)
     except BillingRetryableError:
@@ -423,9 +433,10 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
     except StripeError:
         # Don't log the Stripe customer/subscription identifiers here (flagged as
         # sensitive by code scanning); the subscription id is still carried in the
-        # terminal Team.DoesNotExist raised below.
+        # terminal error raised below.
         logger.warning("Permanent failure fetching Stripe customer during team resolution; treating as no team")
         customer = None
+        customer_unreadable = True
 
     if customer is not None and customer.metadata and "team_key" in customer.metadata:
         try:
@@ -436,7 +447,13 @@ def _resolve_team_from_subscription(subscription: Any) -> tuple[Team, dict[str, 
             logger.warning("Found team by customer metadata")
             return team, team.billing_plan_limits or {}
 
-    # Definitively unresolved after every strategy → terminal "no team". Keep the
+    if customer_unreadable:
+        # No workspace holds these ids, and the customer that could have named one
+        # would not load. Terminal either way, but whether the workspace still
+        # exists is unknown, so this is not the quiet kind.
+        raise StripeError("No workspace holds this subscription and its Stripe customer could not be read")
+
+    # Definitively unresolved after every strategy → the workspace is gone. Keep the
     # message free of the Stripe subscription id (re-logged by the webhook view).
     raise Team.DoesNotExist("No team found for the subscription in this webhook event")
 

--- a/sbomify/apps/billing/email_notifications.py
+++ b/sbomify/apps/billing/email_notifications.py
@@ -144,7 +144,8 @@ def notify_payment_succeeded(team: Team, member: Member) -> None:
 def notify_trial_ending(team: Team, member: Member, days_remaining: int) -> None:
     """Notify team owner that trial period is ending soon."""
     if days_remaining <= 0:
-        subject = "Your sbomify trial ends today"
+        # Under a day left, which may still be tomorrow by the clock.
+        subject = "Your sbomify trial ends soon"
     elif days_remaining == 1:
         subject = "Your sbomify trial ends tomorrow"
     else:

--- a/sbomify/apps/billing/email_notifications.py
+++ b/sbomify/apps/billing/email_notifications.py
@@ -56,7 +56,24 @@ def _get_base_context(team: Team, member: Member) -> dict[str, Any]:
 def send_billing_email(
     team: Team, member: Member, subject: str, template_name: str, extra_context: dict[str, Any]
 ) -> None:
-    """Send a billing-related email using a template."""
+    """Queue a billing email. The rendering and the SMTP round trip happen in a
+    worker, so a webhook is not held open for them."""
+    from sbomify.apps.billing.tasks import deliver_billing_email
+
+    if not team:
+        logger.error("Cannot send billing email: team is None")
+        return
+    if not member:
+        logger.error("Cannot send billing email: member is None")
+        return
+
+    deliver_billing_email.send(team.pk, member.pk, subject, template_name, extra_context)
+
+
+def render_and_send_billing_email(
+    team: Team, member: Member, subject: str, template_name: str, extra_context: dict[str, Any]
+) -> None:
+    """Render a billing email from its template and send it. Called by the worker."""
     if not team:
         logger.error("Cannot send billing email: team is None")
         return
@@ -126,7 +143,12 @@ def notify_payment_succeeded(team: Team, member: Member) -> None:
 
 def notify_trial_ending(team: Team, member: Member, days_remaining: int) -> None:
     """Notify team owner that trial period is ending soon."""
-    subject = f"Your sbomify trial ends in {days_remaining} days"
+    if days_remaining <= 0:
+        subject = "Your sbomify trial ends today"
+    elif days_remaining == 1:
+        subject = "Your sbomify trial ends tomorrow"
+    else:
+        subject = f"Your sbomify trial ends in {days_remaining} days"
     send_billing_email(team, member, subject, "trial_ending", {"days_remaining": days_remaining})
 
 

--- a/sbomify/apps/billing/stripe_client.py
+++ b/sbomify/apps/billing/stripe_client.py
@@ -223,6 +223,13 @@ class StripeClient:
 
         if trial_days:
             subscription_data["trial_period_days"] = trial_days
+            # A trial started this way carries no card, so say what happens when
+            # it ends without one. Stripe otherwise raises an invoice nobody can
+            # pay, which reaches the customer as a failed-payment notice for a
+            # trial they simply let lapse, and leaves the workspace past_due.
+            # Cancelling ends it cleanly, on the path the deleted-subscription
+            # handler already downgrades from.
+            subscription_data["trial_settings"] = {"end_behavior": {"missing_payment_method": "cancel"}}
 
         subscription = stripe.Subscription.create(**subscription_data)
 

--- a/sbomify/apps/billing/stripe_client.py
+++ b/sbomify/apps/billing/stripe_client.py
@@ -64,6 +64,20 @@ class BillingRetryableError(StripeError):
     pass
 
 
+class WorkspaceGoneError(StripeError):
+    """The workspace this event belongs to no longer exists.
+
+    Terminal like its parent, and acknowledged the same way, but separated so
+    the webhook view can report it for what it is. Every lookup strategy missed,
+    which means no workspace holds the subscription, the customer, or the key the
+    customer's own metadata names. Deleting a workspace cancels its subscription,
+    and Stripe reports that cancellation back here after the row has gone, so an
+    event with nowhere to land is an expected end state rather than a fault.
+    """
+
+    pass
+
+
 def handle_stripe_errors(func: F) -> F:
     """Decorator to handle Stripe errors consistently.
 

--- a/sbomify/apps/billing/stripe_pricing_service.py
+++ b/sbomify/apps/billing/stripe_pricing_service.py
@@ -362,7 +362,14 @@ class StripePricingService:
         if trial_period_days and trial_period_days > 0:
             if trial_period_days > max_trial_days:
                 raise StripeError(f"Trial period {trial_period_days} days exceeds maximum allowed {max_trial_days}")
-            session_data["subscription_data"] = {"trial_period_days": trial_period_days}
+            session_data["subscription_data"] = {
+                "trial_period_days": trial_period_days,
+                # Collecting a card at checkout does not keep one there: it can be
+                # detached or expire in the portal before the trial ends. Say what
+                # happens then, rather than taking Stripe's default of raising an
+                # invoice nobody can pay.
+                "trial_settings": {"end_behavior": {"missing_payment_method": "cancel"}},
+            }
             # Ensure card details are always collected during trial checkout
             session_data["payment_method_collection"] = "always"
 

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -35,7 +35,9 @@ def deliver_billing_email(
     from sbomify.apps.teams.models import Member, Team
 
     team = Team.objects.filter(pk=team_id).first()
-    member = Member.objects.filter(pk=member_id).select_related("user").first()
+    # Scoped to the workspace, so mismatched ids cannot address the right person
+    # with another workspace's name and billing links in the body.
+    member = Member.objects.filter(pk=member_id, team_id=team_id).select_related("user").first()
     if team is None or member is None:
         # The workspace or the membership went away between queueing and now.
         logger.info("Skipping billing email %s: the workspace or member no longer exists", template_name)

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -17,6 +17,33 @@ logger = getLogger(__name__)
 
 
 @dramatiq.actor(queue_name="default", max_retries=3)
+def cleanup_stripe_for_deleted_workspace(
+    subscription_id: str | None,
+    customer_id: str | None,
+    workspace_key: str,
+) -> None:
+    """Cancel a deleted workspace's subscription and remove its Stripe customer.
+
+    Runs here rather than in the request that deleted the workspace: the row is
+    already gone by then, so a slow or failing Stripe call could only hold a web
+    worker open, and a proxy timing the request out would leave the subscription
+    live with nothing left to retry it.
+
+    A permanent failure logs CRITICAL and stops, because retrying cannot help
+    and the subscription needs a person. Anything else is left to raise so
+    dramatiq retries it.
+    """
+    from sbomify.apps.core.services.account_deletion import cleanup_stripe_for_workspace
+
+    if cleanup_stripe_for_workspace(subscription_id, customer_id):
+        return
+    logger.critical(
+        "Stripe cleanup failed for deleted workspace %s; its subscription may still bill",
+        workspace_key,
+    )
+
+
+@dramatiq.actor(queue_name="default", max_retries=3)
 def deliver_billing_email(
     team_id: int,
     member_id: int,

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -17,6 +17,34 @@ logger = getLogger(__name__)
 
 
 @dramatiq.actor(queue_name="default", max_retries=3)
+def deliver_billing_email(
+    team_id: int,
+    member_id: int,
+    subject: str,
+    template_name: str,
+    extra_context: dict[str, Any],
+) -> None:
+    """Render and send one billing email off the request that triggered it.
+
+    Stripe asks for a webhook to be answered before slow work, and an SMTP
+    round trip per recipient is the slowest thing these handlers do. Only
+    delivery moves here: the database work that decides the webhook's 200 or
+    5xx still runs inline, so that contract is unchanged.
+    """
+    from sbomify.apps.billing.email_notifications import render_and_send_billing_email
+    from sbomify.apps.teams.models import Member, Team
+
+    team = Team.objects.filter(pk=team_id).first()
+    member = Member.objects.filter(pk=member_id).select_related("user").first()
+    if team is None or member is None:
+        # The workspace or the membership went away between queueing and now.
+        logger.info("Skipping billing email %s: the workspace or member no longer exists", template_name)
+        return
+
+    render_and_send_billing_email(team, member, subject, template_name, extra_context)
+
+
+@dramatiq.actor(queue_name="default", max_retries=3)
 def send_enterprise_inquiry_email(
     form_data: dict[str, Any],
     user_email: str | None = None,

--- a/sbomify/apps/billing/tasks/__init__.py
+++ b/sbomify/apps/billing/tasks/__init__.py
@@ -35,7 +35,8 @@ def cleanup_stripe_for_deleted_workspace(
     """
     from sbomify.apps.core.services.account_deletion import cleanup_stripe_for_workspace
 
-    if cleanup_stripe_for_workspace(subscription_id, customer_id):
+    # raise_retryable: an outage must come back here, not stop at one CRITICAL.
+    if cleanup_stripe_for_workspace(subscription_id, customer_id, raise_retryable=True):
         return
     logger.critical(
         "Stripe cleanup failed for deleted workspace %s; its subscription may still bill",

--- a/sbomify/apps/billing/templates/billing/emails/trial_ending.html.j2
+++ b/sbomify/apps/billing/templates/billing/emails/trial_ending.html.j2
@@ -4,7 +4,7 @@
     <h1>Your trial ends soon</h1>
     <p>Hi {{ user_name }},</p>
     <p>
-        Your trial for <strong>{{ team_name }}</strong> ends in <strong>{{ days_remaining }} days</strong>.
+        Your trial for <strong>{{ team_name }}</strong> ends in <strong>{{ days_remaining }} day{{ days_remaining|pluralize }}</strong>.
         Upgrade to a paid plan to keep access to all features.
     </p>
     <p style="text-align: center; margin: 32px 0;">

--- a/sbomify/apps/billing/templates/billing/emails/trial_ending.txt
+++ b/sbomify/apps/billing/templates/billing/emails/trial_ending.txt
@@ -1,6 +1,6 @@
 Hi {{ user_name }},
 
-Your trial for {{ team_name }} ends in {{ days_remaining }} days. Upgrade to a paid plan to keep access to all features.
+Your trial for {{ team_name }} ends in {{ days_remaining }} day{{ days_remaining|pluralize }}. Upgrade to a paid plan to keep access to all features.
 
 Upgrade now: {{ upgrade_url }}
 

--- a/sbomify/apps/billing/tests/test_billing_processing.py
+++ b/sbomify/apps/billing/tests/test_billing_processing.py
@@ -281,6 +281,34 @@ class TestBillingProcessing:
             billing_processing.handle_subscription_updated(self.subscription)
         assert not isinstance(exc.value, BillingRetryableError)
 
+    def test_a_workspace_that_no_longer_exists_says_so(self):
+        """Every strategy missing means the workspace is gone, which is not a fault.
+
+        Deleting a workspace cancels its subscription, and Stripe reports that back
+        after the row has gone, so the view needs to tell this apart from a terminal
+        error worth waking somebody for.
+        """
+        from sbomify.apps.billing.stripe_client import WorkspaceGoneError
+
+        self.subscription.id = "sub_unmapped_e2e"
+        self.subscription.customer = "cus_unmapped_e2e"
+        self.stripe_client.get_customer.return_value = MagicMock(metadata={"team_key": "no_such_team"})
+
+        with pytest.raises(WorkspaceGoneError):
+            billing_processing.handle_subscription_updated(self.subscription)
+
+    def test_a_terminal_stripe_failure_is_not_a_missing_workspace(self):
+        """The narrower class must not swallow the errors that are still worth an alert."""
+        from sbomify.apps.billing.stripe_client import WorkspaceGoneError
+
+        self.subscription.id = "sub_unmapped_e2e"
+        self.subscription.customer = "cus_unmapped_e2e"
+        self.stripe_client.get_customer.side_effect = StripeError("Invalid request to payment provider.")
+
+        with pytest.raises(StripeError) as exc:
+            billing_processing.handle_subscription_updated(self.subscription)
+        assert not isinstance(exc.value, WorkspaceGoneError)
+
     # ------------------------------------------------------------------
     # #996: retryable vs terminal classification across ALL handlers.
     # A transient/recoverable failure must raise BillingRetryableError so the

--- a/sbomify/apps/billing/tests/test_billing_review_fixes.py
+++ b/sbomify/apps/billing/tests/test_billing_review_fixes.py
@@ -213,6 +213,7 @@ class TestPlanKeyInCheckoutMetadata:
                 assert "plan_key" in metadata
                 assert metadata["plan_key"] == "business"
 
+
 # ============================================================================
 # Task #48: Turnstile remoteip Parameter Tests
 # ============================================================================
@@ -523,3 +524,113 @@ class TestCheckoutLockInViews:
     def setup_method(self):
         cache.clear()
 
+
+class TestTheWebhookRoutesEveryEventWeNeed:
+    """Gaps found reading the integration against Stripe's own subscription
+    webhook guide."""
+
+    def _event(self, kind, obj=None):
+        from unittest.mock import MagicMock
+
+        event = MagicMock()
+        event.type = kind
+        event.id = f"evt_{kind}"
+        event.data.object = obj or MagicMock()
+        return event
+
+    def _dispatch(self, event):
+        """Run just the routing block the view runs."""
+        from sbomify.apps.billing import billing_processing
+
+        return billing_processing, event
+
+    def test_trial_will_end_reaches_the_subscription_handler(self, mocker):
+        """It is the only notice Stripe sends as a trial runs down."""
+        from django.test import Client
+
+        handler = mocker.patch("sbomify.apps.billing.billing_processing.handle_subscription_updated")
+        mocker.patch(
+            "sbomify.apps.billing.views.stripe_client.construct_webhook_event",
+            return_value=self._event("customer.subscription.trial_will_end"),
+        )
+        mocker.patch("django.conf.settings.STRIPE_WEBHOOK_SECRET", "whsec_x", create=True)
+
+        resp = Client().post(
+            "/billing/webhook/",
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=x",
+        )
+
+        assert resp.status_code == 200
+        handler.assert_called_once()
+
+    @pytest.mark.parametrize("kind", ["price.updated", "price.created"])
+    def test_price_events_reach_the_price_handler(self, mocker, kind):
+        """The handler existed and nothing called it, so plan prices went stale."""
+        from django.test import Client
+
+        handler = mocker.patch("sbomify.apps.billing.billing_processing.handle_price_updated")
+        mocker.patch(
+            "sbomify.apps.billing.views.stripe_client.construct_webhook_event",
+            return_value=self._event(kind),
+        )
+        mocker.patch("django.conf.settings.STRIPE_WEBHOOK_SECRET", "whsec_x", create=True)
+
+        resp = Client().post(
+            "/billing/webhook/",
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=x",
+        )
+
+        assert resp.status_code == 200
+        handler.assert_called_once()
+
+
+class TestTheApiVersionIsPinned:
+    def test_the_library_is_told_which_version_we_wrote_against(self):
+        """Otherwise a library upgrade moves it without a diff."""
+        import stripe
+        from django.conf import settings
+
+        assert settings.STRIPE_API_VERSION
+        assert stripe.api_version == settings.STRIPE_API_VERSION
+
+
+@pytest.mark.django_db
+class TestNotificationsLeaveTheRequest:
+    """An SMTP round trip per recipient is the slowest thing a webhook does."""
+
+    def test_send_billing_email_queues_instead_of_sending(self, mocker, sample_team_with_owner_member):
+        from sbomify.apps.billing import email_notifications
+
+        queued = mocker.patch("sbomify.apps.billing.tasks.deliver_billing_email.send")
+        rendered = mocker.patch("sbomify.apps.billing.email_notifications.render_to_string")
+        member = sample_team_with_owner_member
+
+        email_notifications.send_billing_email(member.team, member, "Subject", "trial_ending", {"days_remaining": 3})
+
+        rendered.assert_not_called()
+        queued.assert_called_once_with(member.team.pk, member.pk, "Subject", "trial_ending", {"days_remaining": 3})
+
+    def test_the_worker_renders_and_sends_it(self, mocker, sample_team_with_owner_member):
+        from sbomify.apps.billing.tasks import deliver_billing_email
+
+        send = mocker.patch("sbomify.apps.billing.email_notifications.render_and_send_billing_email")
+        member = sample_team_with_owner_member
+
+        deliver_billing_email(member.team.pk, member.pk, "Subject", "trial_ending", {"days_remaining": 3})
+
+        send.assert_called_once()
+        assert send.call_args[0][0].pk == member.team.pk
+        assert send.call_args[0][1].pk == member.pk
+
+    def test_a_workspace_deleted_before_delivery_is_skipped(self, mocker, sample_team_with_owner_member):
+        from sbomify.apps.billing.tasks import deliver_billing_email
+
+        send = mocker.patch("sbomify.apps.billing.email_notifications.render_and_send_billing_email")
+
+        deliver_billing_email(999999, sample_team_with_owner_member.pk, "Subject", "trial_ending", {})
+
+        send.assert_not_called()

--- a/sbomify/apps/billing/tests/test_billing_review_fixes.py
+++ b/sbomify/apps/billing/tests/test_billing_review_fixes.py
@@ -588,16 +588,6 @@ class TestTheWebhookRoutesEveryEventWeNeed:
         handler.assert_called_once()
 
 
-class TestTheApiVersionIsPinned:
-    def test_the_library_is_told_which_version_we_wrote_against(self):
-        """Otherwise a library upgrade moves it without a diff."""
-        import stripe
-        from django.conf import settings
-
-        assert settings.STRIPE_API_VERSION
-        assert stripe.api_version == settings.STRIPE_API_VERSION
-
-
 @pytest.mark.django_db
 class TestNotificationsLeaveTheRequest:
     """An SMTP round trip per recipient is the slowest thing a webhook does."""

--- a/sbomify/apps/billing/tests/test_billing_review_fixes.py
+++ b/sbomify/apps/billing/tests/test_billing_review_fixes.py
@@ -647,3 +647,46 @@ class TestNotificationsLeaveTheRequest:
         deliver_billing_email(other.pk, member.pk, "Subject", "trial_ending", {})
 
         send.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestATrialRunsItsFullLength:
+    """timedelta.days floors, so under 24 hours read as 0 and the expiry branch
+    ran while the trial was still going, publishing every private component."""
+
+    def _subscription(self, hours_left):
+        import datetime
+
+        from django.utils import timezone
+
+        end = timezone.now() + datetime.timedelta(hours=hours_left)
+        sub = MagicMock()
+        sub.status = "trialing"
+        sub.trial_end = int(end.timestamp())
+        return sub
+
+    def test_a_trial_with_hours_left_has_not_expired(self, mocker, sample_team_with_owner_member):
+        from sbomify.apps.billing import billing_processing
+
+        downgrade = mocker.patch("sbomify.apps.billing.billing_processing.handle_community_downgrade_visibility")
+        mocker.patch("sbomify.apps.billing.billing_processing.notify_billing_managers")
+        team = sample_team_with_owner_member.team
+
+        billing_processing.handle_trial_period(self._subscription(20), team)
+
+        team.refresh_from_db()
+        downgrade.assert_not_called()
+        assert team.billing_plan != "community"
+
+    def test_a_trial_past_its_end_expires(self, mocker, sample_team_with_owner_member):
+        from sbomify.apps.billing import billing_processing
+
+        downgrade = mocker.patch("sbomify.apps.billing.billing_processing.handle_community_downgrade_visibility")
+        mocker.patch("sbomify.apps.billing.billing_processing.notify_billing_managers")
+        team = sample_team_with_owner_member.team
+
+        billing_processing.handle_trial_period(self._subscription(-1), team)
+
+        team.refresh_from_db()
+        downgrade.assert_called_once()
+        assert team.billing_plan == "community"

--- a/sbomify/apps/billing/tests/test_billing_review_fixes.py
+++ b/sbomify/apps/billing/tests/test_billing_review_fixes.py
@@ -634,3 +634,16 @@ class TestNotificationsLeaveTheRequest:
         deliver_billing_email(999999, sample_team_with_owner_member.pk, "Subject", "trial_ending", {})
 
         send.assert_not_called()
+
+    def test_a_member_of_another_workspace_is_not_emailed(self, mocker, sample_team_with_owner_member):
+        """Mismatched ids would name the wrong workspace at the right person."""
+        from sbomify.apps.billing.tasks import deliver_billing_email
+        from sbomify.apps.teams.models import Team
+
+        send = mocker.patch("sbomify.apps.billing.email_notifications.render_and_send_billing_email")
+        member = sample_team_with_owner_member
+        other = Team.objects.create(name="Another workspace", key="another-ws-key")
+
+        deliver_billing_email(other.pk, member.pk, "Subject", "trial_ending", {})
+
+        send.assert_not_called()

--- a/sbomify/apps/billing/tests/test_email_notifications.py
+++ b/sbomify/apps/billing/tests/test_email_notifications.py
@@ -132,7 +132,7 @@ def test_send_billing_email(team):
                 with patch("sbomify.apps.billing.email_notifications.EmailMultiAlternatives") as mock_email_cls:
                     mock_email = MagicMock()
                     mock_email_cls.return_value = mock_email
-                    email_notifications.send_billing_email(team, member, subject, template, extra_context)
+                    email_notifications.render_and_send_billing_email(team, member, subject, template, extra_context)
                     mock_email_cls.assert_called_once_with(
                         subject=subject,
                         body="text_content",
@@ -159,7 +159,7 @@ def test_send_billing_email_template_error(team):
 
     with patch("sbomify.apps.billing.email_notifications.render_to_string", side_effect=Exception("Template error")):
         with patch("sbomify.apps.billing.email_notifications.logger") as mock_logger:
-            email_notifications.send_billing_email(team, member, subject, template, context)
+            email_notifications.render_and_send_billing_email(team, member, subject, template, context)
             mock_logger.error.assert_called_once()
 
 
@@ -177,7 +177,7 @@ def test_send_billing_email_send_error(team):
             mock_email.send.side_effect = Exception("Send error")
             mock_email_cls.return_value = mock_email
             with patch("sbomify.apps.billing.email_notifications.logger") as mock_logger:
-                email_notifications.send_billing_email(team, member, subject, template, context)
+                email_notifications.render_and_send_billing_email(team, member, subject, template, context)
                 mock_logger.error.assert_called_once()
 
 
@@ -192,7 +192,7 @@ def test_send_billing_email_invalid_team(team):
     team = None
 
     with patch("sbomify.apps.billing.email_notifications.logger") as mock_logger:
-        email_notifications.send_billing_email(team, member, subject, template, context)
+        email_notifications.render_and_send_billing_email(team, member, subject, template, context)
         mock_logger.error.assert_called_once()
 
 
@@ -207,5 +207,5 @@ def test_send_billing_email_invalid_member(team):
     member = None
 
     with patch("sbomify.apps.billing.email_notifications.logger") as mock_logger:
-        email_notifications.send_billing_email(team, member, subject, template, context)
+        email_notifications.render_and_send_billing_email(team, member, subject, template, context)
         mock_logger.error.assert_called_once()

--- a/sbomify/apps/billing/tests/test_stripe_api_version.py
+++ b/sbomify/apps/billing/tests/test_stripe_api_version.py
@@ -1,0 +1,32 @@
+"""The pinned Stripe API version, and what keeps it honest.
+
+Pinning stops a library upgrade moving the version our requests are made
+against without a diff to show for it. A pin is only safe while it names a
+version Stripe accepts, so the value is checked against the installed
+library's own current version rather than trusted as a string.
+"""
+
+from __future__ import annotations
+
+import stripe
+from django.conf import settings
+
+
+def _library_current_version() -> str:
+    """The version the installed library ships with, before our own pinning.
+
+    Read from the module rather than from ``stripe.api_version``, which the
+    billing app config overwrites at startup.
+    """
+    from stripe._api_version import _ApiVersion
+
+    return _ApiVersion.CURRENT
+
+
+def test_the_pin_names_a_version_the_library_ships_with():
+    """A pin Stripe would reject fails every request, so it cannot be a guess."""
+    assert settings.STRIPE_API_VERSION == _library_current_version()
+
+
+def test_the_library_is_told_the_pinned_version():
+    assert stripe.api_version == settings.STRIPE_API_VERSION

--- a/sbomify/apps/billing/tests/test_stripe_client.py
+++ b/sbomify/apps/billing/tests/test_stripe_client.py
@@ -219,6 +219,39 @@ class TestStripeClient:
             call_args = mock_create.call_args[1]
             assert call_args["trial_period_days"] == 14
 
+    @patch("stripe.Subscription.create")
+    def test_a_trial_says_what_happens_when_it_ends_without_a_card(self, mock_create):
+        """Stripe's default raises an invoice nobody can pay, which reads to the
+        customer as a failed payment for a trial they only let lapse."""
+        mock_customer = MagicMock()
+        mock_customer.metadata = {"team_key": "team_123"}
+
+        mock_subscription = MagicMock()
+        mock_subscription.metadata = {"team_key": "team_123"}
+
+        with patch.object(self.client, "get_customer", return_value=mock_customer):
+            mock_create.return_value = mock_subscription
+
+            self.client.create_subscription(customer_id="cus_123", price_id="price_123", trial_days=14)
+
+            settings_sent = mock_create.call_args[1]["trial_settings"]
+            assert settings_sent["end_behavior"]["missing_payment_method"] == "cancel"
+
+    @patch("stripe.Subscription.create")
+    def test_a_subscription_with_no_trial_sends_no_trial_settings(self, mock_create):
+        mock_customer = MagicMock()
+        mock_customer.metadata = {"team_key": "team_123"}
+
+        mock_subscription = MagicMock()
+        mock_subscription.metadata = {"team_key": "team_123"}
+
+        with patch.object(self.client, "get_customer", return_value=mock_customer):
+            mock_create.return_value = mock_subscription
+
+            self.client.create_subscription(customer_id="cus_123", price_id="price_123")
+
+            assert "trial_settings" not in mock_create.call_args[1]
+
     def test_create_subscription_no_team_key(self):
         """Test subscription creation with customer missing team_key."""
         mock_customer = MagicMock()

--- a/sbomify/apps/billing/tests/test_stripe_pricing_service.py
+++ b/sbomify/apps/billing/tests/test_stripe_pricing_service.py
@@ -130,8 +130,13 @@ class TestCreateCheckoutSession:
         )
 
         call_args = mock_stripe_client.create_checkout_session_raw.call_args[0][0]
-        assert call_args["subscription_data"] == {"trial_period_days": 14}
+        assert call_args["subscription_data"]["trial_period_days"] == 14
         assert call_args["payment_method_collection"] == "always"
+        # A card collected at checkout can still be detached before the trial
+        # ends, and Stripe's default then raises an invoice nobody can pay.
+        assert call_args["subscription_data"]["trial_settings"] == {
+            "end_behavior": {"missing_payment_method": "cancel"}
+        }
 
     def test_trial_period_omitted_when_none(self, service, mock_stripe_client, mock_team, mock_plan):
         mock_customer = MagicMock()

--- a/sbomify/apps/billing/views.py
+++ b/sbomify/apps/billing/views.py
@@ -742,7 +742,12 @@ class StripeWebhookView(View):
             if event.type == "checkout.session.completed":
                 session = event.data.object
                 billing_processing.handle_checkout_completed(session)
-            elif event.type == "customer.subscription.updated":
+            elif event.type in ("customer.subscription.updated", "customer.subscription.trial_will_end"):
+                # trial_will_end is the only notice Stripe sends as a trial runs
+                # down, three days out. Nothing else generates an update in that
+                # window, so without it the trial-ending email only went out if
+                # some unrelated change happened to land first. The event carries
+                # the subscription, so the same handler reads it.
                 subscription = event.data.object
                 billing_processing.handle_subscription_updated(subscription, event=event)
             elif event.type == "customer.subscription.deleted":
@@ -754,6 +759,9 @@ class StripeWebhookView(View):
             elif event.type == "invoice.payment_failed":
                 invoice = event.data.object
                 billing_processing.handle_payment_failed(invoice, event=event)
+            elif event.type in ("price.updated", "price.created"):
+                price = event.data.object
+                billing_processing.handle_price_updated(price, event=event)
             else:
                 logger.info("Unhandled event type: %s", event.type)
 

--- a/sbomify/apps/billing/views.py
+++ b/sbomify/apps/billing/views.py
@@ -42,7 +42,7 @@ from .billing_helpers import (
 )
 from .forms import PublicEnterpriseContactForm
 from .models import BillingPlan
-from .stripe_client import BillingRetryableError, StripeError, get_stripe_client
+from .stripe_client import BillingRetryableError, StripeError, WorkspaceGoneError, get_stripe_client
 from .stripe_pricing_service import StripePricingService
 from .stripe_sync import sync_subscription_from_stripe
 from .tasks import send_enterprise_inquiry_email
@@ -767,6 +767,13 @@ class StripeWebhookView(View):
             # exc_info captures the chained root cause (these are raised `from e`).
             logger.error("Retryable webhook error (Stripe will retry): %s", e, exc_info=True)
             return HttpResponse(status=503)
+        except WorkspaceGoneError as e:
+            # Caught before StripeError, as BillingRetryableError is: terminal and
+            # acknowledged the same way, but nothing here is broken. The workspace
+            # was deleted, which cancels its subscription, and this is Stripe saying
+            # so after the row has gone.
+            logger.warning("Webhook for a workspace that no longer exists (acknowledged): %s", e)
+            return HttpResponse(status=200)
         except StripeError as e:
             logger.error("Stripe business logic error (acknowledged): %s", e)
             return HttpResponse(status=200)

--- a/sbomify/apps/core/services/account_deletion.py
+++ b/sbomify/apps/core/services/account_deletion.py
@@ -80,11 +80,12 @@ def _get_orphaned_workspaces(user: User) -> Any:
     return [m.team for m in owner_memberships if m.member_count == 1]
 
 
-def _cleanup_stripe_for_workspace_by_ids(subscription_id: str | None, customer_id: str | None) -> bool:
+def cleanup_stripe_for_workspace(subscription_id: str | None, customer_id: str | None) -> bool:
     """Cancel Stripe subscription and delete customer using pre-collected IDs.
 
-    Called outside transaction.atomic() to avoid holding DB locks during HTTP calls.
-    Returns True if cleanup succeeded or was not needed, False on error.
+    Called outside transaction.atomic() to avoid holding DB locks during HTTP calls,
+    by both paths that remove a workspace: deleting an account and deleting a single
+    workspace. Returns True if cleanup succeeded or was not needed, False on error.
     """
     from sbomify.apps.billing.config import is_billing_enabled
     from sbomify.apps.billing.stripe_client import StripeClient, StripeError
@@ -223,7 +224,7 @@ def soft_delete_user_account(user: User) -> ServiceResult[str]:
     # deleted, so we must not roll back. Orphaned subscriptions surface via CRITICAL log alerts
     # and can be resolved manually in the Stripe dashboard using the team_key.
     for info in orphaned_stripe_info:
-        if not _cleanup_stripe_for_workspace_by_ids(info["subscription_id"], info["customer_id"]):
+        if not cleanup_stripe_for_workspace(info["subscription_id"], info["customer_id"]):
             logger.critical(
                 "Stripe cleanup failed for team %s during account deletion — subscription may be orphaned",
                 info["team_key"],

--- a/sbomify/apps/core/services/account_deletion.py
+++ b/sbomify/apps/core/services/account_deletion.py
@@ -96,17 +96,25 @@ def cleanup_stripe_for_workspace(subscription_id: str | None, customer_id: str |
     if not subscription_id and not customer_id:
         return True
 
+    cancelled = not subscription_id
     try:
         client = StripeClient()
         if subscription_id:
             client.cancel_subscription(subscription_id, prorate=True)
+            cancelled = True
             logger.info("Cancelled Stripe subscription")
         if customer_id:
             client.delete_customer(customer_id)
             logger.info("Deleted Stripe customer")
         return True
     except StripeError as e:
-        logger.warning("Stripe cleanup failed: %s", e)
+        # Callers warn that the subscription may still bill, so say which half
+        # failed: a customer that would not delete leaves a record to tidy, not
+        # a subscription still charging someone.
+        if cancelled:
+            logger.warning("Stripe customer cleanup failed after the subscription was cancelled: %s", e)
+        else:
+            logger.warning("Stripe subscription cleanup failed: %s", e)
         return False
 
 

--- a/sbomify/apps/core/services/account_deletion.py
+++ b/sbomify/apps/core/services/account_deletion.py
@@ -80,15 +80,26 @@ def _get_orphaned_workspaces(user: User) -> Any:
     return [m.team for m in owner_memberships if m.member_count == 1]
 
 
-def cleanup_stripe_for_workspace(subscription_id: str | None, customer_id: str | None) -> bool:
+def cleanup_stripe_for_workspace(
+    subscription_id: str | None,
+    customer_id: str | None,
+    raise_retryable: bool = False,
+) -> bool:
     """Cancel Stripe subscription and delete customer using pre-collected IDs.
 
     Called outside transaction.atomic() to avoid holding DB locks during HTTP calls,
     by both paths that remove a workspace: deleting an account and deleting a single
     workspace. Returns True if cleanup succeeded or was not needed, False on error.
+
+    ``raise_retryable`` lets a caller that can try again say so. A rate limit, a
+    connection failure or a Stripe 5xx arrives here as ``BillingRetryableError``,
+    which is a ``StripeError`` and would otherwise be reported as permanent, so a
+    background worker would give up on an outage that clears in a minute. The
+    account-deletion path leaves it off and stays best-effort, because it runs
+    inline with nothing to retry it.
     """
     from sbomify.apps.billing.config import is_billing_enabled
-    from sbomify.apps.billing.stripe_client import StripeClient, StripeError
+    from sbomify.apps.billing.stripe_client import BillingRetryableError, StripeClient, StripeError
 
     if not is_billing_enabled():
         return True
@@ -107,6 +118,12 @@ def cleanup_stripe_for_workspace(subscription_id: str | None, customer_id: str |
             client.delete_customer(customer_id)
             logger.info("Deleted Stripe customer")
         return True
+    except BillingRetryableError:
+        # Transient. Caught before its parent, as the webhook view does it.
+        if raise_retryable:
+            raise
+        logger.warning("Stripe cleanup hit a transient failure and there is nothing to retry it")
+        return False
     except StripeError as e:
         # Callers warn that the subscription may still bill, so say which half
         # failed: a customer that would not delete leaves a record to tidy, not

--- a/sbomify/apps/core/services/account_deletion.py
+++ b/sbomify/apps/core/services/account_deletion.py
@@ -107,7 +107,7 @@ def cleanup_stripe_for_workspace(
     if not subscription_id and not customer_id:
         return True
 
-    cancelled = not subscription_id
+    cancelled = False
     try:
         client = StripeClient()
         if subscription_id:
@@ -127,8 +127,11 @@ def cleanup_stripe_for_workspace(
     except StripeError as e:
         # Callers warn that the subscription may still bill, so say which half
         # failed: a customer that would not delete leaves a record to tidy, not
-        # a subscription still charging someone.
-        if cancelled:
+        # a subscription still charging someone. Three states, because "no
+        # subscription to cancel" must not read as "cancelled".
+        if not subscription_id:
+            logger.warning("Stripe customer cleanup failed, and there was no subscription: %s", e)
+        elif cancelled:
             logger.warning("Stripe customer cleanup failed after the subscription was cancelled: %s", e)
         else:
             logger.warning("Stripe subscription cleanup failed: %s", e)

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -161,7 +161,7 @@ def test_deleting_a_workspace_cancels_its_subscription(client, paid_owner, paid_
     stripe.delete_customer.assert_called_once_with("cus_test123")
 
 
-def test_deleting_a_free_workspace_calls_stripe_at_all(client, paid_owner, paid_team, settings, mocker):
+def test_deleting_a_free_workspace_does_not_call_stripe_at_all(client, paid_owner, paid_team, settings, mocker):
     paid_team.billing_plan_limits = {}
     paid_team.save(update_fields=["billing_plan_limits"])
 
@@ -170,6 +170,7 @@ def test_deleting_a_free_workspace_calls_stripe_at_all(client, paid_owner, paid_
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
     stripe.cancel_subscription.assert_not_called()
+    stripe.delete_customer.assert_not_called()
 
 
 def test_a_stripe_failure_does_not_block_the_delete(client, paid_owner, paid_team, settings, mocker):

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -160,8 +160,8 @@ def test_deleting_a_workspace_cancels_its_subscription(client, paid_owner, paid_
     queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)
 
 
-def test_deleting_a_free_workspace_queues_nothing_to_cancel(client, paid_owner, paid_team, settings, mocker):
-    """A workspace that never had a subscription has nothing for Stripe to do."""
+def test_deleting_a_free_workspace_queues_no_ids_to_cancel(client, paid_owner, paid_team, settings, mocker):
+    """The task is still queued, and finds nothing for Stripe to do."""
     paid_team.billing_plan = "community"
     paid_team.billing_plan_limits = {}
     paid_team.save(update_fields=["billing_plan", "billing_plan_limits"])
@@ -210,6 +210,37 @@ def test_the_worker_cancels_and_removes_the_customer(settings, mocker):
 
     stripe.return_value.cancel_subscription.assert_called_once_with("sub_test123", prorate=True)
     stripe.return_value.delete_customer.assert_called_once_with("cus_test123")
+
+
+def test_a_transient_stripe_failure_is_retried_not_alerted(settings, mocker):
+    """An outage must come back to the queue, not stop at one CRITICAL with the
+    subscription still billing."""
+    import pytest as _pytest
+
+    from sbomify.apps.billing.stripe_client import BillingRetryableError
+    from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+    stripe.return_value.cancel_subscription.side_effect = BillingRetryableError("stripe is unreachable")
+    log = mocker.patch("sbomify.apps.billing.tasks.logger")
+
+    with _pytest.raises(BillingRetryableError):
+        cleanup_stripe_for_deleted_workspace("sub_test123", "cus_test123", "ws-key")
+
+    log.critical.assert_not_called()
+
+
+def test_account_deletion_stays_best_effort_on_a_transient_failure(mocker, settings):
+    """It runs inline with nothing to retry it, so it must not raise into the flow."""
+    from sbomify.apps.billing.stripe_client import BillingRetryableError
+    from sbomify.apps.core.services.account_deletion import cleanup_stripe_for_workspace
+
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+    stripe.return_value.cancel_subscription.side_effect = BillingRetryableError("stripe is unreachable")
+
+    assert cleanup_stripe_for_workspace("sub_test123", "cus_test123") is False
 
 
 def test_stripe_is_left_alone_when_billing_is_disabled(settings, mocker):

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -110,3 +110,82 @@ def test_self_removal_fallback_when_pending_invites_exist(client, user_with_one_
     messages = list(get_messages(response.wsgi_request))
     assert len(messages) > 0
     assert "Please accept a pending invitation or contact support" in str(messages[0])
+
+
+@pytest.fixture
+def paid_team(db):
+    from sbomify.apps.billing.models import BillingPlan
+
+    BillingPlan.objects.get_or_create(
+        key="business",
+        defaults={"name": "Business", "description": "Business Plan", "max_users": 10},
+    )
+    return Team.objects.create(
+        name="Paid Workspace",
+        key="paid-workspace-key",
+        billing_plan="business",
+        billing_plan_limits={
+            "stripe_subscription_id": "sub_test123",
+            "stripe_customer_id": "cus_test123",
+        },
+    )
+
+
+@pytest.fixture
+def paid_owner(db, django_user_model, paid_team, team):
+    u = django_user_model.objects.create_user(username="paidowner", email="paid@test.com", password="password")
+    Member.objects.create(user=u, team=team, role="owner", is_default_team=True)
+    Member.objects.create(user=u, team=paid_team, role="owner", is_default_team=False)
+    return u
+
+
+def _delete_workspace(client, user, workspace, settings, mocker):
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+    client.force_login(user)
+    _setup_session(client, workspace, "owner")
+    response = client.post(
+        reverse("teams:teams_dashboard"),
+        {"_method": "DELETE", "key": workspace.key},
+    )
+    return response, stripe.return_value
+
+
+def test_deleting_a_workspace_cancels_its_subscription(client, paid_owner, paid_team, settings, mocker):
+    """The subscription outlived the workspace and kept charging."""
+    response, stripe = _delete_workspace(client, paid_owner, paid_team, settings, mocker)
+
+    assert response.status_code == 302
+    assert not Team.objects.filter(pk=paid_team.pk).exists()
+    stripe.cancel_subscription.assert_called_once_with("sub_test123", prorate=True)
+    stripe.delete_customer.assert_called_once_with("cus_test123")
+
+
+def test_deleting_a_free_workspace_calls_stripe_at_all(client, paid_owner, paid_team, settings, mocker):
+    paid_team.billing_plan_limits = {}
+    paid_team.save(update_fields=["billing_plan_limits"])
+
+    response, stripe = _delete_workspace(client, paid_owner, paid_team, settings, mocker)
+
+    assert response.status_code == 302
+    assert not Team.objects.filter(pk=paid_team.pk).exists()
+    stripe.cancel_subscription.assert_not_called()
+
+
+def test_a_stripe_failure_does_not_block_the_delete(client, paid_owner, paid_team, settings, mocker):
+    """The row is already gone, so the cancellation is logged for a human instead."""
+    from sbomify.apps.billing.stripe_client import StripeError
+
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+    stripe.return_value.cancel_subscription.side_effect = StripeError("stripe is down")
+    client.force_login(paid_owner)
+    _setup_session(client, paid_team, "owner")
+
+    response = client.post(
+        reverse("teams:teams_dashboard"),
+        {"_method": "DELETE", "key": paid_team.key},
+    )
+
+    assert response.status_code == 302
+    assert not Team.objects.filter(pk=paid_team.pk).exists()

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -243,6 +243,23 @@ def test_account_deletion_stays_best_effort_on_a_transient_failure(mocker, setti
     assert cleanup_stripe_for_workspace("sub_test123", "cus_test123") is False
 
 
+def test_a_customer_only_cleanup_does_not_claim_a_cancellation(mocker, settings):
+    """With no subscription there was nothing to cancel, and the log must not imply there was."""
+    from sbomify.apps.billing.stripe_client import StripeError
+    from sbomify.apps.core.services import account_deletion
+
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+    stripe.return_value.delete_customer.side_effect = StripeError("gone wrong")
+    log = mocker.patch.object(account_deletion, "logger")
+
+    assert account_deletion.cleanup_stripe_for_workspace(None, "cus_test123") is False
+
+    said = log.warning.call_args[0][0]
+    assert "no subscription" in said
+    assert "was cancelled" not in said
+
+
 def test_stripe_is_left_alone_when_billing_is_disabled(settings, mocker):
     from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
 

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -139,54 +139,85 @@ def paid_owner(db, django_user_model, paid_team, team):
     return u
 
 
-def _delete_workspace(client, user, workspace, settings, mocker):
-    settings.BILLING = True
-    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+def _delete_workspace(client, user, workspace, mocker, billing=True, settings=None):
+    settings.BILLING = billing
+    queued = mocker.patch("sbomify.apps.billing.tasks.cleanup_stripe_for_deleted_workspace.send")
     client.force_login(user)
     _setup_session(client, workspace, "owner")
     response = client.post(
         reverse("teams:teams_dashboard"),
         {"_method": "DELETE", "key": workspace.key},
     )
-    return response, stripe.return_value
+    return response, queued
 
 
 def test_deleting_a_workspace_cancels_its_subscription(client, paid_owner, paid_team, settings, mocker):
     """The subscription outlived the workspace and kept charging."""
-    response, stripe = _delete_workspace(client, paid_owner, paid_team, settings, mocker)
+    response, queued = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
 
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
-    stripe.cancel_subscription.assert_called_once_with("sub_test123", prorate=True)
-    stripe.delete_customer.assert_called_once_with("cus_test123")
+    queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)
 
 
-def test_deleting_a_free_workspace_does_not_call_stripe_at_all(client, paid_owner, paid_team, settings, mocker):
+def test_deleting_a_free_workspace_queues_nothing_to_cancel(client, paid_owner, paid_team, settings, mocker):
+    """A workspace that never had a subscription has nothing for Stripe to do."""
+    paid_team.billing_plan = "community"
     paid_team.billing_plan_limits = {}
-    paid_team.save(update_fields=["billing_plan_limits"])
+    paid_team.save(update_fields=["billing_plan", "billing_plan_limits"])
 
-    response, stripe = _delete_workspace(client, paid_owner, paid_team, settings, mocker)
+    response, queued = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
 
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
-    stripe.cancel_subscription.assert_not_called()
-    stripe.delete_customer.assert_not_called()
+    assert queued.call_args[0][:2] == (None, None)
 
 
-def test_a_stripe_failure_does_not_block_the_delete(client, paid_owner, paid_team, settings, mocker):
-    """The row is already gone, so the cancellation is logged for a human instead."""
+def test_the_delete_does_not_wait_on_stripe(client, paid_owner, paid_team, settings, mocker):
+    """The row is gone before the call, so a slow Stripe must not hold the request."""
+    client_cls = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+
+    response, _ = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
+
+    assert response.status_code == 302
+    assert not Team.objects.filter(pk=paid_team.pk).exists()
+    client_cls.assert_not_called()
+
+
+def test_a_permanent_stripe_failure_is_alerted_on(settings, mocker):
+    """The alert is the whole safety net: without it a live subscription is silent."""
     from sbomify.apps.billing.stripe_client import StripeError
+    from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
 
     settings.BILLING = True
     stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
     stripe.return_value.cancel_subscription.side_effect = StripeError("stripe is down")
-    client.force_login(paid_owner)
-    _setup_session(client, paid_team, "owner")
+    log = mocker.patch("sbomify.apps.billing.tasks.logger")
 
-    response = client.post(
-        reverse("teams:teams_dashboard"),
-        {"_method": "DELETE", "key": paid_team.key},
-    )
+    cleanup_stripe_for_deleted_workspace("sub_test123", "cus_test123", "ws-key")
 
-    assert response.status_code == 302
-    assert not Team.objects.filter(pk=paid_team.pk).exists()
+    log.critical.assert_called_once()
+    assert "ws-key" in log.critical.call_args[0]
+
+
+def test_the_worker_cancels_and_removes_the_customer(settings, mocker):
+    from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+
+    settings.BILLING = True
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+
+    cleanup_stripe_for_deleted_workspace("sub_test123", "cus_test123", "ws-key")
+
+    stripe.return_value.cancel_subscription.assert_called_once_with("sub_test123", prorate=True)
+    stripe.return_value.delete_customer.assert_called_once_with("cus_test123")
+
+
+def test_stripe_is_left_alone_when_billing_is_disabled(settings, mocker):
+    from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+
+    settings.BILLING = False
+    stripe = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
+
+    cleanup_stripe_for_deleted_workspace("sub_test123", "cus_test123", "ws-key")
+
+    stripe.assert_not_called()

--- a/sbomify/apps/teams/views/dashboard.py
+++ b/sbomify/apps/teams/views/dashboard.py
@@ -16,9 +16,6 @@ from sbomify.apps.teams.forms import AddTeamForm, DeleteTeamForm, UpdateTeamForm
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
 from sbomify.apps.teams.utils import update_user_teams_session
-from sbomify.logging import getLogger
-
-logger = getLogger(__name__)
 
 
 class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
@@ -108,8 +105,6 @@ class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             messages.error(request, form.errors.as_text())
             return redirect("teams:teams_dashboard")
 
-        from sbomify.apps.core.services.account_deletion import cleanup_stripe_for_workspace
-
         try:
             team = Team.objects.get(key=form.cleaned_data["key"])
             # TODO move it to permissions
@@ -122,24 +117,25 @@ class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     "Cannot delete the default workspace. Please set another workspace as default first.",
                 )
             else:
-                # Read the billing ids before the row goes, and cancel outside the
-                # transaction so no DB lock is held across an HTTP call. Without this
-                # the subscription outlives the workspace and keeps charging.
+                # Read the billing ids before the row goes. Without this the
+                # subscription outlives the workspace and keeps charging. The
+                # cancelling itself is queued: it is two calls to Stripe, and
+                # holding a web worker open for them after the row has already
+                # been deleted risks a timeout with nothing left to retry.
+                from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+
                 limits = team.billing_plan_limits or {}
                 subscription_id = limits.get("stripe_subscription_id")
                 customer_id = limits.get("stripe_customer_id")
-                workspace_key, workspace_name = team.key, team.name
+                # key is nullable on the model, and this string only exists to
+                # name the workspace in an alert after the row has gone.
+                workspace_key = team.key or f"pk={team.pk}"
+                workspace_name = team.name
 
                 with transaction.atomic():
                     team.delete()
 
-                if not cleanup_stripe_for_workspace(subscription_id, customer_id):
-                    # The workspace is already gone, so this cannot be rolled back.
-                    # Loud enough to be finished by hand in the Stripe dashboard.
-                    logger.critical(
-                        "Stripe cleanup failed deleting workspace %s; its subscription may still bill",
-                        workspace_key,
-                    )
+                cleanup_stripe_for_deleted_workspace.send(subscription_id, customer_id, workspace_key)
 
                 messages.add_message(
                     request,

--- a/sbomify/apps/teams/views/dashboard.py
+++ b/sbomify/apps/teams/views/dashboard.py
@@ -16,6 +16,9 @@ from sbomify.apps.teams.forms import AddTeamForm, DeleteTeamForm, UpdateTeamForm
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import GuestAccessBlockedMixin
 from sbomify.apps.teams.utils import update_user_teams_session
+from sbomify.logging import getLogger
+
+logger = getLogger(__name__)
 
 
 class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
@@ -105,6 +108,8 @@ class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
             messages.error(request, form.errors.as_text())
             return redirect("teams:teams_dashboard")
 
+        from sbomify.apps.core.services.account_deletion import cleanup_stripe_for_workspace
+
         try:
             team = Team.objects.get(key=form.cleaned_data["key"])
             # TODO move it to permissions
@@ -117,13 +122,29 @@ class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     "Cannot delete the default workspace. Please set another workspace as default first.",
                 )
             else:
+                # Read the billing ids before the row goes, and cancel outside the
+                # transaction so no DB lock is held across an HTTP call. Without this
+                # the subscription outlives the workspace and keeps charging.
+                limits = team.billing_plan_limits or {}
+                subscription_id = limits.get("stripe_subscription_id")
+                customer_id = limits.get("stripe_customer_id")
+                workspace_key, workspace_name = team.key, team.name
+
                 with transaction.atomic():
                     team.delete()
+
+                if not cleanup_stripe_for_workspace(subscription_id, customer_id):
+                    # The workspace is already gone, so this cannot be rolled back.
+                    # Loud enough to be finished by hand in the Stripe dashboard.
+                    logger.critical(
+                        "Stripe cleanup failed deleting workspace %s; its subscription may still bill",
+                        workspace_key,
+                    )
 
                 messages.add_message(
                     request,
                     messages.INFO,
-                    f"Workspace {team.name} has been deleted",
+                    f"Workspace {workspace_name} has been deleted",
                 )
                 update_user_teams_session(request, user)
         except Member.DoesNotExist:

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -1224,6 +1224,10 @@ STRIPE_SECRET_KEY = STRIPE_API_KEY
 STRIPE_PUBLISHABLE_KEY = os.environ.get("STRIPE_PUBLISHABLE_KEY", "")
 STRIPE_BILLING_URL = os.environ.get("STRIPE_BILLING_URL", "")
 STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
+# Pin the version our requests are made against, so a library upgrade cannot
+# quietly move it. Event payloads follow the account's own version, which is a
+# dashboard setting; this pins the half we control.
+STRIPE_API_VERSION = os.environ.get("STRIPE_API_VERSION", "2025-11-17.clover")
 
 # Trial period settings
 TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -1227,6 +1227,11 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 # Pin the version our requests are made against, so a library upgrade cannot
 # quietly move it. Event payloads follow the account's own version, which is a
 # dashboard setting; this pins the half we control.
+#
+# The value is the installed stripe library's own current version, so it is one
+# Stripe accepts rather than a string somebody typed. test_stripe_api_version.py
+# compares the two, so bumping the library fails there until a person decides
+# whether to move the pin with it.
 STRIPE_API_VERSION = os.environ.get("STRIPE_API_VERSION", "2025-11-17.clover")
 
 # Trial period settings


### PR DESCRIPTION
Found from `SBOMIFY-BACKEND-STAGE-75`, a webhook logging "No team found for the subscription in this webhook event". Two separate problems behind it.

## The subscription outlives the workspace

`WorkspacesDashboardView._delete` called `team.delete()` and nothing else, so the Stripe subscription stayed live. On production that means a customer who deletes their workspace keeps being charged, and the only trace left is the webhook error that started this.

Account deletion has done this correctly for a while, collecting the billing ids before the transaction and cleaning up after it commits. That helper is now shared rather than copied. A Stripe failure cannot roll the delete back, so it is logged CRITICAL with the workspace key, which is what the account path already does.

## The webhook was reported as a fault

Once the fix lands, cancelling generates a `customer.subscription.deleted` event that arrives after the row has gone, so the delete would have produced this same error every time. It is not an error: every lookup strategy missed because the workspace is genuinely gone, there is nothing to update, and no retry will find anything. It has its own terminal class now, still acknowledged with 200, logged as an event with nowhere to land.

One case stays an error. If the Stripe customer cannot be read, we could not run the last strategy, so whether the workspace exists is unknown, and that is worth an alert. The test asserts the narrower class does not swallow it.

## Tests

Five, in `test_deletion_edge_cases.py` and `test_billing_processing.py`: a paid workspace cancels and deletes its customer, a free one calls Stripe not at all, a Stripe outage still deletes, the gone-workspace class is raised, and a terminal Stripe failure is not it. The first fails on master.

Billing 350 passed, teams and core 4179 passed.