### PR TITLE
fix(billing): bound how long a Stripe request may take

### DIFF
--- a/sbomify/apps/billing/apps.py
+++ b/sbomify/apps/billing/apps.py
@@ -3,6 +3,23 @@ from __future__ import annotations
 from django.apps import AppConfig
 
 
+def usable_timeout(value: object) -> float | None:
+    """``value`` as a timeout in seconds, or None when it cannot be one.
+
+    Rejects bool before number, because bool is a subclass of int and ``True``
+    would otherwise install a one second timeout without saying so. Rejects
+    anything not positive and finite as well: requests raises on a negative
+    timeout, and an infinite one is the unbounded wait the caller is trying to
+    remove.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    # NaN fails every comparison, so this rejects it too.
+    if not (0 < value < float("inf")):
+        return None
+    return float(value)
+
+
 class BillingConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "sbomify.apps.billing"
@@ -31,10 +48,10 @@ class BillingConfig(AppConfig):
         # and returned 504 instead of rendering from stored billing data.
         # The client keeps one requests session per thread, so a single shared
         # instance is safe here.
-        # Compared rather than tested for truth: a negative timeout raises
-        # inside requests and an infinite one is the unbounded wait again, so
-        # neither may reach the client. Settings already screens the
-        # environment; this keeps an override honest too.
-        timeout = getattr(settings, "STRIPE_TIMEOUT_SECONDS", 0)
-        if isinstance(timeout, int | float) and 0 < timeout < float("inf"):
+        # Screened rather than trusted: settings already filters the
+        # environment, but STRIPE_TIMEOUT_SECONDS can also be set directly by
+        # another settings module, and a value that is not a positive finite
+        # number must not reach the client.
+        timeout = usable_timeout(getattr(settings, "STRIPE_TIMEOUT_SECONDS", None))
+        if timeout is not None:
             stripe.default_http_client = stripe.new_default_http_client(timeout=timeout)

--- a/sbomify/apps/billing/apps.py
+++ b/sbomify/apps/billing/apps.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
+
+# Used when the configured value cannot be a timeout. Falling back to the
+# library's own default instead would be an 80 second wait, which is the wait
+# this whole mechanism exists to remove.
+DEFAULT_STRIPE_TIMEOUT_SECONDS = 10.0
 
 
 def usable_timeout(value: object) -> float | None:
@@ -18,6 +27,32 @@ def usable_timeout(value: object) -> float | None:
     if not (0 < value < float("inf")):
         return None
     return float(value)
+
+
+def install_bounded_http_client(configured: object) -> float:
+    """Give Stripe an HTTP client that cannot wait forever, and say how long.
+
+    Always installs one. Skipping the install when the configured value is
+    unusable would leave the library's own 80 second default in place, which
+    is the unbounded wait this exists to remove, and it would do so silently.
+    Settings already screens the environment, so reaching the fallback means
+    another settings module set the value directly.
+
+    The client keeps one requests session per thread, so a single shared
+    instance is safe under concurrent requests.
+    """
+    import stripe
+
+    timeout = usable_timeout(configured)
+    if timeout is None:
+        logger.warning(
+            "STRIPE_TIMEOUT_SECONDS is not a positive finite number (%r); using %s seconds instead.",
+            configured,
+            DEFAULT_STRIPE_TIMEOUT_SECONDS,
+        )
+        timeout = DEFAULT_STRIPE_TIMEOUT_SECONDS
+    stripe.default_http_client = stripe.new_default_http_client(timeout=timeout)
+    return timeout
 
 
 class BillingConfig(AppConfig):
@@ -46,12 +81,4 @@ class BillingConfig(AppConfig):
         # subscription while rendering, on every tab and twice per tab, so an
         # unreachable Stripe took the whole section past the edge's own limit
         # and returned 504 instead of rendering from stored billing data.
-        # The client keeps one requests session per thread, so a single shared
-        # instance is safe here.
-        # Screened rather than trusted: settings already filters the
-        # environment, but STRIPE_TIMEOUT_SECONDS can also be set directly by
-        # another settings module, and a value that is not a positive finite
-        # number must not reach the client.
-        timeout = usable_timeout(getattr(settings, "STRIPE_TIMEOUT_SECONDS", None))
-        if timeout is not None:
-            stripe.default_http_client = stripe.new_default_http_client(timeout=timeout)
+        install_bounded_http_client(getattr(settings, "STRIPE_TIMEOUT_SECONDS", None))

--- a/sbomify/apps/billing/apps.py
+++ b/sbomify/apps/billing/apps.py
@@ -31,6 +31,10 @@ class BillingConfig(AppConfig):
         # and returned 504 instead of rendering from stored billing data.
         # The client keeps one requests session per thread, so a single shared
         # instance is safe here.
+        # Compared rather than tested for truth: a negative timeout raises
+        # inside requests and an infinite one is the unbounded wait again, so
+        # neither may reach the client. Settings already screens the
+        # environment; this keeps an override honest too.
         timeout = getattr(settings, "STRIPE_TIMEOUT_SECONDS", 0)
-        if timeout:
+        if isinstance(timeout, int | float) and 0 < timeout < float("inf"):
             stripe.default_http_client = stripe.new_default_http_client(timeout=timeout)

--- a/sbomify/apps/billing/apps.py
+++ b/sbomify/apps/billing/apps.py
@@ -23,3 +23,14 @@ class BillingConfig(AppConfig):
         # cannot change request or response shapes underneath us.
         if getattr(settings, "STRIPE_API_VERSION", ""):
             stripe.api_version = settings.STRIPE_API_VERSION
+
+        # Bound every Stripe request. The library defaults to 80 seconds, which
+        # is longer than a page render can afford: workspace settings syncs the
+        # subscription while rendering, on every tab and twice per tab, so an
+        # unreachable Stripe took the whole section past the edge's own limit
+        # and returned 504 instead of rendering from stored billing data.
+        # The client keeps one requests session per thread, so a single shared
+        # instance is safe here.
+        timeout = getattr(settings, "STRIPE_TIMEOUT_SECONDS", 0)
+        if timeout:
+            stripe.default_http_client = stripe.new_default_http_client(timeout=timeout)

--- a/sbomify/apps/billing/tests/test_stripe_timeout.py
+++ b/sbomify/apps/billing/tests/test_stripe_timeout.py
@@ -109,3 +109,54 @@ class TestUsableTimeout:
         assert self._usable(float("inf")) is None
         assert self._usable(float("-inf")) is None
         assert self._usable(float("nan")) is None
+
+
+class TestInstallBoundedHttpClient:
+    """A bounded client goes in whatever the setting says, because the
+    alternative to a bad value is the library's 80 second wait."""
+
+    @staticmethod
+    def _install(value):
+        import stripe
+
+        from sbomify.apps.billing.apps import install_bounded_http_client
+
+        previous = stripe.default_http_client
+        try:
+            applied = install_bounded_http_client(value)
+            return applied, stripe.default_http_client._timeout
+        finally:
+            stripe.default_http_client = previous
+
+    def test_a_usable_value_is_applied(self):
+        assert self._install(4) == (4.0, 4.0)
+
+    def test_an_unusable_value_falls_back_rather_than_installing_nothing(self):
+        """Installing nothing would leave the 80 second default in place."""
+        from sbomify.apps.billing.apps import DEFAULT_STRIPE_TIMEOUT_SECONDS
+
+        for bad in (None, True, 0, -1, "10", float("inf"), float("nan")):
+            applied, on_client = self._install(bad)
+            assert applied == DEFAULT_STRIPE_TIMEOUT_SECONDS, bad
+            assert on_client == DEFAULT_STRIPE_TIMEOUT_SECONDS, bad
+
+    def test_the_fallback_is_shorter_than_the_library_default(self):
+        from sbomify.apps.billing.apps import DEFAULT_STRIPE_TIMEOUT_SECONDS
+
+        assert DEFAULT_STRIPE_TIMEOUT_SECONDS < _library_default_timeout()
+
+    def test_an_unusable_value_is_logged(self):
+        """Silence would hide a misconfiguration that changes request timing.
+
+        The call is asserted rather than the captured text: this logger does
+        not propagate to root, so caplog sees nothing.
+        """
+        from unittest.mock import patch
+
+        from sbomify.apps.billing import apps as billing_apps
+
+        with patch.object(billing_apps.logger, "warning") as warned:
+            self._install(True)
+
+        assert warned.call_count == 1
+        assert "STRIPE_TIMEOUT_SECONDS" in warned.call_args.args[0]

--- a/sbomify/apps/billing/tests/test_stripe_timeout.py
+++ b/sbomify/apps/billing/tests/test_stripe_timeout.py
@@ -44,3 +44,35 @@ def test_the_library_is_given_a_bounded_client():
 def test_the_client_does_not_pin_one_session_across_threads():
     """A shared client is only safe while each thread gets its own session."""
     assert stripe.default_http_client._session is None
+
+
+class TestTimeoutFromTheEnvironment:
+    """A typo in deployment config must not crash startup or remove the bound."""
+
+    @staticmethod
+    def _parse(value):
+        from sbomify.settings import _env_positive_float
+
+        return _env_positive_float(value, 10.0)
+
+    def test_a_normal_value_is_used(self):
+        assert self._parse("2.5") == 2.5
+
+    def test_an_unset_value_takes_the_default(self):
+        assert self._parse(None) == 10.0
+
+    def test_a_malformed_value_takes_the_default(self):
+        """float("abc") would raise at import and take the process down."""
+        assert self._parse("abc") == 10.0
+        assert self._parse("") == 10.0
+
+    def test_a_non_positive_value_takes_the_default(self):
+        """requests raises on a negative timeout, and zero would mean no wait."""
+        assert self._parse("-1") == 10.0
+        assert self._parse("0") == 10.0
+
+    def test_infinity_and_nan_take_the_default(self):
+        """Infinity is the unbounded wait this setting exists to remove."""
+        assert self._parse("inf") == 10.0
+        assert self._parse("-inf") == 10.0
+        assert self._parse("nan") == 10.0

--- a/sbomify/apps/billing/tests/test_stripe_timeout.py
+++ b/sbomify/apps/billing/tests/test_stripe_timeout.py
@@ -76,3 +76,36 @@ class TestTimeoutFromTheEnvironment:
         assert self._parse("inf") == 10.0
         assert self._parse("-inf") == 10.0
         assert self._parse("nan") == 10.0
+
+
+class TestUsableTimeout:
+    """What may reach the Stripe client when a settings module sets the value
+    directly, rather than through the environment."""
+
+    @staticmethod
+    def _usable(value):
+        from sbomify.apps.billing.apps import usable_timeout
+
+        return usable_timeout(value)
+
+    def test_a_number_is_returned_as_a_float(self):
+        assert self._usable(10) == 10.0
+        assert self._usable(2.5) == 2.5
+
+    def test_a_bool_is_rejected(self):
+        """bool subclasses int, so True would install a one second timeout."""
+        assert self._usable(True) is None
+        assert self._usable(False) is None
+
+    def test_a_non_number_is_rejected(self):
+        assert self._usable("10") is None
+        assert self._usable(None) is None
+
+    def test_a_non_positive_value_is_rejected(self):
+        assert self._usable(0) is None
+        assert self._usable(-1) is None
+
+    def test_infinity_and_nan_are_rejected(self):
+        assert self._usable(float("inf")) is None
+        assert self._usable(float("-inf")) is None
+        assert self._usable(float("nan")) is None

--- a/sbomify/apps/billing/tests/test_stripe_timeout.py
+++ b/sbomify/apps/billing/tests/test_stripe_timeout.py
@@ -1,0 +1,46 @@
+"""The bound on how long a Stripe request may take.
+
+The library's own default is 80 seconds. Workspace settings reaches Stripe
+while rendering, on every tab and twice per tab, so an unreachable Stripe held
+the page past the edge's limit and the whole section answered 504 rather than
+rendering from stored billing data. Syncing already fails soft, so the bound
+costs nothing worse than slightly stale limits.
+"""
+
+from __future__ import annotations
+
+import stripe
+from django.conf import settings
+
+
+def _library_default_timeout() -> float:
+    """What one request would wait if we set nothing."""
+    import inspect
+
+    from stripe._http_client import RequestsClient
+
+    default = inspect.signature(RequestsClient.__init__).parameters["timeout"].default
+    return float(default)
+
+
+def test_the_configured_timeout_is_shorter_than_the_library_default():
+    """A bound no tighter than the default would not have changed anything."""
+    assert settings.STRIPE_TIMEOUT_SECONDS < _library_default_timeout()
+
+
+def test_two_requests_still_fit_inside_a_page_render():
+    """Settings syncs twice per render, so one request may take at most half
+    the budget. 30 seconds is the shortest edge timeout we sit behind."""
+    assert settings.STRIPE_TIMEOUT_SECONDS * 2 < 30
+
+
+def test_the_library_is_given_a_bounded_client():
+    """Set on the default client rather than per call, so a request added
+    later cannot reintroduce the unbounded wait by forgetting to pass it."""
+    assert stripe.default_http_client is not None
+    assert stripe.default_http_client._timeout == settings.STRIPE_TIMEOUT_SECONDS
+
+
+def test_the_client_does_not_pin_one_session_across_threads():
+    """A shared client is only safe while each thread gets its own session."""
+    assert stripe.default_http_client._session is None

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -1234,6 +1234,14 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 # whether to move the pin with it.
 STRIPE_API_VERSION = os.environ.get("STRIPE_API_VERSION", "2025-11-17.clover")
 
+# How long any one Stripe request may take. The library's own default is 80
+# seconds, and workspace settings reaches Stripe while rendering, twice: once
+# in TeamSettingsView and again through TeamPricingService. Unreachable Stripe
+# therefore held the page for longer than the edge would wait, and every tab of
+# the section answered 504 rather than rendering without fresh billing data.
+# Sync already fails soft, so a bounded wait degrades to slightly stale limits.
+STRIPE_TIMEOUT_SECONDS = float(os.environ.get("STRIPE_TIMEOUT_SECONDS", "10"))
+
 # Trial period settings
 TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))
 TRIAL_ENDING_NOTIFICATION_DAYS = int(os.environ.get("TRIAL_ENDING_NOTIFICATION_DAYS", "3"))

--- a/sbomify/settings.py
+++ b/sbomify/settings.py
@@ -94,6 +94,26 @@ def _env_bool(value: str | None, default: bool) -> bool:
     return value.lower() in ("true", "1", "yes")
 
 
+def _env_positive_float(value: str | None, default: float) -> float:
+    """A positive, finite number from the environment, else the default.
+
+    Used for timeouts, where the value reaches a client library that raises on
+    a negative one and waits forever on an infinite one. A typo in deployment
+    config should fall back to the default rather than take startup down or
+    quietly disable the bound it was meant to set.
+    """
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    # NaN fails every comparison, so this rejects it too.
+    if not (0 < parsed < float("inf")):
+        return default
+    return parsed
+
+
 # Request timing logging is disabled by default to avoid performance impact
 # Enable explicitly when needed for profiling (e.g., REQUEST_TIMING_LOGGING_ENABLED=true)
 REQUEST_TIMING_LOGGING_ENABLED = _env_bool(os.environ.get("REQUEST_TIMING_LOGGING_ENABLED"), default=False)
@@ -1240,7 +1260,7 @@ STRIPE_API_VERSION = os.environ.get("STRIPE_API_VERSION", "2025-11-17.clover")
 # therefore held the page for longer than the edge would wait, and every tab of
 # the section answered 504 rather than rendering without fresh billing data.
 # Sync already fails soft, so a bounded wait degrades to slightly stale limits.
-STRIPE_TIMEOUT_SECONDS = float(os.environ.get("STRIPE_TIMEOUT_SECONDS", "10"))
+STRIPE_TIMEOUT_SECONDS = _env_positive_float(os.environ.get("STRIPE_TIMEOUT_SECONDS"), 10.0)
 
 # Trial period settings
 TRIAL_PERIOD_DAYS = int(os.environ.get("TRIAL_PERIOD_DAYS", "14"))


### PR DESCRIPTION
Every tab of workspace settings answers 504 on staging. The section is unreachable.

## Measured

Signed in, build a0c87e8:

```
/workspaces/<key>/settings/             504
/workspaces/<key>/settings/general      timeout
/workspaces/<key>/settings/trust-center timeout
/workspaces/<key>/settings/members      timeout
/workspaces/<key>/settings/danger       timeout
/workspaces/<key>/settings/branding     timeout
/workspaces/<key>/settings/billing      timeout
/workspaces/<key>/tokens                200 in 750 ms
/api/v1/billing/plans                   200 in 327 ms
```

`/tokens` is a different view in the same app, so the app and database are fine.

## What this changes

`TeamSettingsView.get` syncs the subscription from Stripe while rendering, on **every** tab rather than only billing (`teams/views/team_settings.py:149`), and `TeamPricingService.get_plan_pricing` syncs again (`billing/team_pricing_service.py:97-107`). `stripe_sync.py:158` force-refreshes whenever `last_updated` is older than 60 seconds, so nearly every load bypasses the cache and makes live calls.

Nothing bounded those calls. `stripe` 14.0.1 defaults to **80 seconds** per request and no override existed anywhere, so two syncs could occupy 160 seconds, well past the edge's limit.

This sets a bounded timeout on the default HTTP client, configurable through `STRIPE_TIMEOUT_SECONDS` and defaulting to 10.

Setting it on the default client rather than per call means a Stripe call added later cannot reintroduce the unbounded wait by forgetting to pass a timeout. It follows the existing precedent in the same `ready()`, which already pins `stripe.api_version` centrally for the same reason.

## Why this is safe

Failure already degrades softly. A timeout raises `APIConnectionError`, `handle_stripe_errors` converts it to `BillingRetryableError`, and `sync_subscription_from_stripe` catches broadly and returns `False`, leaving the page to render from stored `billing_plan_limits`. So the cost of the bound is slightly stale billing limits, not an error page.

`RequestsClient` keeps one `requests` session per thread when constructed without one, so a single shared client stays safe under concurrent requests. A test pins that.

## What this does not claim

It does not prove Stripe is the sole cause of the staging slowness. Public Trust Center pages on the same instance also answer in roughly 20 seconds and never touch Stripe, so the instance is broadly slow and settings may simply be the heaviest page. What this fixes is the part that is wrong regardless: a page render must not depend on an unbounded third-party call.

The other half of #1533, syncing on every tab and twice per tab, is left alone here because it changes billing freshness semantics and deserves its own decision.

## Tests

`sbomify/apps/billing/tests/test_stripe_timeout.py` pins that the bound is tighter than the library default, that two requests still fit inside a render budget, that the library is actually handed a bounded client, and that the shared client does not pin one session across threads.

Billing suite: 367 passed.

Refs #1533
