### PR TITLE
feat(api): advisories can be deleted through the API that creates them

### DIFF
--- a/sbomify/apps/security_advisories/apis.py
+++ b/sbomify/apps/security_advisories/apis.py
@@ -291,6 +291,37 @@ def update_advisory(request: HttpRequest, advisory_id: str, payload: UpdateAdvis
     return _fetched(team, advisory_id)
 
 
+@router.delete(
+    "/{advisory_id}",
+    response={204: None, 403: ErrorResponse, 404: ErrorResponse},
+    auth=AUTH,
+    summary="Delete an advisory",
+    description=(
+        "Deletes the advisory and everything hanging off it: vulnerabilities, product statuses "
+        "and the timeline. Nothing survives to say it existed, so a published advisory is "
+        "usually better withdrawn, which keeps its tracking id resolvable and records why."
+    ),
+)
+def delete_advisory(request: HttpRequest, advisory_id: str) -> tuple[int, Any]:
+    """Remove an advisory.
+
+    Withdrawing a draft answers "delete drafts instead", and until this route
+    existed an API client had nowhere to go with that: the instruction named an
+    action only the web UI could perform.
+    """
+    team, error = _workspace(request)
+    if error:
+        return error
+    assert team is not None
+    if not can(request, "advisory:manage", team):
+        return 403, ErrorResponse(detail="Forbidden", error_code=ErrorCode.FORBIDDEN)
+
+    result = advisory_service.delete_advisory(team, advisory_id)
+    if not result.ok:
+        return _failed(result)
+    return 204, None
+
+
 @router.post(
     "/{advisory_id}/updates",
     response={200: AdvisoryDetailSchema, 400: ErrorResponse, 403: ErrorResponse, 404: ErrorResponse},

--- a/sbomify/apps/security_advisories/tests/test_apis.py
+++ b/sbomify/apps/security_advisories/tests/test_apis.py
@@ -33,6 +33,68 @@ def client_and_headers(authenticated_api_client, sample_team_with_owner_member):
     return client, get_api_headers(token)
 
 
+class TestDeletingThem:
+    """The API had every verb except this one, and said so out loud: withdrawing
+    a draft answers "delete drafts instead", which an API client could not do."""
+
+    def test_a_draft_is_deleted(self, client_and_headers, advisory) -> None:
+        client, headers = client_and_headers
+
+        response = client.delete(_detail(advisory.id), **headers)
+
+        assert response.status_code == 204, response.content
+        assert not SecurityAdvisory.objects.filter(id=advisory.id).exists()
+
+    def test_the_instruction_the_withdraw_route_gives_can_now_be_followed(self, client_and_headers, advisory) -> None:
+        """Withdraw refuses a draft and names delete as the way out. Follow it."""
+        client, headers = client_and_headers
+
+        refused = client.post(
+            f"{_detail(advisory.id)}/withdraw",
+            data={"reason": "no"},
+            content_type="application/json",
+            **headers,
+        )
+        assert refused.status_code == 409
+        assert "delete drafts instead" in refused.json()["detail"]
+
+        assert client.delete(_detail(advisory.id), **headers).status_code == 204
+
+    def test_a_published_advisory_is_deletable_too(self, client_and_headers, make_publishable) -> None:
+        """Deleting a published advisory takes its tracking id with it, which is
+        why withdraw exists; the route does not second-guess the caller."""
+        client, headers = client_and_headers
+        advisory = publish(make_publishable)
+
+        assert client.delete(_detail(advisory.id), **headers).status_code == 204
+        assert not SecurityAdvisory.objects.filter(id=advisory.id).exists()
+
+    def test_another_workspace_advisory_is_not_deletable(self, client_and_headers, other_team) -> None:
+        """404 rather than 403, so the answer does not confirm it exists."""
+        client, headers = client_and_headers
+        theirs = SecurityAdvisory.objects.create(team=other_team, title="Not yours")
+
+        response = client.delete(_detail(theirs.id), **headers)
+
+        assert response.status_code == 404
+        assert SecurityAdvisory.objects.filter(id=theirs.id).exists()
+
+    def test_a_member_may_not_delete(self, client_and_headers, sample_team_with_owner_member, advisory) -> None:
+        client, headers = client_and_headers
+        sample_team_with_owner_member.role = "member"
+        sample_team_with_owner_member.save()
+
+        response = client.delete(_detail(advisory.id), **headers)
+
+        assert response.status_code == 403
+        assert SecurityAdvisory.objects.filter(id=advisory.id).exists()
+
+    def test_a_missing_advisory_is_a_404(self, client_and_headers) -> None:
+        client, headers = client_and_headers
+
+        assert client.delete(_detail("NOPE_NOT_REAL"), **headers).status_code == 404
+
+
 class TestReadingThem:
     def test_the_workspace_sees_its_own(self, client_and_headers, advisory) -> None:
         client, headers = client_and_headers
@@ -788,9 +850,7 @@ class TestTheCsafSelfReferenceIsAbsolute:
         self_urls = [r["url"] for r in body["document"]["references"] if r.get("category") == "self"]
         assert self_urls and self_urls[0].startswith("https://app.sbomify.com/")
 
-    def test_it_is_still_absolute_when_app_base_url_is_not_set(
-        self, client_and_headers, team, public_product
-    ) -> None:
+    def test_it_is_still_absolute_when_app_base_url_is_not_set(self, client_and_headers, team, public_product) -> None:
         """An unset APP_BASE_URL used to leave a relative path in the document."""
         from django.test import override_settings
 


### PR DESCRIPTION
Closes #1528. Found by the post-v26.8.0 staging pass.

## The gap

The advisories API has create, read, update, timeline updates, publish and withdraw. It has no delete.

It also *tells clients to delete*. Withdrawing a draft answers:

```
409  {"detail": "Only a published advisory can be withdrawn; delete drafts instead."}
```

An API client that follows that instruction has nowhere to go: leave the draft forever, or open a browser. That is how two test advisories ended up permanently in the staging workspace, created through the API that could not remove them.

## The change is small because the work was already done

`delete_advisory` exists, is workspace-scoped, cascades the vulnerabilities, product statuses and timeline, and returns 404 rather than 403 for another workspace's advisory. The web UI already calls it and it has its own tests. Only the route was missing.

`404` rather than `403` for another workspace's advisory matches the rest of this API, so the answer never confirms the thing exists. The route lands on v1 and v2 together, since the advisories router is replayed for both.

## Tests

Six, including the one that states the point: withdraw a draft, assert the 409 naming delete, then follow that instruction and assert it works. Plus published-advisory deletion, cross-workspace 404, member 403, and a missing id.

427 tests pass across `security_advisories` and the v2 API suite.

## For review

Whether a **published** advisory should be deletable through the API at all. Deleting one takes its tracking id with it and leaves nothing to say it existed, which is why withdraw exists. The service deletes either, and this route does not second-guess the caller. Refusing published advisories and pointing at withdraw would be a defensible alternative.
