### PR TITLE
fix(sboms): read the SPDX subject from the relationship Yocto actually writes

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -298,16 +298,20 @@ def _spdx2_described_ids(payload: SPDXSchema) -> list[str]:
     document_id = getattr(payload, "spdx_id", None) or "SPDXRef-DOCUMENT"
     described: list[str] = []
     # SPDXSchema is the lenient parser: it declares six fields and keeps the
-    # rest of the document as raw extras, so relationships arrive as dicts.
+    # rest of the document as raw extras, so relationships arrive as raw dicts
+    # holding whatever the uploader put there. Every value read out of one is
+    # checked before it is used as an ID: this list is compared against
+    # package.SPDXID, and a number or a nested object reaching that comparison
+    # would be a silent no-match rather than an error.
     for rel in getattr(payload, "relationships", None) or []:
         if not isinstance(rel, dict):
             continue
         rel_type = rel.get("relationshipType")
         source = rel.get("spdxElementId")
         target = rel.get("relatedSpdxElement")
-        if rel_type == "DESCRIBES" and source == document_id and target:
+        if rel_type == "DESCRIBES" and source == document_id and isinstance(target, str) and target:
             described.append(target)
-        elif rel_type == "DESCRIBED_BY" and target == document_id and source:
+        elif rel_type == "DESCRIBED_BY" and target == document_id and isinstance(source, str) and source:
             described.append(source)
     return described
 
@@ -328,14 +332,16 @@ def _extract_spdx2_primary_package(
 
     package: SPDXPackage | None = None
 
-    # Strategy 1: the documentDescribes shorthand
+    # Strategy 1: the documentDescribes shorthand. Read off the raw extras for
+    # the same reason as the relationships above, so its shape is checked too.
     document_describes = getattr(payload, "documentDescribes", None)
-    if document_describes:
-        described_ref: str = document_describes[0]
-        for pkg in payload.packages:
-            if getattr(pkg, "SPDXID", None) == described_ref:
-                package = pkg
-                break
+    if isinstance(document_describes, list) and document_describes:
+        described_ref = document_describes[0]
+        if isinstance(described_ref, str):
+            for pkg in payload.packages:
+                if getattr(pkg, "SPDXID", None) == described_ref:
+                    package = pkg
+                    break
 
     # Strategy 2: the relationship form of the same statement
     if not package:

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -289,7 +289,13 @@ def _spdx2_described_ids(payload: SPDXSchema) -> list[str]:
     back at it, states the same thing. Yocto writes the relationship form and
     never the shorthand, so a reader that only knows ``documentDescribes``
     sees no subject at all.
+
+    The document's own identifier comes from the document rather than from the
+    convention: ``SPDXRef-DOCUMENT`` is what every producer writes and what the
+    fallback assumes, but the schema types the field as a free string, so a
+    document that names itself otherwise still has its relationships read.
     """
+    document_id = getattr(payload, "spdx_id", None) or "SPDXRef-DOCUMENT"
     described: list[str] = []
     # SPDXSchema is the lenient parser: it declares six fields and keeps the
     # rest of the document as raw extras, so relationships arrive as dicts.
@@ -299,9 +305,9 @@ def _spdx2_described_ids(payload: SPDXSchema) -> list[str]:
         rel_type = rel.get("relationshipType")
         source = rel.get("spdxElementId")
         target = rel.get("relatedSpdxElement")
-        if rel_type == "DESCRIBES" and source == "SPDXRef-DOCUMENT" and target:
+        if rel_type == "DESCRIBES" and source == document_id and target:
             described.append(target)
-        elif rel_type == "DESCRIBED_BY" and target == "SPDXRef-DOCUMENT" and source:
+        elif rel_type == "DESCRIBED_BY" and target == document_id and source:
             described.append(source)
     return described
 

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -281,37 +281,77 @@ def _extract_spdx_primary_package(
     return _extract_spdx2_primary_package(payload)
 
 
+def _spdx2_described_ids(payload: SPDXSchema) -> list[str]:
+    """SPDX IDs the document declares as its subject, through relationships.
+
+    ``documentDescribes`` is the shorthand. The spec says a DESCRIBES
+    relationship from the document, or a DESCRIBED_BY relationship pointing
+    back at it, states the same thing. Yocto writes the relationship form and
+    never the shorthand, so a reader that only knows ``documentDescribes``
+    sees no subject at all.
+    """
+    described: list[str] = []
+    # SPDXSchema is the lenient parser: it declares six fields and keeps the
+    # rest of the document as raw extras, so relationships arrive as dicts.
+    for rel in getattr(payload, "relationships", None) or []:
+        if not isinstance(rel, dict):
+            continue
+        rel_type = rel.get("relationshipType")
+        source = rel.get("spdxElementId")
+        target = rel.get("relatedSpdxElement")
+        if rel_type == "DESCRIBES" and source == "SPDXRef-DOCUMENT" and target:
+            described.append(target)
+        elif rel_type == "DESCRIBED_BY" and target == "SPDXRef-DOCUMENT" and source:
+            described.append(source)
+    return described
+
+
 def _extract_spdx2_primary_package(
     payload: SPDXSchema,
 ) -> tuple[SPDXPackage, str] | tuple[None, str]:
     """Extract primary package from SPDX 2.x document.
 
-    Strategy:
-    1. Look for a package referenced by documentDescribes field
-    2. Fall back to matching package name with document name
+    Strategy, the same ladder the SPDX 3.0 reader already walks:
+    1. A package referenced by the documentDescribes field
+    2. A package named by a DESCRIBES or DESCRIBED_BY relationship
+    3. A package whose name matches the document name
+    4. The first package
     """
     if not payload.packages:
         return None, "No packages found in SPDX document"
 
     package: SPDXPackage | None = None
 
-    # First check if documentDescribes is present and points to a valid package
-    if hasattr(payload, "documentDescribes") and payload.documentDescribes:
-        described_ref: str = payload.documentDescribes[0]
+    # Strategy 1: the documentDescribes shorthand
+    document_describes = getattr(payload, "documentDescribes", None)
+    if document_describes:
+        described_ref: str = document_describes[0]
         for pkg in payload.packages:
-            if hasattr(pkg, "SPDXID") and pkg.SPDXID == described_ref:
+            if getattr(pkg, "SPDXID", None) == described_ref:
                 package = pkg
                 break
 
-    # If not found via documentDescribes, fall back to name matching
+    # Strategy 2: the relationship form of the same statement
+    if not package:
+        for described_id in _spdx2_described_ids(payload):
+            for pkg in payload.packages:
+                if getattr(pkg, "SPDXID", None) == described_id:
+                    package = pkg
+                    break
+            if package:
+                break
+
+    # Strategy 3: name match
     if not package:
         for pkg in payload.packages:
             if pkg.name == payload.name:
                 package = pkg
                 break
 
+    # Strategy 4: first package. A document that names no subject still carries
+    # an inventory worth storing, and the SPDX 3.0 reader has always taken it.
     if not package:
-        return None, f"No package found with name '{payload.name}' in SPDX document"
+        package = payload.packages[0]
 
     return package, ""
 

--- a/sbomify/apps/sboms/tests/test_spdx_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx_document_subject.py
@@ -203,6 +203,49 @@ class TestTheDocumentSubject:
         assert response.status_code == 201, response.json()
         assert SBOM.objects.get(id=response.json()["id"]).version == "1.0"
 
+    @pytest.mark.parametrize(
+        "relationships",
+        [
+            pytest.param([{"spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES"}], id="no-target"),
+            pytest.param(
+                [
+                    {
+                        "spdxElementId": "SPDXRef-DOCUMENT",
+                        "relationshipType": "DESCRIBES",
+                        "relatedSpdxElement": 42,
+                    }
+                ],
+                id="numeric-target",
+            ),
+            pytest.param(
+                [
+                    {
+                        "spdxElementId": "SPDXRef-DOCUMENT",
+                        "relationshipType": "DESCRIBES",
+                        "relatedSpdxElement": {"nested": "object"},
+                    }
+                ],
+                id="object-target",
+            ),
+            pytest.param(["not a relationship"], id="not-an-object"),
+        ],
+    )
+    def test_a_relationship_that_names_nothing_usable_falls_through(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+        relationships: list,
+    ) -> None:
+        """Relationships come off the lenient parser as raw dicts, so their
+        values are whatever the uploader wrote. None of these is an ID, and
+        none of them should reach the ID comparison."""
+        document = _document(name="openssl", relationships=relationships)
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
+
     def test_a_document_with_no_packages_is_still_rejected(
         self,
         sample_access_token: AccessToken,

--- a/sbomify/apps/sboms/tests/test_spdx_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx_document_subject.py
@@ -141,6 +141,44 @@ class TestTheDocumentSubject:
         assert response.status_code == 201, response.json()
         assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
 
+    def test_the_document_id_is_read_from_the_document(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        """SPDXRef-DOCUMENT is the convention, not a constraint the schema imposes."""
+        document = _document(
+            SPDXID="SPDXRef-recipe-openssl-doc",
+            relationships=[
+                {
+                    "spdxElementId": "SPDXRef-recipe-openssl-doc",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Recipe-openssl",
+                }
+            ],
+            packages=[
+                {
+                    "SPDXID": "SPDXRef-Download-openssl-1",
+                    "name": "openssl-source-1",
+                    "versionInfo": "0.0.0",
+                    "downloadLocation": "https://example.test/openssl-3.2.3.tar.gz",
+                    "filesAnalyzed": False,
+                },
+                {
+                    "SPDXID": "SPDXRef-Recipe-openssl",
+                    "name": "openssl",
+                    "versionInfo": "3.2.3",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                },
+            ],
+        )
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
+
     def test_a_document_that_names_no_subject_is_still_accepted(
         self,
         sample_access_token: AccessToken,

--- a/sbomify/apps/sboms/tests/test_spdx_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx_document_subject.py
@@ -1,0 +1,179 @@
+"""How an SPDX 2.x document says which package it is about.
+
+``documentDescribes`` is one way. A DESCRIBES relationship from the document
+is the other, and the SPDX 2.2 spec treats them as the same statement. Yocto
+writes only the relationship, and names the document after the recipe file
+rather than after the package, so a reader that knows only the shorthand and a
+name match rejects every document a Yocto build produces.
+"""
+
+import json
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+from sbomify.apps.sboms.models import SBOM
+
+
+def _document(**overrides):
+    """A minimal SPDX 2.2 document in the shape Yocto emits."""
+    doc = {
+        "spdxVersion": "SPDX-2.2",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "recipe-openssl",
+        "documentNamespace": "http://spdx.org/spdxdocs/recipe-openssl-0f2c1f0e",
+        "creationInfo": {
+            "created": "2026-01-01T00:00:00Z",
+            "creators": ["Tool: OpenEmbedded Core create-spdx.bbclass"],
+        },
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-Recipe-openssl",
+                "name": "openssl",
+                "versionInfo": "3.2.3",
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": False,
+            }
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _upload(client: Client, component: Component, token: AccessToken, document: dict):
+    url = reverse("api-1:sbom_upload_spdx", kwargs={"component_id": component.id})
+    return client.post(
+        url,
+        data=json.dumps(document),
+        content_type="application/json",
+        **get_api_headers(token),
+    )
+
+
+@pytest.mark.django_db
+class TestTheDocumentSubject:
+    @pytest.fixture(autouse=True)
+    def _clean(self, mocker):
+        mocker.patch("boto3.resource")
+        mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+        SBOM.objects.all().delete()
+
+    def test_a_describes_relationship_names_the_subject(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        """The document name matches no package, so only the relationship can resolve it."""
+        document = _document(
+            relationships=[
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Recipe-openssl",
+                }
+            ]
+        )
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
+
+    def test_the_relationship_is_read_in_either_direction(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        document = _document(
+            relationships=[
+                {
+                    "spdxElementId": "SPDXRef-Recipe-openssl",
+                    "relationshipType": "DESCRIBED_BY",
+                    "relatedSpdxElement": "SPDXRef-DOCUMENT",
+                }
+            ]
+        )
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
+
+    def test_the_named_subject_wins_over_the_first_package(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        """Yocto lists the source archive first; the recipe is the one described."""
+        document = _document(
+            packages=[
+                {
+                    "SPDXID": "SPDXRef-Download-openssl-1",
+                    "name": "openssl-source-1",
+                    "versionInfo": "0.0.0",
+                    "downloadLocation": "https://example.test/openssl-3.2.3.tar.gz",
+                    "filesAnalyzed": False,
+                },
+                {
+                    "SPDXID": "SPDXRef-Recipe-openssl",
+                    "name": "openssl",
+                    "versionInfo": "3.2.3",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                },
+            ],
+            relationships=[
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-Recipe-openssl",
+                }
+            ],
+        )
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "3.2.3"
+
+    def test_a_document_that_names_no_subject_is_still_accepted(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        """The Yocto image document: no documentDescribes, no relationships, no name match."""
+        document = _document(
+            name="core-image-minimal-qemux86-64.rootfs-20241109141548",
+            packages=[
+                {
+                    "SPDXID": "SPDXRef-Image-core-image-minimal",
+                    "name": "core-image-minimal",
+                    "versionInfo": "1.0",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": False,
+                }
+            ],
+        )
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 201, response.json()
+        assert SBOM.objects.get(id=response.json()["id"]).version == "1.0"
+
+    def test_a_document_with_no_packages_is_still_rejected(
+        self,
+        sample_access_token: AccessToken,
+        sample_component: Component,
+    ) -> None:
+        """The fallback accepts documents with an inventory, not documents without one."""
+        document = _document(packages=[])
+
+        response = _upload(Client(), sample_component, sample_access_token, document)
+
+        assert response.status_code == 400
+        assert "No packages found" in response.json()["detail"]


### PR DESCRIPTION
Part of #1506. This is the step before the scanning work in #1502 and #1503: a Yocto document has to get into the system before anything can scan it, and today it does not.

## What happens now

Downloaded the Yocto Project's own release artifacts for 5.0.5 (`core-image-minimal-qemux86-64`, scarthgap, SPDX 2.2) and uploaded them:

```
recipe-openssl.spdx.json          400  No package found with name 'recipe-openssl' in SPDX document
core-image-minimal-....spdx.json  400  No package found with name 'core-image-minimal-qemux86-64.rootfs-20241109141548'
```

Two different reasons, both from the same reader.

`_extract_spdx2_primary_package` knew two ways to find the package a document is about: the `documentDescribes` field, or a package whose `name` equals the document `name`. Yocto uses neither. It declares the subject with a `DESCRIBES` relationship, which the 2.2 spec treats as the same statement, and it names the document after the recipe file (`recipe-openssl`) while the package inside is `openssl`. The image document goes further and declares no subject at all: one package named `core-image-minimal` in a document named `core-image-minimal-qemux86-64.rootfs-20241109141548`.

## What changed

The SPDX 2.x reader now walks the ladder the SPDX 3.0 reader in the same file has always walked:

1. `documentDescribes`
2. a `DESCRIBES` or `DESCRIBED_BY` relationship
3. the name match
4. the first package

Steps 2 and 4 are new. Step 4 is what accepts the image document, and it is not a loosening so much as parity: `_extract_spdx3_primary_package` has taken the first package since it was written, so an SPDX 3 document with no declared subject already uploads and the 2.x equivalent did not.

Relationships arrive as raw dicts rather than the `Relationship` model, because SPDX 2.x parses through the lenient `SPDXSchema`, which declares six fields and keeps everything else as extras. Same reason `documentDescribes` is read with `getattr`.

## Scope

This is not Yocto-specific. Any SPDX 2.x producer that states its subject with a relationship instead of the deprecated field was being turned away; `documentDescribes` is deprecated as of 2.3, so the shape this rejected is the one the spec now prefers.

## Tests

Five, in `test_spdx_document_subject.py`, all in the shapes the real files have: the relationship names a package the document name does not, the reverse `DESCRIBED_BY` direction, the named subject beating the first package when Yocto lists the source archive first, the image document with no subject at all, and a document with no packages still refused.

Worth flagging: `test_spdx_2_3_with_relationships` already existed and passes on master, which reads as coverage for this. It is not. Its package name equals the document name, so the name match answers before the relationship is ever consulted. The new tests break that tie.

`sboms` suite green: 641 passed, 5 skipped.