### PR TITLE
fix(sboms): follow an SPDX 3 document that roots itself on its Sbom

### DIFF
--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -330,7 +330,12 @@ def _spdx3_bom_roots(graph: Any, root_element_ids: set[str]) -> set[str]:
         elem_type = element.get("type", element.get("@type", ""))
         if not isinstance(elem_type, str) or "Sbom" not in elem_type:
             continue
-        if element.get("spdxId", element.get("@id", "")) not in root_element_ids:
+        element_id = element.get("spdxId", element.get("@id", ""))
+        # Checked for str before the set lookup, not for tidiness: a list or a
+        # dict here is unhashable and `in` against a set raises TypeError, so a
+        # producer emitting `spdxId: []` would crash extraction on a path whose
+        # whole design is to fall through to the next strategy.
+        if not isinstance(element_id, str) or element_id not in root_element_ids:
             continue
         nested = element.get("rootElement") or []
         if isinstance(nested, str):

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -316,6 +316,31 @@ def _extract_spdx2_primary_package(
     return package, ""
 
 
+def _spdx3_bom_roots(graph: Any, root_element_ids: set[str]) -> set[str]:
+    """The rootElements of any Sbom the document roots itself on.
+
+    One hop only. An Sbom's rootElement names what the BOM is about, so
+    resolving it is reading the document as written rather than guessing;
+    following further would be walking a graph the caller has not asked about.
+    """
+    roots: set[str] = set()
+    for element in graph if isinstance(graph, list) else []:
+        if not isinstance(element, dict):
+            continue
+        elem_type = element.get("type", element.get("@type", ""))
+        if not isinstance(elem_type, str) or "Sbom" not in elem_type:
+            continue
+        if element.get("spdxId", element.get("@id", "")) not in root_element_ids:
+            continue
+        nested = element.get("rootElement") or []
+        if isinstance(nested, str):
+            nested = [nested]
+        if not isinstance(nested, list):
+            continue
+        roots.update(r for r in nested if isinstance(r, str) and r)
+    return roots
+
+
 def _extract_spdx3_primary_package(
     payload: SPDX3Schema,
 ) -> tuple[SPDX3Package, str] | tuple[None, str]:
@@ -323,7 +348,8 @@ def _extract_spdx3_primary_package(
 
     Strategy:
     1. Follow the SpdxDocument's rootElement — how SPDX 3 declares the BOM
-       subject
+       subject — and, where that names a BOM rather than a package, the
+       rootElement of that BOM
     2. Find a 'describes' relationship and use its target package (SPDX 2
        idiom some producers still write)
     3. Fall back to matching package name with document name
@@ -340,6 +366,13 @@ def _extract_spdx3_primary_package(
     from sbomify.apps.plugins.builtins._spdx_shared import spdx3_document_subjects
 
     _, root_element_ids = spdx3_document_subjects({"@graph": payload.graph})
+    # A document is free to root itself on its Sbom rather than straight onto
+    # the thing the Sbom is about, and Yocto does: SpdxDocument.rootElement
+    # names a software_Sbom, and that element's own rootElement names the
+    # image. Stopping at the first hop found no package and dropped through to
+    # the last resort, which labelled a whole image with the version of
+    # whichever package happened to serialise first.
+    root_element_ids |= _spdx3_bom_roots(payload.graph, root_element_ids)
     for pkg in packages:
         if pkg.spdx_id and pkg.spdx_id in root_element_ids:
             package = pkg

--- a/sbomify/apps/sboms/apis.py
+++ b/sbomify/apps/sboms/apis.py
@@ -316,6 +316,11 @@ def _extract_spdx2_primary_package(
     return package, ""
 
 
+#: Every spelling of the Sbom element type: the spec's underscore compact form
+#: and the bare name a full or compact IRI reduces to.
+_SBOM_TYPE_NAMES = frozenset({"software_Sbom", "Sbom"})
+
+
 def _spdx3_bom_roots(graph: Any, root_element_ids: set[str]) -> set[str]:
     """The rootElements of any Sbom the document roots itself on.
 
@@ -328,7 +333,12 @@ def _spdx3_bom_roots(graph: Any, root_element_ids: set[str]) -> set[str]:
         if not isinstance(element, dict):
             continue
         elem_type = element.get("type", element.get("@type", ""))
-        if not isinstance(elem_type, str) or "Sbom" not in elem_type:
+        if not isinstance(elem_type, str):
+            continue
+        # Matched on the bare name rather than by substring: an element type
+        # arrives as a full IRI, a compact IRI or the underscore form, and a
+        # substring test says yes to anything merely containing the word.
+        if elem_type.rsplit("/", 1)[-1].rsplit(":", 1)[-1] not in _SBOM_TYPE_NAMES:
             continue
         element_id = element.get("spdxId", element.get("@id", ""))
         # Checked for str before the set lookup, not for tidiness: a list or a

--- a/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
@@ -1,0 +1,109 @@
+"""Which package an SPDX 3 document is about, when it roots itself on its Sbom.
+
+SPDX 3 lets a document point rootElement at the Sbom rather than straight at
+the thing the Sbom describes, and Yocto does exactly that: SpdxDocument
+rootElement names a software_Sbom, and that element's own rootElement names the
+image. Reading only the first hop found no package and fell through to "take
+the first one", which labelled a whole OS image with the version of whichever
+recipe happened to serialise first.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sbomify.apps.sboms.apis import _extract_spdx_primary_package
+from sbomify.apps.sboms.schemas import validate_spdx_sbom
+
+DOC = "https://example.test/spdxdocs/image"
+SBOM_ID = "https://example.test/spdxdocs/image/sbom"
+IMAGE = "https://example.test/spdxdocs/image/rootfs/core-image-minimal"
+DECOY = "https://example.test/spdxdocs/acl/package/acl"
+
+
+AGENT = "https://example.test/agent/openembedded"
+
+
+def _document(*, root: str, sbom_root: str | None = None) -> dict[str, Any]:
+    graph: list[dict[str, Any]] = [
+        {
+            "type": "CreationInfo",
+            "@id": "_:c1",
+            "specVersion": "3.0.1",
+            "created": "2026-08-19T09:11:34Z",
+            "createdBy": [AGENT],
+        },
+        {"type": "Organization", "spdxId": AGENT, "creationInfo": "_:c1", "name": "OpenEmbedded"},
+        {
+            "type": "SpdxDocument",
+            "spdxId": DOC,
+            "creationInfo": "_:c1",
+            "name": "core-image-minimal-qemux86-64.rootfs-20260819091134",
+            "rootElement": [root],
+        },
+        # Serialised first, exactly as Yocto orders it, so a first-package
+        # fallback picks this one.
+        {
+            "type": "software_Package",
+            "spdxId": DECOY,
+            "creationInfo": "_:c1",
+            "name": "acl",
+            "software_packageVersion": "2.3.2",
+        },
+        {
+            "type": "software_Package",
+            "spdxId": IMAGE,
+            "creationInfo": "_:c1",
+            "name": "core-image-minimal",
+            "software_packageVersion": "1.0",
+        },
+    ]
+    if sbom_root is not None:
+        graph.append(
+            {
+                "type": "software_Sbom",
+                "spdxId": SBOM_ID,
+                "creationInfo": "_:c1",
+                "software_sbomType": ["build"],
+                "rootElement": [sbom_root],
+            }
+        )
+    return {"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": graph}
+
+
+def _primary(document: dict[str, Any]):
+    payload, _ = validate_spdx_sbom(document)
+    package, error = _extract_spdx_primary_package(payload)
+    assert error == "", error
+    return package
+
+
+class TestTheDeclaredSubject:
+    def test_a_document_rooted_on_its_sbom_resolves_through_it(self) -> None:
+        package = _primary(_document(root=SBOM_ID, sbom_root=IMAGE))
+
+        assert package.name == "core-image-minimal"
+
+    def test_a_document_rooted_straight_on_the_package_still_works(self) -> None:
+        package = _primary(_document(root=IMAGE))
+
+        assert package.name == "core-image-minimal"
+
+    def test_an_sbom_root_pointing_at_nothing_falls_through(self) -> None:
+        """Still returns a package, just not one the document managed to name."""
+        package = _primary(_document(root=SBOM_ID, sbom_root="https://example.test/nothing-here"))
+
+        assert package is not None
+
+    def test_a_root_that_is_not_an_sbom_at_all_is_not_followed(self) -> None:
+        """The document roots on something that is neither package nor Sbom."""
+        package = _primary(_document(root=AGENT))
+
+        assert package is not None
+
+    def test_an_sbom_the_document_does_not_root_on_is_not_followed(self) -> None:
+        """Only the Sbom the document points at gets resolved, not every Sbom
+        in the graph."""
+        document = _document(root=IMAGE, sbom_root=DECOY)
+
+        assert _primary(document).name == "core-image-minimal"

--- a/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from sbomify.apps.sboms.apis import _extract_spdx_primary_package
-from sbomify.apps.sboms.schemas import validate_spdx_sbom
+from sbomify.apps.sboms.schemas import SPDX3Schema, validate_spdx_sbom
 
 DOC = "https://example.test/spdxdocs/image"
 SBOM_ID = "https://example.test/spdxdocs/image/sbom"
@@ -99,6 +101,28 @@ class TestTheDeclaredSubject:
         """The document roots on something that is neither package nor Sbom."""
         package = _primary(_document(root=AGENT))
 
+        assert package is not None
+
+    @pytest.mark.parametrize("bad_id", [[], {}, 42, None], ids=["list", "dict", "int", "null"])
+    def test_an_sbom_whose_id_is_not_a_string_does_not_crash(self, bad_id: object) -> None:
+        """A list or a dict is unhashable, and ``in`` against a set raises on one.
+
+        Parsed straight through SPDX3Schema rather than validate_spdx_sbom,
+        because the schema gate rejects a non-string spdxId on a small
+        document. It does not reject it on a large one: validation stops at
+        MAX_VALIDATED_ELEMENTS, and a Yocto graph runs to thousands of
+        elements, so anything past the cap arrives here unchecked. Falling
+        through is the designed behaviour for what this cannot read; raising
+        out of extraction is not.
+        """
+        document = _document(root=SBOM_ID, sbom_root=IMAGE)
+        for element in document["@graph"]:
+            if element.get("type") == "software_Sbom":
+                element["spdxId"] = bad_id
+
+        package, error = _extract_spdx_primary_package(SPDX3Schema.model_validate(document))
+
+        assert error == ""
         assert package is not None
 
     def test_an_sbom_the_document_does_not_root_on_is_not_followed(self) -> None:

--- a/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
+++ b/sbomify/apps/sboms/tests/test_spdx3_document_subject.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 
 from sbomify.apps.sboms.apis import _extract_spdx_primary_package
-from sbomify.apps.sboms.schemas import SPDX3Schema, validate_spdx_sbom
+from sbomify.apps.sboms.schemas import SPDX3Package, SPDX3Schema, validate_spdx_sbom
 
 DOC = "https://example.test/spdxdocs/image"
 SBOM_ID = "https://example.test/spdxdocs/image/sbom"
@@ -73,7 +73,18 @@ def _document(*, root: str, sbom_root: str | None = None) -> dict[str, Any]:
     return {"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": graph}
 
 
-def _primary(document: dict[str, Any]):
+def _primary_lenient(document: dict[str, Any]) -> SPDX3Package:
+    """Straight through the lenient parser, skipping the schema gate.
+
+    The gate rejects type spellings the schema has no term for, and the point
+    of these cases is what the extractor does with what reaches it.
+    """
+    package, error = _extract_spdx_primary_package(SPDX3Schema.model_validate(document))
+    assert error == "", error
+    return package
+
+
+def _primary(document: dict[str, Any]) -> SPDX3Package:
     payload, _ = validate_spdx_sbom(document)
     package, error = _extract_spdx_primary_package(payload)
     assert error == "", error
@@ -124,6 +135,28 @@ class TestTheDeclaredSubject:
 
         assert error == ""
         assert package is not None
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["software_Sbom", "Sbom", "https://spdx.org/rdf/3.0.1/terms/Software/Sbom", "software:Sbom"],
+        ids=["underscore", "bare", "full-iri", "compact-iri"],
+    )
+    def test_every_spelling_of_the_sbom_type_is_read(self, spelling: str) -> None:
+        document = _document(root=SBOM_ID, sbom_root=IMAGE)
+        for element in document["@graph"]:
+            if element.get("type") == "software_Sbom":
+                element["type"] = spelling
+
+        assert _primary_lenient(document).name == "core-image-minimal"
+
+    def test_a_type_that_merely_contains_the_word_is_not_an_sbom(self) -> None:
+        """A substring test says yes to this; matching the bare name does not."""
+        document = _document(root=SBOM_ID, sbom_root=IMAGE)
+        for element in document["@graph"]:
+            if element.get("type") == "software_Sbom":
+                element["type"] = "software_SbomType"
+
+        assert _primary_lenient(document).name != "core-image-minimal"
 
     def test_an_sbom_the_document_does_not_root_on_is_not_followed(self) -> None:
         """Only the Sbom the document points at gets resolved, not every Sbom


### PR DESCRIPTION
Part of #1506, found by uploading the Yocto Project's current release SBOM.

## What the artifact looked like

Uploading `core-image-minimal-qemux86-64.rootfs` from Yocto 6.0.3 produced an artifact versioned **2.3.2**. That is the version of `acl`, a recipe in the image, and has nothing to do with the image.

## Why

SPDX 3 lets a document point `rootElement` at the Sbom rather than straight at what the Sbom describes. Yocto writes it that way:

```
SpdxDocument.rootElement  -> software_Sbom
software_Sbom.rootElement -> the core-image-minimal package
```

`_extract_spdx3_primary_package` reads `SpdxDocument.rootElement` through `spdx3_document_subjects`, found no package with that id, and fell through the describes-relationship and name-match strategies to strategy 4, which takes whichever package serialised first. In a Yocto graph that is `acl`.

So the fallback was working exactly as designed, on a document that had declared its subject perfectly well one hop away.

## What changed

Strategy 1 now resolves one hop through an Sbom the document roots itself on. An Sbom's `rootElement` names what the BOM is about, so following it is reading the document as written rather than guessing. One hop only: going further would be walking a graph nobody asked about.

Checked against both SPDX 3 releases the Yocto Project publishes:

| | before | after |
| --- | --- | --- |
| 5.1.4 core-image-minimal | core-image-minimal | core-image-minimal |
| 6.0.3 core-image-minimal | acl 2.3.2 | core-image-minimal |

The image carries no version of its own, so the artifact now has an empty version where it had a wrong one. That is the better of the two.

## Tests

Five in `test_spdx3_document_subject.py`, with the decoy package serialised first so the old fallback would pick it: rooted on the Sbom, rooted straight on the package, an Sbom root pointing at nothing, a root that is neither package nor Sbom, and an Sbom in the graph the document does not root on (which must not be followed).

The first fails on master. `sboms` suite: 641 passed, 5 skipped.