### PR TITLE
fix(vex): the preview counts advisories, not scan rows

### DIFF
--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -32,6 +32,28 @@ from .utils import extract_severity_counts
 from .vex import finding_dict_is_suppressed
 
 
+def _preview_identity(finding: dict[str, Any]) -> tuple[str, str]:
+    """What makes two scanned rows the same vulnerability for counting.
+
+    The advisory half folds aliases, so the GHSA one provider reports and the
+    CVE another reports are one advisory as soon as either row carries the
+    other id. The package half prefers the purl and falls back to name and
+    version, which is what a scanner records when it has no purl to give.
+    """
+    from .vex import _finding_ids
+
+    ids = _finding_ids(finding)
+    advisory = min(ids) if ids else ""
+    raw_component = finding.get("component")
+    component = raw_component if isinstance(raw_component, dict) else {}
+    purl = str(component.get("purl") or "").strip().lower()
+    if purl:
+        return advisory, purl
+    name = str(component.get("name") or "").strip().lower()
+    version = str(component.get("version") or "").strip().lower()
+    return advisory, f"{name}@{version}"
+
+
 def _apply_latest_sbom_filter(queryset: QuerySet[AssessmentRun], component_id: str) -> QuerySet[AssessmentRun]:
     """Filter queryset to the latest SBOM for a component."""
     from sbomify.apps.sboms.queries import get_latest_sbom_id_for_component
@@ -1285,7 +1307,6 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     # run per (sbom, plugin) across ALL the component's SBOMs. Scoping preview to
     # the latest SBOM alone under-reports a VEX that suppresses in an older SBOM.
     base = AssessmentRun.objects.filter(sbom__component_id=component_id, category="security", status="completed")
-    findings: list[dict[str, Any]] = []
     # Only the newest run per (sbom, plugin), so the multi-MB result blob of every
     # historical run is neither transferred nor deserialised. DISTINCT ON is
     # Postgres-only; fall back to a Python newest-per-key pass on SQLite.
@@ -1308,13 +1329,32 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
             if current is None or value > current:
                 newest_by_key[key] = value
         latest_run_ids = [run_id for _, run_id in newest_by_key.values()]
+    # One advisory on one package, however many times it has been scanned. The
+    # scope above is every SBOM the component has ever carried, so an advisory
+    # that has been present for fifty uploads arrives fifty times, once more per
+    # provider that reports it. Counting those rows told a workspace whose
+    # component page reads "7 findings" that a VEX had been checked against
+    # 1525 of them. Every surface that shows findings folds them first; this one
+    # was reporting rows.
+    by_identity: dict[tuple[str, str], dict[str, Any]] = {}
     for run in AssessmentRun.objects.filter(id__in=latest_run_ids).iterator():
         result = run.result if isinstance(run.result, dict) else {}
         for finding in result.get("findings") or []:
             # Scanner status markers are not vulnerabilities; counting them
             # inflates findings_checked and can never match a statement.
-            if isinstance(finding, dict) and is_vulnerability(finding):
-                findings.append(finding)
+            if not (isinstance(finding, dict) and is_vulnerability(finding)):
+                continue
+            key = _preview_identity(finding)
+            kept = by_identity.get(key)
+            # An advisory still live in any one of the component's SBOMs is one
+            # this VEX would act on, so an unsuppressed row wins over a
+            # suppressed one. Without that the count would depend on which SBOM
+            # the database happened to hand back first.
+            if kept is None or (finding_dict_is_suppressed(kept) and not finding_dict_is_suppressed(finding)):
+                by_identity[key] = finding
+    # Sorted so the sample list under the counters is the same on every preview
+    # of the same document.
+    findings = [by_identity[key] for key in sorted(by_identity)]
 
     matched: list[dict[str, Any]] = []
     matched_statement_ids: set[int] = set()

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from typing import Any, cast
 
@@ -32,26 +33,52 @@ from .utils import extract_severity_counts
 from .vex import finding_dict_is_suppressed
 
 
-def _preview_identity(finding: dict[str, Any]) -> tuple[str, str]:
-    """What makes two scanned rows the same vulnerability for counting.
+def _package_scope(finding: dict[str, Any]) -> str:
+    """The package a finding speaks about, keyed the way the merger keys it.
 
-    The advisory half folds aliases, so the GHSA one provider reports and the
-    CVE another reports are one advisory as soon as either row carries the
-    other id. The package half prefers the purl and falls back to name and
-    version, which is what a scanner records when it has no purl to give.
+    The artifact tail rather than the whole name, because providers disagree
+    about the prefix (OSV writes ``group:artifact`` where Dependency Track
+    writes ``artifact``), and never the purl, because one provider records a
+    purl and another records only a name, so keying on it splits rows that are
+    about the same package.
     """
-    from .vex import _finding_ids
-
-    ids = _finding_ids(finding)
-    advisory = min(ids) if ids else ""
     raw_component = finding.get("component")
     component = raw_component if isinstance(raw_component, dict) else {}
-    purl = str(component.get("purl") or "").strip().lower()
-    if purl:
-        return advisory, purl
-    name = str(component.get("name") or "").strip().lower()
-    version = str(component.get("version") or "").strip().lower()
-    return advisory, f"{name}@{version}"
+    name = str(component.get("name") or "").split(":")[-1]
+    return f"{name}:{component.get('version') or ''}".lower()
+
+
+def _canonical_advisory_ids(results: Sequence[dict[str, Any] | None]) -> dict[tuple[str, str], str]:
+    """Map every id a scanned advisory is known by to one id per package.
+
+    Built by the same merger the component page uses, so preview counting and
+    the page a user compares it against group findings identically. A canonical
+    id per package rather than per document is what keeps one advisory hitting
+    two packages counted as two.
+    """
+    from .utils import merge_findings_by_alias
+
+    canonical: dict[tuple[str, str], str] = {}
+    for merged in merge_findings_by_alias(list(results)).get("findings") or []:
+        scope = _package_scope(merged)
+        display = str(merged.get("id") or "")
+        for identifier in [display, *(merged.get("aliases") or [])]:
+            if identifier:
+                canonical[(scope, str(identifier).lower())] = display
+    return canonical
+
+
+def _preview_identity(finding: dict[str, Any], canonical: dict[tuple[str, str], str]) -> tuple[str, str]:
+    """What makes two scanned rows the same vulnerability for counting."""
+    from .vex import _finding_ids
+
+    scope = _package_scope(finding)
+    ids = _finding_ids(finding)
+    for identifier in sorted(ids):
+        display = canonical.get((scope, identifier))
+        if display:
+            return scope, display
+    return scope, min(ids) if ids else ""
 
 
 def _apply_latest_sbom_filter(queryset: QuerySet[AssessmentRun], component_id: str) -> QuerySet[AssessmentRun]:
@@ -1336,15 +1363,19 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     # component page reads "7 findings" that a VEX had been checked against
     # 1525 of them. Every surface that shows findings folds them first; this one
     # was reporting rows.
+    results = [
+        run.result if isinstance(run.result, dict) else {}
+        for run in AssessmentRun.objects.filter(id__in=latest_run_ids)
+    ]
+    canonical = _canonical_advisory_ids(results)
     by_identity: dict[tuple[str, str], dict[str, Any]] = {}
-    for run in AssessmentRun.objects.filter(id__in=latest_run_ids).iterator():
-        result = run.result if isinstance(run.result, dict) else {}
+    for result in results:
         for finding in result.get("findings") or []:
             # Scanner status markers are not vulnerabilities; counting them
             # inflates findings_checked and can never match a statement.
             if not (isinstance(finding, dict) and is_vulnerability(finding)):
                 continue
-            key = _preview_identity(finding)
+            key = _preview_identity(finding, canonical)
             kept = by_identity.get(key)
             # An advisory still live in any one of the component's SBOMs is one
             # this VEX would act on, so an unsuppressed row wins over a

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterable, Iterator
 from datetime import date, datetime, timedelta
 from typing import Any, cast
 
@@ -48,7 +48,7 @@ def _package_scope(finding: dict[str, Any]) -> str:
     return f"{name}:{component.get('version') or ''}".lower()
 
 
-def _canonical_advisory_ids(results: Sequence[dict[str, Any] | None]) -> dict[tuple[str, str], str]:
+def _canonical_advisory_ids(results: Iterable[dict[str, Any] | None]) -> dict[tuple[str, str], str]:
     """Map every id a scanned advisory is known by to one id per package.
 
     Built by the same merger the component page uses, so preview counting and
@@ -59,7 +59,7 @@ def _canonical_advisory_ids(results: Sequence[dict[str, Any] | None]) -> dict[tu
     from .utils import merge_findings_by_alias
 
     canonical: dict[tuple[str, str], str] = {}
-    for merged in merge_findings_by_alias(list(results)).get("findings") or []:
+    for merged in merge_findings_by_alias(results).get("findings") or []:
         scope = _package_scope(merged)
         display = str(merged.get("id") or "")
         for identifier in [display, *(merged.get("aliases") or [])]:
@@ -1356,6 +1356,7 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
             if current is None or value > current:
                 newest_by_key[key] = value
         latest_run_ids = [run_id for _, run_id in newest_by_key.values()]
+
     # One advisory on one package, however many times it has been scanned. The
     # scope above is every SBOM the component has ever carried, so an advisory
     # that has been present for fifty uploads arrives fifty times, once more per
@@ -1363,13 +1364,17 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     # component page reads "7 findings" that a VEX had been checked against
     # 1525 of them. Every surface that shows findings folds them first; this one
     # was reporting rows.
-    results = [
-        run.result if isinstance(run.result, dict) else {}
-        for run in AssessmentRun.objects.filter(id__in=latest_run_ids)
-    ]
-    canonical = _canonical_advisory_ids(results)
+    # Two streaming passes rather than one materialised list: the folding needs
+    # to see every advisory before it can say which rows are the same one, and
+    # a component with a long upload history holds a multi-MB result blob per
+    # run. Only the JSON column is fetched, so no model is built either.
+    def _stream_results() -> Iterator[dict[str, Any]]:
+        for result in AssessmentRun.objects.filter(id__in=latest_run_ids).values_list("result", flat=True).iterator():
+            yield result if isinstance(result, dict) else {}
+
+    canonical = _canonical_advisory_ids(_stream_results())
     by_identity: dict[tuple[str, str], dict[str, Any]] = {}
-    for result in results:
+    for result in _stream_results():
         for finding in result.get("findings") or []:
             # Scanner status markers are not vulnerabilities; counting them
             # inflates findings_checked and can never match a statement.

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -227,6 +227,29 @@ def test_merge_findings_by_alias_tolerates_a_non_dict_component():
     assert {f["id"] for f in merged} == {"CVE-1", "CVE-2", "CVE-3"}
 
 
+def test_merge_findings_by_alias_walks_only_what_it_can_walk():
+    """The rest of the shapes a malformed stored result can take. Each one used
+    to raise, and this merger is behind the component page and the VEX preview,
+    so either answered 500 rather than skipping the row it could not read."""
+    from sbomify.apps.vulnerability_scanning.utils import merge_findings_by_alias
+
+    component = {"name": "lodash", "version": "4.17.15"}
+    results = [
+        None,
+        "not a result at all",
+        {"findings": "not a list"},
+        {"findings": ["a bare string where a finding should be", 42, None]},
+        {"findings": [{"id": "CVE-REAL", "severity": "high", "component": component, "aliases": "GHSA-x"}]},
+    ]
+
+    merged = merge_findings_by_alias(results)["findings"]
+
+    # The one readable finding survives, and its unusable aliases are dropped
+    # rather than walked one character at a time.
+    assert [f["id"] for f in merged] == ["CVE-REAL"]
+    assert merged[0]["aliases"] == []
+
+
 def test_extract_finding_rows_stamps_kev_by_id_and_alias():
     from sbomify.apps.vulnerability_scanning.utils import extract_finding_rows
 

--- a/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_result_annotations.py
@@ -81,8 +81,9 @@ def test_reconstructed_counts_match_reading_the_blob(sample_team_with_owner_memb
 
     annotated = {
         row["id"]: row
-        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
-        .values("id", *RESULT_SUMMARY_COLUMNS)
+        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()]).values(
+            "id", *RESULT_SUMMARY_COLUMNS
+        )
     }
 
     for label, result in RESULT_SHAPES:
@@ -100,8 +101,9 @@ def test_reconstruction_preserves_status_helper_verdicts(sample_team_with_owner_
 
     annotated = {
         row["id"]: row
-        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()])
-        .values("id", "category", "status", *RESULT_SUMMARY_COLUMNS)
+        for row in AssessmentRun.objects.filter(id__in=[r.id for r in runs.values()]).values(
+            "id", "category", "status", *RESULT_SUMMARY_COLUMNS
+        )
     }
 
     for label, original in RESULT_SHAPES:
@@ -204,6 +206,25 @@ def test_merge_findings_by_alias_is_transitive():
     assert set(only["aliases"]) == {"GHSA-x", "OSV-9"}
     assert only["severity"] == "critical"
     assert only["cvss_score"] == 9.1
+
+
+def test_merge_findings_by_alias_tolerates_a_non_dict_component():
+    """Stored scan results are provider-controlled JSON. A component that is a
+    string rather than an object must not raise: this function is read by the
+    component page and by the VEX preview, and either would answer 500."""
+    from sbomify.apps.vulnerability_scanning.utils import merge_findings_by_alias
+
+    results = [
+        {"findings": [{"id": "CVE-1", "severity": "high", "component": "lodash 4.17.15"}]},
+        {"findings": [{"id": "CVE-2", "severity": "low", "component": None}]},
+        {"findings": [{"id": "CVE-3", "severity": "low", "component": ["lodash"]}]},
+    ]
+
+    merged = merge_findings_by_alias(results)["findings"]
+
+    # Nameless findings cannot be shown to be the same package, so they stay
+    # apart rather than folding into one another.
+    assert {f["id"] for f in merged} == {"CVE-1", "CVE-2", "CVE-3"}
 
 
 def test_extract_finding_rows_stamps_kev_by_id_and_alias():

--- a/sbomify/apps/vulnerability_scanning/tests/test_triage.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_triage.py
@@ -1074,11 +1074,13 @@ class TestPreviewApi:
             ],
         }
 
-        body = client.post(
+        response = client.post(
             f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
             data=json.dumps(document),
             content_type="application/json",
-        ).json()
+        )
+        assert response.status_code == 200, response.content
+        body = response.json()
 
         # One advisory on one package, not 24 rows.
         assert body["findings_checked"] == 1
@@ -1141,11 +1143,13 @@ class TestPreviewApi:
             ],
         }
 
-        body = client.post(
+        response = client.post(
             f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
             data=json.dumps(document),
             content_type="application/json",
-        ).json()
+        )
+        assert response.status_code == 200, response.content
+        body = response.json()
 
         assert body["findings_checked"] == 1
         assert body["would_suppress"] == 1
@@ -1217,11 +1221,13 @@ class TestPreviewApi:
             ],
         }
 
-        body = client.post(
+        response = client.post(
             f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
             data=json.dumps(document),
             content_type="application/json",
-        ).json()
+        )
+        assert response.status_code == 200, response.content
+        body = response.json()
 
         assert body["findings_checked"] == 1
         assert body["would_suppress"] == 1

--- a/sbomify/apps/vulnerability_scanning/tests/test_triage.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_triage.py
@@ -1010,6 +1010,222 @@ class TestPreviewApi:
         assert body["would_suppress"] == 1
         assert body["unmatched_statements"] == 0
 
+    def test_the_same_advisory_across_many_sboms_counts_once(
+        self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
+    ) -> None:
+        """The scope is every SBOM the component has carried, so an advisory
+        that survived twelve uploads arrived twelve times. Counting the rows
+        told a workspace whose component page reads "7 findings" that a VEX had
+        been checked against 1525 of them."""
+        for index in range(12):
+            sbom = SBOM.objects.create(
+                name=f"v{index}",
+                version=f"1.0.{index}",
+                component=component,
+                format="cyclonedx",
+                format_version="1.6",
+                source="api",
+                sbom_filename=f"v{index}.json",
+                bom_type="sbom",
+            )
+            # Two providers report it, which is the second multiplier.
+            for provider in ("osv", "dependency-track"):
+                AssessmentRun.objects.create(
+                    sbom=sbom,
+                    plugin_name=provider,
+                    plugin_version="1.0.0",
+                    category="security",
+                    run_reason="on_upload",
+                    status="completed",
+                    result={
+                        "findings": [
+                            {
+                                "id": "CVE-2026-10",
+                                "title": "a",
+                                "description": "a",
+                                "component": {
+                                    "name": "lodash",
+                                    "version": "4.17.15",
+                                    "purl": "pkg:npm/lodash@4.17.15",
+                                },
+                            }
+                        ]
+                    },
+                )
+        client = _client_for(sample_user, sample_team_with_owner_member.team)
+        document = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "components": [
+                {
+                    "type": "library",
+                    "bom-ref": "pkg:npm/lodash@4.17.15",
+                    "purl": "pkg:npm/lodash@4.17.15",
+                    "name": "lodash",
+                }
+            ],
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2026-10",
+                    "analysis": {"state": "not_affected", "justification": "code_not_present"},
+                    "affects": [{"ref": "pkg:npm/lodash@4.17.15"}],
+                }
+            ],
+        }
+
+        body = client.post(
+            f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
+            data=json.dumps(document),
+            content_type="application/json",
+        ).json()
+
+        # One advisory on one package, not 24 rows.
+        assert body["findings_checked"] == 1
+        assert body["would_suppress"] == 1
+        assert len(body["matched"]) == 1
+
+    def test_an_advisory_still_live_in_one_sbom_reads_as_would_suppress(
+        self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
+    ) -> None:
+        """Folding the duplicates must not let an already-suppressed copy hide a
+        live one: applying the VEX still has work to do."""
+        for index, suppressed in enumerate((True, False)):
+            sbom = SBOM.objects.create(
+                name=f"v{index}",
+                version=f"1.0.{index}",
+                component=component,
+                format="cyclonedx",
+                format_version="1.6",
+                source="api",
+                sbom_filename=f"v{index}.json",
+                bom_type="sbom",
+            )
+            finding: dict = {
+                "id": "CVE-2026-10",
+                "title": "a",
+                "description": "a",
+                "component": {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"},
+            }
+            if suppressed:
+                finding["analysis_state"] = "not_affected"
+                finding["analysis_justification"] = "code_not_present"
+            AssessmentRun.objects.create(
+                sbom=sbom,
+                plugin_name="osv",
+                plugin_version="1.0.0",
+                category="security",
+                run_reason="on_upload",
+                status="completed",
+                result={"findings": [finding]},
+            )
+        client = _client_for(sample_user, sample_team_with_owner_member.team)
+        document = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "components": [
+                {
+                    "type": "library",
+                    "bom-ref": "pkg:npm/lodash@4.17.15",
+                    "purl": "pkg:npm/lodash@4.17.15",
+                    "name": "lodash",
+                }
+            ],
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2026-10",
+                    "analysis": {"state": "not_affected", "justification": "code_not_present"},
+                    "affects": [{"ref": "pkg:npm/lodash@4.17.15"}],
+                }
+            ],
+        }
+
+        body = client.post(
+            f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
+            data=json.dumps(document),
+            content_type="application/json",
+        ).json()
+
+        assert body["findings_checked"] == 1
+        assert body["would_suppress"] == 1
+        assert body["already_suppressed"] == 0
+
+    def test_one_advisory_reported_under_two_ids_counts_once(
+        self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
+    ) -> None:
+        """One provider names the GHSA and another the CVE. They are the same
+        advisory as soon as either row carries the other id."""
+        sbom = SBOM.objects.create(
+            name="only",
+            version="1.0.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            source="api",
+            sbom_filename="only.json",
+            bom_type="sbom",
+        )
+        package = {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"}
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            category="security",
+            run_reason="on_upload",
+            status="completed",
+            result={
+                "findings": [
+                    {
+                        "id": "GHSA-aaaa-bbbb-cccc",
+                        "aliases": ["CVE-2026-10"],
+                        "title": "a",
+                        "description": "a",
+                        "component": package,
+                    }
+                ]
+            },
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="dependency-track",
+            plugin_version="1.0.0",
+            category="security",
+            run_reason="on_upload",
+            status="completed",
+            result={"findings": [{"id": "CVE-2026-10", "title": "a", "description": "a", "component": package}]},
+        )
+        client = _client_for(sample_user, sample_team_with_owner_member.team)
+        document = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "components": [
+                {
+                    "type": "library",
+                    "bom-ref": "pkg:npm/lodash@4.17.15",
+                    "purl": "pkg:npm/lodash@4.17.15",
+                    "name": "lodash",
+                }
+            ],
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2026-10",
+                    "analysis": {"state": "not_affected", "justification": "code_not_present"},
+                    "affects": [{"ref": "pkg:npm/lodash@4.17.15"}],
+                }
+            ],
+        }
+
+        body = client.post(
+            f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
+            data=json.dumps(document),
+            content_type="application/json",
+        ).json()
+
+        assert body["findings_checked"] == 1
+        assert body["would_suppress"] == 1
+
     def test_preview_two_statements_matching_one_finding_none_unmatched(
         self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
     ) -> None:

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for vulnerability scanning."""
 
 import json
+from collections.abc import Iterable
 from typing import Any
 
 from sbomify.apps.vulnerability_scanning.kev import finding_in_kev
@@ -175,7 +176,7 @@ def _fold_finding(dst: dict[str, Any], src: dict[str, Any]) -> None:
             dst[field] = src[field]
 
 
-def merge_findings_by_alias(results: list[dict[str, Any] | None]) -> dict[str, Any]:
+def merge_findings_by_alias(results: Iterable[dict[str, Any] | None]) -> dict[str, Any]:
     """Fold several providers' scan results into one synthetic result dict.
 
     Providers report the same issue under different ids (Dependency-Track the

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -199,7 +199,11 @@ def merge_findings_by_alias(results: Iterable[dict[str, Any] | None]) -> dict[st
         for vuln in result_json.get("findings") or []:
             if not is_vulnerability(vuln):
                 continue
-            component = vuln.get("component") or {}
+            # Stored scan results are provider-controlled JSON, so a component
+            # that is not a dict must not raise on the field reads below. The
+            # release posture guards the same read for the same reason.
+            raw_component = vuln.get("component")
+            component = raw_component if isinstance(raw_component, dict) else {}
             # Providers name the same package differently (OSV "group:artifact",
             # DT "artifact"); scope alias matching to the artifact tail+version
             # so one advisory hitting two packages stays two findings.

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -191,13 +191,18 @@ def merge_findings_by_alias(results: Iterable[dict[str, Any] | None]) -> dict[st
     by_alias: dict[tuple[str, str], dict[str, Any]] = {}
 
     for result_json in results:
-        if not result_json:
+        # Every read below is of provider-controlled JSON, so each level is
+        # type-checked before it is walked. This merger is behind the component
+        # page and the VEX preview, and either answers 500 on an AttributeError
+        # here rather than skipping the one malformed row.
+        if not isinstance(result_json, dict):
             continue
         metadata = result_json.get("metadata") or {}
         if isinstance(metadata, dict) and metadata.get("skipped"):
             continue
-        for vuln in result_json.get("findings") or []:
-            if not is_vulnerability(vuln):
+        findings = result_json.get("findings")
+        for vuln in findings if isinstance(findings, list) else []:
+            if not isinstance(vuln, dict) or not is_vulnerability(vuln):
                 continue
             # Stored scan results are provider-controlled JSON, so a component
             # that is not a dict must not raise on the field reads below. The
@@ -210,7 +215,11 @@ def merge_findings_by_alias(results: Iterable[dict[str, Any] | None]) -> dict[st
             package_scope = (
                 f"{str(component.get('name') or '').split(':')[-1]}:{component.get('version') or ''}".lower()
             )
-            ids = {str(vuln.get("id") or "")} | {str(alias) for alias in vuln.get("aliases") or []}
+            # Tolerate a non-list aliases, as vex._finding_ids does: a string
+            # there would otherwise be walked one character at a time.
+            raw_aliases = vuln.get("aliases")
+            aliases = raw_aliases if isinstance(raw_aliases, list) else []
+            ids = {str(vuln.get("id") or "")} | {str(alias) for alias in aliases}
             ids.discard("")
             alias_keys = {(package_scope, i.lower()) for i in ids}
 


### PR DESCRIPTION
Reported from production: the VEX preview numbers are implausible.

```
91 WOULD SUPPRESS      0 ALREADY SUPPRESSED      0 STATEMENTS MATCHING NOTHING      1525 FINDINGS CHECKED
```

against a component whose own page reads 7 findings.

## Where 1525 comes from

The preview is scoped to the whole component, deliberately: applying a VEX runs `reannotate_component_runs`, which re-annotates every one of the component's completed security runs, so a preview scoped to the latest SBOM alone would under-report a VEX that suppresses in an older one. That scope is correct and this change keeps it.

What was missing is the fold afterwards. The rows were counted raw:

```python
if isinstance(finding, dict) and is_vulnerability(finding):
    findings.append(finding)
...
"findings_checked": len(findings),
```

So one advisory on one package was counted once per SBOM version it appeared in, multiplied again by every provider reporting it. A component with a long upload history and two scanners lands in the thousands. `would_suppress` was inflated the same way, which is where 91 came from.

Every other surface folds before it counts: the release posture uses `_fold_finding` and `_identity_keys`, the component page uses `merge_findings_by_alias`. The preview was the one place reporting database rows to a human.

## The change

Findings fold to one advisory on one package before counting, and both halves of that key come from `merge_findings_by_alias`, the merger the component page already folds with, so the preview and the page a user compares it against group findings identically.

The package half keys on the artifact tail and version, never the purl. Dependency Track records a purl and OSV records only a name, so keying on the purl splits rows that are about the same package: `posture.py` documents that exact bug. The advisory half takes the canonical id the merger assigns, rather than picking one out of the alias set, because two providers rarely carry the same aliases and any rule for choosing among them breaks as soon as one knows an id the other does not.

Where copies of the same advisory disagree, the live one wins. An advisory still unsuppressed in any of the component's SBOMs is one this VEX has work to do on, and taking whichever row the database returned first made the answer depend on nothing. The folded list is sorted, so the sample under the counters is the same on every preview of the same document.

## Tests

Three added, each failing before the change and passing after:

- the same advisory across twelve SBOM versions and two providers counts once, not twenty-four times
- an already-suppressed copy does not hide a live one, so `would_suppress` stays 1
- one advisory reported as a GHSA by one scanner and a CVE by another counts once

`test_preview_is_component_wide_not_latest_sbom_only` still passes: the scope is unchanged, only the counting is.

458 tests pass in vulnerability_scanning.

