### PR TITLE
fix(trust-center): a count of one reads as one

### DIFF
--- a/sbomify/apps/core/templates/core/workspace_public.html.j2
+++ b/sbomify/apps/core/templates/core/workspace_public.html.j2
@@ -31,9 +31,9 @@
             {% endif %}
             </c-slot>
             <c-branded.stats>
-            <c-branded.stat label="Advisories">{{ advisories.total }}</c-branded.stat>
-            <c-branded.stat label="Products">{{ products|length }}</c-branded.stat>
-            <c-branded.stat label="Compliance artifacts">{{ global_components|length }}</c-branded.stat>
+            <c-branded.stat label="Advisor{{ advisories.total|pluralize:'y,ies' }}">{{ advisories.total }}</c-branded.stat>
+            <c-branded.stat label="Product{{ products|length|pluralize }}">{{ products|length }}</c-branded.stat>
+            <c-branded.stat label="Compliance artifact{{ global_components|length|pluralize }}">{{ global_components|length }}</c-branded.stat>
             <c-branded.stat label="Latest advisory">{{ advisories.latest_display|default:"Not yet" }}</c-branded.stat>
             </c-branded.stats>
             </c-branded.page-header>

--- a/sbomify/apps/core/tests/test_workspace_public_view.py
+++ b/sbomify/apps/core/tests/test_workspace_public_view.py
@@ -562,15 +562,11 @@ def test_workspace_public_stat_labels_agree_with_their_counts():
     A new Trust Center usually has one of each, so the singular is the common
     case rather than the edge.
     """
-    client = Client()
-    team = Team.objects.create(name="Singular Workspace", is_public=True)
-    product = Product.objects.create(name="Only Product", team=team, is_public=True)
-    component = Component.objects.create(
-        name="Only Component",
-        team=team,
-        visibility=Component.Visibility.PUBLIC,
-    )
-    ProductComponent.objects.create(product=product, component=component)
+    from django.utils import timezone
+
+    from sbomify.apps.security_advisories.models import SecurityAdvisory
+
+    team = _public_workspace("Singular Workspace")
     Component.objects.create(
         name="Only Artifact",
         team=team,
@@ -578,26 +574,36 @@ def test_workspace_public_stat_labels_agree_with_their_counts():
         is_global=True,
         component_type=Component.ComponentType.DOCUMENT,
     )
+    SecurityAdvisory.objects.create(
+        team=team,
+        title="Only Advisory",
+        tracking_id="QA-SA-2026-0001",
+        status=SecurityAdvisory.Status.PUBLISHED,
+        visibility=SecurityAdvisory.Visibility.PUBLIC,
+        published_at=timezone.now(),
+        made_public_at=timezone.now(),
+    )
 
-    content = client.get(reverse("core:workspace_public", kwargs={"workspace_key": team.key})).content.decode()
-
-    # Zero advisories, one of everything else. Zero takes the plural.
-    assert _stat_labels(content) == ["Advisories", "Product", "Compliance artifact", "Latest advisory"]
+    assert _stat_labels(_visit(team)) == ["Advisory", "Product", "Compliance artifact", "Latest advisory"]
 
 
 @pytest.mark.django_db
 def test_workspace_public_stat_labels_stay_plural_above_one():
-    client = Client()
-    team = Team.objects.create(name="Plural Workspace", is_public=True)
-    for index in range(2):
-        product = Product.objects.create(name=f"Product {index}", team=team, is_public=True)
-        component = Component.objects.create(
-            name=f"Component {index}",
+    team = _public_workspace("Plural Workspace")
+    second = Product.objects.create(name="Second Product", team=team, is_public=True)
+    ProductComponent.objects.create(
+        product=second,
+        component=Component.objects.create(
+            name="Second Component",
             team=team,
             visibility=Component.Visibility.PUBLIC,
-        )
-        ProductComponent.objects.create(product=product, component=component)
+        ),
+    )
 
-    content = client.get(reverse("core:workspace_public", kwargs={"workspace_key": team.key})).content.decode()
+    assert "Products" in _stat_labels(_visit(team))
 
-    assert "Products" in _stat_labels(content)
+
+@pytest.mark.django_db
+def test_workspace_public_stat_labels_use_the_plural_for_zero():
+    """Zero takes the plural, so "0 Advisories" still reads correctly."""
+    assert "Advisories" in _stat_labels(_visit(_public_workspace("Empty Workspace")))

--- a/sbomify/apps/core/tests/test_workspace_public_view.py
+++ b/sbomify/apps/core/tests/test_workspace_public_view.py
@@ -605,5 +605,11 @@ def test_workspace_public_stat_labels_stay_plural_above_one():
 
 @pytest.mark.django_db
 def test_workspace_public_stat_labels_use_the_plural_for_zero():
-    """Zero takes the plural, so "0 Advisories" still reads correctly."""
-    assert "Advisories" in _stat_labels(_visit(_public_workspace("Empty Workspace")))
+    """Zero takes the plural, so "0 Advisories" still reads correctly.
+
+    The workspace has no advisories and no global components, and the one
+    product the fixture creates holds the singular end of the same strip.
+    """
+    labels = _stat_labels(_visit(_public_workspace("Empty Workspace")))
+
+    assert labels == ["Advisories", "Product", "Compliance artifacts", "Latest advisory"]

--- a/sbomify/apps/core/tests/test_workspace_public_view.py
+++ b/sbomify/apps/core/tests/test_workspace_public_view.py
@@ -1,4 +1,5 @@
 import html
+import re
 
 import pytest
 from django.conf import settings
@@ -8,6 +9,11 @@ from django.urls import reverse
 from sbomify.apps.core.models import Component, Product
 from sbomify.apps.sboms.models import ProductComponent
 from sbomify.apps.teams.models import Member, Team
+
+
+def _stat_labels(content: str) -> list[str]:
+    """The label under each figure in the Trust Center summary strip."""
+    return [match.strip() for match in re.findall(r"<dt[^>]*>([^<]*)</dt>", content)]
 
 
 @pytest.mark.django_db
@@ -83,9 +89,7 @@ def test_workspace_public_page_prefers_logo_when_available():
 
     assert response.status_code == 200
     content = response.content.decode()
-    expected_logo_url = (
-        f"{settings.AWS_MEDIA_STORAGE_BUCKET_URL}/workspace-logo.png"
-    )
+    expected_logo_url = f"{settings.AWS_MEDIA_STORAGE_BUCKET_URL}/workspace-logo.png"
     assert expected_logo_url in content
     assert "img/sbomify.svg" not in content
 
@@ -479,9 +483,7 @@ def _public_workspace(name: str) -> Team:
     """A public workspace with one public product, so the page renders its sections."""
     team = Team.objects.create(name=name, is_public=True)
     product = Product.objects.create(name=f"{name} Product", team=team, is_public=True)
-    component = Component.objects.create(
-        name=f"{name} Component", team=team, visibility=Component.Visibility.PUBLIC
-    )
+    component = Component.objects.create(name=f"{name} Component", team=team, visibility=Component.Visibility.PUBLIC)
     ProductComponent.objects.create(product=product, component=component)
     return team
 
@@ -551,3 +553,51 @@ def test_scanning_prompt_hidden_once_a_scanner_is_enabled(sample_user):
     TeamPluginSettings.objects.create(team=team, enabled_plugins=["osv"])
 
     assert ADMIN_PROMPT not in _visit(team, sample_user)
+
+
+@pytest.mark.django_db
+def test_workspace_public_stat_labels_agree_with_their_counts():
+    """The summary strip read "1 Products" to the first person who saw it.
+
+    A new Trust Center usually has one of each, so the singular is the common
+    case rather than the edge.
+    """
+    client = Client()
+    team = Team.objects.create(name="Singular Workspace", is_public=True)
+    product = Product.objects.create(name="Only Product", team=team, is_public=True)
+    component = Component.objects.create(
+        name="Only Component",
+        team=team,
+        visibility=Component.Visibility.PUBLIC,
+    )
+    ProductComponent.objects.create(product=product, component=component)
+    Component.objects.create(
+        name="Only Artifact",
+        team=team,
+        visibility=Component.Visibility.PUBLIC,
+        is_global=True,
+        component_type=Component.ComponentType.DOCUMENT,
+    )
+
+    content = client.get(reverse("core:workspace_public", kwargs={"workspace_key": team.key})).content.decode()
+
+    # Zero advisories, one of everything else. Zero takes the plural.
+    assert _stat_labels(content) == ["Advisories", "Product", "Compliance artifact", "Latest advisory"]
+
+
+@pytest.mark.django_db
+def test_workspace_public_stat_labels_stay_plural_above_one():
+    client = Client()
+    team = Team.objects.create(name="Plural Workspace", is_public=True)
+    for index in range(2):
+        product = Product.objects.create(name=f"Product {index}", team=team, is_public=True)
+        component = Component.objects.create(
+            name=f"Component {index}",
+            team=team,
+            visibility=Component.Visibility.PUBLIC,
+        )
+        ProductComponent.objects.create(product=product, component=component)
+
+    content = client.get(reverse("core:workspace_public", kwargs={"workspace_key": team.key})).content.decode()
+
+    assert "Products" in _stat_labels(content)


### PR DESCRIPTION
The summary strip on a public workspace page labels every figure in the plural, so a Trust Center with one product reads **"1 Products"**.

Found while running the Trust Center disclosure audit on staging, where the strip read:

> 2 Advisories · **1 Products** · **1 Compliance artifacts**

A new Trust Center usually has one of each, so the singular is the common case rather than the edge, and this is the first page a prospect sees.

## The change

Three labels carry a count and are now pluralised from it:

| Count | Before | After |
| --- | --- | --- |
| 1 product | 1 Products | 1 Product |
| 1 compliance artifact | 1 Compliance artifacts | 1 Compliance artifact |
| 1 advisory | 1 Advisories | 1 Advisory |
| 0 advisories | 0 Advisories | 0 Advisories |

"Latest advisory" is not a count and keeps its wording. Zero keeps the plural, which is what a reader expects from "0 Advisories".

`pluralize:'y,ies'` inside a cotton attribute follows the existing use in `trust_center/restricted_notice.html.j2`, which builds "advisory/advisories" the same way.

The other `c-branded.stat` callers are the branding preview and the cotton probe, which use fixed numbers that are already plural-correct, so they are untouched.

## Tests

Two tests in `test_workspace_public_view.py` read the labels out of the rendered strip: one asserts the exact set at a count of one, the other that plurals survive above one.

## One thing to know when reading the diff

Two unrelated lines in the test file are collapsed by `ruff format`. That file already fails a format check on master, and the pre-commit hook rewrites them on the way past, so they ride along rather than being a deliberate edit.
