### PR TITLE
fix(upload): the declared artifact type has to match the document

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -35,6 +35,7 @@ from sbomify.apps.sboms.utils import (
     _contains_crypto_assets,
     _is_cbom,
     _is_duplicate_integrity_error,
+    _is_vex,
     verify_download_token,
 )
 from sbomify.apps.teams.models import ContactProfile
@@ -490,6 +491,20 @@ def sbom_upload_cyclonedx(
         sbom_version = sbom_dict.get("version", "")
         sbom_format = "cyclonedx"
 
+        # A VEX is not an inventory. It validates as CycloneDX because the spec
+        # makes both components and vulnerabilities optional, so nothing before
+        # this point can tell the two apart, and one stored as bom_type=sbom is
+        # scanned and then scored against NTIA, BSI and FDA as though its empty
+        # component list were the truth. Say so instead of accepting it.
+        if bom_type == SBOM.BomType.SBOM.value and _is_vex(sbom_data):
+            return 400, {
+                "detail": (
+                    "This looks like a VEX document: it carries vulnerability statements and no "
+                    "components. Upload it as a VEX rather than as an SBOM."
+                ),
+                "error_code": ErrorCode.VALIDATION_ERROR,
+            }
+
         # Auto-detect CBOM content: an action-published CBOM arrives with the
         # default bom_type; tag it cbom so the cbom-gated PQC plugin runs. Only
         # when the caller left the type as the default — an explicit bom_type
@@ -615,6 +630,19 @@ def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, d
             }
         is_xml = looks_like_xml(request.body)
         if vex_format == VEX_FORMAT_CYCLONEDX and not is_xml:
+            # detect_vex_format answers which format a document is written in,
+            # not whether it is a VEX: every CycloneDX document carries the
+            # bomFormat marker it keys on. So an inventory posted here would be
+            # stored as a VEX and would rewrite the component's posture from a
+            # document that states nothing about any vulnerability.
+            if isinstance(document, dict) and not _is_vex(document):
+                return 400, {
+                    "detail": (
+                        "This looks like an SBOM: it carries components and no vulnerability "
+                        "statements. Upload it as an SBOM rather than as a VEX."
+                    ),
+                    "error_code": ErrorCode.VALIDATION_ERROR,
+                }
             return sbom_upload_cyclonedx(request, component_id, bom_type=SBOM.BomType.VEX.value)
 
         component = Component.objects.filter(id=component_id).first()
@@ -1373,6 +1401,18 @@ def sbom_upload_file(
 
             sbom_version = sbom_dict.get("version", "")
             sbom_format = "cyclonedx"
+
+            # A VEX is not an inventory; see the same guard on the CycloneDX
+            # API endpoint. Stored as bom_type=sbom it is scanned and scored
+            # against the SBOM compliance plugins as though it were one.
+            if bom_type == SBOM.BomType.SBOM.value and _is_vex(sbom_data):
+                return 400, {
+                    "detail": (
+                        "This looks like a VEX document: it carries vulnerability statements and no "
+                        "components. Choose VEX as the artifact type rather than SBOM."
+                    ),
+                    "error_code": ErrorCode.VALIDATION_ERROR,
+                }
 
             # Auto-detect CBOM content: tag a crypto BOM uploaded with the
             # default bom_type as cbom so the cbom-gated PQC plugin runs. Only when

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -36,6 +36,7 @@ from sbomify.apps.sboms.utils import (
     _is_cbom,
     _is_duplicate_integrity_error,
     _is_vex,
+    _states_vulnerabilities,
     verify_download_token,
 )
 from sbomify.apps.teams.models import ContactProfile
@@ -635,11 +636,11 @@ def vex_artifact_upload(request: HttpRequest, component_id: str) -> tuple[int, d
             # bomFormat marker it keys on. So an inventory posted here would be
             # stored as a VEX and would rewrite the component's posture from a
             # document that states nothing about any vulnerability.
-            if isinstance(document, dict) and not _is_vex(document):
+            if isinstance(document, dict) and not _states_vulnerabilities(document):
                 return 400, {
                     "detail": (
-                        "This looks like an SBOM: it carries components and no vulnerability "
-                        "statements. Upload it as an SBOM rather than as a VEX."
+                        "This document makes no vulnerability statement, so it is not a VEX. "
+                        "Upload it as an SBOM rather than as a VEX."
                     ),
                     "error_code": ErrorCode.VALIDATION_ERROR,
                 }
@@ -1401,6 +1402,18 @@ def sbom_upload_file(
 
             sbom_version = sbom_dict.get("version", "")
             sbom_format = "cyclonedx"
+
+            # The type comes from a dropdown here, so the mismatch runs both
+            # ways: picking VEX for an inventory stores a document that states
+            # nothing about any vulnerability as the component's VEX.
+            if bom_type == SBOM.BomType.VEX.value and not _states_vulnerabilities(sbom_data):
+                return 400, {
+                    "detail": (
+                        "This document makes no vulnerability statement, so it is not a VEX. "
+                        "Choose SBOM as the artifact type rather than VEX."
+                    ),
+                    "error_code": ErrorCode.VALIDATION_ERROR,
+                }
 
             # A VEX is not an inventory; see the same guard on the CycloneDX
             # API endpoint. Stored as bom_type=sbom it is scanned and scored

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -3966,6 +3966,83 @@ def test_cyclonedx_upload_document_carrying_both_stays_an_sbom(
 
 
 @pytest.mark.django_db
+def test_vex_artifact_upload_accepts_a_vex_that_lists_components(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """The ordinary shape: a VEX lists the components its affects entries point
+    at. Requiring an empty inventory of a VEX would refuse most real ones."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    document = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+        "components": [
+            {"type": "library", "bom-ref": "pkg:npm/lodash@4.17.15", "name": "lodash", "version": "4.17.15"}
+        ],
+        "vulnerabilities": [
+            {
+                "id": "CVE-2021-23337",
+                "analysis": {"state": "not_affected", "justification": "code_not_reachable"},
+                "affects": [{"ref": "pkg:npm/lodash@4.17.15"}],
+            }
+        ],
+    }
+
+    client = Client()
+    url = reverse("api-1:vex_artifact_upload", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url,
+        data=json.dumps(document),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert resp.status_code == 201, resp.content
+    assert SBOM.objects.get(id=resp.json()["id"]).bom_type == "vex"
+
+
+@pytest.mark.django_db
+def test_upload_file_rejects_an_inventory_declared_as_vex(
+    sample_user,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """The session upload takes the type from a dropdown, so the mismatch runs
+    both ways and this path needs the guard the API route has."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    document = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+        "components": [{"type": "library", "name": "lodash", "version": "4.17.15"}],
+    }
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    client = Client()
+    setup_test_session(client, sample_component.team, sample_component.team.members.first())
+    upload = SimpleUploadedFile("doc.json", json.dumps(document).encode(), content_type="application/json")
+    resp = client.post(
+        f"/api/v1/sboms/upload-file/{sample_component.id}?bom_type=vex",
+        {"sbom_file": upload},
+    )
+
+    assert resp.status_code == 400
+    assert "not a VEX" in resp.json()["detail"]
+    assert SBOM.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_vex_artifact_upload_rejects_a_plain_sbom(
     sample_access_token: AccessToken,  # noqa: F811
     sample_component: Component,  # noqa: F811

--- a/sbomify/apps/sboms/tests/test_apis.py
+++ b/sbomify/apps/sboms/tests/test_apis.py
@@ -18,6 +18,7 @@ from sbomify.apps.teams.models import ContactProfile, Member
 from ..models import SBOM, Component, Product
 from .fixtures import (  # noqa: F401
     create_spdx3_test_sbom,
+    load_sample_cyclonedx_vex,
     sample_access_token,
     sample_component,
     sample_sbom,
@@ -3882,6 +3883,121 @@ def test_cyclonedx_upload_autodetects_cbom_bom_type(
     sbom = SBOM.objects.get(id=resp.json()["id"])
     assert sbom.bom_type == "cbom"
     assert sbom.has_crypto_assets is True
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_rejects_a_vex_declared_as_sbom(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """A VEX validates as CycloneDX, because the spec makes both components and
+    vulnerabilities optional. Stored as bom_type=sbom it was scanned and then
+    scored against NTIA, BSI and FDA as though its empty inventory were real."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url,
+        data=json.dumps(load_sample_cyclonedx_vex()),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert resp.status_code == 400
+    assert "VEX" in resp.json()["detail"]
+    assert SBOM.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_keeps_accepting_a_vex_declared_as_vex(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """The guard is about the declared type disagreeing with the document, so
+    the same document goes in fine when it is declared for what it is."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url + "?bom_type=vex",
+        data=json.dumps(load_sample_cyclonedx_vex()),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert resp.status_code == 201, resp.content
+    assert SBOM.objects.get(id=resp.json()["id"]).bom_type == "vex"
+
+
+@pytest.mark.django_db
+def test_cyclonedx_upload_document_carrying_both_stays_an_sbom(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """An inventory that also carries vulnerability statements is a VDR. Its
+    components are real, so every assessment that reads them still runs."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    document = load_sample_cyclonedx_vex()
+    document["components"] = [{"type": "library", "name": "lodash", "version": "4.17.15"}]
+
+    client = Client()
+    url = reverse("api-1:sbom_upload_cyclonedx", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url,
+        data=json.dumps(document),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert resp.status_code == 201, resp.content
+    assert SBOM.objects.get(id=resp.json()["id"]).bom_type == "sbom"
+
+
+@pytest.mark.django_db
+def test_vex_artifact_upload_rejects_a_plain_sbom(
+    sample_access_token: AccessToken,  # noqa: F811
+    sample_component: Component,  # noqa: F811
+    mocker: MockerFixture,  # noqa: F811
+):
+    """The inverse of the same confusion: detect_vex_format answers which
+    format a document is written in, not whether it is a VEX, so an inventory
+    posted here was stored as one and rewrote the component's posture."""
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    document = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+        "components": [{"type": "library", "name": "lodash", "version": "4.17.15"}],
+    }
+
+    client = Client()
+    url = reverse("api-1:vex_artifact_upload", kwargs={"component_id": sample_component.id})
+    resp = client.post(
+        url,
+        data=json.dumps(document),
+        content_type="application/json",
+        **get_api_headers(sample_access_token),
+    )
+
+    assert resp.status_code == 400
+    assert "SBOM" in resp.json()["detail"]
+    assert SBOM.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -2281,6 +2281,28 @@ def _contains_crypto_assets(sbom_data: dict[str, Any]) -> bool:
     return isinstance(metadata, dict) and is_crypto_asset(metadata.get("component"))
 
 
+def _is_vex(sbom_data: dict[str, Any]) -> bool:
+    """True when a CycloneDX document is a *pure* VEX: it carries vulnerability
+    statements and no inventory of its own.
+
+    A VEX and an SBOM are the same Pydantic model, because CycloneDX makes both
+    ``components`` and ``vulnerabilities`` optional, so nothing in schema
+    validation separates them. The subject of a VEX is named in
+    ``metadata.component``, which an SBOM fills in too, and that is why a VEX
+    uploaded as an SBOM was accepted, scanned, and then scored against NTIA,
+    BSI and FDA as though it were an inventory.
+
+    Mixed documents stay SBOMs, on the same reasoning as ``_is_cbom``: an
+    inventory that also carries vulnerability statements is a VDR, its
+    components are real, and every assessment that reads them should still run.
+    """
+    vulnerabilities = sbom_data.get("vulnerabilities")
+    if not (isinstance(vulnerabilities, list) and vulnerabilities):
+        return False
+    components = sbom_data.get("components")
+    return not (isinstance(components, list) and components)
+
+
 def _is_cbom(sbom_data: dict[str, Any]) -> bool:
     """True when a CycloneDX document is a *pure* CBOM: its
     ``metadata.component`` is a crypto asset, or every entry in a non-empty

--- a/sbomify/apps/sboms/utils.py
+++ b/sbomify/apps/sboms/utils.py
@@ -2281,6 +2281,18 @@ def _contains_crypto_assets(sbom_data: dict[str, Any]) -> bool:
     return isinstance(metadata, dict) and is_crypto_asset(metadata.get("component"))
 
 
+def _states_vulnerabilities(sbom_data: dict[str, Any]) -> bool:
+    """Whether a CycloneDX document makes any vulnerability statement.
+
+    This is the whole of what a VEX has to carry. It is deliberately not
+    ``_is_vex``: a VEX routinely lists the components its ``affects`` entries
+    point at, so requiring an empty inventory would refuse the ordinary shape.
+    What no VEX can be is a document that says nothing about any vulnerability.
+    """
+    vulnerabilities = sbom_data.get("vulnerabilities")
+    return isinstance(vulnerabilities, list) and bool(vulnerabilities)
+
+
 def _is_vex(sbom_data: dict[str, Any]) -> bool:
     """True when a CycloneDX document is a *pure* VEX: it carries vulnerability
     statements and no inventory of its own.


### PR DESCRIPTION
Reported from production: leave the upload type on SBOM, pick a VEX file, and it is accepted as an SBOM.

## Why it went through

`bom_type` is a caller-declared string that no upload path reconciles against the document. The only content inference that exists is CBOM detection, and it has no VEX counterpart.

Schema validation cannot help, because a VEX and an SBOM are the same model: CycloneDX makes both `components` and `vulnerabilities` optional, and `bomFormat` is never asserted on the SBOM path. The metadata read afterwards pulls `metadata.component.name` and `version`, which a VEX fills in too, so the upload returned 201.

Downstream, every affected plugin declares `supported_bom_types=["sbom"]`, so one mis-set `bom_type` opened all of them. The reported result was NTIA, BSI TR-03183 and FDA reporting issues against a document that lists no components at all, plus a vulnerability scan of an empty inventory.

## The rule

A pure VEX, meaning vulnerability statements and no components of its own, is refused on the SBOM path with a message naming the type to pick instead.

A document carrying both stays an SBOM. That is a VDR: its components are real and every assessment that reads them should still run. This is the same line `_is_cbom` already draws for mixed crypto documents, and it is drawn in the same place for the same reason.

## The inverse, which was equally open

`detect_vex_format` answers which format a document is written in, not whether it is a VEX, and the CycloneDX branch keys on the `bomFormat` marker every CycloneDX document carries. So an inventory posted to `/artifact/vex/` was stored as a VEX, and a VEX rewrites the component's stored vulnerability posture. That path now refuses a document with components and no vulnerability statements.

Both guards call one helper rather than living in each caller.

## Tests

Four added:

- a VEX declared as an SBOM is refused and nothing is stored
- the same document declared as a VEX still uploads and is tagged `vex`
- a document carrying components and vulnerabilities stays an SBOM
- an inventory posted to the VEX route is refused

The first and last fail without the change. `sample_cyclonedx_vex.json` and its loader already existed in the fixtures and nothing had ever called them, which is roughly why this was unguarded in both directions.

1820 tests pass across sboms and plugins.
