### PR TITLE
fix(copy): counts agree with the nouns beside them

### DIFF
--- a/sbomify/apps/core/templates/core/components/recent_activity.html.j2
+++ b/sbomify/apps/core/templates/core/components/recent_activity.html.j2
@@ -77,7 +77,7 @@ Parameters:
                             {% if activity.type == 'scan' and activity.scan_details %}
                                 {# Enhanced scan display with severity badges #}
                                 <div class="flex flex-wrap items-center gap-1 mt-1">
-                                    <span class="text-xs text-text-muted">{{ activity.scan_details.total }} vulns:</span>
+                                    <span class="text-xs text-text-muted">{{ activity.scan_details.total }} vulnerabilit{{ activity.scan_details.total|pluralize:"y,ies" }}:</span>
                                     {% if activity.scan_details.critical > 0 %}
                                         <c-badges.severity level="critical">{{ activity.scan_details.critical }}C</c-badges.severity>
                                     {% endif %}

--- a/sbomify/apps/core/templates/core/components/site_notifications.html.j2
+++ b/sbomify/apps/core/templates/core/components/site_notifications.html.j2
@@ -8,7 +8,7 @@
         {% endcomment %}
         {% if team.is_in_grace_period %}
             <c-feedback.alert variant="warning" title="Payment Failed" class="mb-6">
-            Your grace period is active. Update your payment method within {{ grace_period_days }} days to avoid service interruption.
+            Your grace period is active. Update your payment method within {{ grace_period_days }} day{{ grace_period_days|pluralize }} to avoid service interruption.
             <c-buttons.warning size="sm" href="{% url 'billing:create_portal_session' team.key %}" class="ml-2 align-middle no-underline">Fix Payment</c-buttons.warning>
             </c-feedback.alert>
         {% else %}

--- a/sbomify/apps/core/tests/test_count_noun_agreement.py
+++ b/sbomify/apps/core/tests/test_count_noun_agreement.py
@@ -1,0 +1,67 @@
+"""Counts and the nouns beside them have to agree.
+
+The Trust Center summary strip read "1 Products" to the first person who saw
+it, which is what started this. These two are the same defect on internal
+pages: a grace period can be configured to one day, and a scan can find one
+vulnerability, and both then read as plurals.
+
+Rendered rather than grepped, because the point is what a reader sees.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("days", "expected"),
+    [(1, "within 1 day to avoid"), (3, "within 3 days to avoid")],
+)
+def test_the_grace_period_agrees_with_its_count(days, expected):
+    """PAYMENT_GRACE_PERIOD_DAYS is configurable, so one day is reachable."""
+
+    # The template reads the workspace out of the session, and only renders
+    # the alert for a past_due subscription seen by someone who can act on it.
+    team = {
+        "key": "abc123",
+        "is_in_grace_period": True,
+        "billing_plan_limits": {"subscription_status": "past_due"},
+    }
+    request = RequestFactory().get("/")
+    request.user = AnonymousUser()
+    request.session = {"current_team": team}
+
+    rendered = render_to_string(
+        "core/components/site_notifications.html.j2",
+        {"can_administer": True, "grace_period_days": days},
+        request=request,
+    )
+
+    assert expected in " ".join(rendered.split())
+
+
+@pytest.mark.parametrize(
+    ("total", "expected"),
+    [(1, "1 vulnerability:"), (2, "2 vulnerabilities:")],
+)
+def test_the_scan_count_agrees_and_uses_the_whole_word(total, expected):
+    """It read "1 vulns", which is two problems in four characters.
+
+    The glossary makes "vulnerability" the user-facing word, so the
+    abbreviation was wrong before the agreement was.
+    """
+    activity = {
+        "type": "scan",
+        "scan_details": {"total": total, "critical": 0, "high": 0, "medium": 0, "low": 0},
+        "title": "scan",
+        "timestamp": None,
+    }
+
+    rendered = render_to_string("core/components/recent_activity.html.j2", {"activities": [activity]})
+
+    assert expected in " ".join(rendered.split())
+    assert "vulns" not in rendered


### PR DESCRIPTION
Two more instances of the defect [#1536](https://github.com/sbomify/sbomify/pull/1536) fixed on the Trust Center strip, found by sweeping for the class rather than stopping at the instance that was reported.

| Where | Read | Now reads |
| --- | --- | --- |
| grace period notice | "within **1 days** to avoid service interruption" | "within 1 day to avoid service interruption" |
| activity feed | "**1 vulns**:" | "1 vulnerability:" |

`PAYMENT_GRACE_PERIOD_DAYS` is configurable and defaults to 3, so one day is reachable by configuration rather than being a theoretical edge.

The activity feed line had two problems in four characters. The count did not agree, and `vulns` is not the word: the glossary is explicit that **vulnerability** is the user-facing term and that abbreviations are not copy. So the abbreviation was wrong before the agreement was, and fixing only the plural would have left the worse half.

## Tests

Rendered rather than grepped, because what a reader sees is the point.

Three of the four fail against the previous templates. The fourth is the plural grace period, which was never broken, and it is kept so the fix cannot swing the other way and start saying "3 day".

Getting the first version to render took two goes, both recorded in the test so the next person does not repeat them: the notice reads its workspace out of `request.session.current_team` rather than a `team` context variable, and it renders only for a `past_due` subscription seen by someone who `can_administer`.

## Scope

Held back from #1536 deliberately while that PR was mid-review, since broadening it would have restarted the review cycle for an unrelated page.
