### PR TITLE
fix(sboms): an SPDX upload that fails on our side leaves a record

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -814,6 +814,13 @@ def sbom_upload_spdx(request: HttpRequest, component_id: str, bom_type: str = "s
         return 201, {"id": sbom.id}
 
     except Exception:
+        # Logged for the same reason the CycloneDX and VEX handlers beside this
+        # one log: everything reaching here becomes one opaque "Invalid
+        # request", and without a record there is nothing to tell a malformed
+        # document apart from a fault on our side. A missing jsonschema in the
+        # SPDX 3 validator surfaced as exactly that 400, with no trace of the
+        # ImportError anywhere.
+        log.exception("Error processing SPDX BOM upload")
         return 400, {"detail": "Invalid request"}
 
 

--- a/sbomify/apps/sboms/tests/test_spdx_upload_failure_is_logged.py
+++ b/sbomify/apps/sboms/tests/test_spdx_upload_failure_is_logged.py
@@ -45,7 +45,6 @@ def test_a_failure_inside_the_handler_is_logged(
     sample_access_token: AccessToken,
     sample_component: Component,
     mocker,
-    caplog,
 ) -> None:
     mocker.patch("boto3.resource")
     mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
@@ -69,4 +68,6 @@ def test_a_failure_inside_the_handler_is_logged(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid request"
-    logger.exception.assert_called_once()
+    # The message too, not just the call: a handler that logs something else
+    # while still reaching .exception() would leave the same gap this closes.
+    logger.exception.assert_called_once_with("Error processing SPDX BOM upload")

--- a/sbomify/apps/sboms/tests/test_spdx_upload_failure_is_logged.py
+++ b/sbomify/apps/sboms/tests/test_spdx_upload_failure_is_logged.py
@@ -1,0 +1,72 @@
+"""An SPDX upload that fails for our reasons leaves a record.
+
+Everything the handler raises becomes one opaque ``400 Invalid request``. The
+CycloneDX and VEX handlers next to it log before returning that; the SPDX one
+did not, so a fault on our side was indistinguishable from a malformed document
+and left nothing behind to find it by. A missing jsonschema in the SPDX 3
+validator surfaced as exactly that 400, silently.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.access_tokens.models import AccessToken
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.tests.shared_fixtures import get_api_headers
+from sbomify.apps.sboms.models import SBOM
+
+DOCUMENT = {
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "openssl",
+    "documentNamespace": "https://example.test/openssl",
+    "creationInfo": {"created": "2026-01-01T00:00:00Z", "creators": ["Tool: test"]},
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package",
+            "name": "openssl",
+            "versionInfo": "3.2.3",
+            "downloadLocation": "NOASSERTION",
+            "filesAnalyzed": False,
+        }
+    ],
+}
+
+
+@pytest.mark.django_db
+def test_a_failure_inside_the_handler_is_logged(
+    sample_access_token: AccessToken,
+    sample_component: Component,
+    mocker,
+    caplog,
+) -> None:
+    mocker.patch("boto3.resource")
+    mocker.patch("sbomify.apps.core.object_store.S3Client.upload_data_as_file")
+    SBOM.objects.all().delete()
+
+    url = reverse("api-1:sbom_upload_spdx", kwargs={"component_id": sample_component.id})
+
+    # Stands in for any fault on our side, which is what the silent branch hid:
+    # the real one was a missing jsonschema inside the SPDX 3 validator.
+    with patch(
+        "sbomify.apps.sboms.apis.validate_spdx_sbom",
+        side_effect=ModuleNotFoundError("No module named 'jsonschema'"),
+    ):
+        with patch("sbomify.apps.sboms.apis.log") as logger:
+            response = Client().post(
+                url,
+                data=json.dumps(DOCUMENT),
+                content_type="application/json",
+                **get_api_headers(sample_access_token),
+            )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid request"
+    logger.exception.assert_called_once()


### PR DESCRIPTION
Part of #1506, found while testing the current Yocto release.

## What happened

Uploaded the Yocto Project's 6.0.3 release SBOM for `core-image-minimal`. It came back:

```
400 {"detail": "Invalid request", "error_code": "BAD_REQUEST"}
```

The document is valid. The real error was a `ModuleNotFoundError: No module named 'jsonschema'` inside the SPDX 3 validator, which imports it lazily so nothing fails until an SPDX 3 document arrives. The only way to see that was to run the validator by hand in a shell, because the handler ends in:

```python
    except Exception:
        return 400, {"detail": "Invalid request"}
```

No log line. Nothing for Sentry. A fault on our side and a malformed document are indistinguishable to anyone reading the logs, and identical to the caller.

## What changed

One `log.exception`, matching the two handlers on either side of it. `sbom_upload_cyclonedx` logs "Error processing CycloneDX BOM upload" and the VEX handler logs "Error processing VEX upload" before returning the same 400; this one was the odd one out.

## What did not change

The status. The same branch still catches genuinely malformed documents, where 400 is right. Telling those apart from faults on our side means catching the validation exceptions by name and letting everything else 500, which is a real improvement and a larger change than making the failure visible. Worth doing separately if we want it.

## Test

`test_spdx_upload_failure_is_logged.py` drives the endpoint with `validate_spdx_sbom` raising the same `ModuleNotFoundError` that caused this, and asserts the 400 still comes back and `log.exception` was called. Fails on master.