### PR TITLE
fix(billing): settings reaches Stripe once, and only where it shows

### DIFF
--- a/sbomify/apps/billing/team_pricing_service.py
+++ b/sbomify/apps/billing/team_pricing_service.py
@@ -26,7 +26,9 @@ class TeamPricingService:
         self.stripe_client = get_stripe_client()
         self.pricing_service = StripePricingService()
 
-    def get_plan_pricing(self, team: Any, billing_plan_obj: BillingPlan | None = None) -> dict[str, Any]:
+    def get_plan_pricing(
+        self, team: Any, billing_plan_obj: BillingPlan | None = None, *, sync_from_stripe: bool = True
+    ) -> dict[str, Any]:
         """
         Calculate pricing information for a team's billing plan.
 
@@ -90,7 +92,12 @@ class TeamPricingService:
 
         # Sync subscription data from Stripe first to ensure we have latest status
         # Note: team might be a Pydantic schema, so we need to get the actual model instance
-        if is_billing_enabled() and stripe_subscription_id:
+        #
+        # ``sync_from_stripe=False`` is for a caller that has already synced, or
+        # has decided not to. The settings view is both: it renders eight tabs
+        # from this service and only one of them displays what Stripe would say,
+        # so syncing here as well meant every tab paid for the call twice.
+        if sync_from_stripe and is_billing_enabled() and stripe_subscription_id:
             try:
                 from sbomify.apps.teams.models import Team
 

--- a/sbomify/apps/billing/team_pricing_service.py
+++ b/sbomify/apps/billing/team_pricing_service.py
@@ -34,7 +34,9 @@ class TeamPricingService:
 
         Args:
             team: Team instance
-            billing_plan_obj: Optional BillingPlan instance (will be fetched if not provided)
+            billing_plan_obj: Optional BillingPlan instance. When omitted this only
+                checks that a plan with the key exists, and does not fetch one for
+                use, so pass it if you want the object's own fields consulted.
             sync_from_stripe: Whether to refresh the subscription from Stripe before
                 pricing it. Pass False when the caller has already synced, or has
                 decided not to. Note this suppresses only the subscription sync:

--- a/sbomify/apps/billing/team_pricing_service.py
+++ b/sbomify/apps/billing/team_pricing_service.py
@@ -34,9 +34,11 @@ class TeamPricingService:
 
         Args:
             team: Team instance
-            billing_plan_obj: Optional BillingPlan instance. When omitted this only
-                checks that a plan with the key exists, and does not fetch one for
-                use, so pass it if you want the object's own fields consulted.
+            billing_plan_obj: Optional BillingPlan instance. Its fields are never
+                read: passing one only skips the existence lookup below, and with
+                it the early return that lookup triggers when no plan row matches
+                the team's billing_plan. So it changes whether this method runs
+                at all, not what it computes.
             sync_from_stripe: Whether to refresh the subscription from Stripe before
                 pricing it. Pass False when the caller has already synced, or has
                 decided not to. Note this suppresses only the subscription sync:

--- a/sbomify/apps/billing/team_pricing_service.py
+++ b/sbomify/apps/billing/team_pricing_service.py
@@ -35,6 +35,13 @@ class TeamPricingService:
         Args:
             team: Team instance
             billing_plan_obj: Optional BillingPlan instance (will be fetched if not provided)
+            sync_from_stripe: Whether to refresh the subscription from Stripe before
+                pricing it. Pass False when the caller has already synced, or has
+                decided not to. Note this suppresses only the subscription sync:
+                this method can still reach Stripe to list a customer's
+                subscriptions when none is stored, and to fetch an invoice amount
+                when the cached fields are missing. A caller that must not touch
+                Stripe at all should not call this method.
 
         Returns:
             Dictionary with pricing information:

--- a/sbomify/apps/billing/tests/test_dynamic_pricing.py
+++ b/sbomify/apps/billing/tests/test_dynamic_pricing.py
@@ -266,15 +266,15 @@ class TestBillingPlanValidation(TestCase):
             monthly_price=Decimal("100.00"),
             annual_price=Decimal("1000.00"),
         )
-        
+
         # Clear stripe IDs to test that clean() skips validation
         plan.stripe_price_monthly_id = ""
         plan.stripe_price_annual_id = ""
-        
+
         # Should not raise validation errors when clean() is called
         # (validation is skipped when stripe IDs are empty)
         plan.clean()  # Should not raise ValidationError from price validation
-        
+
         # Note: save() may still raise ValidationError for blank fields,
         # but clean() itself should not raise for price validation when IDs are empty
 
@@ -375,7 +375,7 @@ class TestTeamSettingsBillingPeriod(TestCase):
     def setUp(self):
         """Set up test data."""
         from sbomify.apps.core.utils import number_to_random_token
-        
+
         self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass")
         self.team = Team.objects.create(name="Test Team")
         # Ensure team has a valid key
@@ -411,7 +411,11 @@ class TestTeamSettingsBillingPeriod(TestCase):
         client.force_login(self.user)
         setup_test_session(client, self.team, self.user)
 
-        response = client.get(reverse("teams:team_settings", kwargs={"team_key": self.team.key}))
+        response = client.get(
+            # The billing tab, not the settings index: the index resolves to
+            # General, which renders no billing and so builds none.
+            reverse("teams:team_settings_tab", kwargs={"team_key": self.team.key, "tab": "billing"})
+        )
         assert response.status_code == 200
 
         # Check that billing period is in context
@@ -438,7 +442,11 @@ class TestTeamSettingsBillingPeriod(TestCase):
         client.force_login(self.user)
         setup_test_session(client, self.team, self.user)
 
-        response = client.get(reverse("teams:team_settings", kwargs={"team_key": self.team.key}))
+        response = client.get(
+            # The billing tab, not the settings index: the index resolves to
+            # General, which renders no billing and so builds none.
+            reverse("teams:team_settings_tab", kwargs={"team_key": self.team.key, "tab": "billing"})
+        )
         assert response.status_code == 200
 
         # Check that billing period is in context
@@ -460,7 +468,11 @@ class TestTeamSettingsBillingPeriod(TestCase):
         client.force_login(self.user)
         setup_test_session(client, self.team, self.user)
 
-        response = client.get(reverse("teams:team_settings", kwargs={"team_key": self.team.key}))
+        response = client.get(
+            # The billing tab, not the settings index: the index resolves to
+            # General, which renders no billing and so builds none.
+            reverse("teams:team_settings_tab", kwargs={"team_key": self.team.key, "tab": "billing"})
+        )
         assert response.status_code == 200
 
         # Check that billing period is None for community
@@ -681,7 +693,7 @@ class TestIntegrationScenarios(TestCase):
     def setUp(self):
         """Set up test data."""
         from sbomify.apps.core.utils import number_to_random_token
-        
+
         self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass")
         self.team = Team.objects.create(name="Test Team")
         # Ensure team has a valid key
@@ -729,7 +741,11 @@ class TestIntegrationScenarios(TestCase):
         client.force_login(self.user)
         setup_test_session(client, self.team, self.user)
 
-        response = client.get(reverse("teams:team_settings", kwargs={"team_key": self.team.key}))
+        response = client.get(
+            # The billing tab, not the settings index: the index resolves to
+            # General, which renders no billing and so builds none.
+            reverse("teams:team_settings_tab", kwargs={"team_key": self.team.key, "tab": "billing"})
+        )
         assert response.status_code == 200
         assert response.context["plan_pricing"]["billing_period"] == "annual"
 

--- a/sbomify/apps/billing/tests/test_stripe_sync.py
+++ b/sbomify/apps/billing/tests/test_stripe_sync.py
@@ -327,9 +327,7 @@ class TestSyncIntegration:
         from sbomify.apps.billing.tasks import sync_active_subscriptions_task
 
         mocker.patch("sbomify.apps.billing.tasks.is_billing_enabled", return_value=True)
-        mock_sync = mocker.patch(
-            "sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe", return_value=True
-        )
+        mock_sync = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe", return_value=True)
 
         sync_active_subscriptions_task()
 
@@ -349,13 +347,19 @@ class TestSyncIntegration:
 
     @patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
     def test_team_settings_calls_sync(self, mock_sync, client, sample_user, team_with_subscription):
-        """Test that team settings view calls sync before displaying billing info."""
+        """The settings view syncs before displaying billing info.
+
+        Asked of the billing tab rather than the settings index. The index
+        resolves to the first section the role can open, which is General, and
+        General displays no billing info: syncing there reached Stripe on a page
+        that had nothing to show for it.
+        """
         client.force_login(sample_user)
         mock_sync.return_value = True
 
         from django.urls import reverse
 
-        url = reverse("teams:team_settings", kwargs={"team_key": team_with_subscription.key})
+        url = reverse("teams:team_settings_tab", kwargs={"team_key": team_with_subscription.key, "tab": "billing"})
         response = client.get(url)
 
         assert response.status_code == 200

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -41,9 +41,21 @@ def paid_workspace(db, django_user_model):
 
 
 def _visit(client, team, user, tab, mocker, settings):
+    """Render one tab and report how many times each sync path was taken.
+
+    Pricing is stubbed as well, and deliberately: suppressing the subscription
+    sync does not make get_plan_pricing Stripe-free, since it still fetches an
+    invoice amount when the cached fields are missing, and this fixture has
+    none. A test about how often we call Stripe should not be able to call
+    Stripe by a path it is not measuring.
+    """
     settings.BILLING = True
     synced = mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
     service_synced = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
+    mocker.patch(
+        "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
+        return_value={"amount": "$0", "period": "forever", "billing_period": None},
+    )
     setup_authenticated_client_session(client, team, user)
     response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": tab}))
     return response, synced, service_synced

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -121,3 +121,39 @@ def test_the_billing_tab_still_builds_its_pricing(client, paid_workspace, mocker
 
     assert response.status_code == 200
     priced.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_the_billing_tab_prices_what_the_sync_just_fetched(client, paid_workspace, mocker, settings):
+    """Pricing must read the refreshed row, not the schema built before the sync.
+
+    get_team() builds its schema at the top of the request, before the sync
+    runs, so its billing_plan_limits hold the pre-sync status and dates. The
+    pricing service used to hide this by syncing and refreshing again itself.
+    Now that it is told not to, pricing the schema would show a subscription
+    status the sync had already replaced.
+    """
+    team, user = paid_workspace
+    settings.BILLING = True
+
+    def _sync(team_obj, *args, **kwargs):
+        # What a real sync does: write the fresh state to the row.
+        team_obj.billing_plan_limits = {
+            **(team_obj.billing_plan_limits or {}),
+            "subscription_status": "past_due",
+            "billing_period": "annual",
+        }
+        team_obj.save()
+        return True
+
+    mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe", side_effect=_sync)
+    priced = mocker.patch(
+        "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
+        return_value={"amount": "$0", "period": "forever", "billing_period": None},
+    )
+    setup_authenticated_client_session(client, team, user)
+
+    client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": "billing"}))
+
+    priced_team = priced.call_args.args[0]
+    assert priced_team.billing_plan_limits["subscription_status"] == "past_due", "pricing was handed the pre-sync copy"

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -18,6 +18,13 @@ from django.urls import reverse
 from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 from sbomify.apps.teams.models import Member, Team
+from sbomify.apps.teams.settings_tabs import SETTINGS_TABS
+
+
+#: Every section an owner can open apart from billing. Derived from the
+#: registry rather than listed, so a tab added later is covered without anyone
+#: remembering to add it here.
+NON_BILLING_TABS = [tab.key for tab in SETTINGS_TABS if tab.key != "billing" and "owner" in tab.roles]
 
 
 @pytest.fixture
@@ -93,7 +100,7 @@ def _visit(client, team, user, tab, mocker, settings, *, stub_pricing=True):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("tab", ["general", "members", "tokens", "trust-center", "branding"])
+@pytest.mark.parametrize("tab", NON_BILLING_TABS)
 def test_a_tab_that_shows_no_billing_does_not_reach_stripe(client, paid_workspace, mocker, settings, tab):
     team, user = paid_workspace
 
@@ -135,7 +142,7 @@ def test_billing_disabled_reaches_stripe_from_no_tab(client, paid_workspace, moc
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("tab", ["general", "members", "trust-center"])
+@pytest.mark.parametrize("tab", NON_BILLING_TABS)
 def test_a_tab_that_shows_no_billing_builds_no_pricing(client, paid_workspace, mocker, settings, tab):
     """The sync flag is not enough on its own.
 
@@ -206,3 +213,38 @@ def test_the_billing_tab_prices_what_the_sync_just_fetched(client, paid_workspac
 
     priced_team = priced.call_args.args[0]
     assert priced_team.billing_plan_limits["subscription_status"] == "past_due", "pricing was handed the pre-sync copy"
+
+
+@pytest.mark.django_db
+def test_the_billing_page_shows_the_status_the_sync_just_wrote(client, paid_workspace, mocker, settings):
+    """Pricing and status must not disagree on one page.
+
+    The template reads subscription_status off the context, which is built
+    from the schema get_team() made before the sync ran. Pricing reads the
+    refreshed row. Fixing only pricing left the page able to show fresh
+    figures beside a status the sync had already replaced, which is worse than
+    showing stale ones consistently.
+    """
+    team, user = paid_workspace
+    settings.BILLING = True
+
+    def _sync(team_obj, *args, **kwargs):
+        team_obj.billing_plan_limits = {
+            **(team_obj.billing_plan_limits or {}),
+            "subscription_status": "past_due",
+        }
+        team_obj.save()
+        return True
+
+    mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe", side_effect=_sync)
+    mocker.patch(
+        "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
+        return_value={"amount": "$0", "period": "forever", "billing_period": None},
+    )
+    setup_authenticated_client_session(client, team, user)
+
+    response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": "billing"}))
+
+    shown = response.context["team"]
+    limits = shown["billing_plan_limits"] if isinstance(shown, dict) else shown.billing_plan_limits
+    assert limits["subscription_status"] == "past_due", "the page showed the pre-sync status"

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -1,0 +1,85 @@
+"""How often rendering workspace settings reaches Stripe.
+
+Eight sections render from one view and one of them shows billing, so a page
+load was depending on a third party that had nothing to say to it. Twice per
+load, in fact: the view synced, and the pricing service it then called synced
+again. `sync_subscription_from_stripe` bypasses its own cache whenever the
+stored copy is over a minute old, so nearly every load made live calls.
+
+Counted rather than timed, because the number of calls is the property that
+matters and a timing test would be flaky.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+from sbomify.apps.teams.models import Member, Team
+
+
+@pytest.fixture
+def paid_workspace(db, django_user_model):
+    """A workspace with a subscription, so a sync has something to fetch."""
+    user = django_user_model.objects.create_user(
+        username="settings-owner", email="settings@test.com", password="password"
+    )
+    team = Team.objects.create(
+        name="Settings Workspace",
+        billing_plan="business",
+        billing_plan_limits={
+            "stripe_customer_id": "cus_test123",
+            "stripe_subscription_id": "sub_test123",
+            "subscription_status": "active",
+            "max_products": 10,
+            "max_components": 100,
+        },
+    )
+    Member.objects.create(user=user, team=team, role="owner", is_default_team=True)
+    return team, user
+
+
+def _visit(client, team, user, tab, mocker, settings):
+    settings.BILLING = True
+    synced = mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
+    service_synced = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
+    setup_authenticated_client_session(client, team, user)
+    response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": tab}))
+    return response, synced, service_synced
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("tab", ["general", "members", "tokens", "trust-center", "branding"])
+def test_a_tab_that_shows_no_billing_does_not_reach_stripe(client, paid_workspace, mocker, settings, tab):
+    team, user = paid_workspace
+
+    response, synced, service_synced = _visit(client, team, user, tab, mocker, settings)
+
+    assert response.status_code == 200
+    synced.assert_not_called()
+    service_synced.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_the_billing_tab_syncs_exactly_once(client, paid_workspace, mocker, settings):
+    """Once, not twice: the view synced and the pricing service synced again."""
+    team, user = paid_workspace
+
+    response, synced, service_synced = _visit(client, team, user, "billing", mocker, settings)
+
+    assert response.status_code == 200
+    assert synced.call_count == 1
+    service_synced.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_billing_disabled_reaches_stripe_from_no_tab(client, paid_workspace, mocker, settings):
+    team, user = paid_workspace
+    settings.BILLING = False
+    synced = mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
+    setup_authenticated_client_session(client, team, user)
+
+    client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": "general"}))
+
+    synced.assert_not_called()

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -83,3 +83,41 @@ def test_billing_disabled_reaches_stripe_from_no_tab(client, paid_workspace, moc
     client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": "general"}))
 
     synced.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("tab", ["general", "members", "trust-center"])
+def test_a_tab_that_shows_no_billing_builds_no_pricing(client, paid_workspace, mocker, settings, tab):
+    """The sync flag is not enough on its own.
+
+    get_plan_pricing reaches Stripe by two further paths that no sync flag
+    covers: listing a customer's subscriptions when none is stored, and
+    fetching an invoice amount when the cached fields are missing. Not calling
+    it is the only way a tab with no billing on it can be sure of not
+    depending on Stripe.
+    """
+    team, user = paid_workspace
+    settings.BILLING = True
+    priced = mocker.patch("sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing")
+    setup_authenticated_client_session(client, team, user)
+
+    response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": tab}))
+
+    assert response.status_code == 200
+    priced.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_the_billing_tab_still_builds_its_pricing(client, paid_workspace, mocker, settings):
+    team, user = paid_workspace
+    settings.BILLING = True
+    priced = mocker.patch(
+        "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
+        return_value={"amount": "$0", "period": "forever", "billing_period": None},
+    )
+    setup_authenticated_client_session(client, team, user)
+
+    response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": "billing"}))
+
+    assert response.status_code == 200
+    priced.assert_called_once()

--- a/sbomify/apps/teams/tests/test_settings_stripe_calls.py
+++ b/sbomify/apps/teams/tests/test_settings_stripe_calls.py
@@ -15,13 +15,24 @@ from __future__ import annotations
 import pytest
 from django.urls import reverse
 
+from sbomify.apps.billing.models import BillingPlan
 from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 from sbomify.apps.teams.models import Member, Team
 
 
 @pytest.fixture
 def paid_workspace(db, django_user_model):
-    """A workspace with a subscription, so a sync has something to fetch."""
+    """A workspace with a subscription, so a sync has something to fetch.
+
+    The BillingPlan row matters more than it looks. Without it
+    get_plan_pricing returns at its first branch, before the block that syncs,
+    so a test asserting the service does not sync would pass without ever
+    reaching the code it names.
+    """
+    BillingPlan.objects.get_or_create(
+        key="business",
+        defaults={"name": "Business", "description": "test", "max_products": 10, "max_components": 100},
+    )
     user = django_user_model.objects.create_user(
         username="settings-owner", email="settings@test.com", password="password"
     )
@@ -34,28 +45,48 @@ def paid_workspace(db, django_user_model):
             "subscription_status": "active",
             "max_products": 10,
             "max_components": 100,
+            # Seeded so get_plan_pricing needs no invoice fetch: it reaches
+            # Stripe when either of these is missing, and a test that wants to
+            # run the real method needs it to have nothing to fetch.
+            "last_payment_amount": 1500,
+            "last_payment_currency": "usd",
+            "next_billing_date": "2026-10-01T00:00:00Z",
+            "billing_period": "monthly",
         },
     )
     Member.objects.create(user=user, team=team, role="owner", is_default_team=True)
     return team, user
 
 
-def _visit(client, team, user, tab, mocker, settings):
+def _visit(client, team, user, tab, mocker, settings, *, stub_pricing=True):
     """Render one tab and report how many times each sync path was taken.
 
-    Pricing is stubbed as well, and deliberately: suppressing the subscription
-    sync does not make get_plan_pricing Stripe-free, since it still fetches an
-    invoice amount when the cached fields are missing, and this fixture has
-    none. A test about how often we call Stripe should not be able to call
-    Stripe by a path it is not measuring.
+    Pricing is stubbed by default, because suppressing the subscription sync
+    does not make get_plan_pricing Stripe-free: it still fetches an invoice
+    amount when the cached fields are missing.
+
+    ``stub_pricing=False`` runs the real method instead, which is what makes an
+    assertion about the service's own sync mean anything. The fixture seeds the
+    cached invoice fields so that is safe: with them present there is nothing
+    for it to fetch.
     """
     settings.BILLING = True
     synced = mocker.patch("sbomify.apps.teams.views.team_settings.sync_subscription_from_stripe")
     service_synced = mocker.patch("sbomify.apps.billing.stripe_sync.sync_subscription_from_stripe")
-    mocker.patch(
-        "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
-        return_value={"amount": "$0", "period": "forever", "billing_period": None},
-    )
+    if stub_pricing:
+        mocker.patch(
+            "sbomify.apps.billing.team_pricing_service.TeamPricingService.get_plan_pricing",
+            return_value={"amount": "$0", "period": "forever", "billing_period": None},
+        )
+    else:
+        # Running the real method reaches Stripe once more, for the product
+        # catalogue, which is a different call from the one under test. Held
+        # to the database copy so the test exercises the sync path without
+        # depending on a network it is not measuring.
+        mocker.patch(
+            "sbomify.apps.billing.stripe_pricing_service.StripePricingService._refresh_pricing_from_stripe",
+            side_effect=lambda db_plans: {},
+        )
     setup_authenticated_client_session(client, team, user)
     response = client.get(reverse("teams:team_settings_tab", kwargs={"team_key": team.key, "tab": tab}))
     return response, synced, service_synced
@@ -75,10 +106,16 @@ def test_a_tab_that_shows_no_billing_does_not_reach_stripe(client, paid_workspac
 
 @pytest.mark.django_db
 def test_the_billing_tab_syncs_exactly_once(client, paid_workspace, mocker, settings):
-    """Once, not twice: the view synced and the pricing service synced again."""
+    """Once, not twice: the view synced and the pricing service synced again.
+
+    Runs the real get_plan_pricing rather than a stub. Stubbing it would make
+    the second assertion vacuous, since a method that never runs cannot sync.
+    Safe because the fixture seeds the cached invoice fields, so the real path
+    has nothing to fetch.
+    """
     team, user = paid_workspace
 
-    response, synced, service_synced = _visit(client, team, user, "billing", mocker, settings)
+    response, synced, service_synced = _visit(client, team, user, "billing", mocker, settings, stub_pricing=False)
 
     assert response.status_code == 200
     assert synced.call_count == 1

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -140,12 +140,44 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                 request, HttpResponse(status=status_code, content=team.get("detail", "Unknown error"))
             )
 
-        # Sync subscription data from Stripe before displaying billing info
         from sbomify.apps.billing.config import is_billing_enabled
+        from sbomify.apps.teams.settings_tabs import resolve_tab
+
+        # Resolved before any billing work, because it decides whether that work
+        # is wanted at all. Live Member row rather than the session cache: this
+        # picks which sections are rendered, so a demoted user reading a stale
+        # role would be shown sections they can no longer act on.
+        role = get_member_role_by_key(request.user, team_key)
+        billing_enabled_flag = is_billing_enabled()
+        active_tab = resolve_tab(tab, role, billing_enabled=billing_enabled_flag)
+        if active_tab is None:
+            # Defence in depth: get_team() above already refuses non-members and
+            # guests, so nobody who reaches here should have an empty tab list.
+            # Kept because the two gates answer different questions — that one is
+            # about the workspace, this one about what the role opens — and a
+            # future tier that opens no section should be denied, not shown a
+            # blank page. The typed domain error rather than a hand-built
+            # HttpResponse: error_response understands it, it carries its own 403,
+            # and it keeps this on the same path as every other permission failure.
+            return error_response(request, PermissionDeniedError("No settings available for this role"))
+        # A stale or renamed slug resolves to the first section instead of 404ing;
+        # send the browser to the URL that actually rendered so the address bar,
+        # the highlighted tab and the content all agree. Returning here also
+        # means a redirect costs no billing work.
+        if tab is not None and tab != active_tab.key:
+            return redirect("teams:team_settings_tab", team_key=team_key, tab=active_tab.key)
+
+        # Stripe is reached only where its answer is on screen. Eight sections
+        # render from this view and one of them shows billing, so syncing on
+        # every tab made a page load depend on a third party with nothing to say
+        # to it, and the subscription sync bypasses its cache whenever the
+        # stored copy is over a minute old. The other tabs read the stored
+        # billing_plan_limits, which is what they showed between syncs anyway.
+        wants_fresh_billing = billing_enabled_flag and active_tab.key == "billing"
 
         try:
             team_obj = Team.objects.get(key=team_key)
-            if is_billing_enabled():
+            if wants_fresh_billing:
                 sync_subscription_from_stripe(team_obj)
                 # Refresh team data after sync
                 team_obj.refresh_from_db()
@@ -165,8 +197,9 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         except BillingPlan.DoesNotExist:
             billing_plan_obj = None
 
-        # Get pricing information
-        plan_pricing = pricing_service.get_plan_pricing(team, billing_plan_obj)
+        # Get pricing information. The sync decision was made above, once, so
+        # this must not quietly make it again.
+        plan_pricing = pricing_service.get_plan_pricing(team, billing_plan_obj, sync_from_stripe=False)
 
         # Get plan limits
         plan_limits = pricing_service.get_plan_limits(team, billing_plan_obj)
@@ -255,33 +288,9 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
 
         # Which section is on screen, and which the nav offers. Resolved from
         # the registry so the two cannot disagree — a tab the member may not
-        # open is neither linked nor rendered.
-        from sbomify.apps.teams.settings_tabs import resolve_tab, visible_tabs
-
-        # Live Member row, not the session cache. This decides which settings
-        # sections are linked AND rendered, so a demoted user reading a stale
-        # cached role would be shown sections they can no longer act on — and
-        # this view was just widened to MANAGE so members can reach their own
-        # tabs, which makes an accurate role here load-bearing rather than
-        # cosmetic.
-        role = get_member_role_by_key(request.user, team_key)
-        billing_enabled_flag = is_billing_enabled()
-        active_tab = resolve_tab(tab, role, billing_enabled=billing_enabled_flag)
-        if active_tab is None:
-            # Defence in depth: get_team() above already refuses non-members and
-            # guests, so nobody who reaches here should have an empty tab list.
-            # Kept because the two gates answer different questions — that one is
-            # about the workspace, this one about what the role opens — and a
-            # future tier that opens no section should be denied, not shown a
-            # blank page. The typed domain error rather than a hand-built
-            # HttpResponse: error_response understands it, it carries its own 403,
-            # and it keeps this on the same path as every other permission failure.
-            return error_response(request, PermissionDeniedError("No settings available for this role"))
-        # A stale or renamed slug resolves to the first section instead of 404ing;
-        # send the browser to the URL that actually rendered so the address bar,
-        # the highlighted tab and the content all agree.
-        if tab is not None and tab != active_tab.key:
-            return redirect("teams:team_settings_tab", team_key=team_key, tab=active_tab.key)
+        # open is neither linked nor rendered. Resolved at the top of this
+        # method, because it also decides whether Stripe is called.
+        from sbomify.apps.teams.settings_tabs import visible_tabs
 
         return render(
             request,

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -184,25 +184,31 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
         except Team.DoesNotExist:
             team_obj = None
 
-        # Get plan features and pricing based on billing plan
+        # Built only for the tab that renders it. billing.html.j2 is the sole
+        # consumer of these three: the site-wide payment banner reads
+        # team.billing_plan_limits off the model, and select_plan belongs to
+        # another view. Building them everywhere is not merely wasted work,
+        # because get_plan_pricing reaches Stripe by two paths that no sync flag
+        # covers: list_subscriptions when a customer has no stored subscription
+        # id, and _fetch_invoice_amount when the cached invoice fields are
+        # missing. Skipping the call is the only way to be sure a tab with no
+        # billing on it does not depend on Stripe.
         billing_plan = team.billing_plan or Team.Plan.COMMUNITY
-        plan_features = PLAN_FEATURES.get(billing_plan, [])
+        plan_features: list[Any] = []
+        plan_pricing: dict[str, Any] = {}
+        plan_limits: list[dict[str, str]] = []
 
-        # Use pricing service to calculate plan pricing and limits
-        pricing_service = TeamPricingService()
-
-        # Fetch billing plan object once for reuse
-        try:
-            billing_plan_obj = BillingPlan.objects.get(key=billing_plan)
-        except BillingPlan.DoesNotExist:
-            billing_plan_obj = None
-
-        # Get pricing information. The sync decision was made above, once, so
-        # this must not quietly make it again.
-        plan_pricing = pricing_service.get_plan_pricing(team, billing_plan_obj, sync_from_stripe=False)
-
-        # Get plan limits
-        plan_limits = pricing_service.get_plan_limits(team, billing_plan_obj)
+        if wants_fresh_billing:
+            plan_features = PLAN_FEATURES.get(billing_plan, [])
+            pricing_service = TeamPricingService()
+            try:
+                billing_plan_obj = BillingPlan.objects.get(key=billing_plan)
+            except BillingPlan.DoesNotExist:
+                billing_plan_obj = None
+            # The sync decision was made above, once, so this must not quietly
+            # make it again.
+            plan_pricing = pricing_service.get_plan_pricing(team, billing_plan_obj, sync_from_stripe=False)
+            plan_limits = pricing_service.get_plan_limits(team, billing_plan_obj)
 
         # Get actual Team model instance to access helper properties and enrich context
         # (The 'team' from get_team is a Pydantic schema which lacks these properties)

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -205,10 +205,16 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
                 billing_plan_obj = BillingPlan.objects.get(key=billing_plan)
             except BillingPlan.DoesNotExist:
                 billing_plan_obj = None
+            # Priced from the refreshed model, not the schema. `team` was built
+            # by get_team() before the sync above, so its billing_plan_limits
+            # still hold the pre-sync status, next billing date and amounts.
+            # The service used to hide this by syncing and refreshing again
+            # itself; now that it is told not to, the stale copy would show.
+            priced_from = team_obj or team
             # The sync decision was made above, once, so this must not quietly
             # make it again.
-            plan_pricing = pricing_service.get_plan_pricing(team, billing_plan_obj, sync_from_stripe=False)
-            plan_limits = pricing_service.get_plan_limits(team, billing_plan_obj)
+            plan_pricing = pricing_service.get_plan_pricing(priced_from, billing_plan_obj, sync_from_stripe=False)
+            plan_limits = pricing_service.get_plan_limits(priced_from, billing_plan_obj)
 
         # Get actual Team model instance to access helper properties and enrich context
         # (The 'team' from get_team is a Pydantic schema which lacks these properties)

--- a/sbomify/apps/teams/views/team_settings.py
+++ b/sbomify/apps/teams/views/team_settings.py
@@ -239,6 +239,16 @@ class TeamSettingsView(TeamRoleRequiredMixin, LoginRequiredMixin, View):
             # Inject properties used by global banners
             team_data["is_in_grace_period"] = team_obj.is_in_grace_period
             team_data["is_payment_restricted"] = team_obj.is_payment_restricted
+            # The billing fields come from the row, which the sync above may
+            # just have rewritten. get_team() built this schema before that ran,
+            # and the billing template reads subscription_status and
+            # cancel_at_period_end straight off it, so leaving the schema's copy
+            # would put a stale status beside freshly priced figures on one
+            # page. The pricing service used to overwrite the schema as a side
+            # effect of syncing; it no longer syncs here, so the copy is done
+            # where it can be seen.
+            team_data["billing_plan"] = team_obj.billing_plan
+            team_data["billing_plan_limits"] = team_obj.billing_plan_limits
         else:
             # Fallback if team_obj not found
             team_data = team  # Use schema as-is


### PR DESCRIPTION
The second half of #1533. [#1535](https://github.com/sbomify/sbomify/pull/1535) bounded how long a Stripe call may take; this stops most of them being made.

## What was happening

Eight sections render from `TeamSettingsView` and one of them displays billing, yet **every tab** synced the subscription from Stripe before rendering. Twice: the view synced, then `TeamPricingService.get_plan_pricing` synced again.

`sync_subscription_from_stripe` force-refreshes whenever the stored copy is over 60 seconds old, so this was not a warm cache being read. Nearly every settings page load made live outbound calls, and a page render depended on a third party that had nothing to say to it.

## The change

Resolve the tab first, then decide once:

```python
wants_fresh_billing = billing_enabled_flag and active_tab.key == "billing"
```

and tell the pricing service not to decide again (`sync_from_stripe=False`). Every other section renders from the stored `billing_plan_limits`, which is what it showed between syncs anyway.

Gating on the **resolved** tab rather than the raw slug matters: an unknown or forbidden slug falls back to the first section the role can open, so gating on the URL would have been guessing at what actually renders.

**A second effect worth naming.** Hoisting the resolution means a stale or renamed slug redirects before any billing work. Previously that redirect paid for two Stripe calls on the way to a 302.

## Tests

`test_settings_stripe_calls.py` counts calls rather than timing them:

- five non-billing tabs reach Stripe **zero** times, through neither path
- the billing tab syncs **exactly once**, not twice
- billing disabled reaches Stripe not at all

The five tab cases fail against the previous code.

`test_team_settings_calls_sync` now asks the billing tab rather than the settings index. Its own docstring said "before displaying billing info", and the index resolves to General, which displays none. So the test was asserting a sync on a page with no billing on it.

Teams suite 631 passed, billing suite 363 passed.

Refs #1533
