### PR TITLE
fix(plugins): an external-reference type written as an IRI is the same type

### DIFF
--- a/sbomify/apps/plugins/builtins/_spdx_shared.py
+++ b/sbomify/apps/plugins/builtins/_spdx_shared.py
@@ -56,6 +56,32 @@ def iter_spdx3_elements(data: dict[str, Any]) -> Iterator[dict[str, Any]]:
             yield element
 
 
+#: The external-reference types that identify a package, bare. SPDX 2.x also
+#: allows each written as the full IRI it abbreviates, which is what
+#: spdx2_reference_type strips before comparing.
+SPDX2_IDENTIFIER_TYPES = frozenset({"purl", "cpe22Type", "cpe23Type", "swid"})
+
+
+def spdx2_reference_type(ref: Any) -> str:
+    """The bare external-reference type, whatever spelling the document used.
+
+    SPDX 2.x permits ``referenceType`` as the bare term or as the full IRI it
+    abbreviates, and the two mean the same thing. Yocto writes only the IRI:
+    every one of the 108 external references in the Yocto Project's 5.0.5
+    release SBOM is ``http://spdx.org/rdf/references/cpe23Type``, so comparing
+    against bare terms alone scored an entire build as carrying no identifiers.
+
+    Returns "" for anything that is not a reference with a string type, so a
+    caller can compare the result without checking the shape first.
+    """
+    if not isinstance(ref, dict):
+        return ""
+    value = ref.get("referenceType")
+    if not isinstance(value, str):
+        return ""
+    return value.rsplit("/", 1)[-1]
+
+
 def spdx2_root_spdxid(data: dict[str, Any]) -> str | None:
     """Return the SPDXID of the BOM subject for an SPDX 2.x document.
 

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -1367,10 +1367,7 @@ class BSICompliancePlugin(AssessmentPlugin):
             if not isinstance(external_refs, list):
                 external_refs = []
             has_id = (isinstance(purl, str) and bool(purl)) or any(
-                isinstance(ref, dict)
-                and isinstance(ref.get("referenceType"), str)
-                and spdx2_reference_type(ref) in ("purl", "cpe22Type", "cpe23Type")
-                for ref in external_refs
+                spdx2_reference_type(ref) in ("purl", "cpe22Type", "cpe23Type") for ref in external_refs
             )
             if not has_id:
                 identifier_warnings.append(pkg.get("name", f"Package {i}"))

--- a/sbomify/apps/plugins/builtins/bsi.py
+++ b/sbomify/apps/plugins/builtins/bsi.py
@@ -66,7 +66,7 @@ from sbomify.apps.plugins.builtins._spdx3_helpers import (
     iter_spdx3_external_identifiers,
     resolve_spdx3_agent,
 )
-from sbomify.apps.plugins.builtins._spdx_shared import spdx3_document_subjects
+from sbomify.apps.plugins.builtins._spdx_shared import spdx2_reference_type, spdx3_document_subjects
 from sbomify.apps.plugins.sdk.base import AssessmentPlugin, SBOMContext
 from sbomify.apps.plugins.sdk.enums import AssessmentCategory
 from sbomify.apps.plugins.sdk.results import (
@@ -1369,7 +1369,7 @@ class BSICompliancePlugin(AssessmentPlugin):
             has_id = (isinstance(purl, str) and bool(purl)) or any(
                 isinstance(ref, dict)
                 and isinstance(ref.get("referenceType"), str)
-                and ref["referenceType"] in ("purl", "cpe22Type", "cpe23Type")
+                and spdx2_reference_type(ref) in ("purl", "cpe22Type", "cpe23Type")
                 for ref in external_refs
             )
             if not has_id:

--- a/sbomify/apps/plugins/builtins/cisa.py
+++ b/sbomify/apps/plugins/builtins/cisa.py
@@ -71,8 +71,10 @@ from sbomify.apps.plugins.builtins._spdx3_helpers import (
     is_spdx3,
 )
 from sbomify.apps.plugins.builtins._spdx_shared import (
+    SPDX2_IDENTIFIER_TYPES,
     iter_spdx3_elements,
     spdx2_annotation_targets_document,
+    spdx2_reference_type,
     spdx2_root_spdxid,
     spdx3_annotation_subject_matches,
     spdx3_document_subjects,
@@ -348,17 +350,14 @@ class CISAMinimumElementsPlugin(AssessmentPlugin):
                 version_failures.append(package_name)
 
             # 5. Software Identifiers (at least one required)
-            # Only accept externalRefs with valid identifier types (purl, cpe22Type, cpe23Type, swid)
-            valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
+            # The type is read bare, so the IRI spelling SPDX 2.x also allows
+            # counts as the same identifier.
             purl = package.get("purl")
             external_refs = package.get("externalRefs")
             if not isinstance(external_refs, list):
                 external_refs = []
             has_identifier = (isinstance(purl, str) and bool(purl)) or any(
-                isinstance(ref, dict)
-                and isinstance(ref.get("referenceType"), str)
-                and ref["referenceType"] in valid_identifier_types
-                for ref in external_refs
+                spdx2_reference_type(ref) in SPDX2_IDENTIFIER_TYPES for ref in external_refs
             )
             if not has_identifier:
                 identifier_failures.append(package_name)

--- a/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
+++ b/sbomify/apps/plugins/builtins/fda_medical_device_cybersecurity.py
@@ -82,8 +82,10 @@ from sbomify.apps.plugins.builtins._spdx3_helpers import (
     is_spdx3,
 )
 from sbomify.apps.plugins.builtins._spdx_shared import (
+    SPDX2_IDENTIFIER_TYPES,
     iter_spdx3_elements,
     spdx2_annotation_targets_document,
+    spdx2_reference_type,
     spdx2_root_spdxid,
     spdx3_annotation_subject_matches,
     spdx3_document_subjects,
@@ -362,16 +364,12 @@ class FDAMedicalDevicePlugin(AssessmentPlugin):
                 version_failures.append(package_name)
 
             # 4. Unique identifiers (PURL, CPE, SWID via externalRefs)
-            valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
             purl = package.get("purl")
             external_refs = package.get("externalRefs")
             if not isinstance(external_refs, list):
                 external_refs = []
             has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
-                isinstance(ref, dict)
-                and isinstance(ref.get("referenceType"), str)
-                and ref["referenceType"] in valid_identifier_types
-                for ref in external_refs
+                spdx2_reference_type(ref) in SPDX2_IDENTIFIER_TYPES for ref in external_refs
             )
             if not has_unique_id:
                 unique_id_failures.append(package_name)

--- a/sbomify/apps/plugins/builtins/ntia.py
+++ b/sbomify/apps/plugins/builtins/ntia.py
@@ -38,6 +38,10 @@ from sbomify.apps.plugins.builtins._spdx3_helpers import (
     has_spdx3_supplier,
     is_spdx3,
 )
+from sbomify.apps.plugins.builtins._spdx_shared import (
+    SPDX2_IDENTIFIER_TYPES,
+    spdx2_reference_type,
+)
 from sbomify.apps.plugins.sdk.base import AssessmentPlugin, SBOMContext
 from sbomify.apps.plugins.sdk.enums import AssessmentCategory
 from sbomify.apps.plugins.sdk.results import (
@@ -270,12 +274,9 @@ class NTIAMinimumElementsPlugin(AssessmentPlugin):
             # Only accept externalRefs with valid identifier types
             # Note: hashes are for "Component Hash" (RECOMMENDED), not "Unique Identifiers" (MINIMUM)
             if not is_file_entry:
-                valid_identifier_types = {"purl", "cpe22Type", "cpe23Type", "swid"}
                 purl = package.get("purl")
                 has_unique_id = (isinstance(purl, str) and bool(purl)) or any(
-                    isinstance(ref, dict)
-                    and isinstance(ref.get("referenceType"), str)
-                    and ref["referenceType"] in valid_identifier_types
+                    spdx2_reference_type(ref) in SPDX2_IDENTIFIER_TYPES
                     for ref in (_as_list(package.get("externalRefs")))
                 )
                 if not has_unique_id:

--- a/sbomify/apps/plugins/tests/test_spdx2_identifier_iri.py
+++ b/sbomify/apps/plugins/tests/test_spdx2_identifier_iri.py
@@ -26,12 +26,14 @@ BARE = "cpe23Type"
 IRI = "http://spdx.org/rdf/references/cpe23Type"
 CPE = "cpe:2.3:*:openssl:openssl:3.2.3:*:*:*:*:*:*:*"
 
-#: Each plugin with the finding id its identifier check reports under.
+#: Each plugin with the exact finding id its identifier check reports under, and
+#: the extra arguments its _validate_spdx takes. BSI wants the version because
+#: TR-03183-2 grades 2.x and 3.x differently; the rest take the document alone.
 PLUGINS = [
-    pytest.param(CISAMinimumElementsPlugin, "software-identifiers", id="cisa"),
-    pytest.param(NTIAMinimumElementsPlugin, "unique-identifiers", id="ntia"),
-    pytest.param(BSICompliancePlugin, "identifier", id="bsi"),
-    pytest.param(FDAMedicalDevicePlugin, "identifier", id="fda"),
+    pytest.param(CISAMinimumElementsPlugin, "cisa-2025:software-identifiers", (), id="cisa"),
+    pytest.param(NTIAMinimumElementsPlugin, "ntia-2021:unique-identifiers", (), id="ntia"),
+    pytest.param(BSICompliancePlugin, "bsi-tr03183:unique-identifiers", ("2.2",), id="bsi"),
+    pytest.param(FDAMedicalDevicePlugin, "fda-2025:ntia:unique-identifiers", (), id="fda"),
 ]
 
 
@@ -78,32 +80,27 @@ def _document(reference_type: str) -> dict[str, Any]:
     }
 
 
-def _identifier_finding(plugin_cls: type, finding_id_part: str, reference_type: str):
-    import inspect
-
-    plugin = plugin_cls()
-    document = _document(reference_type)
-    # BSI takes the version too, since TR-03183-2 grades 2.x and 3.x differently.
-    if "format_version" in inspect.signature(plugin._validate_spdx).parameters:
-        findings = plugin._validate_spdx(document, "2.2")
-    else:
-        findings = plugin._validate_spdx(document)
-    matches = [f for f in findings if finding_id_part in str(getattr(f, "id", "")).lower()]
-    assert matches, f"{plugin_cls.__name__} reported no identifier check at all"
+def _identifier_finding(plugin_cls: type, finding_id: str, extra_args: tuple, reference_type: str):
+    findings = plugin_cls()._validate_spdx(_document(reference_type), *extra_args)
+    matches = [f for f in findings if getattr(f, "id", None) == finding_id]
+    assert matches, (
+        f"{plugin_cls.__name__} reported no finding {finding_id!r}; "
+        f"it reported {[getattr(f, 'id', None) for f in findings]}"
+    )
     return matches[0]
 
 
-@pytest.mark.parametrize(("plugin_cls", "finding_id_part"), PLUGINS)
+@pytest.mark.parametrize(("plugin_cls", "finding_id", "extra_args"), PLUGINS)
 class TestTheIriSpellingIsReadAsAnIdentifier:
-    def test_the_iri_form_scores_as_an_identifier(self, plugin_cls: type, finding_id_part: str) -> None:
-        finding = _identifier_finding(plugin_cls, finding_id_part, IRI)
+    def test_the_iri_form_scores_as_an_identifier(self, plugin_cls: type, finding_id: str, extra_args: tuple) -> None:
+        finding = _identifier_finding(plugin_cls, finding_id, extra_args, IRI)
 
         assert finding.status != "fail", (
             f"{plugin_cls.__name__} scored a package carrying {CPE} as missing an identifier"
         )
 
-    def test_the_bare_form_still_scores_as_one(self, plugin_cls: type, finding_id_part: str) -> None:
+    def test_the_bare_form_still_scores_as_one(self, plugin_cls: type, finding_id: str, extra_args: tuple) -> None:
         """The guard against a fix that stops reading the spelling everyone else writes."""
-        finding = _identifier_finding(plugin_cls, finding_id_part, BARE)
+        finding = _identifier_finding(plugin_cls, finding_id, extra_args, BARE)
 
         assert finding.status != "fail"

--- a/sbomify/apps/plugins/tests/test_spdx2_identifier_iri.py
+++ b/sbomify/apps/plugins/tests/test_spdx2_identifier_iri.py
@@ -1,0 +1,109 @@
+"""An external-reference type written as an IRI is the same type as the bare term.
+
+SPDX 2.x permits `referenceType` as the bare term or as the full IRI it
+abbreviates. Every compliance plugin compared against bare terms only, so a
+package identified solely by an IRI-form cpe23Type scored as having no
+identifier at all.
+
+Yocto writes the IRI and nothing else: all 108 external references across the
+176 documents of the Yocto Project's 5.0.5 release SBOM are
+`http://spdx.org/rdf/references/cpe23Type`, so an entire Yocto build scored
+zero identifiers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sbomify.apps.plugins.builtins.bsi import BSICompliancePlugin
+from sbomify.apps.plugins.builtins.cisa import CISAMinimumElementsPlugin
+from sbomify.apps.plugins.builtins.fda_medical_device_cybersecurity import FDAMedicalDevicePlugin
+from sbomify.apps.plugins.builtins.ntia import NTIAMinimumElementsPlugin
+
+BARE = "cpe23Type"
+IRI = "http://spdx.org/rdf/references/cpe23Type"
+CPE = "cpe:2.3:*:openssl:openssl:3.2.3:*:*:*:*:*:*:*"
+
+#: Each plugin with the finding id its identifier check reports under.
+PLUGINS = [
+    pytest.param(CISAMinimumElementsPlugin, "software-identifiers", id="cisa"),
+    pytest.param(NTIAMinimumElementsPlugin, "unique-identifiers", id="ntia"),
+    pytest.param(BSICompliancePlugin, "identifier", id="bsi"),
+    pytest.param(FDAMedicalDevicePlugin, "identifier", id="fda"),
+]
+
+
+def _document(reference_type: str) -> dict[str, Any]:
+    """One SPDX 2.2 package whose only identifier is a CPE, as Yocto emits it."""
+    return {
+        "spdxVersion": "SPDX-2.2",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "recipe-openssl",
+        "documentNamespace": "http://spdx.org/spdxdocs/recipe-openssl-0f2c1f0e",
+        "creationInfo": {
+            "created": "2026-01-01T00:00:00Z",
+            "creators": ["Tool: OpenEmbedded Core create-spdx.bbclass", "Organization: OpenEmbedded"],
+        },
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-Recipe-openssl",
+                "name": "openssl",
+                "versionInfo": "3.2.3",
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": False,
+                "supplier": "Organization: OpenEmbedded ()",
+                "licenseConcluded": "NOASSERTION",
+                "licenseDeclared": "OpenSSL",
+                "copyrightText": "NOASSERTION",
+                "checksums": [{"algorithm": "SHA256", "checksumValue": "a" * 64}],
+                "externalRefs": [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": reference_type,
+                        "referenceLocator": CPE,
+                    }
+                ],
+            }
+        ],
+        "relationships": [
+            {
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": "SPDXRef-Recipe-openssl",
+            }
+        ],
+    }
+
+
+def _identifier_finding(plugin_cls: type, finding_id_part: str, reference_type: str):
+    import inspect
+
+    plugin = plugin_cls()
+    document = _document(reference_type)
+    # BSI takes the version too, since TR-03183-2 grades 2.x and 3.x differently.
+    if "format_version" in inspect.signature(plugin._validate_spdx).parameters:
+        findings = plugin._validate_spdx(document, "2.2")
+    else:
+        findings = plugin._validate_spdx(document)
+    matches = [f for f in findings if finding_id_part in str(getattr(f, "id", "")).lower()]
+    assert matches, f"{plugin_cls.__name__} reported no identifier check at all"
+    return matches[0]
+
+
+@pytest.mark.parametrize(("plugin_cls", "finding_id_part"), PLUGINS)
+class TestTheIriSpellingIsReadAsAnIdentifier:
+    def test_the_iri_form_scores_as_an_identifier(self, plugin_cls: type, finding_id_part: str) -> None:
+        finding = _identifier_finding(plugin_cls, finding_id_part, IRI)
+
+        assert finding.status != "fail", (
+            f"{plugin_cls.__name__} scored a package carrying {CPE} as missing an identifier"
+        )
+
+    def test_the_bare_form_still_scores_as_one(self, plugin_cls: type, finding_id_part: str) -> None:
+        """The guard against a fix that stops reading the spelling everyone else writes."""
+        finding = _identifier_finding(plugin_cls, finding_id_part, BARE)
+
+        assert finding.status != "fail"


### PR DESCRIPTION
Answers the identifier inconsistency Viktor raised against #1512, from the other end: not which identifiers we accept, but whether we recognise the ones already there.

## What happens

SPDX 2.x permits `referenceType` as the bare term or as the full IRI it abbreviates. The compliance plugins compared against bare terms only. Yocto writes the IRI and nothing else: all 108 external references across the 176 documents of the Yocto Project's 5.0.5 release SBOM are `http://spdx.org/rdf/references/cpe23Type`.

So a package carrying a perfectly good CPE scored as having no identifier. Against the real `recipe-openssl.spdx.json` from that release:

```
before   Missing for: openssl, openssl-source-1
after    Missing for: openssl-source-1
```

`openssl` is the recipe and carries the CPE. `openssl-source-1` is Yocto's source archive, which genuinely has no purl, CPE or SWID, so it still fails and should. A Yocto build's identifier score improves but does not reach pass, which is the honest outcome.

## What changed

One `spdx2_reference_type` in `_spdx_shared`, beside the other SPDX 2.x helpers these plugins already share, with `SPDX2_IDENTIFIER_TYPES` alongside it. CISA, NTIA and FDA were each carrying a private copy of the same four-name set and the same three-clause comprehension.

Same defect and same shape as the converter fix in #1502 (`8d8b730`), which was silently dropping every Yocto CPE on the scan path for exactly this reason.

## BSI is in the change without being in the bug

`bsi.py:1372` had the same bare-form tuple, but its SPDX 2.x path never reaches that comparison — the parametrised tests show BSI passing both cases before the fix. It shares the helper anyway rather than keep a private copy of a set that is wrong everywhere else.

## Tests

Eight, parametrised over all four plugins: the IRI form scores as an identifier, and the bare form still does. The second is the guard against a fix that stops reading the spelling everyone else writes, and it passes on master already.

Plugins suite: 1242 passed.

## Still open

Whether Yocto's source-archive pseudo-package should be exempt the way the CycloneDX path exempts `type=file`. Separate question, not decided here.

And the one for you: should a SWHID or an OmniBOR ID count as a software identifier? CycloneDX 1.6 defines `omniborId` and `swhid`, we accept neither, and the SPDX 3 path accepts both — so the same component passes as SPDX 3 and fails as CycloneDX. Adding them makes the three formats agree but also makes documents pass that fail today, so it is a scoring change rather than a fix and I have left it alone.