### PR TITLE
fix(vex): a statement matches every id the advisory is known by

### DIFF
--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -1264,6 +1264,7 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     """
     from sbomify.apps.vulnerability_scanning.utils import is_vulnerability
     from sbomify.apps.vulnerability_scanning.vex import (
+        _finding_ids,
         _matches_in_index,
         _statement_index,
         derive_vex_suppressions,
@@ -1374,6 +1375,7 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
 
     canonical = _canonical_advisory_ids(_stream_results())
     by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    ids_by_identity: dict[tuple[str, str], set[str]] = {}
     for result in _stream_results():
         for finding in result.get("findings") or []:
             # Scanner status markers are not vulnerabilities; counting them
@@ -1381,6 +1383,13 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
             if not (isinstance(finding, dict) and is_vulnerability(finding)):
                 continue
             key = _preview_identity(finding, canonical)
+            # Folding keeps one row, so every id the others carried would stop
+            # naming this advisory. Providers rarely agree: Dependency Track
+            # reports the CVE where OSV reports the GHSA or the PYSEC id, and
+            # only one of them tends to list the other as an alias. Matching
+            # the survivor's own ids meant a VEX written against the id the
+            # page displays cleared nothing at all.
+            ids_by_identity.setdefault(key, set()).update(_finding_ids(finding))
             kept = by_identity.get(key)
             # An advisory still live in any one of the component's SBOMs is one
             # this VEX would act on, so an unsuppressed row wins over a
@@ -1390,7 +1399,17 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
                 by_identity[key] = finding
     # Sorted so the sample list under the counters is the same on every preview
     # of the same document.
-    findings = [by_identity[key] for key in sorted(by_identity)]
+    findings = []
+    for key in sorted(by_identity):
+        finding = by_identity[key]
+        extra = ids_by_identity[key] - _finding_ids(finding)
+        if extra:
+            # Copied rather than mutated: the row belongs to the streamed
+            # result. Only the matcher reads aliases, so the displayed id is
+            # untouched.
+            existing = finding.get("aliases")
+            finding = {**finding, "aliases": [*(existing if isinstance(existing, list) else []), *sorted(extra)]}
+        findings.append(finding)
 
     matched: list[dict[str, Any]] = []
     matched_statement_ids: set[int] = set()

--- a/sbomify/apps/vulnerability_scanning/tests/test_triage.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_triage.py
@@ -1232,6 +1232,98 @@ class TestPreviewApi:
         assert body["findings_checked"] == 1
         assert body["would_suppress"] == 1
 
+    def test_preview_matches_every_id_the_advisory_is_known_by(
+        self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
+    ) -> None:
+        """Either provider's id has to suppress the folded advisory.
+
+        The two rows fold into one finding, and only one of them survives the
+        fold. Matching the survivor's own ids means a VEX written against the
+        id that was on the other row clears nothing, while the page that told
+        the reader that id goes on displaying it.
+        """
+        sbom = SBOM.objects.create(
+            name="only",
+            version="1.0.0",
+            component=component,
+            format="cyclonedx",
+            format_version="1.6",
+            source="api",
+            sbom_filename="only.json",
+            bom_type="sbom",
+        )
+        package = {"name": "lodash", "version": "4.17.15", "purl": "pkg:npm/lodash@4.17.15"}
+        # Only the OSV row carries both ids; the Dependency Track row names the
+        # CVE alone. Whichever row the fold keeps, both ids name this advisory.
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            category="security",
+            run_reason="on_upload",
+            status="completed",
+            result={
+                "findings": [
+                    {
+                        "id": "GHSA-aaaa-bbbb-cccc",
+                        "aliases": ["CVE-2026-10"],
+                        "title": "a",
+                        "description": "a",
+                        "component": package,
+                    }
+                ]
+            },
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="dependency-track",
+            plugin_version="1.0.0",
+            category="security",
+            run_reason="on_upload",
+            status="completed",
+            result={"findings": [{"id": "CVE-2026-10", "title": "a", "description": "a", "component": package}]},
+        )
+        client = _client_for(sample_user, sample_team_with_owner_member.team)
+
+        def _preview(vulnerability_id: str) -> dict:
+            document = {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "version": 1,
+                "components": [
+                    {
+                        "type": "library",
+                        "bom-ref": "pkg:npm/lodash@4.17.15",
+                        "purl": "pkg:npm/lodash@4.17.15",
+                        "name": "lodash",
+                    }
+                ],
+                "vulnerabilities": [
+                    {
+                        "id": vulnerability_id,
+                        "analysis": {"state": "not_affected", "justification": "code_not_present"},
+                        "affects": [{"ref": "pkg:npm/lodash@4.17.15"}],
+                    }
+                ],
+            }
+            response = client.post(
+                f"/api/v1/vulnerability-scanning/components/{component.id}/vex-preview",
+                data=json.dumps(document),
+                content_type="application/json",
+            )
+            assert response.status_code == 200, response.content
+            return response.json()
+
+        by_cve = _preview("CVE-2026-10")
+        by_ghsa = _preview("GHSA-aaaa-bbbb-cccc")
+
+        assert by_cve["findings_checked"] == 1
+        assert by_ghsa["findings_checked"] == 1
+        assert by_cve["would_suppress"] == 1
+        assert by_ghsa["would_suppress"] == 1
+        assert by_cve["unmatched_statements"] == 0
+        assert by_ghsa["unmatched_statements"] == 0
+
     def test_preview_two_statements_matching_one_finding_none_unmatched(
         self, sample_user, sample_team_with_owner_member, component, s3, reapply_stub
     ) -> None:


### PR DESCRIPTION
A VEX statement only suppressed a finding when it named the id the surviving scan row happened to carry, so a VEX written against the id the page displays could clear nothing.

## What was wrong

`preview_vex` folds the component's scan rows so one advisory counts once, then keeps a single row per identity. Matching ran `_matches_in_index` against that survivor, which reads only its own `id` and `aliases`.

Providers disagree about which id an advisory has. Dependency Track reports the CVE where OSV reports the GHSA or the PYSEC id, and usually only one of the two lists the other as an alias. Whenever the row without the alias won the fold, every id the other row carried stopped naming the advisory.

`_canonical_advisory_ids` already had the full set, built from `merge_findings_by_alias`, which unions the ids. The matcher was the only thing that could not see it.

## Reproduced on staging

Same package, same version, same document, only the id changed:

| Statement | would_suppress |
| --- | --- |
| `GHSA-cfqr-cjx5-5jcm` @ `pkg:pypi/sqlparse@0.5.5` | 1 |
| `PYSEC-2026-3697` @ `pkg:pypi/sqlparse@0.5.5` | 0 |
| `GHSA-jq35-7prp-9v3f` @ `pkg:pypi/pyjwt@2.12.1` | 1 |
| `PYSEC-2026-178` @ `pkg:pypi/pyjwt@2.12.1` | 0 |

Seven statements across four packages matched nothing. OSV supplies the PYSEC ids for the Python ecosystem, so this reaches a large share of findings on a Python project.

## The change

Accumulate the union of `_finding_ids` across every row that folds into an identity, and pass it to the matcher as aliases on a copied row. The streamed result is not mutated and the displayed id does not change, since only the matcher reads aliases.

## Test

`test_preview_matches_every_id_the_advisory_is_known_by` builds two runs on one package where only the OSV row carries both ids, then previews by each id in turn. Previewing by the CVE passed before this change; previewing by the GHSA returned `would_suppress: 0`. Both pass now.

Full `vulnerability_scanning` suite: 461 passed.

Closes #1531
