### PR TITLE
fix(vulns): a suppressed finding is not a vulnerability count

### DIFF
--- a/sbomify/apps/core/services/product_page.py
+++ b/sbomify/apps/core/services/product_page.py
@@ -42,6 +42,7 @@ def build_product_components_rows(product_id: str) -> dict[str, Any]:
         extract_finding_rows,
         merge_findings_by_alias,
         result_scanned_nothing,
+        severity_counts_from_rows,
     )
     from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
 
@@ -93,9 +94,7 @@ def build_product_components_rows(product_id: str) -> dict[str, Any]:
                 statements = load_vex_suppressions(component["id"], cache=vex_cache) if merged["findings"] else []
                 findings = extract_finding_rows(merged, statements)
                 if findings:
-                    counts = {"total": len(findings)}
-                    for severity in _SEVERITIES:
-                        counts[severity] = sum(1 for f in findings if f["severity"] == severity)
+                    counts = severity_counts_from_rows(findings)
                 else:
                     # Summary-only results (no findings list) still carry counts.
                     from sbomify.apps.vulnerability_scanning.utils import extract_severity_counts

--- a/sbomify/apps/core/tests/test_embedded_vex_on_artifact_card.py
+++ b/sbomify/apps/core/tests/test_embedded_vex_on_artifact_card.py
@@ -141,3 +141,83 @@ class TestTheCardCountsOnlyLiveFindings:
         assert summary is not None
         assert summary["total"] == 1
         assert summary["high"] == 1
+
+
+@pytest.mark.django_db
+class TestTheOtherTwoSurfacesThatTallyRows:
+    """The artifacts table and the product page count the same rows the card does.
+
+    Fixing one and leaving them would put three answers on three pages for one
+    scan, which is the shape of the bug rather than an improvement on it.
+    """
+
+    def test_the_artifacts_table_does_not_count_a_suppressed_finding(
+        self, sample_team_with_owner_member: Member
+    ) -> None:
+        from sbomify.apps.sboms.services.sboms_table import _attach_vulnerability_counts
+
+        component = Component.objects.create(
+            team=sample_team_with_owner_member.team,
+            name="yocto-image-table",
+            component_type=Component.ComponentType.BOM,
+        )
+        sbom = SBOM.objects.create(
+            component=component,
+            name="core-image-minimal",
+            format="spdx",
+            format_version="3.0.1",
+            version="",
+            sbom_filename="x.json",
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            plugin_config_hash="0" * 64,
+            category="security",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status="completed",
+            result=SUPPRESSED_RESULT,
+        )
+
+        items = [{"sbom": {"id": sbom.id}}]
+        _attach_vulnerability_counts(items, component.id)
+
+        assert items[0]["vuln"]["total"] == 0, "the table counted a suppressed finding"
+        assert items[0]["vuln"]["high"] == 0
+
+    def test_the_product_page_does_not_count_a_suppressed_finding(self, sample_team_with_owner_member: Member) -> None:
+        from sbomify.apps.core.models import Product
+        from sbomify.apps.core.services.product_page import build_product_components_rows
+        from sbomify.apps.sboms.models import ProductComponent
+
+        team = sample_team_with_owner_member.team
+        product = Product.objects.create(team=team, name="yocto-product")
+        component = Component.objects.create(
+            team=team, name="yocto-image-product", component_type=Component.ComponentType.BOM
+        )
+        ProductComponent.objects.create(product=product, component=component)
+        sbom = SBOM.objects.create(
+            component=component,
+            name="core-image-minimal",
+            format="spdx",
+            format_version="3.0.1",
+            version="",
+            sbom_filename="x.json",
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            plugin_config_hash="0" * 64,
+            category="security",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status="completed",
+            result=SUPPRESSED_RESULT,
+        )
+
+        rows = build_product_components_rows(product.id)["rows"]
+        row = next(r for r in rows if r["id"] == component.id)
+
+        assert row["vuln"]["total"] == 0, "the product page counted a suppressed finding"
+        assert row["vuln"]["high"] == 0

--- a/sbomify/apps/core/tests/test_embedded_vex_on_artifact_card.py
+++ b/sbomify/apps/core/tests/test_embedded_vex_on_artifact_card.py
@@ -1,0 +1,143 @@
+"""A finding the scan suppressed must not be counted as a live vulnerability.
+
+`extract_finding_rows` returns every finding, each carrying `vex_suppressed`,
+because the drill-down table renders the suppressed ones marked as such. Three
+tally sites then counted `len(rows)` without asking, so a finding the scan had
+already cleared still landed in the card's total and its severity counts.
+
+Yocto is how this surfaced. Its SBOMs carry their own VEX: a
+`security_VexFixedVulnAssessmentRelationship` stores as `analysis_state
+"resolved"`, which is in SUPPRESSED_STATES. On the Yocto 6.0.3 release SBOM the
+stored run read `total_findings 0, suppressed_count 2` while the page above it
+read `1 HIGH`, for the same run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.plugins.sdk.enums import RunReason
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.teams.models import Member
+
+# Shaped after the real stored run for the Yocto 6.0.3 core-image-minimal SBOM:
+# two ids for one advisory, both annotated "resolved" by the document's own VEX.
+SUPPRESSED_RESULT: dict[str, Any] = {
+    "summary": {
+        "total_findings": 0,
+        "suppressed_count": 2,
+        "by_severity": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+    },
+    "findings": [
+        {
+            "id": "PYSEC-2026-3447",
+            "title": "PYSEC-2026-3447",
+            "severity": "high",
+            "aliases": ["CVE-2026-59890", "GHSA-h35f-9h28-mq5c"],
+            "component": {"name": "setuptools", "version": "82.0.1", "ecosystem": "PyPI"},
+            "analysis_state": "resolved",
+        },
+        {
+            "id": "GHSA-h35f-9h28-mq5c",
+            "title": "setuptools: MANIFEST.in exclusion bypass",
+            "severity": "high",
+            "aliases": ["CVE-2026-59890", "PYSEC-2026-3447"],
+            "component": {"name": "setuptools", "version": "82.0.1", "ecosystem": "PyPI"},
+            "analysis_state": "resolved",
+        },
+    ],
+    "metadata": {"scanner": "osv-scanner", "sbom_format": "spdx3", "converted_from": "SPDX-3.0"},
+}
+
+LIVE_RESULT: dict[str, Any] = {
+    "summary": {"total_findings": 1, "by_severity": {"critical": 0, "high": 1, "medium": 0, "low": 0}},
+    "findings": [
+        {
+            "id": "CVE-2026-11111",
+            "title": "something genuinely open",
+            "severity": "high",
+            "component": {"name": "openssl", "version": "3.2.3", "ecosystem": "PyPI"},
+        }
+    ],
+    "metadata": {"scanner": "osv-scanner"},
+}
+
+
+@pytest.mark.django_db
+class TestTheCardCountsOnlyLiveFindings:
+    @pytest.fixture
+    def signed_in(self, sample_team_with_owner_member: Member) -> tuple[Client, Component]:
+        component = Component.objects.create(
+            team=sample_team_with_owner_member.team,
+            name="yocto-image",
+            component_type=Component.ComponentType.BOM,
+        )
+        client = Client()
+        setup_authenticated_client_session(
+            client, sample_team_with_owner_member.team, sample_team_with_owner_member.user
+        )
+        return client, component
+
+    @staticmethod
+    def _sbom(component: Component) -> SBOM:
+        return SBOM.objects.create(
+            component=component,
+            name="core-image-minimal",
+            format="spdx",
+            format_version="3.0.1",
+            version="",
+            sbom_filename="x.json",
+        )
+
+    @staticmethod
+    def _run(sbom: SBOM, result: dict[str, Any]) -> AssessmentRun:
+        return AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            plugin_config_hash="0" * 64,
+            category="security",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status="completed",
+            result=result,
+        )
+
+    def _summary(self, client: Client, component: Component, sbom: SBOM):
+        response = client.get(
+            reverse(
+                "core:component_item",
+                kwargs={"component_id": component.id, "item_type": "sboms", "item_id": sbom.id},
+            )
+        )
+        assert response.status_code == 200
+        return response.context["vulnerability_summary"]
+
+    def test_a_finding_the_scan_suppressed_is_not_counted(self, signed_in: tuple[Client, Component]) -> None:
+        client, component = signed_in
+        sbom = self._sbom(component)
+        self._run(sbom, SUPPRESSED_RESULT)
+
+        summary = self._summary(client, component, sbom)
+
+        assert summary is not None
+        assert summary["total"] == 0, "a suppressed finding was counted as a live vulnerability"
+        assert summary["high"] == 0
+
+    def test_a_live_finding_is_still_counted(self, signed_in: tuple[Client, Component]) -> None:
+        """The guard against a fix that just zeroes the card."""
+        client, component = signed_in
+        sbom = self._sbom(component)
+        self._run(sbom, LIVE_RESULT)
+
+        summary = self._summary(client, component, sbom)
+
+        assert summary is not None
+        assert summary["total"] == 1
+        assert summary["high"] == 1

--- a/sbomify/apps/core/views/component_item.py
+++ b/sbomify/apps/core/views/component_item.py
@@ -239,6 +239,7 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                     extract_finding_rows,
                     merge_findings_by_alias,
                     result_scanned_nothing,
+                    severity_counts_from_rows,
                 )
                 from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
 
@@ -284,13 +285,7 @@ class ComponentItemView(GuestAccessBlockedMixin, LoginRequiredMixin, View):
                 merged = merge_findings_by_alias([result for _, result, _ in provider_runs])
                 rows = extract_finding_rows(merged, load_vex_suppressions(component_id_from_item))
                 if rows:
-                    counts = {
-                        "total": len(rows),
-                        "critical": sum(1 for row in rows if row["severity"] == "critical"),
-                        "high": sum(1 for row in rows if row["severity"] == "high"),
-                        "medium": sum(1 for row in rows if row["severity"] == "medium"),
-                        "low": sum(1 for row in rows if row["severity"] == "low"),
-                    }
+                    counts = severity_counts_from_rows(rows)
                 else:
                     # Summary-only results (no findings list) still carry counts.
                     from sbomify.apps.vulnerability_scanning.utils import extract_severity_counts

--- a/sbomify/apps/sboms/services/sboms_table.py
+++ b/sbomify/apps/sboms/services/sboms_table.py
@@ -31,6 +31,7 @@ def _attach_vulnerability_counts(sbom_items: list[dict[str, Any]], component_id:
         merge_findings_by_alias,
         reconstruct_result_summary,
         result_scanned_nothing,
+        severity_counts_from_rows,
     )
     from sbomify.apps.vulnerability_scanning.vex import load_vex_suppressions
 
@@ -82,13 +83,7 @@ def _attach_vulnerability_counts(sbom_items: list[dict[str, Any]], component_id:
         scanned_nothing = all(result_scanned_nothing(result) for result in provider_results)
         rows = extract_finding_rows(merge_findings_by_alias(provider_results), vex_statements)
         if rows:
-            item["vuln"] = {
-                "total": len(rows),
-                "critical": sum(1 for row in rows if row["severity"] == "critical"),
-                "high": sum(1 for row in rows if row["severity"] == "high"),
-                "medium": sum(1 for row in rows if row["severity"] == "medium"),
-                "low": sum(1 for row in rows if row["severity"] == "low"),
-            }
+            item["vuln"] = severity_counts_from_rows(rows)
         else:
             # A result can carry a summary but no findings list (summary-only
             # providers, legacy blobs). Fall back to the stored summary — the

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -368,6 +368,11 @@ def extract_finding_rows(
 RESULT_SUMMARY_COLUMNS: tuple[str, ...] = ("result_summary", "result_skipped")
 
 
+#: The severities a badge breaks out. "info" and "unknown" are real severities
+#: a finding can carry, and they count toward the total without a column.
+_COUNTED_SEVERITIES = ("critical", "high", "medium", "low")
+
+
 def severity_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
     """Tally display rows into the counts a badge shows, suppressed ones excluded.
 
@@ -381,10 +386,14 @@ def severity_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
     The three surfaces that tally rows share this rather than repeating the
     comprehension, so the next one cannot forget the filter.
     """
-    live = [row for row in rows if not row.get("vex_suppressed")]
-    counts = {"total": len(live)}
-    for severity in ("critical", "high", "medium", "low"):
-        counts[severity] = sum(1 for row in live if row.get("severity") == severity)
+    counts = {"total": 0, "critical": 0, "high": 0, "medium": 0, "low": 0}
+    for row in rows:
+        if row.get("vex_suppressed"):
+            continue
+        counts["total"] += 1
+        severity = row.get("severity")
+        if severity in _COUNTED_SEVERITIES:
+            counts[severity] += 1
     return counts
 
 

--- a/sbomify/apps/vulnerability_scanning/utils.py
+++ b/sbomify/apps/vulnerability_scanning/utils.py
@@ -368,6 +368,26 @@ def extract_finding_rows(
 RESULT_SUMMARY_COLUMNS: tuple[str, ...] = ("result_summary", "result_skipped")
 
 
+def severity_counts_from_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Tally display rows into the counts a badge shows, suppressed ones excluded.
+
+    ``extract_finding_rows`` returns every finding, suppressed included, because
+    the drill-down table renders those marked rather than hiding them. A count
+    is the other question: how many are still open. Tallying the rows whole
+    therefore reports findings the scan already cleared, which is how a Yocto
+    image whose own VEX resolves a CVE still read "1 HIGH" on the artifact card
+    while the stored run read zero.
+
+    The three surfaces that tally rows share this rather than repeating the
+    comprehension, so the next one cannot forget the filter.
+    """
+    live = [row for row in rows if not row.get("vex_suppressed")]
+    counts = {"total": len(live)}
+    for severity in ("critical", "high", "medium", "low"):
+        counts[severity] = sum(1 for row in live if row.get("severity") == severity)
+    return counts
+
+
 def _ann(row: Any, key: str) -> Any:
     return row.get(key) if isinstance(row, dict) else getattr(row, key, None)
 


### PR DESCRIPTION
Found re-testing the merged Yocto work on stage (build 79dd1cf).

## What the page showed

The Yocto Project's 6.0.3 release SBOM for `core-image-minimal`. Stored OSV run:

```
summary:  {"total_findings": 0, "suppressed_count": 2, "by_severity": {"high": 0, ...}}
findings: PYSEC-2026-3447 (high), GHSA-h35f-9h28-mq5c (high)
          both setuptools 82.0.1, aliases of CVE-2026-59890
```

The card above it: **1 total findings, 1 HIGH**. Same run.

Yocto ships VEX inside the SBOM. Its `security_VexFixedVulnAssessmentRelationship` for CVE-2026-59890 stores as `analysis_state "resolved"`, which is in `SUPPRESSED_STATES`, and the document also carries the patch file that fixed it. So we were reporting a HIGH against a build that patched it, on evidence we parsed ourselves.

## Why

Nothing was under-resolved. `extract_finding_rows` reads the stored `analysis_state` first and correctly set `vex_suppressed` on the row. It then returns that row, along with every other, because the drill-down table renders suppressed findings marked rather than hiding them.

Three surfaces tallied those rows whole:

| | |
| --- | --- |
| `component_item.py:287` | the artifact card |
| `product_page.py:95` | the product page counts |
| `sboms_table.py:84` | the artifacts table |

all `len(rows)` and `sum(... row["severity"] ...)`, with no filter. Meanwhile `dashboard_page.py:59`, `component_details_private.py:135` and `csv_exports.py:302` all ask about `vex_suppressed`. The three were the outliers, not the rule, which is why this reads as a slip rather than a design.

This is not Yocto-specific. Any VEX-suppressed finding in any workspace was still counted on those three surfaces; Yocto only made it easy to hit, because Yocto ships embedded VEX in every build.

## What changed

One `severity_counts_from_rows` in `vulnerability_scanning/utils.py`, next to `extract_finding_rows`, and the three surfaces route through it. That fixes the count once and deletes three copies of the same comprehension, so the next surface to tally rows cannot forget the filter.

## Tests

Two, shaped after the real stored run: the suppressed run counts zero, and a live finding still counts one. The second is the guard against a fix that just zeroes the card, and it passes on master already.

Suites: 4744 passed across `core`, `sboms` and `vulnerability_scanning`. The 9 failures in `test_additional_packages_purls.py` are pre-existing and environmental: `docker-compose.tests.yml` mounts only `./sbomify`, so `bin/generate_additional_packages.sh` comes from the image (February, no `go_module_path`).

## Not in this change

`/sbom/<id>/vulnerabilities` has no VEX handling at all, not even the stored `analysis_state`, so it still lists suppressed advisories as live. Different view, different fix, tracked separately.