### PR TITLE
fix(exports): a CSV export must not sit in a shared cache

### DIFF
--- a/sbomify/apps/controls/apis.py
+++ b/sbomify/apps/controls/apis.py
@@ -365,6 +365,9 @@ def export_csv(request: HttpRequest, catalog_id: str, product_id: str | None = N
     filename = f"{safe_name}-controls.csv"
     response = HttpResponse(result.value, content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    # Workspace-scoped, so it must not sit in a shared cache; see the note on
+    # core.apis._csv_response.
+    response["Cache-Control"] = "private, no-store"
     return response
 
 
@@ -398,6 +401,8 @@ def export_summary_csv(request: HttpRequest, catalog_id: str) -> HttpResponse | 
 
     response = HttpResponse(result.value, content_type="text/csv")
     response["Content-Disposition"] = 'attachment; filename="controls-summary.csv"'
+    # Workspace-scoped; see the note on core.apis._csv_response.
+    response["Cache-Control"] = "private, no-store"
     return response
 
 

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -275,28 +275,39 @@ class TestEndpoints:
         authorised or not. That was reproduced against a gated component: the
         origin answered 403 while the edge answered 200 from cache.
 
-        This walks the source instead of a list, so the next CSV endpoint is
-        covered the day it is written rather than the day it leaks.
+        This walks the source rather than a list, so the next CSV endpoint is
+        covered the day it is written. It scans every module, not just apis.py,
+        because one app already routes from api.py, and it looks for the header
+        being *assigned* an uncacheable value rather than merely mentioned: a
+        comment about Cache-Control sitting near a response would otherwise
+        pass a check that only searched for the words.
         """
         import pathlib
+        import re
 
         root = pathlib.Path(__file__).resolve().parents[3]
+        assigns_uncacheable = re.compile(
+            r"""\[["']Cache-Control["']\]\s*=\s*["'][^"']*\b(?:no-store|private)\b""",
+            re.IGNORECASE,
+        )
         offenders = []
-        for path in root.rglob("apis.py"):
-            if "/tests/" in str(path):
+        for path in root.rglob("*.py"):
+            parts = path.parts
+            if "tests" in parts or "migrations" in parts or ".venv" in parts:
                 continue
-            lines = path.read_text(encoding="utf-8").splitlines()
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
             for index, line in enumerate(lines):
                 if 'content_type="text/csv' not in line:
                     continue
                 # The directive belongs with the response it is set on, so look
                 # only at the few lines that build and return this one.
                 window = "\n".join(lines[index : index + 12])
-                if "Cache-Control" not in window:
+                if not assigns_uncacheable.search(window):
                     offenders.append(f"{path.relative_to(root)}:{index + 1}")
 
         assert offenders == [], (
-            f"CSV responses with no Cache-Control, reachable through a CDN that caches by extension: {offenders}"
+            "CSV responses that never assign an uncacheable Cache-Control, "
+            f"reachable through a CDN that caches by extension: {offenders}"
         )
 
     def test_another_user_sees_none_of_this_workspaces_data(self, inventory, stub_sbom_bytes, guest_user, client):

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -265,6 +265,40 @@ class TestEndpoints:
             assert response.status_code == 200, url
             assert response["Cache-Control"] == "private, no-store", url
 
+    def test_every_csv_response_in_the_tree_refuses_a_shared_cache(self):
+        """The list above is hand-written, which is how three CSV endpoints were
+        missed: the crypto cipher-suite export and both controls exports built
+        their own HttpResponse and set no directive at all.
+
+        A CDN caches .csv by extension and ignores Vary: Cookie, so an
+        authorised body with no directive is handed to the next caller,
+        authorised or not. That was reproduced against a gated component: the
+        origin answered 403 while the edge answered 200 from cache.
+
+        This walks the source instead of a list, so the next CSV endpoint is
+        covered the day it is written rather than the day it leaks.
+        """
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parents[3]
+        offenders = []
+        for path in root.rglob("apis.py"):
+            if "/tests/" in str(path):
+                continue
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if 'content_type="text/csv' not in line:
+                    continue
+                # The directive belongs with the response it is set on, so look
+                # only at the few lines that build and return this one.
+                window = "\n".join(lines[index : index + 12])
+                if "Cache-Control" not in window:
+                    offenders.append(f"{path.relative_to(root)}:{index + 1}")
+
+        assert offenders == [], (
+            f"CSV responses with no Cache-Control, reachable through a CDN that caches by extension: {offenders}"
+        )
+
     def test_another_user_sees_none_of_this_workspaces_data(self, inventory, stub_sbom_bytes, guest_user, client):
         """Signup gives every user their own workspace, so the export succeeds —
         against their workspace, never this one."""

--- a/sbomify/apps/core/tests/test_csv_exports.py
+++ b/sbomify/apps/core/tests/test_csv_exports.py
@@ -286,10 +286,18 @@ class TestEndpoints:
         import re
 
         root = pathlib.Path(__file__).resolve().parents[3]
+        # The invariant core.apis._csv_response established is both directives
+        # together, so accept nothing weaker: "private" alone still lets a
+        # browser keep a copy, and a guard that accepts half the rule stops
+        # describing the rule.
         assigns_uncacheable = re.compile(
-            r"""\[["']Cache-Control["']\]\s*=\s*["'][^"']*\b(?:no-store|private)\b""",
+            r"""\[["']Cache-Control["']\]\s*=\s*(["'])(?=[^"']*\bprivate\b)(?=[^"']*\bno-store\b)[^"']*\1""",
             re.IGNORECASE,
         )
+        # Quoting and spacing around the content type are the author's choice,
+        # and a detector that misses one is worse than a checker that does: the
+        # endpoint would never be looked at.
+        builds_csv = re.compile(r"""content_type\s*=\s*["']text/csv""", re.IGNORECASE)
         offenders = []
         for path in root.rglob("*.py"):
             parts = path.parts
@@ -297,7 +305,7 @@ class TestEndpoints:
                 continue
             lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
             for index, line in enumerate(lines):
-                if 'content_type="text/csv' not in line:
+                if not builds_csv.search(line):
                     continue
                 # The directive belongs with the response it is set on, so look
                 # only at the few lines that build and return this one.

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -988,6 +988,12 @@ def download_cipher_suite_inventory_csv(request: HttpRequest, sbom_id: str) -> A
             )
     response = HttpResponse(buffer.getvalue(), content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="cipher-suite-inventory-{sbom_id}.csv"'
+    # This route answers for public SBOMs and refuses the rest, so the same URL
+    # serves an authorised body to one caller and a 403 to the next. Without an
+    # explicit directive the 200 is publicly cacheable, and a CDN caches .csv by
+    # extension while ignoring Vary: Cookie, so the edge hands an authorised
+    # export to anyone who asks for it next.
+    response["Cache-Control"] = "private, no-store"
     return response
 
 


### PR DESCRIPTION
Found while running the Trust Center disclosure audit on staging. **Reproduced live, not inferred.**

## The observation

`GET /api/v1/sboms/<id>/crypto-inventory/cipher-suites.csv` for a **gated** component.

Anonymous, through the CDN:

```
HTTP 200
cache-control: max-age=14400
cf-cache-status: HIT
age: 1572
vary: Cookie
```

Anonymous, same URL with a cache-buster so the request reaches the origin:

```
HTTP 403  {"detail": "Forbidden", "error_code": "FORBIDDEN"}
```

The origin authorises correctly. The edge does not. An authorised download populates a cache entry, and the CDN then serves that body to anyone who asks for the next four hours.

## Why

The handler builds its own `HttpResponse` and sets no `Cache-Control`, so the 200 is publicly cacheable by default. `Vary: Cookie` does not help: a CDN caches `.csv` by extension and ignores `Vary`. The JSON siblings on the identical auth model are `cf-cache-status: DYNAMIC`, which is what pinned the cause to the extension rather than the route.

This is the defect #1441 fixed for the workspace exports. Its `_csv_response` sets `private, no-store` and carries a comment describing this exact failure. Three CSV responses never went through that helper:

| Endpoint | Before |
| --- | --- |
| `sboms/apis.py` cipher-suites.csv | none — verified `HIT` |
| `controls/apis.py` controls export | none |
| `controls/apis.py` controls summary | none |

## Impact

A full authorization bypass for the cached window. For the component I tested the body held only a header row, so nothing sensitive actually left the building, but the controls exports carry workspace compliance data and the mechanism does not care what the body is.

## The test

The existing test listed four URLs by hand, which is how these three were missed. The new one walks the source for `text/csv` responses and fails on any that set no directive, so the next CSV endpoint is covered the day it is written rather than the day it leaks. It reports all three without the fix.

Not introduced by this release: the endpoints predate v26.8.0.

114 tests pass across the CSV exports and controls suites.
