### PR TITLE
test(trust-center): posture toggle authz, and the workspace delete cascade

### DIFF
--- a/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
+++ b/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
@@ -140,15 +140,11 @@ def test_a_non_member_cannot_publish_the_posture(client, django_user_model, work
     Member.objects.create(user=outsider, team=other, role="owner", is_default_team=True)
     _signed_in(client, outsider, other)
 
-    client.post(
-        reverse("teams:team_settings_tab", kwargs={"team_key": workspace.key, "tab": "trust-center"}),
-        {
-            "vulnerability_posture_action": "update",
-            "publish_vulnerability_posture": "true",
-            "active_tab": "trust-center",
-        },
-        follow=True,
-    )
+    # Posts at the *other* workspace, through the same URL the form uses.
+    response = _post_toggle(client, workspace)
 
     workspace.refresh_from_db()
     assert workspace.publish_vulnerability_posture is False
+    # Assert the refusal, not just the unchanged value: a redirect or a 404
+    # would leave the value alone too, and prove nothing about authorization.
+    assert response.status_code == 403

--- a/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
+++ b/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
@@ -1,0 +1,139 @@
+"""Who may publish the workspace's vulnerability posture.
+
+The toggle decides whether a Trust Center shows counts of the workspace's own
+findings to anonymous readers, so the gate on it is the one that keeps a
+release page from publishing what it should not. The control is disabled in the
+browser for anyone below admin, which stops a click and nothing else: the form
+posts to a normal endpoint and a client can post to it directly.
+
+The role is read from the live Member row rather than the session, because the
+session's copy is a 300 second cache and a demoted admin would keep the
+capability until it turned over.
+"""
+
+import pytest
+from django.urls import reverse
+
+from sbomify.apps.teams.models import Member, Team
+
+
+@pytest.fixture
+def workspace(db):
+    return Team.objects.create(name="Posture Workspace", publish_vulnerability_posture=False)
+
+
+def _user(django_user_model, workspace, role, name):
+    user = django_user_model.objects.create_user(username=name, email=f"{name}@test.com", password="password")
+    Member.objects.create(user=user, team=workspace, role=role, is_default_team=True)
+    return user
+
+
+def _signed_in(client, user, workspace, role):
+    client.force_login(user)
+    session = client.session
+    session["current_team"] = {
+        "key": workspace.key,
+        "name": workspace.name,
+        "role": role,
+        "id": workspace.id,
+    }
+    session["user_teams"] = {workspace.key: {"role": role, "name": workspace.name}}
+    session.save()
+    return client
+
+
+def _post_toggle(client, workspace, value="true"):
+    return client.post(
+        reverse("teams:team_settings_tab", kwargs={"team_key": workspace.key, "tab": "trust-center"}),
+        {
+            "vulnerability_posture_action": "update",
+            "publish_vulnerability_posture": value,
+            "active_tab": "trust-center",
+        },
+        follow=True,
+    )
+
+
+@pytest.mark.django_db
+def test_a_member_is_refused_by_the_handler(client, django_user_model, workspace):
+    """Posting the form directly must be refused, not merely un-clickable.
+
+    A member reaches the handler, because members are allowed into the settings
+    section for the tabs they do own, so the refusal is the handler's message.
+    """
+    user = _user(django_user_model, workspace, "member", "member-user")
+    _signed_in(client, user, workspace, "member")
+
+    response = _post_toggle(client, workspace)
+
+    workspace.refresh_from_db()
+    assert workspace.publish_vulnerability_posture is False
+    assert "Only workspace owners and admins can change Trust Center settings" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_a_guest_is_refused_before_the_handler(client, django_user_model, workspace):
+    """Guests hold no capability tier, so the section turns them away first.
+
+    Two different refusals, both correct: the guest never reaches the handler
+    and so never sees its message. Asserting the message for both roles is what
+    made the first version of this test fail.
+    """
+    user = _user(django_user_model, workspace, "guest", "guest-user")
+    _signed_in(client, user, workspace, "guest")
+
+    response = _post_toggle(client, workspace)
+
+    workspace.refresh_from_db()
+    assert workspace.publish_vulnerability_posture is False
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize("role", ["owner", "admin"])
+@pytest.mark.django_db
+def test_owner_and_admin_can_publish_the_posture(client, django_user_model, workspace, role):
+    user = _user(django_user_model, workspace, role, f"{role}-user")
+    _signed_in(client, user, workspace, role)
+
+    _post_toggle(client, workspace)
+
+    workspace.refresh_from_db()
+    assert workspace.publish_vulnerability_posture is True
+
+
+@pytest.mark.django_db
+def test_a_stale_session_role_does_not_unlock_the_toggle(client, django_user_model, workspace):
+    """A demoted admin keeps an admin session for up to 300 seconds.
+
+    The handler reads the Member row, so the stale claim buys nothing.
+    """
+    user = _user(django_user_model, workspace, "member", "demoted")
+    _signed_in(client, user, workspace, "owner")
+
+    _post_toggle(client, workspace)
+
+    workspace.refresh_from_db()
+    assert workspace.publish_vulnerability_posture is False
+
+
+@pytest.mark.django_db
+def test_a_non_member_cannot_publish_the_posture(client, django_user_model, workspace):
+    outsider = django_user_model.objects.create_user(
+        username="outsider", email="outsider@test.com", password="password"
+    )
+    other = Team.objects.create(name="Their Own Workspace")
+    Member.objects.create(user=outsider, team=other, role="owner", is_default_team=True)
+    _signed_in(client, outsider, other, "owner")
+
+    client.post(
+        reverse("teams:team_settings_tab", kwargs={"team_key": workspace.key, "tab": "trust-center"}),
+        {
+            "vulnerability_posture_action": "update",
+            "publish_vulnerability_posture": "true",
+            "active_tab": "trust-center",
+        },
+        follow=True,
+    )
+
+    workspace.refresh_from_db()
+    assert workspace.publish_vulnerability_posture is False

--- a/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
+++ b/sbomify/apps/teams/tests/test_vulnerability_posture_authz.py
@@ -12,8 +12,10 @@ capability until it turned over.
 """
 
 import pytest
+from django.contrib.messages import get_messages
 from django.urls import reverse
 
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 from sbomify.apps.teams.models import Member, Team
 
 
@@ -28,23 +30,30 @@ def _user(django_user_model, workspace, role, name):
     return user
 
 
-def _signed_in(client, user, workspace, role):
-    client.force_login(user)
-    session = client.session
-    session["current_team"] = {
-        "key": workspace.key,
-        "name": workspace.name,
-        "role": role,
-        "id": workspace.id,
-    }
-    session["user_teams"] = {workspace.key: {"role": role, "name": workspace.name}}
-    session.save()
+def _signed_in(client, user, workspace, claimed_role=None):
+    """Sign in through the shared helper, which reads the role from the Member row.
+
+    ``claimed_role`` overrides only the role the *session* carries, which is how
+    the stale-session case is built: the row says one thing and the 300 second
+    cache still says another.
+    """
+    setup_authenticated_client_session(client, workspace, user)
+    if claimed_role is not None:
+        session = client.session
+        session["current_team"] = {**session["current_team"], "role": claimed_role}
+        session["user_teams"] = {key: {**data, "role": claimed_role} for key, data in session["user_teams"].items()}
+        session.save()
     return client
 
 
 def _post_toggle(client, workspace, value="true"):
+    """Post where the real form posts.
+
+    trust_center.html.j2 targets teams:team_settings, the settings index, not
+    the per-tab route, so the test follows it rather than the other way round.
+    """
     return client.post(
-        reverse("teams:team_settings_tab", kwargs={"team_key": workspace.key, "tab": "trust-center"}),
+        reverse("teams:team_settings", kwargs={"team_key": workspace.key}),
         {
             "vulnerability_posture_action": "update",
             "publish_vulnerability_posture": value,
@@ -62,13 +71,14 @@ def test_a_member_is_refused_by_the_handler(client, django_user_model, workspace
     section for the tabs they do own, so the refusal is the handler's message.
     """
     user = _user(django_user_model, workspace, "member", "member-user")
-    _signed_in(client, user, workspace, "member")
+    _signed_in(client, user, workspace)
 
     response = _post_toggle(client, workspace)
 
     workspace.refresh_from_db()
     assert workspace.publish_vulnerability_posture is False
-    assert "Only workspace owners and admins can change Trust Center settings" in response.content.decode()
+    messages = [str(m) for m in get_messages(response.wsgi_request)]
+    assert "Only workspace owners and admins can change Trust Center settings" in messages
 
 
 @pytest.mark.django_db
@@ -80,7 +90,7 @@ def test_a_guest_is_refused_before_the_handler(client, django_user_model, worksp
     made the first version of this test fail.
     """
     user = _user(django_user_model, workspace, "guest", "guest-user")
-    _signed_in(client, user, workspace, "guest")
+    _signed_in(client, user, workspace)
 
     response = _post_toggle(client, workspace)
 
@@ -93,7 +103,7 @@ def test_a_guest_is_refused_before_the_handler(client, django_user_model, worksp
 @pytest.mark.django_db
 def test_owner_and_admin_can_publish_the_posture(client, django_user_model, workspace, role):
     user = _user(django_user_model, workspace, role, f"{role}-user")
-    _signed_in(client, user, workspace, role)
+    _signed_in(client, user, workspace)
 
     _post_toggle(client, workspace)
 
@@ -108,7 +118,12 @@ def test_a_stale_session_role_does_not_unlock_the_toggle(client, django_user_mod
     The handler reads the Member row, so the stale claim buys nothing.
     """
     user = _user(django_user_model, workspace, "member", "demoted")
-    _signed_in(client, user, workspace, "owner")
+    _signed_in(client, user, workspace, claimed_role="owner")
+
+    # Without this the test passes either way: a session that still said
+    # "member" would be refused for the ordinary reason, proving nothing.
+    assert client.session["current_team"]["role"] == "owner"
+    assert Member.objects.get(user=user, team=workspace).role == "member"
 
     _post_toggle(client, workspace)
 
@@ -123,7 +138,7 @@ def test_a_non_member_cannot_publish_the_posture(client, django_user_model, work
     )
     other = Team.objects.create(name="Their Own Workspace")
     Member.objects.create(user=outsider, team=other, role="owner", is_default_team=True)
-    _signed_in(client, outsider, other, "owner")
+    _signed_in(client, outsider, other)
 
     client.post(
         reverse("teams:team_settings_tab", kwargs={"team_key": workspace.key, "tab": "trust-center"}),

--- a/sbomify/apps/teams/tests/test_workspace_delete_cascade.py
+++ b/sbomify/apps/teams/tests/test_workspace_delete_cascade.py
@@ -1,0 +1,115 @@
+"""Deleting a workspace must not leave anything of it behind.
+
+Seventeen tables point at Team directly, and far more hang below them. The
+check that matters is not that the seventeen go, which the field definitions
+already say, but that nothing survives anywhere in the graph: an orphaned SBOM
+or advisory row keeps a deleted workspace's data alive and readable by id.
+
+Rather than name the tables and go stale the next time one is added, this walks
+the reverse relations from Team and asserts every reachable model is empty. A
+new child table is covered the day it is created.
+
+Scope, stated plainly: the walk reaches 62 models and the fixture populates ten
+of them, so the behavioural test proves those ten leave nothing behind and would
+catch an orphan anywhere in the other 52. Every one of the seventeen tables that
+point at Team directly is covered structurally by the second test instead, which
+is the check that fails when someone adds a child with SET_NULL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.models import Component, Product
+from sbomify.apps.security_advisories.models import SecurityAdvisory
+from sbomify.apps.teams.models import ContactProfile, Invitation, Member, Supplier, Team
+
+
+def _models_reachable_from_team() -> list[type]:
+    """Every model reachable from Team by following reverse relations."""
+    seen: set[type] = set()
+    frontier = [Team]
+    while frontier:
+        nxt = []
+        for model in frontier:
+            if model in seen:
+                continue
+            seen.add(model)
+            for field in model._meta.get_fields():
+                if field.auto_created and not field.concrete:
+                    nxt.append(field.related_model)
+        frontier = nxt
+    seen.discard(Team)
+    return sorted(seen, key=lambda m: m._meta.label)
+
+
+@pytest.fixture
+def populated_workspace(db, django_user_model):
+    """A workspace with a row in the child tables that are cheap to make."""
+    user = django_user_model.objects.create_user(username="cascade", email="cascade@test.com", password="password")
+    team = Team.objects.create(name="Doomed Workspace")
+
+    Member.objects.create(user=user, team=team, role="owner", is_default_team=True)
+    Invitation.objects.create(team=team, email="invitee@test.com", role="member")
+    ContactProfile.objects.create(team=team, name="Security")
+    Supplier.objects.create(team=team, name="Acme Supplies")
+    AccessToken.objects.create(user=user, team=team, encoded_token="tok-cascade", description="cascade")
+
+    product = Product.objects.create(name="Doomed Product", team=team)
+    component = Component.objects.create(name="Doomed Component", team=team)
+    product.components.add(component)
+
+    SecurityAdvisory.objects.create(team=team, title="Doomed Advisory")
+
+    return team
+
+
+@pytest.mark.django_db
+def test_deleting_a_workspace_leaves_nothing_reachable_behind(populated_workspace):
+    """The database holds this workspace and nothing else, so after the delete
+    every table reachable from Team must be empty. Anything left is an orphan."""
+    reachable = _models_reachable_from_team()
+    before = {m._meta.label: m._default_manager.count() for m in reachable}
+    assert sum(before.values()) > 0, "the fixture populated nothing, so this proves nothing"
+
+    populated_workspace.delete()
+
+    survivors = {
+        label: count for label, count in ((m._meta.label, m._default_manager.count()) for m in reachable) if count
+    }
+    assert survivors == {}, f"rows outlived their workspace: {survivors}"
+
+
+@pytest.mark.django_db
+def test_every_table_pointing_at_a_workspace_cascades(db):
+    """A child added with SET_NULL or PROTECT would strand or block a delete."""
+    offenders = []
+    for field in Team._meta.get_fields():
+        if not (field.auto_created and not field.concrete):
+            continue
+        remote = getattr(field.field, "remote_field", None)
+        behaviour = getattr(remote, "on_delete", None)
+        if getattr(behaviour, "__name__", "") != "CASCADE":
+            offenders.append(f"{field.related_model._meta.label}.{field.field.name}")
+
+    assert offenders == [], f"these point at Team without cascading: {offenders}"
+
+
+@pytest.mark.django_db
+def test_deleting_a_workspace_spares_its_neighbours(populated_workspace, django_user_model):
+    """A cascade that reached across workspaces would be worse than an orphan."""
+    other_user = django_user_model.objects.create_user(
+        username="bystander", email="bystander@test.com", password="password"
+    )
+    other = Team.objects.create(name="Innocent Workspace")
+    Member.objects.create(user=other_user, team=other, role="owner", is_default_team=True)
+    kept_product = Product.objects.create(name="Kept Product", team=other)
+    kept_advisory = SecurityAdvisory.objects.create(team=other, title="Kept Advisory")
+
+    populated_workspace.delete()
+
+    assert Team.objects.filter(pk=other.pk).exists()
+    assert Product.objects.filter(pk=kept_product.pk).exists()
+    assert SecurityAdvisory.objects.filter(pk=kept_advisory.pk).exists()
+    assert Member.objects.filter(team=other).count() == 1


### PR DESCRIPTION
The vulnerability posture toggle decides whether a Trust Center shows counts of a workspace's own findings to anonymous readers. Nothing tested its gate.

That matters because the control is only disabled in the browser for anyone below admin. Disabling a control stops a click; the form posts to an ordinary endpoint, and a client can post to it directly. So the guard that counts is the server one, and it had no coverage at all.

Found while working case A6 of the staging test plan, which could not be run against staging because the QA account is an owner and there is no member-role login to hand.

## What the tests pin

| Case | Expected |
| --- | --- |
| member posts the form directly | refused by the handler's message, value unchanged |
| guest posts the form directly | 403 before the handler, value unchanged |
| owner posts | value changes |
| admin posts | value changes |
| member whose session still claims owner | refused, value unchanged |
| owner of a different workspace posts at this one | refused, value unchanged |

**Two refusal paths, not one.** A member reaches the handler and gets "Only workspace owners and admins can change Trust Center settings". A guest never reaches it: guests hold no capability tier, so the settings section turns them away with a 403 first. Both are correct. Asserting the handler's message for both roles is what made the first draft of this fail, and the split is now the point of two of the tests rather than an accident.

**The stale-session case is the one most easily lost in a refactor.** `current_team` in the session carries a role and is a 300 second cache, so a demoted admin keeps an admin-looking session for up to five minutes. The handler reads the live `Member` row instead, which is what makes the stale claim worthless. A refactor that reached for the session value would still pass every other test here.

Tests only, no production change. Full teams suite: 630 passed.
