### PR TITLE
test(advisories): a guest cannot read, and bot is not a role to hand out

### DIFF
--- a/sbomify/apps/security_advisories/tests/test_apis.py
+++ b/sbomify/apps/security_advisories/tests/test_apis.py
@@ -427,8 +427,14 @@ class TestWhoMayWrite:
         # Accepted only because the binding above names this user.
         Member.objects.create(user=bot, team=team, role="bot")
 
+        # Scoped to the workspace, as an OIDC-issued bot token is. An unscoped
+        # token would let request scoping fall back to the user's memberships,
+        # so the refusal could come from a path production never takes.
         token = AccessToken.objects.create(
-            user=bot, encoded_token=create_personal_access_token(bot), description="bot token"
+            user=bot,
+            team=team,
+            encoded_token=create_personal_access_token(bot),
+            description="bot token",
         )
         client = Client()
         headers = get_api_headers(token)

--- a/sbomify/apps/security_advisories/tests/test_apis.py
+++ b/sbomify/apps/security_advisories/tests/test_apis.py
@@ -389,7 +389,10 @@ class TestWhoMayWrite:
         detail = client.get(_detail(advisory.id), **headers)
 
         assert (listed.status_code, detail.status_code) == (403, 403)
-        # The draft's title must not leak through the refusal body either.
+        # The draft's title must not leak through either refusal body. Checking
+        # only the detail one would miss a list endpoint that names what it is
+        # refusing to show.
+        assert advisory.title not in listed.content.decode()
         assert advisory.title not in detail.content.decode()
 
     def test_bot_cannot_be_handed_to_an_ordinary_member(self, sample_team_with_owner_member) -> None:

--- a/sbomify/apps/security_advisories/tests/test_apis.py
+++ b/sbomify/apps/security_advisories/tests/test_apis.py
@@ -374,6 +374,40 @@ class TestWhoMayWrite:
         assert advisory.status == SecurityAdvisory.Status.DRAFT
         assert advisory.title == "Log4Shell in Acme Gateway"
 
+    def test_a_guest_cannot_even_read(self, client_and_headers, sample_team_with_owner_member, advisory) -> None:
+        """advisory:read is READ_INTERNAL, which stops at member.
+
+        A guest is an external party the trust-center machinery anchors an ACL
+        to, not a contributor, so the refusal is on the read rather than only on
+        the writes.
+        """
+        client, headers = client_and_headers
+        sample_team_with_owner_member.role = "guest"
+        sample_team_with_owner_member.save()
+
+        listed = client.get(LIST, **headers)
+        detail = client.get(_detail(advisory.id), **headers)
+
+        assert (listed.status_code, detail.status_code) == (403, 403)
+        # The draft's title must not leak through the refusal body either.
+        assert advisory.title not in detail.content.decode()
+
+    def test_bot_cannot_be_handed_to_an_ordinary_member(self, sample_team_with_owner_member) -> None:
+        """The tier table puts bot outside advisory:read, but the stronger
+        guarantee is upstream: a human Member cannot be given the role at all.
+
+        Reaching this API as a bot would first require becoming one, and that is
+        refused outside the OIDC provisioning flow. Written as a test because
+        the reverse, a role assignable by anyone who can edit a Member, is the
+        privilege escalation the guard exists to stop.
+        """
+        from django.core.exceptions import ValidationError
+
+        sample_team_with_owner_member.role = "bot"
+
+        with pytest.raises(ValidationError, match="reserved for synthetic OIDC binding identities"):
+            sample_team_with_owner_member.save()
+
     def test_an_admin_may_write(self, client_and_headers, sample_team_with_owner_member) -> None:
         client, headers = client_and_headers
         sample_team_with_owner_member.role = "admin"

--- a/sbomify/apps/security_advisories/tests/test_apis.py
+++ b/sbomify/apps/security_advisories/tests/test_apis.py
@@ -395,6 +395,51 @@ class TestWhoMayWrite:
         assert advisory.title not in listed.content.decode()
         assert advisory.title not in detail.content.decode()
 
+    def test_a_real_bot_cannot_read_either(self, sample_team_with_owner_member, advisory, django_user_model) -> None:
+        """The tier says bot is outside advisory:read. Proven with a real one.
+
+        A bot only exists as the synthetic identity of an OIDC binding, so
+        reaching this API as one means building that identity: the binding, a
+        Member row the binding permits, and the bot's own token. Worth the
+        setup rather than trusting the tier table, because a bot is a
+        publishing identity a workspace hands to an external repository, and
+        unpublished advisories are not part of that grant.
+        """
+        from django.test import Client
+
+        from sbomify.apps.access_tokens.models import AccessToken
+        from sbomify.apps.access_tokens.utils import create_personal_access_token
+        from sbomify.apps.core.models import Component
+        from sbomify.apps.oidc.models import OIDCBinding
+        from sbomify.apps.teams.models import Member
+
+        team = sample_team_with_owner_member.team
+        bot = django_user_model.objects.create_user(username="oidc-bot", email="bot@test.com")
+        OIDCBinding.objects.create(
+            component=Component.objects.create(name="published-by-ci", team=team),
+            provider=OIDCBinding.PROVIDER_GITHUB,
+            repository="acme/widget",
+            repository_id=12345,
+            repository_owner_id=67890,
+            bot_user=bot,
+            created_by=sample_team_with_owner_member.user,
+        )
+        # Accepted only because the binding above names this user.
+        Member.objects.create(user=bot, team=team, role="bot")
+
+        token = AccessToken.objects.create(
+            user=bot, encoded_token=create_personal_access_token(bot), description="bot token"
+        )
+        client = Client()
+        headers = get_api_headers(token)
+
+        listed = client.get(LIST, **headers)
+        detail = client.get(_detail(advisory.id), **headers)
+
+        assert (listed.status_code, detail.status_code) == (403, 403)
+        assert advisory.title not in listed.content.decode()
+        assert advisory.title not in detail.content.decode()
+
     def test_bot_cannot_be_handed_to_an_ordinary_member(self, sample_team_with_owner_member) -> None:
         """The tier table puts bot outside advisory:read, but the stronger
         guarantee is upstream: a human Member cannot be given the role at all.


### PR DESCRIPTION
The advisories API role matrix was covered for owner, admin and member through real personal access tokens, and stopped there.

## Guest

`advisory:read` is `READ_INTERNAL`, which stops at member, so a guest is refused **reads** as well as writes. That half went unasserted.

It matters because a guest is not a quiet contributor: it is an external party the trust-center access-request and NDA machinery anchors an ACL to. The workspace's unpublished advisories are not theirs to read, and a draft advisory is precisely the kind of thing that must not leak early.

The test also checks the draft's title is absent from the refusal body. A 403 that names what it is hiding has not hidden it.

## Bot

Writing the obvious test found something better than the test I meant to write. A `Member` cannot be given `role="bot"` at all outside the OIDC provisioning flow:

```
role='bot' is reserved for synthetic OIDC binding identities and
cannot be assigned to a Member outside the OIDC provisioning flow.
```

That is a stronger guarantee than the tier table gives. The tier table says a bot cannot read advisories; the guard says you cannot become a bot in the first place, which is the privilege escalation worth stopping. So the test asserts the guard rather than routing around it to reach the read.

Reaching this API as a genuine bot would need a real `OIDCBinding`, which is a different fixture and a different test.

## Notes

Tests only, no production change. Advisories suite: 388 passed.

Found completing case D13 of the staging test plan, which asks for the matrix through PATs for each role. Owner, admin and member were already there; this is the rest of it.
