### PR TITLE
fix(trust-center): the release VEX download respects component visibility

### DIFF
--- a/sbomify/apps/core/apis.py
+++ b/sbomify/apps/core/apis.py
@@ -3683,10 +3683,24 @@ def download_release_vex(request: HttpRequest, release_id: str) -> Any:
     slot_state = ReleaseArtifact.objects.filter(release=release, sbom__bom_type=SBOM.BomType.VEX).aggregate(
         n=Count("id"), newest=Max("sbom__created_at")
     )
-    cache_key = f"release-vex:{release.id}:{slot_state['n']}:{slot_state['newest']}"
+    # A member reading a public product's release gets the whole VEX, gated and
+    # private components included. Everyone else gets the public view, matching
+    # what the aggregate SBOM download hands the same caller: a statement names
+    # a package and a version, so publishing one for a withheld component would
+    # disclose through the side door what the inventory refuses at the front.
+    include_non_public = bool(
+        getattr(request, "user", None)
+        and request.user.is_authenticated
+        and can(request, "release:read", release.product)
+    )
+    # The flag is part of the key. Sharing one entry between the two audiences
+    # would serve whichever build landed first to both, which is the disclosure
+    # this is closing rather than a caching detail.
+    scope = "all" if include_non_public else "public"
+    cache_key = f"release-vex:{release.id}:{scope}:{slot_state['n']}:{slot_state['newest']}"
     document = cache.get(cache_key)
     if document is None:
-        document = vex_module.build_release_vex(release) or {"__absent__": True}
+        document = vex_module.build_release_vex(release, include_non_public=include_non_public) or {"__absent__": True}
         cache.set(cache_key, document, 900)
     if document.get("__absent__"):
         return 404, {"detail": "No VEX available for this release", "error_code": ErrorCode.NOT_FOUND}

--- a/sbomify/apps/vulnerability_scanning/tests/test_release_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_release_vex.py
@@ -15,12 +15,19 @@ from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.vulnerability_scanning import vex
 
 
-def _release_with_components(team, *, is_public: bool):
+def _release_with_components(team, *, is_public: bool, visibility: str = Component.Visibility.PUBLIC):
+    """A product with two components.
+
+    Visibility is passed explicitly rather than left to the model default,
+    which is PRIVATE. An anonymous caller only sees public components, so a
+    fixture that took the default would be testing the withheld path while
+    reading as though it tested the published one.
+    """
     product = Product.objects.create(name="P", team=team, is_public=is_public)
     release = Release.objects.create(product=product, name="v1")
-    c1 = Component.objects.create(name="c1", team=team)
+    c1 = Component.objects.create(name="c1", team=team, visibility=visibility)
     c1.products.add(product)
-    c2 = Component.objects.create(name="c2", team=team)
+    c2 = Component.objects.create(name="c2", team=team, visibility=visibility)
     c2.products.add(product)
     return product, release, c1, c2
 
@@ -195,3 +202,66 @@ def test_build_release_vex_preserves_annotations_and_analysis_detail(sample_team
     assert vuln["analysis"]["detail"] == "Analyst note from DT audit trail."
     assert vuln["analysis"]["response"] == ["will_not_fix"]
     assert merged["annotations"] == dt_doc["annotations"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("hidden", [Component.Visibility.PRIVATE, Component.Visibility.GATED])
+def test_an_anonymous_reader_gets_no_vex_for_a_withheld_component(sample_team_with_owner_member, mocker, hidden):
+    """A VEX statement names a package and a version.
+
+    The aggregate SBOM download withholds a non-public component's inventory
+    from an anonymous reader. Publishing its VEX would disclose the same
+    packages, at pinned versions, through the other door on the same page.
+    """
+    cache.clear()
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True, visibility=hidden)
+    ReleaseArtifact.objects.create(release=release, sbom=_vex_sbom(c1, "c1.vex.json"))
+    _mock_s3(mocker, {"c1.vex.json": _doc("CVE-2026-1", "pkg:pypi/secret@9.9.9")})
+
+    response = Client().get(reverse("api-1:download_release_vex", kwargs={"release_id": release.id}))
+
+    assert response.status_code == 404
+    assert "secret" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_a_member_still_gets_the_withheld_component_s_vex(sample_user, sample_team_with_owner_member, mocker):
+    """The rule is about the audience, not about hiding the data from its owner."""
+    cache.clear()
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True, visibility=Component.Visibility.PRIVATE)
+    ReleaseArtifact.objects.create(release=release, sbom=_vex_sbom(c1, "c1.vex.json"))
+    _mock_s3(mocker, {"c1.vex.json": _doc("CVE-2026-1", "pkg:pypi/secret@9.9.9")})
+
+    client = Client()
+    client.force_login(sample_user)
+    response = client.get(reverse("api-1:download_release_vex", kwargs={"release_id": release.id}))
+
+    assert response.status_code == 200
+    assert "CVE-2026-1" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_the_two_audiences_do_not_share_a_cache_entry(sample_user, sample_team_with_owner_member, mocker):
+    """The member's build must not be handed to the anonymous caller after it.
+
+    Keying the cache on the release alone would serve whichever build landed
+    first to both, which is the disclosure this closes rather than a caching
+    detail. Ordered member first on purpose: that is the direction that leaks.
+    """
+    cache.clear()
+    team = sample_team_with_owner_member.team
+    _product, release, c1, _c2 = _release_with_components(team, is_public=True, visibility=Component.Visibility.PRIVATE)
+    ReleaseArtifact.objects.create(release=release, sbom=_vex_sbom(c1, "c1.vex.json"))
+    _mock_s3(mocker, {"c1.vex.json": _doc("CVE-2026-1", "pkg:pypi/secret@9.9.9")})
+    url = reverse("api-1:download_release_vex", kwargs={"release_id": release.id})
+
+    member = Client()
+    member.force_login(sample_user)
+    assert member.get(url).status_code == 200
+
+    anonymous = Client().get(url)
+
+    assert anonymous.status_code == 404
+    assert "secret" not in anonymous.content.decode()

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -925,7 +925,7 @@ def _load_uncached(component_id: Any) -> list[dict[str, Any]]:
     return statements
 
 
-def build_release_vex(release: Any) -> dict[str, Any] | None:
+def build_release_vex(release: Any, *, include_non_public: bool = True) -> dict[str, Any] | None:
     """Merge the VEX documents pinned in the release's artifact slots into one CycloneDX document.
 
     Consumers want a single VEX per release rather than one per component. Only VEX artifacts
@@ -933,10 +933,17 @@ def build_release_vex(release: Any) -> dict[str, Any] | None:
     manual upload for the same component both contribute) are merged, so the download always
     matches the triage sbomify applies to that release's own stored scans, and a component added
     to the product later never bleeds into an old release. Returns None when the release holds no VEX.
+
+    ``include_non_public=False`` keeps gated and private components out, which is
+    what an anonymous reader of a public product's release gets. A VEX statement
+    names a package and a version, so publishing one for a component whose
+    inventory is withheld would disclose through the side door what the
+    inventory download refuses at the front: the aggregate SBOM applies exactly
+    this rule, and the two are pulled from the same page.
     """
     from django.utils import timezone
 
-    from sbomify.apps.core.models import ReleaseArtifact
+    from sbomify.apps.core.models import Component, ReleaseArtifact
     from sbomify.apps.sboms.models import SBOM
 
     components: list[dict[str, Any]] = []
@@ -1039,6 +1046,8 @@ def build_release_vex(release: Any) -> dict[str, Any] | None:
         .select_related("sbom")
         .order_by("sbom__component_id", "-sbom__created_at")
     )
+    if not include_non_public:
+        artifacts = artifacts.filter(sbom__component__visibility=Component.Visibility.PUBLIC)
     for artifact in artifacts:
         vex_sbom = artifact.sbom
         if vex_sbom is None:
@@ -1052,11 +1061,12 @@ def build_release_vex(release: Any) -> dict[str, Any] | None:
     # In-app triage applies to the release's stored scans regardless of slot
     # contents (see resolve_vex_statements_for_sbom), so the download must
     # carry it too — for every component shipping an SBOM in this release.
-    release_component_ids = set(
-        ReleaseArtifact.objects.filter(release=release, sbom__bom_type=SBOM.BomType.SBOM)
-        .exclude(sbom__component_id=None)
-        .values_list("sbom__component_id", flat=True)
+    triage_scope = ReleaseArtifact.objects.filter(release=release, sbom__bom_type=SBOM.BomType.SBOM).exclude(
+        sbom__component_id=None
     )
+    if not include_non_public:
+        triage_scope = triage_scope.filter(sbom__component__visibility=Component.Visibility.PUBLIC)
+    release_component_ids = set(triage_scope.values_list("sbom__component_id", flat=True))
     if release_component_ids:
         triage_rows = (
             SBOM.objects.filter(component_id__in=release_component_ids, bom_type=SBOM.BomType.VEX, source=TRIAGE_SOURCE)


### PR DESCRIPTION
The aggregate SBOM download withholds a non-public component's inventory from an anonymous reader. The VEX download beside it did not.

A VEX statement names a package and a **pinned version**, so it disclosed through one door what the other refuses, on the same page. On staging, an anonymous caller got `pkg:pypi/django@5.2.3` and `pkg:pypi/urllib3@2.6.3` from a release whose inventory download returned zero components.

## It reached further than I reported

I filed this as a gated-component issue. It is not. The gate keyed on the **product** being public, so a public product's **private** components were published too.

The existing tests demonstrate it. `_release_with_components` created components without naming visibility, so they took the model default, which is `PRIVATE` — and `test_download_release_vex_public_returns_attachment` passed. It was asserting the published path while exercising data that should never have been published. Those two tests fail against this branch until the fixture names visibility explicitly, which is the clearest evidence of the bug I have.

## The change

`build_release_vex` takes `include_non_public`, applied to **both** halves of what it merges: the pinned VEX artifacts, and the in-app triage overlay that is gathered separately by component id. Missing the second would have left triage decisions published for withheld components.

The endpoint computes the flag exactly as `download_release` already does, so the two exports now answer the same caller the same way.

**The flag is part of the cache key.** Without that, one entry is shared between the two audiences and whichever build lands first is served to both. That is the disclosure, not a caching detail, so `test_the_two_audiences_do_not_share_a_cache_entry` runs the member first on purpose: that is the direction that leaks.

## Tests

Three new, all failing against the previous code and passing here:

- an anonymous reader gets 404 for a release whose only VEX belongs to a private or gated component, and the package name is absent from the body
- a member still gets it, since the rule is about the audience rather than hiding data from its owner
- the two audiences do not share a cache entry

`vulnerability_scanning` suite: 464 passed.

Closes #1534
