### PR TITLE
fix(vulns): an advisory body is prose on the page, not its own markup

### DIFF
--- a/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
+++ b/sbomify/apps/plugins/templates/plugins/components/_assessment_run_item.html.j2
@@ -409,7 +409,7 @@
                                     </span>
                                     <div class="flex-1 ml-2">
                                         <div class="finding-title">{{ finding.title }}</div>
-                                        <div class="finding-description">{{ finding.description|format_finding_description }}</div>
+                                        <div class="finding-description">{{ finding.description|advisory_prose|format_finding_description }}</div>
                                         {% if finding.remediation %}
                                             <div class="finding-remediation">
                                                 <i class="fas fa-lightbulb mr-1"></i>

--- a/sbomify/apps/plugins/templatetags/plugins_extras.py
+++ b/sbomify/apps/plugins/templatetags/plugins_extras.py
@@ -14,6 +14,28 @@ register = template.Library()
 # Number of packages to show before collapsing with "Show all" toggle
 VISIBLE_PACKAGE_COUNT = 5
 
+# The CommonMark an advisory body arrives in. OSV serves GHSA's `details`
+# verbatim, so "### Impact", backticked package names and reference links all
+# reach us as markup. Applied in this order: images before links, because an
+# image is a link with a bang in front of it, and emphasis last, because its
+# markers are the ones that also appear inside code spans.
+_MARKDOWN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\s*(?:```|~~~).*$", re.MULTILINE), ""),  # code fences
+    (re.compile(r"^\s{0,3}#{1,6}\s+", re.MULTILINE), ""),  # ATX headings
+    (re.compile(r"^\s{0,3}>\s?", re.MULTILINE), ""),  # block quotes
+    (re.compile(r"^\s{0,3}(?:[-*_]\s*){3,}$", re.MULTILINE), ""),  # thematic breaks
+    (re.compile(r"^\s{0,3}(?:[-*+]|\d+[.)])\s+", re.MULTILINE), ""),  # list markers
+    (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),  # images, kept as their alt text
+    (re.compile(r"\[([^\]]+)\]\([^)]*\)"), r"\1"),  # links, kept as their text
+    (re.compile(r"`+([^`]+)`+"), r"\1"),  # code spans
+    (re.compile(r"(\*\*|__)(.+?)\1", re.DOTALL), r"\2"),  # bold
+    (re.compile(r"(?<![\w*])(\*|_)(?!\s)(.+?)(?<!\s)\1(?![\w*])", re.DOTALL), r"\2"),  # italic
+)
+
+# Same ceiling as format_finding_description: a pathological advisory body must
+# not be handed to a dozen regexes.
+MAX_DESCRIPTION_CHARS = 100_000
+
 
 @register.filter
 def format_run_reason(reason: str) -> str:
@@ -199,6 +221,29 @@ def _build_package_span_args(packages: list[str]) -> list[tuple[str, str, str]]:
         hidden_class = " pkg-hidden" if i >= VISIBLE_PACKAGE_COUNT else ""
         args.append((hidden_class, pkg, pkg))
     return args
+
+
+@register.filter
+def advisory_prose(text: object) -> str:
+    """An advisory body as one line of plain prose.
+
+    The pages that show a description show the opening words of it, so the
+    markup is removed rather than rendered: a heading is not structure inside a
+    twenty-word summary, and flattening first means the truncation that follows
+    can only ever cut prose, never leave a code span or a link half-open.
+
+    Whitespace collapses too. The source is written as paragraphs and lists,
+    and every newline in it would otherwise arrive as a space in a sentence
+    that reads as though a word is missing.
+    """
+    if not isinstance(text, str) or not text:
+        return ""
+    if len(text) > MAX_DESCRIPTION_CHARS:
+        logger.debug("Skipping markdown flattening: length %d exceeds limit", len(text))
+        return text
+    for pattern, replacement in _MARKDOWN_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return " ".join(text.split())
 
 
 @register.filter

--- a/sbomify/apps/plugins/templatetags/plugins_extras.py
+++ b/sbomify/apps/plugins/templatetags/plugins_extras.py
@@ -23,6 +23,9 @@ _MARKDOWN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\s*(?:```|~~~).*$", re.MULTILINE), ""),  # code fences
     (re.compile(r"^\s{0,3}#{1,6}\s+", re.MULTILINE), ""),  # ATX headings
     (re.compile(r"^\s{0,3}>\s?", re.MULTILINE), ""),  # block quotes
+    # GitHub's alert syntax, which rides inside a block quote and so is left
+    # behind once the quote marker goes. GHSA advisories open with it.
+    (re.compile(r"\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*", re.IGNORECASE), ""),
     (re.compile(r"^\s{0,3}(?:[-*_]\s*){3,}$", re.MULTILINE), ""),  # thematic breaks
     (re.compile(r"^\s{0,3}(?:[-*+]|\d+[.)])\s+", re.MULTILINE), ""),  # list markers
     (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),  # images, kept as their alt text

--- a/sbomify/apps/plugins/templatetags/plugins_extras.py
+++ b/sbomify/apps/plugins/templatetags/plugins_extras.py
@@ -16,9 +16,10 @@ VISIBLE_PACKAGE_COUNT = 5
 
 # The CommonMark an advisory body arrives in. OSV serves GHSA's `details`
 # verbatim, so "### Impact", backticked package names and reference links all
-# reach us as markup. Applied in this order: images before links, because an
-# image is a link with a bang in front of it, and emphasis last, because its
-# markers are the ones that also appear inside code spans.
+# reach us as markup. Images come before links, because an image is a link with
+# a bang in front of it. Code spans are not here at all: they are lifted out
+# before any of this runs and put back afterwards, so nothing below can read
+# their contents as markup.
 _MARKDOWN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\s*(?:```|~~~).*$", re.MULTILINE), ""),  # code fences
     (re.compile(r"^\s{0,3}#{1,6}\s+", re.MULTILINE), ""),  # ATX headings
@@ -30,10 +31,20 @@ _MARKDOWN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\s{0,3}(?:[-*+]|\d+[.)])\s+", re.MULTILINE), ""),  # list markers
     (re.compile(r"!\[([^\]]*)\]\([^)]*\)"), r"\1"),  # images, kept as their alt text
     (re.compile(r"\[([^\]]+)\]\([^)]*\)"), r"\1"),  # links, kept as their text
-    (re.compile(r"`+([^`]+)`+"), r"\1"),  # code spans
-    (re.compile(r"(\*\*|__)(.+?)\1", re.DOTALL), r"\2"),  # bold
-    (re.compile(r"(?<![\w*])(\*|_)(?!\s)(.+?)(?<!\s)\1(?![\w*])", re.DOTALL), r"\2"),  # italic
+    (re.compile(r"\*\*(.+?)\*\*", re.DOTALL), r"\1"),  # bold
+    # Underscore bold is guarded where asterisk bold is not: __init__ and
+    # __reduce__ are the shape of a dunder, and an advisory about pickle or
+    # prototype pollution is full of them. CommonMark would read those as
+    # emphasis; a reader would not, and the identifier is what they came for.
+    (re.compile(r"(?<![\w_])__(?!\s)(?![a-z]+__(?![\w_]))(.+?)(?<!\s)__(?![\w_])", re.DOTALL), r"\1"),
+    # Italic, guarded against a doubled marker on either side so __proto__ does
+    # not come out as _proto_ once the bold rule above has declined it.
+    (re.compile(r"(?<![\w*_])(\*|_)(?![\s*_])(.+?)(?<![\s*_])\1(?![\w*_])", re.DOTALL), r"\2"),
 )
+
+#: Lifted out before the patterns above run, and restored after.
+#: One line only, so a fenced block stays the fence pattern's business.
+_CODE_SPAN_RE = re.compile(r"`+([^`\n]+)`+")
 
 # Same ceiling as format_finding_description: a pathological advisory body must
 # not be handed to a dozen regexes.
@@ -244,8 +255,21 @@ def advisory_prose(text: object) -> str:
     if len(text) > MAX_DESCRIPTION_CHARS:
         logger.debug("Skipping markdown flattening: length %d exceeds limit", len(text))
         return text
+
+    # A code span is literal by definition, so its contents are set aside while
+    # the rest runs. Everything an advisory puts in backticks is the thing a
+    # reader is looking for: a package called *star, a header field with a #
+    # in it, a path with an underscore.
+    spans: list[str] = []
+
+    def _stash(match: re.Match[str]) -> str:
+        spans.append(match.group(1))
+        return f"\x00{len(spans) - 1}\x00"
+
+    text = _CODE_SPAN_RE.sub(_stash, text)
     for pattern, replacement in _MARKDOWN_PATTERNS:
         text = pattern.sub(replacement, text)
+    text = re.sub(r"\x00(\d+)\x00", lambda m: spans[int(m.group(1))], text)
     return " ".join(text.split())
 
 

--- a/sbomify/apps/plugins/tests/test_templatetags.py
+++ b/sbomify/apps/plugins/tests/test_templatetags.py
@@ -1,6 +1,7 @@
 """Tests for plugins template tags and filters."""
 
 from sbomify.apps.plugins.templatetags.plugins_extras import (
+    advisory_prose,
     format_finding_description,
     format_run_reason,
     has_compliance_failures,
@@ -386,3 +387,62 @@ class TestVulnerabilityTotal:
         from sbomify.apps.plugins.templatetags.plugins_extras import vulnerability_total
 
         assert vulnerability_total({"by_severity": {"critical": True, "high": 2}}) == 2
+
+
+class TestAdvisoryProse:
+    """OSV serves GHSA's CommonMark verbatim, and the cards show the opening
+    words of it, so the markup has to come off before the text is cut."""
+
+    def test_the_advisory_that_was_rendering_its_own_markup(self) -> None:
+        """The fast-uri body, as it reached the page on production."""
+        body = (
+            "### Impact\n"
+            "`fast-uri` decodes percent-encoded characters in the scheme component "
+            "with the legacy global `unescape()` and serializes the result back.\n"
+        )
+
+        assert advisory_prose(body) == (
+            "Impact fast-uri decodes percent-encoded characters in the scheme component "
+            "with the legacy global unescape() and serializes the result back."
+        )
+
+    def test_headings_of_every_depth_lose_their_markers(self) -> None:
+        assert advisory_prose("# One\n## Two\n###### Six") == "One Two Six"
+
+    def test_a_hash_that_is_not_a_heading_is_left_alone(self) -> None:
+        """C# is a language and #1 is an issue number; neither opens a heading."""
+        assert advisory_prose("Affects C# and issue #1") == "Affects C# and issue #1"
+
+    def test_links_keep_their_text_and_lose_their_target(self) -> None:
+        assert advisory_prose("See [the advisory](https://example.test/a) for more") == ("See the advisory for more")
+
+    def test_an_image_keeps_its_alt_text(self) -> None:
+        assert advisory_prose("![a diagram](https://example.test/d.png) shows it") == "a diagram shows it"
+
+    def test_emphasis_markers_come_off(self) -> None:
+        assert advisory_prose("**Critical** and _urgent_ and *both*") == "Critical and urgent and both"
+
+    def test_a_bare_underscore_inside_a_name_survives(self) -> None:
+        """Package and symbol names carry underscores, and they are not emphasis."""
+        assert advisory_prose("calls parse_uri_string on every request") == "calls parse_uri_string on every request"
+
+    def test_lists_quotes_and_fences_flatten_to_a_sentence(self) -> None:
+        body = "> Note\n\n- first\n- second\n\n1. one\n\n```py\ncode()\n```"
+
+        assert advisory_prose(body) == "Note first second one code()"
+
+    def test_a_thematic_break_leaves_nothing_behind(self) -> None:
+        assert advisory_prose("Before\n\n---\n\nAfter") == "Before After"
+
+    def test_empty_and_non_string_input(self) -> None:
+        assert advisory_prose("") == ""
+        assert advisory_prose(None) == ""
+        assert advisory_prose(3) == ""
+
+    def test_an_oversized_body_is_returned_rather_than_scanned(self) -> None:
+        body = "#" * 200_001
+
+        assert advisory_prose(body) == body
+
+    def test_plain_prose_is_unchanged(self) -> None:
+        assert advisory_prose("A plain sentence about a package.") == "A plain sentence about a package."

--- a/sbomify/apps/plugins/tests/test_templatetags.py
+++ b/sbomify/apps/plugins/tests/test_templatetags.py
@@ -431,6 +431,13 @@ class TestAdvisoryProse:
 
         assert advisory_prose(body) == "Note first second one code()"
 
+    def test_a_github_alert_marker_comes_off_with_its_quote(self) -> None:
+        """GHSA advisories open with one, and it rides inside a block quote, so
+        removing the quote marker alone left the marker sitting in the prose."""
+        body = "> [!NOTE]\n> Scored assuming a deployment where policy is a boundary."
+
+        assert advisory_prose(body) == "Scored assuming a deployment where policy is a boundary."
+
     def test_a_thematic_break_leaves_nothing_behind(self) -> None:
         assert advisory_prose("Before\n\n---\n\nAfter") == "Before After"
 

--- a/sbomify/apps/plugins/tests/test_templatetags.py
+++ b/sbomify/apps/plugins/tests/test_templatetags.py
@@ -422,6 +422,23 @@ class TestAdvisoryProse:
     def test_emphasis_markers_come_off(self) -> None:
         assert advisory_prose("**Critical** and _urgent_ and *both*") == "Critical and urgent and both"
 
+    def test_a_dunder_survives_being_bold_shaped(self) -> None:
+        """__init__ and __reduce__ are the shape of underscore bold. An advisory
+        about pickle or prototype pollution is written almost entirely in them,
+        and the identifier is the thing the reader came for."""
+        assert advisory_prose("calls `__init__` then `__reduce__`") == "calls __init__ then __reduce__"
+        assert advisory_prose("pollutes __proto__ on every merge") == "pollutes __proto__ on every merge"
+        assert advisory_prose("the __init__ method") == "the __init__ method"
+
+    def test_underscore_bold_around_words_still_comes_off(self) -> None:
+        assert advisory_prose("__Impact__ is high") == "Impact is high"
+
+    def test_a_code_span_keeps_whatever_it_holds(self) -> None:
+        """Backticks mean literal, so nothing inside one is read as markup."""
+        assert advisory_prose("the `*` wildcard") == "the * wildcard"
+        assert advisory_prose("send `#include <x>` first") == "send #include <x> first"
+        assert advisory_prose("read `a_b_c` from disk") == "read a_b_c from disk"
+
     def test_a_bare_underscore_inside_a_name_survives(self) -> None:
         """Package and symbol names carry underscores, and they are not emphasis."""
         assert advisory_prose("calls parse_uri_string on every request") == "calls parse_uri_string on every request"

--- a/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
@@ -3,6 +3,7 @@
 {% load static %}
 {% load django_vite %}
 {% load advisory_tags %}
+{% load plugins_extras %}
 {% block title %}sbomify SBOM Vulnerabilities{% endblock %}
 {% block content %}
     <c-layout.page-header title="Vulnerabilities" icon="fas fa-shield-alt" mark="avatar" :breadcrumbs="breadcrumb_items" style="--avatar-accent: var(--color-warning)">
@@ -155,11 +156,15 @@
                                                         {% endif %}
                                                     </div>
                                                 </div>
-                                                {# Summary. Truncate from the FULL description when present — the scanner's own title can be pre-cut mid-word — so truncatewords always ends on a whole word. #}
+                                                {# Summary. Truncate from the FULL description when present — the scanner's own title can be pre-cut mid-word — so truncatewords always ends on a whole word. The body is CommonMark, so it is flattened before it is cut. #}
                                                 {% if vuln.details and ' ' in vuln.details %}
-                                                    <p class="text-sm text-text-muted leading-relaxed mb-2 break-words">{{ vuln.details|truncatewords:20 }}</p>
+                                                    <p class="text-sm text-text-muted leading-relaxed mb-2 break-words">
+                                                        {{ vuln.details|advisory_prose|truncatewords:20 }}
+                                                    </p>
                                                 {% elif vuln.summary and ' ' in vuln.summary %}
-                                                    <p class="text-sm text-text-muted leading-relaxed mb-2 break-words">{{ vuln.summary|truncatewords:20 }}</p>
+                                                    <p class="text-sm text-text-muted leading-relaxed mb-2 break-words">
+                                                        {{ vuln.summary|advisory_prose|truncatewords:20 }}
+                                                    </p>
                                                 {% else %}
                                                     <p class="text-sm text-text-muted mb-2 italic"
                                                        title="No summary provided by the scanner">

--- a/sbomify/apps/sboms/tests/test_sbom_vulnerabilities_view.py
+++ b/sbomify/apps/sboms/tests/test_sbom_vulnerabilities_view.py
@@ -134,3 +134,24 @@ def test_scanner_status_markers_are_not_vulnerability_rows(sample_sbom: SBOM):  
     names = [p["package"]["name"] for p in packages]
     assert "django" in names
     assert len(packages) == 1
+
+
+@pytest.mark.django_db
+def test_the_advisory_body_reaches_the_page_as_prose(sample_sbom: SBOM):  # noqa: F811
+    """OSV serves GHSA's CommonMark verbatim, and the card showed it raw: the
+    page carried the literal text "### Impact" and backticked package names."""
+    finding = _finding("GHSA-5jgf-p345-68v8", "fast-uri", version="3.1.5")
+    finding["description"] = (
+        "### Impact\n`fast-uri` decodes percent-encoded characters in the scheme "
+        "component with the legacy global `unescape()` and serializes the result back."
+    )
+    _run(sample_sbom, "osv", [finding])
+    client = Client()
+    team = sample_sbom.component.team
+    setup_test_session(client, team, team.members.first())
+
+    html = client.get(reverse("sboms:sbom_vulnerabilities", kwargs={"sbom_id": sample_sbom.id})).content.decode()
+
+    assert "### Impact" not in html
+    assert "`fast-uri`" not in html
+    assert "Impact fast-uri decodes percent-encoded characters" in html

--- a/sbomify/apps/sboms/tests/test_sbom_vulnerabilities_view.py
+++ b/sbomify/apps/sboms/tests/test_sbom_vulnerabilities_view.py
@@ -150,8 +150,12 @@ def test_the_advisory_body_reaches_the_page_as_prose(sample_sbom: SBOM):  # noqa
     team = sample_sbom.component.team
     setup_test_session(client, team, team.members.first())
 
-    html = client.get(reverse("sboms:sbom_vulnerabilities", kwargs={"sbom_id": sample_sbom.id})).content.decode()
+    response = client.get(reverse("sboms:sbom_vulnerabilities", kwargs={"sbom_id": sample_sbom.id}))
 
+    # Asserted before the strings below, so a redirect or an error page cannot
+    # pass this test by simply not containing the markup it is looking for.
+    assert response.status_code == 200
+    html = response.content.decode()
     assert "### Impact" not in html
     assert "`fast-uri`" not in html
     assert "Impact fast-uri decodes percent-encoded characters" in html


### PR DESCRIPTION
Reported from production: the vulnerability cards render their own markup.

## What was showing

```
### Impact `fast-uri` decodes percent-encoded characters in the scheme
component with the legacy global `unescape()` and serializes the result back ...
```

OSV serves GHSA's `details` verbatim and it is CommonMark, so `### Impact` arrived as those four characters, package names arrived inside backticks, and reference links arrived as bracket-and-parenthesis pairs.

## The fix

The pages show the opening twenty words of a description rather than the whole of it, so the markup comes off rather than being rendered. A heading is not structure inside a summary that short, and there is nowhere in the card for a rendered list or code block to go.

Flattening also has to happen before the truncation, not after. `truncatewords` counts words and knows nothing about syntax, so cutting first can leave a code span or a link half-open; cutting flattened prose can only ever land between words.

`advisory_prose` sits next to `format_finding_description` in `plugins_extras`, since both take the same finding text. It removes headings, fences, quotes, list markers and thematic breaks, keeps the text of a link and the alt text of an image, drops code-span and emphasis markers, and collapses the paragraph breaks that would otherwise arrive mid-sentence as spaces.

What it deliberately leaves alone, with a test each: `C#` and `#1` do not open headings, and `parse_uri_string` is a symbol name rather than emphasis.

The same body reaches the assessment run list (`_assessment_run_item.html.j2`), so that surface takes the filter too.

## Tests

Twelve filter tests, opening with the fast-uri body exactly as it reached the page. One page-level regression test that renders the vulnerabilities view and asserts `### Impact` and the backticks are gone and the prose is there.

1829 tests pass across plugins and sboms.

`test_sbom_vulnerabilities_snapshot[1920]` and `test_sbom_vulnerabilities_no_data_snapshot[1920]` fail on this branch, and also on a clean master with these changes stashed, so they are not from this work and their baselines are untouched.
