### PR TITLE
test(throttling): cover what happens when the throttle backend is down

### DIFF
--- a/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
+++ b/sbomify/apps/access_tokens/tests/test_anonymous_throttle.py
@@ -7,6 +7,8 @@ access-request POST, the OIDC exchange) had no limit of any kind.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from django.core.cache import cache
 from django.test import RequestFactory, override_settings
@@ -127,3 +129,66 @@ class TestEnforcement:
         limit, remaining, reset = request._access_token_ratelimit
         assert (limit, remaining) == (5, 4)
         assert reset > 0
+
+
+class TestTheBackendGoingDown:
+    """What a throttled request does when the throttle's cache is unreachable.
+
+    The `throttle` alias raises on a Redis failure deliberately, so a swallowed
+    error cannot read as an empty window and hand every caller a fresh budget
+    at the moment Redis being unwell suggests someone is hammering it. That
+    leaves this code responsible for turning the exception into a refusal.
+
+    None of it was covered. The comment in `allow_request` records what it cost
+    the first time: unwrapped, the exception surfaced as a 500 on every
+    throttled endpoint for the length of a blip, because ninja runs throttles
+    outside the handler that would otherwise catch it.
+    """
+
+    @staticmethod
+    def _unreachable(mocker):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        return mocker.patch(
+            "sbomify.apps.access_tokens.throttling.caches",
+            new={"throttle": mocker.Mock(get=mocker.Mock(side_effect=RedisConnectionError("down")))},
+        )
+
+    def test_a_refusal_rather_than_a_traceback(self, mocker):
+        """Returning False is the only safe refusal: anything raised here
+        bypasses ninja's exception handling and lands as a raw 500."""
+        self._unreachable(mocker)
+        throttle = AnonymousIPRateThrottle()
+
+        assert throttle.allow_request(_request()) is False
+
+    def test_the_caller_is_told_when_to_come_back(self, mocker):
+        self._unreachable(mocker)
+        throttle = AnonymousIPRateThrottle()
+
+        throttle.allow_request(_request())
+
+        assert throttle.wait() == 5.0
+
+    def test_the_outage_is_logged_once_per_window_not_once_per_request(self, mocker):
+        """The old 500 was the alert, so silence would hide the outage. A log
+        per refusal would replace one problem with a log storm."""
+        self._unreachable(mocker)
+        logged = mocker.patch("sbomify.apps.access_tokens.throttling.logger")
+        throttle = AnonymousIPRateThrottle()
+
+        for _ in range(5):
+            throttle.allow_request(_request())
+
+        assert logged.exception.call_count == 1
+
+    def test_the_token_throttle_refuses_the_same_way(self, mocker):
+        """Both throttles run on the same request, so one failing open would
+        undo the other."""
+        self._unreachable(mocker)
+        throttle = AccessTokenRateThrottle()
+        request = _request()
+        # The token throttle keys on the resolved row's pk, so it needs one.
+        request.access_token_record = SimpleNamespace(pk=1)
+
+        assert throttle.allow_request(request) is False


### PR DESCRIPTION
The throttle's cache alias raises on a Redis failure **by design**, so a swallowed error cannot read as an empty window and hand every caller a fresh budget at the moment Redis being unwell suggests someone is hammering it.

That leaves `allow_request` responsible for turning the exception into a refusal, and none of that was covered.

## What the uncovered code is worth

Its own comment records the cost the first time round:

> Unwrapped, this surfaced as a 500 on every throttled endpoint for the length of a Redis blip, with the trust-center release download the loudest.

and why the shape is what it is:

> Returning False is the only safe refusal: ninja runs throttles in `_run_checks`, OUTSIDE `Operation.run`'s try, so anything raised here bypasses every exception handler and lands as a raw 500.

So this is a fix with history and no test. A later simplification of that `except` would bring the 500s back silently.

## The cases

| Test | Holds |
| --- | --- |
| a refusal rather than a traceback | `allow_request` returns `False`, does not raise |
| the caller is told when to come back | `wait()` reports the outage `Retry-After` |
| logged once per window, not per request | the old 500 was the alert, so silence hides the outage and a log per refusal replaces it with a storm |
| the token throttle refuses the same way | both run on one request, so either failing open undoes the other |

Verified by letting the exception escape again: **all four fail**.

## Scope

Tests only. Covers the half of staging case H3c that does not need an actual outage. Actually making Redis unreachable also takes down sessions, the dramatiq broker and websockets, and stalls certificate issuance, so it stays a coordinated exercise.

`access_tokens` suite: 38 passed.
