### PR TITLE
fix(sboms): the vulnerabilities page says which advisories the scan cleared

### DIFF
--- a/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
@@ -101,9 +101,13 @@
                                     </c-tables.cell>
                                     <c-tables.cell>
                                     {% if pkg_vuln_info.vulnerabilities %}
-                                        <span class="inline-flex items-center gap-2 text-sm font-medium text-text">{{ pkg_vuln_info.vulnerabilities|length }} vulnerabilit{{ pkg_vuln_info.vulnerabilities|length|pluralize:"y,ies" }}<i class="fas fa-chevron-down text-xs text-text-muted transition-transform"
-   :class="open ? 'rotate-180' : ''"
-   aria-hidden="true"></i></span>
+                                        <span class="inline-flex items-center gap-2 text-sm font-medium text-text">{{ pkg_vuln_info.open_count }} vulnerabilit{{ pkg_vuln_info.open_count|pluralize:"y,ies" }}
+                                            {% if pkg_vuln_info.suppressed_count %}
+                                                <span class="text-xs font-normal text-text-muted">+{{ pkg_vuln_info.suppressed_count }} not affected</span>
+                                            {% endif %}
+                                            <i class="fas fa-chevron-down text-xs text-text-muted transition-transform"
+                                               :class="open ? 'rotate-180' : ''"
+                                               aria-hidden="true"></i></span>
                                     {% else %}
                                         <span class="inline-flex items-center gap-1 text-success text-sm"><i class="fas fa-shield-alt"></i>None</span>
                                     {% endif %}
@@ -144,6 +148,8 @@
                                                         {% if vuln.aliases %}<div class="text-xs text-text-muted mt-1">Aliases: {{ vuln.aliases|join:", " }}</div>{% endif %}
                                                     </div>
                                                     <div class="flex items-center gap-2">
+                                                        {# A finding the scan cleared stays listed and says so, rather than reading as live. #}
+                                                        {% if vuln.vex_suppressed %}<c-badges.secondary size="sm">Not affected</c-badges.secondary>{% endif %}
                                                         {# Severity Badge #}
                                                         {% if vuln.severity and vuln.severity != 'unknown' %}
                                                             <c-badges.severity level="{{ vuln.severity|lower }}">{{ vuln.severity|upper }}</c-badges.severity>

--- a/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
@@ -103,7 +103,7 @@
                                     {% if pkg_vuln_info.vulnerabilities %}
                                         <span class="inline-flex items-center gap-2 text-sm font-medium text-text">{{ pkg_vuln_info.open_count }} vulnerabilit{{ pkg_vuln_info.open_count|pluralize:"y,ies" }}
                                             {% if pkg_vuln_info.suppressed_count %}
-                                                <span class="text-xs font-normal text-text-muted">+{{ pkg_vuln_info.suppressed_count }} not affected</span>
+                                                <span class="text-xs font-normal text-text-muted">+{{ pkg_vuln_info.suppressed_count }} Not affected</span>
                                             {% endif %}
                                             <i class="fas fa-chevron-down text-xs text-text-muted transition-transform"
                                                :class="open ? 'rotate-180' : ''"

--- a/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
+++ b/sbomify/apps/sboms/templates/sboms/sbom_vulnerabilities.html.j2
@@ -102,8 +102,9 @@
                                     <c-tables.cell>
                                     {% if pkg_vuln_info.vulnerabilities %}
                                         <span class="inline-flex items-center gap-2 text-sm font-medium text-text">{{ pkg_vuln_info.open_count }} vulnerabilit{{ pkg_vuln_info.open_count|pluralize:"y,ies" }}
+                                            {% comment %}The same badge the advisory below carries, so the row summary and the row it summarises say it the same way.{% endcomment %}
                                             {% if pkg_vuln_info.suppressed_count %}
-                                                <span class="text-xs font-normal text-text-muted">+{{ pkg_vuln_info.suppressed_count }} Not affected</span>
+                                                <c-badges.secondary size="sm">+{{ pkg_vuln_info.suppressed_count }} Not affected</c-badges.secondary>
                                             {% endif %}
                                             <i class="fas fa-chevron-down text-xs text-text-muted transition-transform"
                                                :class="open ? 'rotate-180' : ''"

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -204,6 +204,22 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
         assert advisory["vex_suppressed"] is True
         assert advisory["vex_state"] == "not_affected"
 
+    def test_a_fully_annotated_page_never_reads_the_vex(
+        self, signed_in: tuple[Client, Component], mocker: "MockerFixture"
+    ) -> None:
+        """The overlay is the fallback, so it must cost nothing when unused.
+
+        A Yocto image carries its verdict on every finding already, and loading
+        the component's VEX to answer a question nobody asked is an S3 fetch on
+        every page load.
+        """
+        client, component = signed_in
+        load = mocker.patch.object(vex, "load_vex_suppressions", return_value=[])
+        sbom = self._scanned(component, [_finding("CVE-2026-59890", [], analysis_state="resolved")])
+
+        assert self._packages(client, sbom)[0]["suppressed_count"] == 1
+        load.assert_not_called()
+
     def test_an_uploaded_vex_for_another_package_suppresses_nothing(
         self, signed_in: tuple[Client, Component], mocker: "MockerFixture"
     ) -> None:

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -214,6 +214,26 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
         assert package["open_count"] == 1
         assert package["vulnerabilities"][0]["vex_suppressed"] is False
 
+    def test_a_live_fold_keeps_a_state_that_is_not_suppressing(self, signed_in: tuple[Client, Component]) -> None:
+        """Clearing the flag must not also discard a state that agrees with it.
+
+        `in_triage` says something true about a finding that is still open, and
+        this page is the only place it would be carried.
+        """
+        client, component = signed_in
+        sbom = self._scanned(
+            component,
+            [
+                _finding("PYSEC-2026-3447", ["CVE-2026-59890"], analysis_state="in_triage"),
+                _finding("CVE-2026-59890", ["PYSEC-2026-3447"]),
+            ],
+        )
+
+        advisory = self._packages(client, sbom)[0]["vulnerabilities"][0]
+
+        assert advisory["vex_suppressed"] is False
+        assert advisory["vex_state"] == "in_triage"
+
     def test_a_live_advisory_still_counts(self, signed_in: tuple[Client, Component]) -> None:
         """The guard against a fix that suppresses everything."""
         client, component = signed_in

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -13,7 +13,8 @@ this page's whole job. What changes is that they no longer count as open.
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from django.test import Client
@@ -25,6 +26,9 @@ from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk.enums import RunReason
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 SETUPTOOLS = {"name": "setuptools", "version": "82.0.1", "ecosystem": "PyPI", "purl": "pkg:pypi/setuptools@82.0.1"}
 
@@ -138,6 +142,77 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
 
         assert advisory["vex_suppressed"] is False
         assert advisory["vex_state"] == "", "the state contradicted the flag"
+
+    @staticmethod
+    def _uploaded_vex(component: Component, mocker: "MockerFixture", *, purl: str, advisory_id: str) -> None:
+        """A component's own uploaded VEX, which the view reads when a finding
+        carries no stored state.
+
+        Patches the reader method rather than S3Client itself: replacing the
+        class rebinds the name in object_store, and a module importing it later
+        keeps the mock past teardown.
+        """
+        SBOM.objects.create(
+            component=component,
+            name="vex",
+            version="1",
+            format="cyclonedx",
+            bom_type=SBOM.BomType.VEX,
+            sbom_filename="vex.json",
+            source="manual",
+        )
+        document = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "vulnerabilities": [
+                {
+                    "id": advisory_id,
+                    "analysis": {"state": "not_affected", "justification": "code_not_reachable"},
+                    "affects": [{"ref": purl}],
+                }
+            ],
+        }
+        mocker.patch(
+            "sbomify.apps.core.object_store.S3Client.get_sbom_data",
+            return_value=json.dumps(document).encode(),
+        )
+
+    def test_an_uploaded_vex_suppresses_a_finding_with_no_stored_state(
+        self, signed_in: tuple[Client, Component], mocker: "MockerFixture"
+    ) -> None:
+        """The second half of the precedence: stored state first, the component's
+        own uploaded VEX second.
+
+        A scanner that never annotated the finding leaves analysis_state empty,
+        which is every finding stored before the annotation existed. Without
+        this path the page reports as live an advisory the workspace has already
+        cleared by hand.
+        """
+        client, component = signed_in
+        self._uploaded_vex(component, mocker, purl=SETUPTOOLS["purl"], advisory_id="CVE-2026-59890")
+        sbom = self._scanned(component, [_finding("CVE-2026-59890", [])])
+
+        package = self._packages(client, sbom)[0]
+
+        assert package["open_count"] == 0, "an uploaded VEX did not clear the advisory it names"
+        assert package["suppressed_count"] == 1
+        advisory = package["vulnerabilities"][0]
+        assert advisory["vex_suppressed"] is True
+        assert advisory["vex_state"] == "not_affected"
+
+    def test_an_uploaded_vex_for_another_package_suppresses_nothing(
+        self, signed_in: tuple[Client, Component], mocker: "MockerFixture"
+    ) -> None:
+        """The guard on the overlay path: reading a VEX must not clear the list."""
+        client, component = signed_in
+        self._uploaded_vex(component, mocker, purl="pkg:pypi/requests@2.32.0", advisory_id="CVE-2026-59890")
+        sbom = self._scanned(component, [_finding("CVE-2026-59890", [])])
+
+        package = self._packages(client, sbom)[0]
+
+        assert package["open_count"] == 1
+        assert package["vulnerabilities"][0]["vex_suppressed"] is False
 
     def test_a_live_advisory_still_counts(self, signed_in: tuple[Client, Component]) -> None:
         """The guard against a fix that suppresses everything."""

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -1,0 +1,151 @@
+"""The vulnerabilities page and the scan agree about what is still open.
+
+The page built its own package-and-alias merge straight off the stored
+findings and never consulted VEX, so an advisory the scan had cleared rendered
+as live. Yocto is how it surfaced: its SBOMs carry their own VEX, a
+`security_VexFixedVulnAssessmentRelationship` stores as `analysis_state
+"resolved"`, and the 6.0.3 release SBOM listed CVE-2026-59890 as a live HIGH
+on a build that had patched it.
+
+Suppressed advisories stay in the list, marked, because listing advisories is
+this page's whole job. What changes is that they no longer count as open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from sbomify.apps.core.models import Component
+from sbomify.apps.core.tests.shared_fixtures import setup_authenticated_client_session
+from sbomify.apps.plugins.models import AssessmentRun
+from sbomify.apps.plugins.sdk.enums import RunReason
+from sbomify.apps.sboms.models import SBOM
+from sbomify.apps.teams.models import Member
+
+SETUPTOOLS = {"name": "setuptools", "version": "82.0.1", "ecosystem": "PyPI", "purl": "pkg:pypi/setuptools@82.0.1"}
+
+
+def _finding(advisory_id: str, aliases: list[str], *, analysis_state: str | None = None) -> dict[str, Any]:
+    finding = {
+        "id": advisory_id,
+        "title": f"{advisory_id} in setuptools",
+        "description": "…",
+        "severity": "high",
+        "aliases": aliases,
+        "component": dict(SETUPTOOLS),
+    }
+    if analysis_state:
+        finding["analysis_state"] = analysis_state
+    return finding
+
+
+def _result(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "summary": {"total_findings": len(findings), "by_severity": {"high": len(findings)}},
+        "findings": findings,
+        "metadata": {"scanner": "osv-scanner"},
+    }
+
+
+@pytest.mark.django_db
+class TestASuppressedAdvisoryIsNotListedAsLive:
+    @pytest.fixture
+    def signed_in(self, sample_team_with_owner_member: Member) -> tuple[Client, Component]:
+        component = Component.objects.create(
+            team=sample_team_with_owner_member.team,
+            name="yocto-image",
+            component_type=Component.ComponentType.BOM,
+        )
+        client = Client()
+        setup_authenticated_client_session(
+            client, sample_team_with_owner_member.team, sample_team_with_owner_member.user
+        )
+        return client, component
+
+    @staticmethod
+    def _scanned(component: Component, findings: list[dict[str, Any]]) -> SBOM:
+        sbom = SBOM.objects.create(
+            component=component,
+            name="core-image-minimal",
+            format="spdx",
+            format_version="3.0.1",
+            version="",
+            sbom_filename="x.json",
+        )
+        AssessmentRun.objects.create(
+            sbom=sbom,
+            plugin_name="osv",
+            plugin_version="1.0.0",
+            plugin_config_hash="0" * 64,
+            category="security",
+            run_reason=RunReason.ON_UPLOAD.value,
+            status="completed",
+            result=_result(findings),
+        )
+        return sbom
+
+    @staticmethod
+    def _packages(client: Client, sbom: SBOM):
+        response = client.get(reverse("sboms:sbom_vulnerabilities", kwargs={"sbom_id": sbom.id}))
+        assert response.status_code == 200
+        data = response.context["vulnerabilities"]
+        assert data and data.get("results"), "the page listed no packages at all"
+        return data["results"][0]["packages"]
+
+    def test_a_cleared_advisory_does_not_count_as_open(self, signed_in: tuple[Client, Component]) -> None:
+        """Both ids of one advisory, both cleared by the document's own VEX."""
+        client, component = signed_in
+        sbom = self._scanned(
+            component,
+            [
+                _finding("PYSEC-2026-3447", ["CVE-2026-59890", "GHSA-h35f-9h28-mq5c"], analysis_state="resolved"),
+                _finding("GHSA-h35f-9h28-mq5c", ["CVE-2026-59890", "PYSEC-2026-3447"], analysis_state="resolved"),
+            ],
+        )
+
+        package = self._packages(client, sbom)[0]
+
+        assert package["open_count"] == 0, "a cleared advisory was counted as open"
+        assert package["suppressed_count"] == 1
+        assert package["vulnerabilities"][0]["vex_suppressed"] is True
+
+    def test_it_is_still_listed_rather_than_hidden(self, signed_in: tuple[Client, Component]) -> None:
+        """The page's job is the advisory list, so a cleared one stays, marked."""
+        client, component = signed_in
+        sbom = self._scanned(component, [_finding("CVE-2026-59890", [], analysis_state="resolved")])
+
+        package = self._packages(client, sbom)[0]
+
+        assert len(package["vulnerabilities"]) == 1
+        assert package["vulnerabilities"][0]["id"] == "CVE-2026-59890"
+
+    def test_a_live_advisory_still_counts(self, signed_in: tuple[Client, Component]) -> None:
+        """The guard against a fix that suppresses everything."""
+        client, component = signed_in
+        sbom = self._scanned(component, [_finding("CVE-2026-11111", [])])
+
+        package = self._packages(client, sbom)[0]
+
+        assert package["open_count"] == 1
+        assert package["suppressed_count"] == 0
+        assert package["vulnerabilities"][0]["vex_suppressed"] is False
+
+    def test_one_provider_still_calling_it_live_wins(self, signed_in: tuple[Client, Component]) -> None:
+        """Folding two reports of one advisory must not lose the live one."""
+        client, component = signed_in
+        sbom = self._scanned(
+            component,
+            [
+                _finding("PYSEC-2026-3447", ["CVE-2026-59890"], analysis_state="resolved"),
+                _finding("CVE-2026-59890", ["PYSEC-2026-3447"]),
+            ],
+        )
+
+        package = self._packages(client, sbom)[0]
+
+        assert package["open_count"] == 1, "a live report was folded away by a suppressed one"
+        assert package["vulnerabilities"][0]["vex_suppressed"] is False

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -13,7 +13,6 @@ this page's whole job. What changes is that they no longer count as open.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -26,6 +25,7 @@ from sbomify.apps.plugins.models import AssessmentRun
 from sbomify.apps.plugins.sdk.enums import RunReason
 from sbomify.apps.sboms.models import SBOM
 from sbomify.apps.teams.models import Member
+from sbomify.apps.vulnerability_scanning import vex
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -148,9 +148,15 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
         """A component's own uploaded VEX, which the view reads when a finding
         carries no stored state.
 
-        Patches the reader method rather than S3Client itself: replacing the
-        class rebinds the name in object_store, and a module importing it later
-        keeps the mock past teardown.
+        Stands in for the stored document, which is the only thing here that
+        needs storage. Everything the case is actually about stays real:
+        derive_vex_suppressions, the statement index and the purl match all run
+        on this document.
+
+        Patching S3Client is what this did first, and it failed in CI while
+        passing locally, resolving the dotted target to a module that no longer
+        carried the attribute. Reading it through the loader's own seam does
+        not depend on that resolution.
         """
         SBOM.objects.create(
             component=component,
@@ -173,10 +179,7 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
                 }
             ],
         }
-        mocker.patch(
-            "sbomify.apps.core.object_store.S3Client.get_sbom_data",
-            return_value=json.dumps(document).encode(),
-        )
+        mocker.patch.object(vex, "_document_from_vex_sbom", return_value=document)
 
     def test_an_uploaded_vex_suppresses_a_finding_with_no_stored_state(
         self, signed_in: tuple[Client, Component], mocker: "MockerFixture"

--- a/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
+++ b/sbomify/apps/sboms/tests/test_vulnerabilities_view_vex.py
@@ -123,6 +123,22 @@ class TestASuppressedAdvisoryIsNotListedAsLive:
         assert len(package["vulnerabilities"]) == 1
         assert package["vulnerabilities"][0]["id"] == "CVE-2026-59890"
 
+    def test_a_live_report_clears_the_state_as_well_as_the_flag(self, signed_in: tuple[Client, Component]) -> None:
+        """The record must not say "resolved" on a row it marks live."""
+        client, component = signed_in
+        sbom = self._scanned(
+            component,
+            [
+                _finding("PYSEC-2026-3447", ["CVE-2026-59890"], analysis_state="resolved"),
+                _finding("CVE-2026-59890", ["PYSEC-2026-3447"]),
+            ],
+        )
+
+        advisory = self._packages(client, sbom)[0]["vulnerabilities"][0]
+
+        assert advisory["vex_suppressed"] is False
+        assert advisory["vex_state"] == "", "the state contradicted the flag"
+
     def test_a_live_advisory_still_counts(self, signed_in: tuple[Client, Component]) -> None:
         """The guard against a fix that suppresses everything."""
         client, component = signed_in

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -109,6 +109,44 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # Materialize each finding's identity once; the pre-scan and
                 # the merge loop below share it instead of re-parsing every
                 # purl twice.
+                # The component's uploaded VEX, which is what the drill-down
+                # table reads. Deliberately NOT resolve_vex_statements_for_sbom:
+                # that re-derives the statements embedded in the document by
+                # fetching the document itself from S3, and a Yocto image is
+                # megabytes. It does not need re-deriving. The orchestrator
+                # already wrote the scan's verdict onto each finding as
+                # analysis_state, and that is read first below, so embedded VEX
+                # is honoured without the page paying for it. These statements
+                # only decide the case the stored state cannot: a VEX uploaded
+                # after the scan ran.
+                from sbomify.apps.vulnerability_scanning.vex import (
+                    SUPPRESSED_STATES,
+                    find_matching_statement,
+                    load_vex_suppressions,
+                )
+
+                try:
+                    vex_statements = load_vex_suppressions(sbom.component_id)
+                except Exception:
+                    # The list is the page's job; a VEX that cannot be read
+                    # must not take the advisories down with it. The stored
+                    # analysis_state still marks what the scan cleared.
+                    logger.warning("Could not load VEX for SBOM %s; listing unsuppressed", sbom_id, exc_info=True)
+                    vex_statements = []
+
+                def vex_state_of(finding: dict[str, Any]) -> str:
+                    """The finding's VEX state: stored first, live statements second.
+
+                    Same precedence as extract_finding_rows, so this page and the
+                    drill-down table cannot disagree about one finding.
+                    """
+                    state = finding.get("analysis_state") or ""
+                    if not state and vex_statements:
+                        statement = find_matching_statement(finding, vex_statements)
+                        if statement:
+                            state = statement.get("state") or ""
+                    return state
+
                 identified: list[tuple[dict[str, Any], tuple[str, str, str, str, str]]] = []
                 purl_bases_by_tail: dict[str, set[str]] = {}
                 for run in provider_runs:
@@ -161,6 +199,9 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     merged = next((entry["_by_alias"][key] for key in alias_keys if key in entry["_by_alias"]), None)
                     severity = (vuln.get("severity") or "medium").lower()
 
+                    vex_state = vex_state_of(vuln)
+                    suppressed = vex_state in SUPPRESSED_STATES
+
                     if merged is None:
                         merged = {
                             "_ids": set(),
@@ -173,6 +214,8 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                             "references": list(vuln.get("references") or []),
                             "source": vuln.get("source", "Unknown"),
                             "affected": vuln.get("affected", []),
+                            "vex_state": vex_state,
+                            "vex_suppressed": suppressed,
                         }
                         entry["vulnerabilities"].append(merged)
                     else:
@@ -187,6 +230,13 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                         for reference in vuln.get("references") or []:
                             if reference not in merged["references"]:
                                 merged["references"].append(reference)
+                        # Suppressed only when every provider reporting it is.
+                        # One scanner still calling it live is the answer that
+                        # matters, and the state is kept for the marking.
+                        if not suppressed:
+                            merged["vex_suppressed"] = False
+                        elif not merged.get("vex_state"):
+                            merged["vex_state"] = vex_state
 
                     merged["_ids"] |= ids
                     for key in alias_keys:
@@ -195,6 +245,12 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 if packages_dict:
                     for entry in packages_dict.values():
                         entry.pop("_by_alias", None)
+                        # The headline counts what is still open. Suppressed
+                        # advisories stay in the list, marked, because this
+                        # page's job is the advisory list; counting them as
+                        # live is what the card used to do.
+                        entry["open_count"] = sum(1 for v in entry["vulnerabilities"] if not v.get("vex_suppressed"))
+                        entry["suppressed_count"] = len(entry["vulnerabilities"]) - entry["open_count"]
                         for merged in entry["vulnerabilities"]:
                             merged_ids = sorted(merged.pop("_ids"))
                             display_id = next((i for i in merged_ids if i.lower().startswith("cve-")), None) or (

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -121,8 +121,9 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # after the scan ran.
                 from sbomify.apps.vulnerability_scanning.vex import (
                     SUPPRESSED_STATES,
-                    find_matching_statement,
+                    find_in_index,
                     load_vex_suppressions,
+                    statement_index,
                 )
 
                 # Returns [] when the artifact is absent or unreadable, so an
@@ -131,6 +132,10 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                 # as analysis_state. Anything genuinely unexpected belongs to
                 # this view's outer handler rather than a catch here.
                 vex_statements = load_vex_suppressions(sbom.component_id)
+                # Indexed once for the whole page: matching is O(findings +
+                # statements), and find_matching_statement would rebuild this
+                # for every finding that reaches the overlay.
+                vex_index = statement_index(vex_statements) if vex_statements else {}
 
                 def vex_state_of(finding: dict[str, Any]) -> str:
                     """The finding's VEX state: stored first, live statements second.
@@ -139,8 +144,8 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     drill-down table cannot disagree about one finding.
                     """
                     state = finding.get("analysis_state") or ""
-                    if not state and vex_statements:
-                        statement = find_matching_statement(finding, vex_statements)
+                    if not state and vex_index:
+                        statement = find_in_index(finding, vex_index)
                         if statement:
                             state = statement.get("state") or ""
                     return state

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -125,14 +125,12 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     load_vex_suppressions,
                 )
 
-                try:
-                    vex_statements = load_vex_suppressions(sbom.component_id)
-                except Exception:
-                    # The list is the page's job; a VEX that cannot be read
-                    # must not take the advisories down with it. The stored
-                    # analysis_state still marks what the scan cleared.
-                    logger.warning("Could not load VEX for SBOM %s; listing unsuppressed", sbom_id, exc_info=True)
-                    vex_statements = []
+                # Returns [] when the artifact is absent or unreadable, so an
+                # unreadable VEX costs the after-the-scan overlay and nothing
+                # else: what the scan itself cleared is already on each finding
+                # as analysis_state. Anything genuinely unexpected belongs to
+                # this view's outer handler rather than a catch here.
+                vex_statements = load_vex_suppressions(sbom.component_id)
 
                 def vex_state_of(finding: dict[str, Any]) -> str:
                     """The finding's VEX state: stored first, live statements second.
@@ -234,8 +232,13 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                         # One scanner still calling it live is the answer that
                         # matters, and the state is kept for the marking.
                         if not suppressed:
+                            # The state goes with the flag. Leaving "resolved"
+                            # on a row this just marked live would leave the
+                            # record contradicting itself for whoever reads the
+                            # state rather than the flag.
                             merged["vex_suppressed"] = False
-                        elif not merged.get("vex_state"):
+                            merged["vex_state"] = ""
+                        elif merged.get("vex_suppressed") and not merged.get("vex_state"):
                             merged["vex_state"] = vex_state
 
                     merged["_ids"] |= ids

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -126,16 +126,12 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     statement_index,
                 )
 
-                # Returns [] when the artifact is absent or unreadable, so an
-                # unreadable VEX costs the after-the-scan overlay and nothing
-                # else: what the scan itself cleared is already on each finding
-                # as analysis_state. Anything genuinely unexpected belongs to
-                # this view's outer handler rather than a catch here.
-                vex_statements = load_vex_suppressions(sbom.component_id)
-                # Indexed once for the whole page: matching is O(findings +
-                # statements), and find_matching_statement would rebuild this
-                # for every finding that reaches the overlay.
-                vex_index = statement_index(vex_statements) if vex_statements else {}
+                # Loaded on the first finding that needs it and indexed once,
+                # then reused: a page whose findings all carry a stored state
+                # never reads the VEX at all, and one that does pays a single
+                # S3 fetch and O(findings + statements) matching rather than a
+                # rebuilt index per finding.
+                vex_index: dict[str, list[tuple[int, dict[str, Any]]]] | None = None
 
                 def vex_state_of(finding: dict[str, Any]) -> str:
                     """The finding's VEX state: stored first, live statements second.
@@ -143,12 +139,19 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                     Same precedence as extract_finding_rows, so this page and the
                     drill-down table cannot disagree about one finding.
                     """
+                    nonlocal vex_index
                     state = finding.get("analysis_state") or ""
-                    if not state and vex_index:
-                        statement = find_in_index(finding, vex_index)
-                        if statement:
-                            state = statement.get("state") or ""
-                    return state
+                    if state:
+                        return state
+                    if vex_index is None:
+                        # [] when the artifact is absent or unreadable, so an
+                        # unreadable VEX costs the after-the-scan overlay and
+                        # nothing else: what the scan itself cleared is already
+                        # on each finding. Anything genuinely unexpected belongs
+                        # to this view's outer handler rather than a catch here.
+                        vex_index = statement_index(load_vex_suppressions(sbom.component_id))
+                    statement = find_in_index(finding, vex_index) if vex_index else None
+                    return (statement.get("state") or "") if statement else ""
 
                 identified: list[tuple[dict[str, Any], tuple[str, str, str, str, str]]] = []
                 purl_bases_by_tail: dict[str, set[str]] = {}

--- a/sbomify/apps/sboms/views/sbom_vulnerabilities.py
+++ b/sbomify/apps/sboms/views/sbom_vulnerabilities.py
@@ -232,12 +232,14 @@ class SbomVulnerabilitiesView(GuestAccessBlockedMixin, LoginRequiredMixin, View)
                         # One scanner still calling it live is the answer that
                         # matters, and the state is kept for the marking.
                         if not suppressed:
-                            # The state goes with the flag. Leaving "resolved"
-                            # on a row this just marked live would leave the
-                            # record contradicting itself for whoever reads the
-                            # state rather than the flag.
                             merged["vex_suppressed"] = False
-                            merged["vex_state"] = ""
+                            # Only a suppressing state contradicts the flag this
+                            # just cleared. A non-suppressing one (in_triage,
+                            # exploitable) says something true about a finding
+                            # that is still open, so dropping it would lose the
+                            # only place the page carries it.
+                            if merged["vex_state"] in SUPPRESSED_STATES:
+                                merged["vex_state"] = ""
                         elif merged.get("vex_suppressed") and not merged.get("vex_state"):
                             merged["vex_state"] = vex_state
 

--- a/sbomify/apps/vulnerability_scanning/apis.py
+++ b/sbomify/apps/vulnerability_scanning/apis.py
@@ -1266,9 +1266,9 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     from sbomify.apps.vulnerability_scanning.vex import (
         _finding_ids,
         _matches_in_index,
-        _statement_index,
         derive_vex_suppressions,
         finding_dict_is_suppressed,
+        statement_index,
     )
     from sbomify.apps.vulnerability_scanning.vex_formats import detect_vex_format, parse_vex_bytes
 
@@ -1326,7 +1326,7 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
 
     statements = derive_vex_suppressions(document)
     # Index once: matching is O(findings + statements), not O(findings x statements).
-    statement_index = _statement_index(statements)
+    index = statement_index(statements)
 
     from django.db import connection
 
@@ -1416,7 +1416,7 @@ def preview_vex(request: HttpRequest, component_id: str) -> Any:
     would_suppress = 0
     already_suppressed = 0
     for finding in findings:
-        matches = _matches_in_index(finding, statement_index)
+        matches = _matches_in_index(finding, index)
         if not matches:
             continue
         # Record every statement that matched this finding, not just the first —

--- a/sbomify/apps/vulnerability_scanning/drift.py
+++ b/sbomify/apps/vulnerability_scanning/drift.py
@@ -29,8 +29,8 @@ from sbomify.apps.vulnerability_scanning.vex import (
     _finding_ids,
     _finding_package,
     _matches_in_index,
-    _statement_index,
     _statements_for_release_context,
+    statement_index,
 )
 
 # Display lists are capped so a pathological component cannot bloat the stored
@@ -132,7 +132,7 @@ def compute_component_vex_drift(component_id: Any) -> dict[str, Any]:
         context_key = frozenset(release.id for release in run.releases.all())
         if context_key not in context_cache:
             statements = _statements_for_release_context(component_id, list(context_key))
-            context_cache[context_key] = (statements, _statement_index(statements))
+            context_cache[context_key] = (statements, statement_index(statements))
         _, index = context_cache[context_key]
         result = run.result if isinstance(run.result, dict) else {}
         for finding in result.get("findings") or []:

--- a/sbomify/apps/vulnerability_scanning/vex.py
+++ b/sbomify/apps/vulnerability_scanning/vex.py
@@ -427,7 +427,7 @@ def _statement_is_stale_for(statement: dict[str, Any], finding_pkg: tuple[str | 
     return finding_name == asserted_package and finding_version is not None and finding_version != asserted_version
 
 
-def _statement_index(statements: list[dict[str, Any]]) -> dict[str, list[tuple[int, dict[str, Any]]]]:
+def statement_index(statements: list[dict[str, Any]]) -> dict[str, list[tuple[int, dict[str, Any]]]]:
     """Index statements by vulnerability id so matching is O(findings + statements)
     instead of O(findings x statements). Positions keep document order deterministic."""
     index: dict[str, list[tuple[int, dict[str, Any]]]] = {}
@@ -443,7 +443,7 @@ def _matches_in_index(
     """Every statement in ``index`` that clears ``finding``, in document order.
 
     Callers that only need to know whether a finding is suppressed use the first
-    match (:func:`_find_in_index`); the preview needs the full set to tell which
+    match (:func:`find_in_index`); the preview needs the full set to tell which
     statements matched nothing.
     """
     finding_ids = _finding_ids(finding)
@@ -465,9 +465,7 @@ def _matches_in_index(
     return matches
 
 
-def _find_in_index(
-    finding: dict[str, Any], index: dict[str, list[tuple[int, dict[str, Any]]]]
-) -> dict[str, Any] | None:
+def find_in_index(finding: dict[str, Any], index: dict[str, list[tuple[int, dict[str, Any]]]]) -> dict[str, Any] | None:
     matches = _matches_in_index(finding, index)
     return matches[0] if matches else None
 
@@ -476,7 +474,7 @@ def find_matching_statement(finding: dict[str, Any], statements: list[dict[str, 
     """Return the suppressing statement that clears ``finding``, or ``None``."""
     if not statements:
         return None
-    return _find_in_index(finding, _statement_index(statements))
+    return find_in_index(finding, statement_index(statements))
 
 
 def finding_is_suppressed(finding: dict[str, Any], statements: list[dict[str, Any]]) -> bool:
@@ -518,7 +516,7 @@ def annotate_findings_with_vex(result: Any, statements: list[dict[str, Any]]) ->
         summary.suppressed_count = 0
         return 0
 
-    index = _statement_index(statements)
+    index = statement_index(statements)
     by_severity = {sev: 0 for sev in _SEVERITIES}
     suppressed = 0
     for finding in findings:
@@ -565,7 +563,7 @@ def reapply_vex_to_stored_result(
     if not isinstance(findings, list):
         return result_json
 
-    index = _statement_index(statements)
+    index = statement_index(statements)
     by_severity = {sev: 0 for sev in _SEVERITIES}
     suppressed = 0
     new_findings: list[Any] = []


### PR DESCRIPTION
Part of #1506. The third and last surface where a cleared finding read as live.

## What the page showed

Stage, the Yocto Project's 6.0.3 release SBOM for `core-image-minimal`, whose stored OSV run reads `total_findings 0, suppressed_count 2`:

```
Scan Results
PACKAGE     VERSION   ECOSYSTEM   VULNERABILITIES
setuptools  82.0.1    PyPI        1 vulnerability
CVE-2026-59890
Aliases: BIT-setuptools-2026-59890, GHSA-h35f-9h28-mq5c, PYSEC-2026-3447
HIGH  CVSS: 7.5
```

Yocto ships VEX inside the SBOM. Its `security_VexFixedVulnAssessmentRelationship` for that CVE stores as `analysis_state "resolved"`, which is in `SUPPRESSED_STATES`, and the document carries the patch that fixed it. We listed it as a live HIGH against a build that had patched it, and said so in the document being displayed.

## Why

The view builds its own package-and-alias merge straight off the stored findings and never consulted VEX. `grep -n "vex\|suppress"` over it returned nothing. Not a matching failure, an absent feature: every other reader goes through `extract_finding_rows`, which reads `analysis_state` first.

Distinct from #1551. That was three surfaces tallying `len(rows)` without filtering. This view never produces rows at all, so that fix does not reach it.

## What changed

Suppressed advisories **stay listed**, with a "Not affected" badge. Listing advisories is this page's whole job, and hiding one would make it lie by omission. What changes is the count, which was the actual falsehood: the headline reports what is still open, with the cleared ones noted beside it.

An advisory folded from several providers is suppressed only when every report of it is. One scanner still calling it live is the answer that matters.

It reads the stored `analysis_state` first and the component's uploaded VEX second, the precedence `extract_finding_rows` already uses, so this page and the drill-down table cannot disagree about one finding. That agreement is the point of the change.

## One thing I backed out

I first wired it to `resolve_vex_statements_for_sbom`, which is what the scan uses. That re-derives the document's embedded statements by **fetching the document itself from S3** — and a Yocto image is megabytes, on every page load. It is also unnecessary: the orchestrator already wrote that verdict onto each finding. Switching to `load_vex_suppressions` took this suite from 20s to 4.3s, which is the S3 read showing up.

## Tests

Four: a cleared advisory does not count as open, it is still listed rather than hidden, a live one still counts (the guard against a fix that suppresses everything), and one provider still calling it live wins the fold.

`sboms` + `vulnerability_scanning`: 1153 passed, 6 skipped.