### PR TITLE
fix(vulns): a fixed finding no longer reads as not affected

### DIFF
--- a/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
+++ b/sbomify/apps/core/templates/core/components/component_vulnerabilities.html.j2
@@ -104,6 +104,8 @@
                     <span class="text-info">
                         {% if vuln.vex_state == 'false_positive' %}
                             False positive
+                        {% elif vuln.vex_state == 'resolved' %}
+                            Fixed
                         {% else %}
                             Not affected
                         {% endif %}
@@ -119,8 +121,6 @@
                     {% endif %}
                 {% elif vuln.vex_state == 'in_triage' %}
                     <span class="text-warning">Under investigation</span>
-                {% elif vuln.vex_state == 'resolved' %}
-                    <span class="text-success">Fixed</span>
                 {% else %}
                     <span class="text-text-muted">Affected</span>
                 {% endif %}

--- a/sbomify/apps/core/templates/core/release_details_public.html.j2
+++ b/sbomify/apps/core/templates/core/release_details_public.html.j2
@@ -144,7 +144,7 @@
                     <span>
                         <span class="font-semibold text-text" x-text="data.suppressed_count"></span>
                         finding<span x-show="data.suppressed_count !== 1">s</span>
-                        suppressed by VEX (not affected / false positive).
+                        suppressed by VEX (not affected, false positive or fixed).
                     </span>
                 </p>
                 {# Findings list #}

--- a/sbomify/apps/core/tests/test_vex_state_labels.py
+++ b/sbomify/apps/core/tests/test_vex_state_labels.py
@@ -1,0 +1,75 @@
+"""Every state that suppresses a finding needs its own label on the table.
+
+A suppressed finding takes one branch in the vulnerabilities table, and that
+branch decided between "False positive" and "Not affected" alone. `resolved`
+therefore read as "Not affected", which says the opposite of what a fixed
+finding means, and the arm further down that would have rendered "Fixed" was
+unreachable: `resolved` is in `SUPPRESSED_STATES`, so `vex_suppressed` is always
+true for it and the first branch wins before that arm is reached.
+
+Checked against the template source rather than a rendered page, because the
+defect was a branch that could not be reached rather than one that rendered
+wrongly, and a render test passes happily while an unreachable arm rots.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sbomify.apps.vulnerability_scanning.vex import SUPPRESSED_STATES
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1] / "templates" / "core" / "components" / "component_vulnerabilities.html.j2"
+)
+
+
+def _split_at_outer_elif(source: str) -> tuple[str, str]:
+    """The suppressed branch, and everything after it in the same if.
+
+    Split on indentation rather than on the first ``elif``: the suppressed
+    branch contains its own nested ``elif``, and matching that one is what made
+    the first version of this test read the wrong block.
+    """
+    lines = source.splitlines(keepends=True)
+    # The tag on a line of its own. The same condition also appears inline
+    # twice, toggling a strikethrough class, and those are not branches.
+    start = next(i for i, ln in enumerate(lines) if ln.strip() == "{% if vuln.vex_suppressed %}")
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    for i in range(start + 1, len(lines)):
+        stripped = lines[i].lstrip()
+        if stripped.startswith(("{% elif", "{% else", "{% endif")) and (len(lines[i]) - len(stripped) == indent):
+            return "".join(lines[start:i]), "".join(lines[i:])
+    raise AssertionError("the if block never closes at its own indentation")
+
+
+def _suppressed_branch(source: str) -> str:
+    """The block that renders a finding something has already suppressed."""
+    return _split_at_outer_elif(source)[0]
+
+
+def test_every_suppressing_state_has_its_own_label():
+    """Sharing a label between two states is how `resolved` read as unaffected."""
+    branch = _suppressed_branch(TEMPLATE.read_text())
+    named = set(re.findall(r"vuln\.vex_state == '([a-z_]+)'", branch))
+
+    # One state may be the else default; the rest must be named explicitly.
+    unnamed = SUPPRESSED_STATES - named
+    assert len(unnamed) <= 1, f"these states share the default label: {sorted(unnamed)}"
+
+
+def test_a_fixed_finding_does_not_read_as_unaffected():
+    branch = _suppressed_branch(TEMPLATE.read_text())
+    resolved_arm = re.search(r"vuln\.vex_state == 'resolved' %\}\s*([^\{]+)", branch)
+    assert resolved_arm, "resolved has no arm in the suppressed branch"
+    assert resolved_arm.group(1).strip() == "Fixed"
+
+
+def test_the_template_keeps_no_unreachable_state_arm():
+    """An arm outside the suppressed branch can never see a suppressing state."""
+    after = _split_at_outer_elif(TEMPLATE.read_text())[1]
+    outside = set(re.findall(r"vuln\.vex_state == '([a-z_]+)'", after))
+
+    assert not (outside & SUPPRESSED_STATES), (
+        f"unreachable: {sorted(outside & SUPPRESSED_STATES)} always take the suppressed branch"
+    )


### PR DESCRIPTION
A finding that an SBOM's own VEX reports as **fixed** renders as **"Not affected"** on the component vulnerabilities table.

Those say different things. "Not affected" claims the vulnerable code cannot be reached; "fixed" claims the builder patched it. A backported patch leaves the version string untouched, which is the case the `resolved` state exists for, so the label was wrong exactly where the state carries its value.

## Why it happened

The suppressed branch chose between two labels only:

```
{% if vuln.vex_suppressed %}
    {% if vuln.vex_state == 'false_positive' %}False positive
    {% else %}Not affected{% endif %} · VEX
```

An arm further down would have rendered "Fixed", but it could never run:

```
{% elif vuln.vex_state == 'resolved' %}<span class="text-success">Fixed</span>
```

`SUPPRESSED_STATES` is `{not_affected, false_positive, resolved}` and `vex_suppressed` is computed as `vex_state in SUPPRESSED_STATES` (`vulnerability_scanning/utils.py:352`), so a `resolved` finding always takes the first branch and never reaches that arm.

So the label existed and was unreachable, which is why this reads as a copy gap rather than a missing feature.

## The change

- Move "Fixed" into the branch that actually renders, and drop the arm that cannot.
- The public release page summarised "not affected / false positive"; it now names all three states it counts.

`component_item.html.j2` was checked and needs nothing: its `else` renders the state through `|cut:"_"|title`, so `resolved` already reads as "Resolved".

## Tests

`test_vex_state_labels.py` reads the template source rather than a rendered page, deliberately: the defect was a branch that could not be reached, and a render test stays green while an unreachable arm rots. Three tests, all failing against the template before this change:

- every state in `SUPPRESSED_STATES` has its own label, at most one riding the `else`
- `resolved` renders "Fixed"
- no suppressing state has an arm outside the suppressed branch, where it could never run

Found while working F5d of the staging test plan, which records this as a known cosmetic gap.
