### PR TITLE
fix: prevent sidebar flash during page navigation

### DIFF
--- a/sbomify/apps/core/templates/core/base.html.j2
+++ b/sbomify/apps/core/templates/core/base.html.j2
@@ -20,6 +20,10 @@
                         effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
                     }
                     document.documentElement.classList.add(effectiveTheme);
+                    // Read the same preference as Alpine persist before the first paint.
+                    try {
+                        document.documentElement.toggleAttribute('data-sidebar-collapsed', localStorage.getItem('sidebar-collapsed') === 'true');
+                    } catch(e) { /* blocked storage: use the expanded layout */ }
                 })();
             </script>
             <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -89,25 +93,11 @@
                 html.light { background-color: #ffffff; color: #25293F; }
                 html { min-height: 100%; }
                 body { min-height: 100vh; }
-                /* Gated on html.js, which the script below adds only after it has
-                   registered the listener that removes the gate. If that script
-                   never runs, whether JavaScript is off, an extension blocked it
-                   or CSP rejected it, the class is absent and the body is visible.
-                   Only the script that can undo the gate is allowed to apply it. */
-                html.js body { opacity: 0; pointer-events: none; transition: opacity 0.1s ease-in; }
-                html.js body.ready { opacity: 1; pointer-events: auto; }
+                html { --sidebar-width: 16rem; }
+                html[data-sidebar-collapsed] { --sidebar-width: 4rem; }
+                html[data-sidebar-collapsed] #sidebar [data-sidebar-view="expanded"],
+                html:not([data-sidebar-collapsed]) #sidebar [data-sidebar-view="collapsed"] { display: none; }
             </style>
-            <script>
-                // Show body once DOM is ready. This block is parsed inside the
-                // document head, so readyState is always "loading" and
-                // document.body is always null here: the listener is the only
-                // path that can fire.
-                document.addEventListener('DOMContentLoaded', function() {
-                    document.body.classList.add('ready');
-                });
-                // Only now, with the listener guaranteed registered, arm the gate.
-                document.documentElement.classList.add('js');
-            </script>
             {% block styles %}{% endblock %}
             <link rel="stylesheet"
                   href="{% vite_asset_url 'sbomify/assets/css/tailwind.src.css' %}">

--- a/sbomify/apps/core/templates/core/components/footer.html.j2
+++ b/sbomify/apps/core/templates/core/components/footer.html.j2
@@ -1,9 +1,8 @@
 {% load cache %}
 {# Tailwind Footer Component #}
 {% if debug %}
-    <footer class="pl-0 lg:pl-64 transition-all duration-300 border-t bg-surface/50"
-            style="border-top-color: color-mix(in srgb, var(--color-border) 70%, transparent)"
-            :class="{ 'lg:!pl-16': sidebarCollapsed }">
+    <footer class="pl-0 lg:pl-[var(--sidebar-width,16rem)] transition-all duration-300 border-t bg-surface/50"
+            style="border-top-color: color-mix(in srgb, var(--color-border) 70%, transparent)">
         <div class="px-6 py-4">
             <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-text-muted">
                 {# Left: Copyright + Version #}
@@ -28,9 +27,8 @@
     {% endif %}
 {% else %}
     {% cache 3600 'footer' app_version build_type request.user.is_authenticated %}
-    <footer class="pl-0 lg:pl-64 transition-all duration-300 border-t bg-surface/50"
-            style="border-top-color: color-mix(in srgb, var(--color-border) 70%, transparent)"
-            :class="{ 'lg:!pl-16': sidebarCollapsed }">
+    <footer class="pl-0 lg:pl-[var(--sidebar-width,16rem)] transition-all duration-300 border-t bg-surface/50"
+            style="border-top-color: color-mix(in srgb, var(--color-border) 70%, transparent)">
         <div class="px-6 py-4">
             <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-text-muted">
                 {# Left: Copyright + Version #}

--- a/sbomify/apps/core/templates/core/components/header.html.j2
+++ b/sbomify/apps/core/templates/core/components/header.html.j2
@@ -1,7 +1,6 @@
 {% load static teams %}
 {# Premium Enterprise Header with Tailwind CSS #}
-<header class="fixed top-0 right-0 left-0 lg:left-64 h-16 bg-surface/95 backdrop-blur-sm border-b border-border flex items-center px-4 gap-4 z-30 transition-all duration-300"
-        :class="{ 'lg:!left-16': sidebarCollapsed }"
+<header class="fixed top-0 right-0 left-0 lg:left-[var(--sidebar-width)] h-16 bg-surface/95 backdrop-blur-sm border-b border-border flex items-center px-4 gap-4 z-30 transition-all duration-300"
         x-data="{ sidebarOpen: false, searchOpen: false }"
         role="banner">
     {# Mobile Sidebar Toggle #}

--- a/sbomify/apps/core/templates/core/components/sidebar.html.j2
+++ b/sbomify/apps/core/templates/core/components/sidebar.html.j2
@@ -16,16 +16,16 @@
      class="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 lg:hidden"
      aria-hidden="true"></div>
 <aside id="sidebar"
-       x-cloak
+       x-effect="document.documentElement.toggleAttribute('data-sidebar-collapsed', sidebarCollapsed)"
        @toggle-sidebar.window="sidebarMobileOpen = !sidebarMobileOpen"
-       class="fixed top-0 left-0 z-50 h-screen transition-all duration-300 ease-in-out bg-surface border-r border-border flex flex-col"
-       :class="[ sidebarCollapsed ? 'w-16' : 'w-64', sidebarMobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0' ]"
+       class="fixed top-0 left-0 z-50 h-screen w-[var(--sidebar-width)] -translate-x-full lg:translate-x-0 transition-all duration-300 ease-in-out bg-surface border-r border-border flex flex-col"
+       :class="{ '!translate-x-0': sidebarMobileOpen }"
        role="navigation"
        aria-label="Main navigation">
     {# Logo Section #}
     <div class="h-16 flex items-center relative shrink-0">
         {# Collapsed Logo #}
-        <a x-show="sidebarCollapsed"
+        <a data-sidebar-view="collapsed"
            href="{% url 'core:dashboard' %}"
            @click="sidebarMobileOpen = false"
            class="flex items-center justify-center w-full"
@@ -33,8 +33,7 @@
             {% include "core/components/brand/emblem.html.j2" with class="w-6 h-auto text-text" %}
         </a>
         {# Expanded Logo #}
-        <a x-show="!sidebarCollapsed"
-           x-cloak
+        <a data-sidebar-view="expanded"
            href="{% url 'core:dashboard' %}"
            @click="sidebarMobileOpen = false"
            class="flex items-center pl-6"
@@ -47,7 +46,7 @@
             button sets display itself, so lg:hidden on it would lose to that.
         {% endcomment %}
         <div class="lg:hidden absolute right-3">
-            <c-buttons.icon label="Close sidebar" x-show="!sidebarCollapsed" x-cloak @click="sidebarMobileOpen = false">
+            <c-buttons.icon label="Close sidebar" data-sidebar-view="expanded" @click="sidebarMobileOpen = false">
             <i class="fas fa-times text-lg" aria-hidden="true"></i>
             </c-buttons.icon>
         </div>
@@ -61,7 +60,7 @@
                      class="relative"
                      @keydown.escape.window="open = false">
                     {# Collapsed Team Button #}
-                    <button x-show="sidebarCollapsed"
+                    <button data-sidebar-view="collapsed"
                             @click="open = !open"
                             :aria-expanded="open"
                             aria-haspopup="true"
@@ -71,8 +70,7 @@
                         <i class="fas fa-briefcase text-primary text-sm"></i>
                     </button>
                     {# Expanded Team Button #}
-                    <button x-show="!sidebarCollapsed"
-                            x-cloak
+                    <button data-sidebar-view="expanded"
                             @click="open = !open"
                             :aria-expanded="open"
                             aria-haspopup="true"
@@ -163,7 +161,7 @@
                 {% if not request.session.current_team.has_completed_wizard %}
                     <li>
                         {# Collapsed #}
-                        <a x-show="sidebarCollapsed"
+                        <a data-sidebar-view="collapsed"
                            href="{% url 'teams:onboarding_wizard' %}"
                            @click="sidebarMobileOpen = false"
                            title="Get Started"
@@ -172,8 +170,7 @@
                             <i class="fas fa-rocket text-base" aria-hidden="true"></i>
                         </a>
                         {# Expanded #}
-                        <a x-show="!sidebarCollapsed"
-                           x-cloak
+                        <a data-sidebar-view="expanded"
                            href="{% url 'teams:onboarding_wizard' %}"
                            @click="sidebarMobileOpen = false"
                            class="flex items-center gap-3 px-3 h-10 rounded-lg bg-primary text-white text-sm font-semibold shadow-sm transition-colors duration-150 hover:bg-primary-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
@@ -183,7 +180,7 @@
                             <span>Get Started</span>
                         </a>
                     </li>
-                    <li class="pt-4 pb-1" x-show="!sidebarCollapsed" x-cloak>
+                    <li class="pt-4 pb-1" data-sidebar-view="expanded">
                         <span class="px-3 text-[10px] font-semibold text-text-muted uppercase tracking-widest">Navigation</span>
                     </li>
                 {% endif %}
@@ -234,7 +231,7 @@
         {% endif %}
         {# Collapse Toggle - Hidden on mobile #}
         {# Collapsed #}
-        <button x-show="sidebarCollapsed"
+        <button data-sidebar-view="collapsed"
                 @click="sidebarCollapsed = false"
                 aria-label="Expand sidebar"
                 title="Expand sidebar"
@@ -242,8 +239,7 @@
             <i class="fas fa-chevron-right text-base" aria-hidden="true"></i>
         </button>
         {# Expanded #}
-        <button x-show="!sidebarCollapsed"
-                x-cloak
+        <button data-sidebar-view="expanded"
                 @click="sidebarCollapsed = true"
                 class="group hidden lg:flex items-center gap-3 px-3 w-full h-10 rounded-lg text-sm font-medium text-text-secondary transition-colors duration-150 sidebar-link-hover">
             <span class="w-5 flex items-center justify-center shrink-0">

--- a/sbomify/apps/core/templates/core/components/sidebar.html.j2
+++ b/sbomify/apps/core/templates/core/components/sidebar.html.j2
@@ -16,6 +16,7 @@
      class="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 lg:hidden"
      aria-hidden="true"></div>
 <aside id="sidebar"
+       x-cloak
        @toggle-sidebar.window="sidebarMobileOpen = !sidebarMobileOpen"
        class="fixed top-0 left-0 z-50 h-screen transition-all duration-300 ease-in-out bg-surface border-r border-border flex flex-col"
        :class="[ sidebarCollapsed ? 'w-16' : 'w-64', sidebarMobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0' ]"

--- a/sbomify/apps/core/templates/core/components/sidebar_link.html.j2
+++ b/sbomify/apps/core/templates/core/components/sidebar_link.html.j2
@@ -1,6 +1,6 @@
 {% comment %}
   Sidebar navigation link — renders both the collapsed (icon square) and
-  expanded (icon + label row) variants; Alpine toggles which one shows.
+  expanded (icon + label row) variants. CSS reads the saved sidebar state.
 
   Parameters:
   - url: href target
@@ -11,7 +11,7 @@
     links with no active state
 {% endcomment %}
 {# Collapsed #}
-<a x-show="sidebarCollapsed"
+<a data-sidebar-view="collapsed"
    href="{{ url }}"
    @click="sidebarMobileOpen = false"
    title="{{ label }}"
@@ -21,8 +21,7 @@
     <i class="fas {{ icon }} text-base" aria-hidden="true"></i>
 </a>
 {# Expanded #}
-<a x-show="!sidebarCollapsed"
-   x-cloak
+<a data-sidebar-view="expanded"
    href="{{ url }}"
    @click="sidebarMobileOpen = false"
    {% if match and match in current_view_name %}aria-current="page"{% endif %}

--- a/sbomify/apps/core/templates/core/dashboard_base.html.j2
+++ b/sbomify/apps/core/templates/core/dashboard_base.html.j2
@@ -19,8 +19,7 @@
 {% endcache %}
 {# Main Content #}
 <main id="main-content"
-      class="flex-1 pt-16 pl-0 lg:pl-64 transition-all duration-300"
-      :class="{ 'lg:!pl-16': sidebarCollapsed }">
+      class="flex-1 pt-16 pl-0 lg:pl-[var(--sidebar-width)] transition-all duration-300">
     <div class="p-6 max-w-7xl mx-auto">
         {# Messages #}
         <div class="mb-4">{% include "core/components/messages.html.j2" %}</div>

--- a/sbomify/apps/core/templates/core/dashboard_base.htmx.j2
+++ b/sbomify/apps/core/templates/core/dashboard_base.htmx.j2
@@ -23,8 +23,7 @@
 {% endcache %}
 {# Main Content #}
 <main id="main-content"
-      class="flex-1 pt-16 pl-0 lg:pl-64 transition-all duration-300"
-      :class="{ 'lg:!pl-16': sidebarCollapsed }">
+      class="flex-1 pt-16 pl-0 lg:pl-[var(--sidebar-width)] transition-all duration-300">
     <div class="p-6 max-w-7xl mx-auto">
         {# HTMX Messages (toast-based) #}
         {% include "core/components/messages.htmx.j2" %}

--- a/sbomify/apps/core/tests/e2e/test_sidebar_initial_render.py
+++ b/sbomify/apps/core/tests/e2e/test_sidebar_initial_render.py
@@ -1,0 +1,52 @@
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("collapsed", [False, True])
+@pytest.mark.parametrize("viewport_width", [1920, 375])
+def test_sidebar_initial_render(authenticated_page: Page, collapsed: bool, viewport_width: int) -> None:
+    """The shell must have its saved layout even while Alpine is unavailable."""
+    page = authenticated_page
+    page.set_viewport_size({"width": viewport_width, "height": 1080})
+    page.add_init_script(
+        "if (localStorage.getItem('sidebar-collapsed') === null) {"
+        f"localStorage.setItem('sidebar-collapsed', '{str(collapsed).lower()}');"
+        "}"
+    )
+
+    def block_scripts(route: Route) -> None:
+        if route.request.resource_type == "script":
+            route.abort()
+        else:
+            route.continue_()
+
+    page.route("**/*", block_scripts)
+    expected_width = 64 if collapsed else 256
+    expected_offset = expected_width if viewport_width == 1920 else 0
+    for path in ["/products/", "/components/"]:
+        page.goto(path)
+        expect(page.locator("body")).to_have_css("opacity", "1")
+        expect(page.locator("#sidebar")).to_have_css("width", f"{expected_width}px")
+        expect(page.locator("header[role=banner]")).to_have_css("left", f"{expected_offset}px")
+        expect(page.locator("#main-content")).to_have_css("padding-left", f"{expected_offset}px")
+        expect(page.locator("#sidebar nav a:visible")).to_have_count(6)
+        expect(page.locator("#sidebar nav a:visible").filter(has_text="Products")).to_have_count(0 if collapsed else 1)
+        sidebar_box = page.locator("#sidebar").bounding_box()
+        assert sidebar_box is not None
+        assert sidebar_box["x"] == (0 if viewport_width == 1920 else -expected_width)
+
+    initial_sidebar = page.locator("#sidebar").screenshot() if viewport_width == 1920 else None
+    page.unroute("**/*", block_scripts)
+    page.reload()
+    expect(page.locator("#sidebar [x-cloak]")).to_have_count(0)
+    expect(page.locator("#sidebar")).to_have_css("width", f"{expected_width}px")
+    if viewport_width == 1920:
+        assert page.locator("#sidebar").screenshot() == initial_sidebar
+        page.get_by_role("button", name="Expand sidebar" if collapsed else "Collapse", exact=True).click()
+        expect(page.locator("#sidebar")).to_have_css("width", "256px" if collapsed else "64px")
+        page.get_by_role("link", name="Products", exact=True).click()
+        expect(page.locator("#sidebar")).to_have_css("width", "256px" if collapsed else "64px")
+    else:
+        page.get_by_role("button", name="Toggle sidebar navigation").click()
+        expect(page.locator("#sidebar")).to_have_css("translate", "0px")


### PR DESCRIPTION
Page navigation briefly rendered the sidebar in the wrong layout while Alpine initialized. Apply the saved collapsed state before the first paint, and use the same CSS visibility rules and shared width for initial rendering and subsequent toggles. Remove the whole-page hide-and-fade.

Validation: 11 targeted tests pass, including desktop/mobile initialization and navigation checks, plus matching sidebar screenshots before and after Alpine loads. Frontend build, template lint/formatting, Ruff, and mypy pass. Confirmed locally by the reporter.
