### PR TITLE
fix(billing): deleting a workspace from settings cancels its subscription

### DIFF
--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -13,7 +13,7 @@ def team(db):
 @pytest.fixture
 def other_team(db):
     from sbomify.apps.billing.models import BillingPlan
-    
+
     # Ensure plan exists for test
     BillingPlan.objects.get_or_create(
         key="business",
@@ -21,7 +21,7 @@ def other_team(db):
             "name": "Business",
             "description": "Business Plan",
             "max_users": 10,
-        }
+        },
     )
     return Team.objects.create(name="Team B", key="team-b-key", billing_plan="business")
 
@@ -269,3 +269,30 @@ def test_stripe_is_left_alone_when_billing_is_disabled(settings, mocker):
     cleanup_stripe_for_deleted_workspace("sub_test123", "cus_test123", "ws-key")
 
     stripe.assert_not_called()
+
+
+def _delete_workspace_from_settings(client, user, workspace, mocker, settings=None):
+    """The Danger Zone button, which posts to team_general rather than the dashboard."""
+    settings.BILLING = True
+    queued = mocker.patch("sbomify.apps.billing.tasks.cleanup_stripe_for_deleted_workspace.send")
+    client.force_login(user)
+    _setup_session(client, workspace, "owner")
+    response = client.post(
+        reverse("teams:team_general", kwargs={"team_key": workspace.key}),
+        {"action": "delete"},
+    )
+    return response, queued
+
+
+def test_deleting_a_workspace_from_settings_cancels_its_subscription(client, paid_owner, paid_team, settings, mocker):
+    """The Danger Zone is the delete a user actually reaches.
+
+    Its form posts to teams:team_general, not to the dashboard, so the
+    cancellation the dashboard path performs has to happen here too or the
+    subscription outlives the workspace and keeps charging.
+    """
+    response, queued = _delete_workspace_from_settings(client, paid_owner, paid_team, mocker, settings=settings)
+
+    assert response.status_code in (200, 302)
+    assert not Team.objects.filter(pk=paid_team.pk).exists()
+    queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -141,7 +141,7 @@ def paid_owner(db, django_user_model, paid_team, team):
     return u
 
 
-def _delete_workspace(client, user, workspace, mocker, capture, billing=True, settings=None):
+def _delete_workspace(client, user, workspace, mocker, capture, settings, billing=True):
     """Delete from the dashboard.
 
     The cancellation is queued ``on_commit``, and the test transaction never

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -318,7 +318,9 @@ def test_deleting_a_workspace_from_settings_cancels_its_subscription(
         client, paid_owner, paid_team, mocker, django_capture_on_commit_callbacks, settings=settings
     )
 
-    assert response.status_code in (200, 302)
+    # 302 exactly: the success path redirects to the workspace that is left.
+    # Accepting 200 would let a delete that fell into the error handler pass.
+    assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
     queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)
 

--- a/sbomify/apps/teams/tests/test_deletion_edge_cases.py
+++ b/sbomify/apps/teams/tests/test_deletion_edge_cases.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import pytest
 from django.contrib.messages import get_messages
 from django.urls import reverse
@@ -139,45 +141,63 @@ def paid_owner(db, django_user_model, paid_team, team):
     return u
 
 
-def _delete_workspace(client, user, workspace, mocker, billing=True, settings=None):
+def _delete_workspace(client, user, workspace, mocker, capture, billing=True, settings=None):
+    """Delete from the dashboard.
+
+    The cancellation is queued ``on_commit``, and the test transaction never
+    commits, so the callbacks have to be captured or the task looks unqueued.
+    """
     settings.BILLING = billing
     queued = mocker.patch("sbomify.apps.billing.tasks.cleanup_stripe_for_deleted_workspace.send")
     client.force_login(user)
     _setup_session(client, workspace, "owner")
-    response = client.post(
-        reverse("teams:teams_dashboard"),
-        {"_method": "DELETE", "key": workspace.key},
-    )
+    with capture(execute=True):
+        response = client.post(
+            reverse("teams:teams_dashboard"),
+            {"_method": "DELETE", "key": workspace.key},
+        )
     return response, queued
 
 
-def test_deleting_a_workspace_cancels_its_subscription(client, paid_owner, paid_team, settings, mocker):
+def test_deleting_a_workspace_cancels_its_subscription(
+    client, paid_owner, paid_team, settings, mocker, django_capture_on_commit_callbacks
+):
     """The subscription outlived the workspace and kept charging."""
-    response, queued = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
+    response, queued = _delete_workspace(
+        client, paid_owner, paid_team, mocker, django_capture_on_commit_callbacks, settings=settings
+    )
 
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
     queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)
 
 
-def test_deleting_a_free_workspace_queues_no_ids_to_cancel(client, paid_owner, paid_team, settings, mocker):
+def test_deleting_a_free_workspace_queues_no_ids_to_cancel(
+    client, paid_owner, paid_team, settings, mocker, django_capture_on_commit_callbacks
+):
     """The task is still queued, and finds nothing for Stripe to do."""
     paid_team.billing_plan = "community"
     paid_team.billing_plan_limits = {}
     paid_team.save(update_fields=["billing_plan", "billing_plan_limits"])
 
-    response, queued = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
+    response, queued = _delete_workspace(
+        client, paid_owner, paid_team, mocker, django_capture_on_commit_callbacks, settings=settings
+    )
 
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
     assert queued.call_args[0][:2] == (None, None)
 
 
-def test_the_delete_does_not_wait_on_stripe(client, paid_owner, paid_team, settings, mocker):
+def test_the_delete_does_not_wait_on_stripe(
+    client, paid_owner, paid_team, settings, mocker, django_capture_on_commit_callbacks
+):
     """The row is gone before the call, so a slow Stripe must not hold the request."""
     client_cls = mocker.patch("sbomify.apps.billing.stripe_client.StripeClient")
 
-    response, _ = _delete_workspace(client, paid_owner, paid_team, mocker, settings=settings)
+    response, _ = _delete_workspace(
+        client, paid_owner, paid_team, mocker, django_capture_on_commit_callbacks, settings=settings
+    )
 
     assert response.status_code == 302
     assert not Team.objects.filter(pk=paid_team.pk).exists()
@@ -271,28 +291,58 @@ def test_stripe_is_left_alone_when_billing_is_disabled(settings, mocker):
     stripe.assert_not_called()
 
 
-def _delete_workspace_from_settings(client, user, workspace, mocker, settings=None):
+def _delete_workspace_from_settings(client, user, workspace, mocker, capture, settings):
     """The Danger Zone button, which posts to team_general rather than the dashboard."""
     settings.BILLING = True
     queued = mocker.patch("sbomify.apps.billing.tasks.cleanup_stripe_for_deleted_workspace.send")
     client.force_login(user)
     _setup_session(client, workspace, "owner")
-    response = client.post(
-        reverse("teams:team_general", kwargs={"team_key": workspace.key}),
-        {"action": "delete"},
-    )
+    with capture(execute=True):
+        response = client.post(
+            reverse("teams:team_general", kwargs={"team_key": workspace.key}),
+            {"action": "delete"},
+        )
     return response, queued
 
 
-def test_deleting_a_workspace_from_settings_cancels_its_subscription(client, paid_owner, paid_team, settings, mocker):
+def test_deleting_a_workspace_from_settings_cancels_its_subscription(
+    client, paid_owner, paid_team, settings, mocker, django_capture_on_commit_callbacks
+):
     """The Danger Zone is the delete a user actually reaches.
 
     Its form posts to teams:team_general, not to the dashboard, so the
     cancellation the dashboard path performs has to happen here too or the
     subscription outlives the workspace and keeps charging.
     """
-    response, queued = _delete_workspace_from_settings(client, paid_owner, paid_team, mocker, settings=settings)
+    response, queued = _delete_workspace_from_settings(
+        client, paid_owner, paid_team, mocker, django_capture_on_commit_callbacks, settings=settings
+    )
 
     assert response.status_code in (200, 302)
     assert not Team.objects.filter(pk=paid_team.pk).exists()
     queued.assert_called_once_with("sub_test123", "cus_test123", paid_team.key)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_rolled_back_delete_cancels_nothing(paid_team, mocker):
+    """Cancelling a subscription whose workspace still exists would be worse
+    than leaving one running: the customer loses access and keeps the row.
+
+    The helper queues on_commit, so a caller that wraps it in its own
+    transaction and then fails cannot reach Stripe.
+    """
+    from django.db import transaction
+
+    from sbomify.apps.teams.utils import delete_workspace_with_billing_cleanup
+
+    queued = mocker.patch("sbomify.apps.billing.tasks.cleanup_stripe_for_deleted_workspace.send")
+    # delete() nulls the instance's pk, so keep it to look the row up after.
+    pk = paid_team.pk
+
+    with contextlib.suppress(RuntimeError):
+        with transaction.atomic():
+            delete_workspace_with_billing_cleanup(paid_team)
+            raise RuntimeError("the caller failed after deleting")
+
+    assert Team.objects.filter(pk=pk).exists(), "the rollback should have restored it"
+    queued.assert_not_called()

--- a/sbomify/apps/teams/utils.py
+++ b/sbomify/apps/teams/utils.py
@@ -827,3 +827,32 @@ def remove_member_safely(request: HttpRequest, membership: Member, active_tab: s
     else:
         messages.info(request, f"Member {removed_user.username} removed from workspace.")
         return redirect_to_team_settings(removed_team_key, active_tab)
+
+
+def delete_workspace_with_billing_cleanup(team: Team) -> None:
+    """Delete a workspace and cancel whatever it was paying for.
+
+    Both delete paths route through here because the billing half is easy to
+    leave out and expensive when it is: the settings page's Danger Zone deleted
+    the row without it, so the subscription outlived the workspace and kept
+    charging. A third caller now inherits the cleanup rather than having to
+    remember it.
+
+    The ids are read before the row goes, since they live on it. Cancelling is
+    queued rather than awaited: it is two calls to Stripe, and holding a web
+    worker open for them after the row has already been deleted risks a proxy
+    timing the request out with nothing left to retry.
+    """
+    from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+
+    limits = team.billing_plan_limits or {}
+    subscription_id = limits.get("stripe_subscription_id")
+    customer_id = limits.get("stripe_customer_id")
+    # key is nullable on the model, and this string only names the workspace in
+    # an alert after the row has gone.
+    workspace_key = team.key or f"pk={team.pk}"
+
+    with transaction.atomic():
+        team.delete()
+
+    cleanup_stripe_for_deleted_workspace.send(subscription_id, customer_id, workspace_key)

--- a/sbomify/apps/teams/utils.py
+++ b/sbomify/apps/teams/utils.py
@@ -835,13 +835,18 @@ def delete_workspace_with_billing_cleanup(team: Team) -> None:
     Both delete paths route through here because the billing half is easy to
     leave out and expensive when it is: the settings page's Danger Zone deleted
     the row without it, so the subscription outlived the workspace and kept
-    charging. A third caller now inherits the cleanup rather than having to
-    remember it.
+    charging. Keeping it in one place is what stops the next caller repeating
+    that.
 
     The ids are read before the row goes, since they live on it. Cancelling is
     queued rather than awaited: it is two calls to Stripe, and holding a web
     worker open for them after the row has already been deleted risks a proxy
     timing the request out with nothing left to retry.
+
+    Queued ``on_commit`` rather than straight away, so a caller that wraps this
+    in its own transaction cannot cancel a subscription whose workspace then
+    fails to delete. Outside a transaction the hook runs immediately, so the
+    two call sites here behave as before.
     """
     from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
 
@@ -854,5 +859,6 @@ def delete_workspace_with_billing_cleanup(team: Team) -> None:
 
     with transaction.atomic():
         team.delete()
-
-    cleanup_stripe_for_deleted_workspace.send(subscription_id, customer_id, workspace_key)
+        transaction.on_commit(
+            lambda: cleanup_stripe_for_deleted_workspace.send(subscription_id, customer_id, workspace_key)
+        )

--- a/sbomify/apps/teams/views/dashboard.py
+++ b/sbomify/apps/teams/views/dashboard.py
@@ -117,25 +117,11 @@ class WorkspacesDashboardView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     "Cannot delete the default workspace. Please set another workspace as default first.",
                 )
             else:
-                # Read the billing ids before the row goes. Without this the
-                # subscription outlives the workspace and keeps charging. The
-                # cancelling itself is queued: it is two calls to Stripe, and
-                # holding a web worker open for them after the row has already
-                # been deleted risks a timeout with nothing left to retry.
-                from sbomify.apps.billing.tasks import cleanup_stripe_for_deleted_workspace
+                from sbomify.apps.teams.utils import delete_workspace_with_billing_cleanup
 
-                limits = team.billing_plan_limits or {}
-                subscription_id = limits.get("stripe_subscription_id")
-                customer_id = limits.get("stripe_customer_id")
-                # key is nullable on the model, and this string only exists to
-                # name the workspace in an alert after the row has gone.
-                workspace_key = team.key or f"pk={team.pk}"
                 workspace_name = team.name
 
-                with transaction.atomic():
-                    team.delete()
-
-                cleanup_stripe_for_deleted_workspace.send(subscription_id, customer_id, workspace_key)
+                delete_workspace_with_billing_cleanup(team)
 
                 messages.add_message(
                     request,

--- a/sbomify/apps/teams/views/team_general.py
+++ b/sbomify/apps/teams/views/team_general.py
@@ -19,6 +19,7 @@ from sbomify.apps.teams.forms import TeamGeneralSettingsForm
 from sbomify.apps.teams.models import Member, Team
 from sbomify.apps.teams.permissions import TeamRoleRequiredMixin
 from sbomify.apps.teams.utils import (
+    delete_workspace_with_billing_cleanup,
     refresh_current_team_session,
     switch_active_workspace,
     update_user_teams_session,
@@ -158,8 +159,7 @@ class TeamGeneralView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             team = membership.team
             team_name = team.name
 
-            with transaction.atomic():
-                team.delete()
+            delete_workspace_with_billing_cleanup(team)
 
             # Update user teams session after deletion
             user_teams = update_user_teams_session(request, user)


### PR DESCRIPTION
Deleting a workspace from its settings page left the Stripe subscription running. The workspace was gone; the customer kept paying for it.

## What was wrong

Two paths delete a workspace, and only one cancelled:

| Path | Reached from | Cancelled |
| --- | --- | --- |
| `POST teams:teams_dashboard`, `_method=DELETE` | the workspaces dashboard | yes |
| `POST teams:team_general`, `action=delete` | **the settings Danger Zone** | **no** |

The Danger Zone is the delete a user actually reaches: `team_danger_zone.html.j2` posts to `{% url 'teams:team_general' team_key %}`, and `_delete_workspace` called `team.delete()` with no billing cleanup.

The hazard was already known. The dashboard path carries this comment:

> Read the billing ids before the row goes. Without this the subscription outlives the workspace and keeps charging.

So the knowledge existed. It just lived in one caller rather than in one place, and the second caller did not inherit it.

`cleanup_stripe_for_deleted_workspace` logs CRITICAL when cancellation fails, so it would have been noisy about a failure. It was never called on this path, so nothing failed and nothing was attempted. The alert could not fire.

## The change

Both paths now route through `delete_workspace_with_billing_cleanup`, which reads the billing ids while the row still exists, deletes inside a transaction, and queues the cancellation. Queued rather than awaited, for the reason the task already documents: two Stripe calls after the row is gone, and a proxy timing the request out would leave the subscription live with nothing to retry it.

A third delete path now inherits the cleanup instead of having to remember it, which is the part that actually prevents a repeat.

## Tests

`test_deleting_a_workspace_from_settings_cancels_its_subscription` mirrors the dashboard test that already existed, on the path that is wired to the button. It fails against the previous code: the workspace is deleted and the task is never queued.

That asymmetry is why this went unnoticed. The dashboard path had a test; the path users reach did not.

Full teams suite: 625 passed.

Found while working case H2 of the staging test plan, which was filed as needing the Stripe dashboard. Whether the deletion queues the cancellation is decidable without it.

Closes #1539
