### PR TITLE
fix(core): a scan every provider declined is not a clean scan

### DIFF
--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -1,9 +1,11 @@
 """The artifact page's vulnerability card, when every scanner declined.
 
 A skipped run contributes no vulnerabilities and zero severity counts, exactly
-as a clean scan does. It is not empty: it stores one status finding saying why
-it skipped, but that is a warning rather than a vulnerability, so it never
-reaches the numbers on the card. The internal tables already tell the two apart.
+as a clean scan does. The stored result is not empty: it carries bookkeeping of
+its own, a status finding naming the reason and the counts that go with it, and
+``metadata.skipped`` is what marks it. None of that bookkeeping is a
+vulnerability, so none of it reaches the numbers on the card. The internal
+tables already tell the two apart.
 The card at the top of the artifact page did not: it read the latest completed
 security runs whatever they were, so an SPDX 3 document that OSV and Dependency
 Track had both refused rendered as

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -131,6 +131,22 @@ class TestTheScanCard:
 
         assert self._summary(client, component, sbom) is None
 
+    def test_a_row_whose_skipped_column_never_got_written_is_still_read(
+        self, signed_in: tuple[Client, Component]
+    ) -> None:
+        """result_skipped is tri-state, and null means unknown.
+
+        The database filter cannot exclude those, so the result itself still
+        has to be read for them. A row predating the column must not slip
+        through as a scan.
+        """
+        client, component = signed_in
+        sbom = self._sbom(component)
+        run = _run(sbom, "osv", SKIPPED_RESULT)
+        AssessmentRun.objects.filter(pk=run.pk).update(result_skipped=None)
+
+        assert self._summary(client, component, sbom) is None
+
     def test_a_real_clean_scan_still_reports_zero(self, signed_in: tuple[Client, Component]) -> None:
         """Zero findings is a fact when something was actually examined."""
         client, component = signed_in

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -1,0 +1,113 @@
+"""The artifact page's vulnerability card, when every scanner declined.
+
+A skipped run stores zero findings exactly as a clean scan does. The internal
+tables already tell the two apart. The card at the top of the artifact page did
+not: it read the latest completed security runs whatever they were, so an SPDX 3
+document that OSV and Dependency Track had both refused rendered as
+
+    Vulnerability Scan  8 Sep 2026  DEPENDENCY-TRACK, OSV
+    0 total findings    0 CRITICAL  0 HIGH  0 MEDIUM  0 LOW
+
+which is what a clean scan looks like.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.teams.models import Member
+
+SKIPPED_RESULT: dict[str, Any] = {
+    "summary": {"total_findings": 1, "warning_count": 1},
+    "findings": [{"id": "osv:no-packages", "title": "No Packages Recognised", "severity": "info"}],
+    "metadata": {"scanner": "osv-scanner", "skipped": True, "no_packages": True},
+}
+CLEAN_RESULT: dict[str, Any] = {
+    "summary": {"total_findings": 0, "by_severity": {"critical": 0, "high": 0, "medium": 0, "low": 0}},
+    "findings": [],
+    "metadata": {"scanner": "osv-scanner"},
+}
+
+
+def _run(sbom: SBOM, plugin_name: str, result: dict[str, Any]) -> AssessmentRun:
+    return AssessmentRun.objects.create(
+        sbom=sbom,
+        plugin_name=plugin_name,
+        plugin_version="1.0.0",
+        category="security",
+        status="completed",
+        result=result,
+    )
+
+
+@pytest.mark.django_db
+class TestTheScanCard:
+    @pytest.fixture
+    def signed_in(self, sample_team_with_owner_member: Member) -> tuple[Client, Component]:
+        component = Component.objects.create(
+            team=sample_team_with_owner_member.team,
+            name="yocto-image",
+            component_type=Component.ComponentType.BOM,
+        )
+        client = Client()
+        setup_authenticated_client_session(
+            client, sample_team_with_owner_member.team, sample_team_with_owner_member.user
+        )
+        return client, component
+
+    @staticmethod
+    def _sbom(component: Component) -> SBOM:
+        return SBOM.objects.create(
+            component=component,
+            name="core-image-minimal",
+            format="spdx",
+            format_version="3.0.0",
+            version="1.0",
+            sbom_filename="x.json",
+        )
+
+    def _summary(self, client: Client, component: Component, sbom: SBOM):
+        url = reverse(
+            "core:component_item",
+            kwargs={"component_id": component.id, "item_type": "sboms", "item_id": sbom.id},
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        return response.context["vulnerability_summary"]
+
+    def test_every_scanner_skipping_leaves_no_scan_to_summarise(self, signed_in: tuple[Client, Component]) -> None:
+        client, component = signed_in
+        sbom = self._sbom(component)
+        _run(sbom, "osv", SKIPPED_RESULT)
+        _run(sbom, "dependency-track", SKIPPED_RESULT)
+
+        assert self._summary(client, component, sbom) is None
+
+    def test_a_real_clean_scan_still_reports_zero(self, signed_in: tuple[Client, Component]) -> None:
+        """Zero findings is a fact when something was actually examined."""
+        client, component = signed_in
+        sbom = self._sbom(component)
+        _run(sbom, "osv", CLEAN_RESULT)
+
+        summary = self._summary(client, component, sbom)
+        assert summary is not None
+        assert summary["total"] == 0
+        assert summary["provider"] == "osv"
+
+    def test_a_scanner_that_ran_is_not_hidden_by_one_that_skipped(self, signed_in: tuple[Client, Component]) -> None:
+        client, component = signed_in
+        sbom = self._sbom(component)
+        _run(sbom, "dependency-track", SKIPPED_RESULT)
+        _run(sbom, "osv", CLEAN_RESULT)
+
+        summary = self._summary(client, component, sbom)
+        assert summary is not None
+        assert summary["provider"] == "osv"

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -33,11 +33,31 @@ from sbomify.apps.plugins.sdk.enums import RunReason
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member
 
-SKIPPED_RESULT: dict[str, Any] = {
-    "summary": {"total_findings": 1, "warning_count": 1},
-    "findings": [{"id": "osv:no-packages", "title": "No Packages Recognised", "severity": "info"}],
-    "metadata": {"scanner": "osv-scanner", "skipped": True, "no_packages": True},
-}
+
+def _skipped(total_findings: int) -> dict[str, Any]:
+    """A skipped result as the plugins actually store one.
+
+    Two shapes are in production and the count is what differs.
+    ``build_single_finding_result`` in the SDK sets total_findings to 0 on
+    purpose, so a skip does not read as "1 finding"; OSV's no-packages skip
+    builds its own summary and sets 1. Both carry the status finding and
+    metadata.skipped, which is what this card reads, so both belong here.
+    """
+    return {
+        "summary": {"total_findings": total_findings, "warning_count": 1},
+        "findings": [
+            {
+                "id": "osv:no-packages",
+                "title": "No Packages Recognised",
+                "status": "warning",
+                "severity": "info",
+            }
+        ],
+        "metadata": {"scanner": "osv-scanner", "skipped": True, "no_packages": True},
+    }
+
+
+SKIPPED_RESULT: dict[str, Any] = _skipped(0)
 CLEAN_RESULT: dict[str, Any] = {
     "summary": {"total_findings": 0, "by_severity": {"critical": 0, "high": 0, "medium": 0, "low": 0}},
     "findings": [],
@@ -98,11 +118,16 @@ class TestTheScanCard:
         assert response.status_code == 200
         return response.context["vulnerability_summary"]
 
-    def test_every_scanner_skipping_leaves_no_scan_to_summarise(self, signed_in: tuple[Client, Component]) -> None:
+    @pytest.mark.parametrize("total_findings", [0, 1], ids=["sdk-shape", "osv-shape"])
+    def test_every_scanner_skipping_leaves_no_scan_to_summarise(
+        self, signed_in: tuple[Client, Component], total_findings: int
+    ) -> None:
+        """Both counts a skip is stored with. metadata.skipped is the marker,
+        and neither shape may reach the card."""
         client, component = signed_in
         sbom = self._sbom(component)
-        _run(sbom, "osv", SKIPPED_RESULT)
-        _run(sbom, "dependency-track", SKIPPED_RESULT)
+        _run(sbom, "osv", _skipped(total_findings))
+        _run(sbom, "dependency-track", _skipped(total_findings))
 
         assert self._summary(client, component, sbom) is None
 

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -13,6 +13,7 @@ which is what a clean scan looks like.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -37,8 +38,8 @@ CLEAN_RESULT: dict[str, Any] = {
 }
 
 
-def _run(sbom: SBOM, plugin_name: str, result: dict[str, Any]) -> AssessmentRun:
-    return AssessmentRun.objects.create(
+def _run(sbom: SBOM, plugin_name: str, result: dict[str, Any], created_at: datetime | None = None) -> AssessmentRun:
+    run = AssessmentRun.objects.create(
         sbom=sbom,
         plugin_name=plugin_name,
         plugin_version="1.0.0",
@@ -46,6 +47,11 @@ def _run(sbom: SBOM, plugin_name: str, result: dict[str, Any]) -> AssessmentRun:
         status="completed",
         result=result,
     )
+    if created_at is not None:
+        # created_at is auto_now_add, so it has to be written back.
+        AssessmentRun.objects.filter(pk=run.pk).update(created_at=created_at)
+        run.refresh_from_db()
+    return run
 
 
 @pytest.mark.django_db
@@ -101,6 +107,21 @@ class TestTheScanCard:
         assert summary is not None
         assert summary["total"] == 0
         assert summary["provider"] == "osv"
+
+    def test_the_date_comes_from_the_scan_it_reports_not_from_a_later_skip(
+        self, signed_in: tuple[Client, Component]
+    ) -> None:
+        """A skip that lands after a real scan must not lend it its timestamp."""
+        client, component = signed_in
+        sbom = self._sbom(component)
+        scanned_at = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+        _run(sbom, "osv", CLEAN_RESULT, created_at=scanned_at)
+        _run(sbom, "dependency-track", SKIPPED_RESULT, created_at=scanned_at + timedelta(days=3))
+
+        summary = self._summary(client, component, sbom)
+        assert summary is not None
+        assert summary["provider"] == "osv"
+        assert summary["scan_date"] == scanned_at
 
     def test_a_scanner_that_ran_is_not_hidden_by_one_that_skipped(self, signed_in: tuple[Client, Component]) -> None:
         client, component = signed_in

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -1,9 +1,12 @@
 """The artifact page's vulnerability card, when every scanner declined.
 
-A skipped run stores zero findings exactly as a clean scan does. The internal
-tables already tell the two apart. The card at the top of the artifact page did
-not: it read the latest completed security runs whatever they were, so an SPDX 3
-document that OSV and Dependency Track had both refused rendered as
+A skipped run contributes no vulnerabilities and zero severity counts, exactly
+as a clean scan does. It is not empty: it stores one status finding saying why
+it skipped, but that is a warning rather than a vulnerability, so it never
+reaches the numbers on the card. The internal tables already tell the two apart.
+The card at the top of the artifact page did not: it read the latest completed
+security runs whatever they were, so an SPDX 3 document that OSV and Dependency
+Track had both refused rendered as
 
     Vulnerability Scan  8 Sep 2026  DEPENDENCY-TRACK, OSV
     0 total findings    0 CRITICAL  0 HIGH  0 MEDIUM  0 LOW

--- a/sbomify/apps/core/tests/test_artifact_scan_card.py
+++ b/sbomify/apps/core/tests/test_artifact_scan_card.py
@@ -19,6 +19,7 @@ which is what a clean scan looks like.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from typing import Any
 
 import pytest
@@ -28,6 +29,7 @@ from django.urls import reverse
 from sbomify.apps.core.models import Component
 from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
 from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.plugins.sdk.enums import RunReason
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member
 
@@ -48,7 +50,9 @@ def _run(sbom: SBOM, plugin_name: str, result: dict[str, Any], created_at: datet
         sbom=sbom,
         plugin_name=plugin_name,
         plugin_version="1.0.0",
+        plugin_config_hash=sha256(plugin_name.encode()).hexdigest(),
         category="security",
+        run_reason=RunReason.ON_UPLOAD.value,
         status="completed",
         result=result,
     )

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -253,8 +253,10 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 )
                 # A skipped run contributes no vulnerabilities and zero
                 # severity counts for the opposite reason a clean one does:
-                # nothing was examined. The status finding it stores saying why
-                # is a warning, so it never reaches these numbers either.
+                # nothing was examined. It is not an empty result. It carries
+                # bookkeeping of its own, a status finding naming the reason
+                # and the counts that go with it, but none of that is a
+                # vulnerability and none of it reaches these numbers.
                 # Counting such a run here put "0 total findings" and a scan
                 # date above a Yocto SBOM whose two scanners had both declined
                 # it, which reads as a clean bill of health on a build nothing

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -251,6 +251,13 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     .distinct("plugin_name")
                     .values_list("id", flat=True)
                 )
+                # Excluded in the database, not in Python: result can be
+                # multi-megabyte and TOASTed, and result_skipped exists as a
+                # denormalised copy so a reader can tell a skip apart without
+                # fetching the blob. Filtering here would have pulled every
+                # blob only to discard it, which is worst in exactly the case
+                # this fixes, where every run is a skip.
+                #
                 # A skipped run contributes no vulnerabilities and zero
                 # severity counts for the opposite reason a clean one does:
                 # nothing was examined. It is not an empty result. It carries
@@ -264,9 +271,14 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 # summarise.
                 provider_runs = [
                     (name, result, created_at)
-                    for name, result, created_at in AssessmentRun.objects.filter(id__in=winner_ids).values_list(
-                        "plugin_name", "result", "created_at"
-                    )
+                    for name, result, created_at in AssessmentRun.objects.filter(id__in=winner_ids)
+                    .exclude(result_skipped=True)
+                    .values_list("plugin_name", "result", "created_at")
+                    # result_skipped is tri-state and null means "unknown", so
+                    # a row written before the column existed still gets read
+                    # properly here. Only rows the database kept reach this,
+                    # and their result is needed for the counts regardless, so
+                    # the second check costs nothing.
                     if not result_scanned_nothing(result)
                 ]
                 merged = merge_findings_by_alias([result for _, result, _ in provider_runs])

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -258,13 +258,13 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 # a clean bill of health on a build nothing looked at. Every
                 # run skipped means there is no scan to summarise.
                 provider_runs = [
-                    (name, result)
-                    for name, result in AssessmentRun.objects.filter(id__in=winner_ids).values_list(
-                        "plugin_name", "result"
+                    (name, result, created_at)
+                    for name, result, created_at in AssessmentRun.objects.filter(id__in=winner_ids).values_list(
+                        "plugin_name", "result", "created_at"
                     )
                     if not result_scanned_nothing(result)
                 ]
-                merged = merge_findings_by_alias([result for _, result in provider_runs])
+                merged = merge_findings_by_alias([result for _, result, _ in provider_runs])
                 rows = extract_finding_rows(merged, load_vex_suppressions(component_id_from_item))
                 if rows:
                     counts = {
@@ -279,15 +279,20 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     from sbomify.apps.vulnerability_scanning.utils import extract_severity_counts
 
                     counts = max(
-                        (extract_severity_counts(result) for _, result in provider_runs),
+                        (extract_severity_counts(result) for _, result, _ in provider_runs),
                         key=lambda c: c["total"],
                         default={"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0},
                     )
                 if provider_runs:
+                    # Dated from the runs the card is actually reporting. Taking
+                    # latest_scan here would stamp a provider that scanned with
+                    # the time a later provider declined, so the card would read
+                    # as "scanned then, found nothing" for a moment when nothing
+                    # was scanned.
                     vulnerability_summary = {
                         **counts,
-                        "provider": ", ".join(sorted({name for name, _ in provider_runs})),
-                        "scan_date": latest_scan.created_at,
+                        "provider": ", ".join(sorted({name for name, _, _ in provider_runs})),
+                        "scan_date": max(created_at for _, _, created_at in provider_runs),
                     }
 
             # Get assessment runs for this SBOM

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -251,12 +251,15 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     .distinct("plugin_name")
                     .values_list("id", flat=True)
                 )
-                # A skipped run completes with no findings for the opposite
-                # reason a clean one does: nothing was examined. Counting it
-                # here put "0 total findings" and a scan date above a Yocto
-                # SBOM whose two scanners had both declined it, which reads as
-                # a clean bill of health on a build nothing looked at. Every
-                # run skipped means there is no scan to summarise.
+                # A skipped run contributes no vulnerabilities and zero
+                # severity counts for the opposite reason a clean one does:
+                # nothing was examined. The status finding it stores saying why
+                # is a warning, so it never reaches these numbers either.
+                # Counting such a run here put "0 total findings" and a scan
+                # date above a Yocto SBOM whose two scanners had both declined
+                # it, which reads as a clean bill of health on a build nothing
+                # looked at. Every run skipped means there is no scan to
+                # summarise.
                 provider_runs = [
                     (name, result, created_at)
                     for name, result, created_at in AssessmentRun.objects.filter(id__in=winner_ids).values_list(

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -238,6 +238,7 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 from sbomify.apps.vulnerability_scanning.utils import (
                     extract_finding_rows,
                     merge_findings_by_alias,
+                    result_scanned_nothing,
                 )
                 from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
 
@@ -250,9 +251,19 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     .distinct("plugin_name")
                     .values_list("id", flat=True)
                 )
-                provider_runs = list(
-                    AssessmentRun.objects.filter(id__in=winner_ids).values_list("plugin_name", "result")
-                )
+                # A skipped run completes with no findings for the opposite
+                # reason a clean one does: nothing was examined. Counting it
+                # here put "0 total findings" and a scan date above a Yocto
+                # SBOM whose two scanners had both declined it, which reads as
+                # a clean bill of health on a build nothing looked at. Every
+                # run skipped means there is no scan to summarise.
+                provider_runs = [
+                    (name, result)
+                    for name, result in AssessmentRun.objects.filter(id__in=winner_ids).values_list(
+                        "plugin_name", "result"
+                    )
+                    if not result_scanned_nothing(result)
+                ]
                 merged = merge_findings_by_alias([result for _, result in provider_runs])
                 rows = extract_finding_rows(merged, load_vex_suppressions(component_id_from_item))
                 if rows:
@@ -272,11 +283,12 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                         key=lambda c: c["total"],
                         default={"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0},
                     )
-                vulnerability_summary = {
-                    **counts,
-                    "provider": ", ".join(sorted({name for name, _ in provider_runs})),
-                    "scan_date": latest_scan.created_at,
-                }
+                if provider_runs:
+                    vulnerability_summary = {
+                        **counts,
+                        "provider": ", ".join(sorted({name for name, _ in provider_runs})),
+                        "scan_date": latest_scan.created_at,
+                    }
 
             # Get assessment runs for this SBOM
             try:


### PR DESCRIPTION
Part of #1506. Found while testing the Yocto path on staging with the Yocto Project's own 5.1.4 release SBOM for `core-image-minimal-qemux86-64`.

## What the page showed

Both scanners refused the document. The page said this, at the top:

```
Vulnerability Scan   8 Sep 2026   DEPENDENCY-TRACK, OSV
0 total findings     0 CRITICAL   0 HIGH   0 MEDIUM   0 LOW
```

and this, further down, under Plugin Results:

```
Dependency Track        Skipped   Format Not Supported
OSV Vulnerability Scanner  Skipped   SPDX 3.0 Not Supported
```

A scan date, both provider names, and four zeroes is what a clean scan looks like. Nothing was examined.

## Why the card was the only place still doing this

`result_scanned_nothing` already exists for exactly this, and the artifact table already uses it, which is why the same artifact reads **Nothing scanned** one page up. The card was built from `AssessmentRun` rows filtered on `category="security", status="completed"` alone, and a skipped run is completed and carries no findings, so it fell straight through into the counts.

The card now filters through the same predicate. When every provider skipped, `provider_runs` is empty, there is no scan to summarise, and the card does not render; the plugin results below are the only account, and they say why. A provider that did run is unaffected by one that skipped beside it.

## Scope

Not Yocto-specific and not fixed by the conversion work in #1502 and #1503. Those make the scan happen for documents a scanner can be made to read. Anything genuinely unscannable still produces a skip, and that skip is what this stops presenting as a pass.

## Tests

Three, in `test_artifact_scan_card.py`, driving the real view:

- both providers skipped, no summary
- a real clean scan still reports zero, because zero is a fact when something was examined
- one provider skipping does not hide the one that ran

The first and third fail on master; the second passes either way and is there to keep the fix from swallowing real clean scans.

`core` suite: 3590 passed. The 9 failures in `test_additional_packages_purls.py` are on master too, unrelated to this.