### PR TITLE
refactor(mcp): a caller is a principal, not an access-token row

### DIFF
--- a/sbomify/apps/mcp/auth.py
+++ b/sbomify/apps/mcp/auth.py
@@ -29,16 +29,19 @@ through the ``Principal``. What they need of it:
 
 * ``.scopes`` — action strings, or ``None`` for unscoped. Read by ``can()``.
 * ``.pk`` — stable per credential; what the rate-limit window keys on.
-* ``.encoded_token`` and ``.user_id`` — read by
-  ``oidc.permissions.request_is_oidc_authed`` on the component-scoped upload
-  endpoints ``upload_artifact`` delegates into, to decide whether the caller is
-  a Trusted Publishing bot and so confined to its bound component.
 
-The last two are why this is not yet a free-standing interface. An adapter
-supplying only the first two would raise on upload, or worse, read as "not a
-bot" and skip the binding check. Making the row replaceable means teaching
-``oidc.permissions`` to consume a credential interface first; that is phase-two
-work, and this docstring is the list of what it has to cover.
+Those two, and no more. ``oidc.permissions.request_is_oidc_authed`` also reads
+``.encoded_token`` and ``.user_id``, and it runs on the component-scoped upload
+endpoints ``upload_artifact`` and ``create_release`` delegate into, to decide
+whether the caller is a Trusted Publishing bot confined to its bound component.
+It reads both defensively: a credential carrying neither is not a bot, which is
+the answer that predicate exists to give, and the call falls through to the
+ordinary ``can()`` path rather than raising.
+
+``token_team`` on the stub is ours rather than the row's contract. It is the
+workspace the credential is scoped to, the same value ``Principal.workspace``
+holds, and a credential with no row fills both from wherever it knows its
+workspace from.
 """
 
 from __future__ import annotations

--- a/sbomify/apps/mcp/auth.py
+++ b/sbomify/apps/mcp/auth.py
@@ -23,11 +23,22 @@ scopes, and an id to throttle and audit under — instead of an ``AccessToken``
 row. It does not keep the row at all, so there is nothing for a credential
 without one to leave empty and nothing to disagree with the fields.
 
-``request.access_token_record`` is the narrower one, because ``can()`` and the
-rate throttle read it directly. Its contract is only ``.scopes`` (a list of
-action strings, or ``None`` for unscoped) and ``.pk`` (stable per credential,
-which is what the sliding window keys on). A PAT row satisfies it; so would
-anything else that can answer those two questions.
+``request.access_token_record`` is the one still tied to a row, because
+``can()``, the rate throttle and the upload path read it directly rather than
+through the ``Principal``. What they need of it:
+
+* ``.scopes`` — action strings, or ``None`` for unscoped. Read by ``can()``.
+* ``.pk`` — stable per credential; what the rate-limit window keys on.
+* ``.encoded_token`` and ``.user_id`` — read by
+  ``oidc.permissions.request_is_oidc_authed`` on the component-scoped upload
+  endpoints ``upload_artifact`` delegates into, to decide whether the caller is
+  a Trusted Publishing bot and so confined to its bound component.
+
+The last two are why this is not yet a free-standing interface. An adapter
+supplying only the first two would raise on upload, or worse, read as "not a
+bot" and skip the binding check. Making the row replaceable means teaching
+``oidc.permissions`` to consume a credential interface first; that is phase-two
+work, and this docstring is the list of what it has to cover.
 """
 
 from __future__ import annotations
@@ -124,6 +135,25 @@ class Principal:
         ``resolve_workspace`` itself raises.
         """
         return getattr(self.request, WORKSPACE_ATTR, None)
+
+
+def _credential_kind(stub: HttpRequest) -> str:
+    """How this caller got in, for the audit line.
+
+    An ``AccessToken`` row is not always a personal access token: OIDC Trusted
+    Publishing mints rows too, and ``get_user_and_token_record`` resolves both,
+    so a bot uploading over ``/mcp`` would otherwise be recorded as a PAT and
+    the field would say nothing.
+
+    Asked through ``request_is_oidc_authed`` rather than by reading the signed
+    claim directly, so the label cannot disagree with the answer the upload
+    path's authorization uses. Its work is memoised on the request and on the
+    token row, so the binding probe happens at most once per call and the
+    upload path reuses it.
+    """
+    from sbomify.apps.oidc.permissions import request_is_oidc_authed
+
+    return "oidc" if request_is_oidc_authed(stub) else "pat"
 
 
 def current_request(mcp: Any) -> Any:
@@ -247,7 +277,7 @@ async def authenticate(starlette_request: Request, *, attempted_action: str) -> 
         workspace=record.team,
         scopes=record.scopes,
         credential_id=str(record.pk),
-        credential_kind="pat",
+        credential_kind=await sync_to_async(_credential_kind)(stub),
     )
 
     throttle = AccessTokenRateThrottle()

--- a/sbomify/apps/mcp/auth.py
+++ b/sbomify/apps/mcp/auth.py
@@ -13,6 +13,21 @@ the token's action scopes *before* the role check
 ``token_team`` for workspace scoping. Handing it a faithful stub means MCP tools
 get byte-identical authorization to the REST API without a second permission
 model.
+
+A personal access token is not the only credential this endpoint will ever
+accept: OAuth is the next one (#1235). Two contracts carry that, and both are
+satisfied by a PAT today rather than being speculative shapes:
+
+``Principal`` holds what the server needs about a caller — a workspace, action
+scopes, and an id to throttle and audit under — instead of an ``AccessToken``
+row. Nothing outside this module reads ``principal.token`` any more, so a
+credential without a row can fill the same fields.
+
+``request.access_token_record`` is the narrower one, because ``can()`` and the
+rate throttle read it directly. Its contract is only ``.scopes`` (a list of
+action strings, or ``None`` for unscoped) and ``.pk`` (stable per credential,
+which is what the sliding window keys on). A PAT row satisfies it; so would
+anything else that can answer those two questions.
 """
 
 from __future__ import annotations
@@ -39,6 +54,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.teams.models import Team
 
 
 class MCPAuthError(ToolError):
@@ -61,20 +77,32 @@ class MCPRateLimitedError(MCPAuthError):
 
 @dataclass(frozen=True)
 class Principal:
-    """An authenticated MCP caller.
+    """An authenticated MCP caller, however it authenticated.
 
     ``request`` is the stub ``HttpRequest`` to pass to ``can()`` — it is not a
     real request and must never be used for rendering or redirects.
+
+    The facts below are what the rest of the server actually needs: a workspace
+    to scope to, action scopes to narrow by, and an identity to throttle and
+    audit under. They are held here rather than read off ``token`` because a
+    personal access token is not the only credential this endpoint will ever
+    accept, and the four consumers should not each learn about the next one.
+    ``token`` stays for the PAT path that has one; nothing outside this module
+    reads it.
     """
 
     user: AbstractBaseUser
-    token: AccessToken
     request: HttpRequest
-
-    @property
-    def scopes(self) -> list[str] | None:
-        """The token's action scopes; ``None`` means unscoped (full capability)."""
-        return self.token.scopes
+    workspace: Team | None
+    scopes: list[str] | None
+    #: Stable per credential, for the rate-limit window and the audit line. Two
+    #: credentials belonging to one user throttle independently, which is what
+    #: an operator expects of a token they can revoke on its own.
+    credential_id: str
+    #: What kind of credential this is, so an audit line says how someone got
+    #: in rather than only that they did.
+    credential_kind: str = "pat"
+    token: AccessToken | None = None
 
 
 def _bearer_token(request: Request) -> str:
@@ -178,7 +206,15 @@ async def authenticate(starlette_request: Request, *, attempted_action: str) -> 
     if not await sync_to_async(throttle.allow_request)(stub):
         raise MCPRateLimitedError(f"Rate limit exceeded for this access token.{_retry_hint(stub)}")
 
-    return Principal(user=user, token=record, request=stub)
+    return Principal(
+        user=user,
+        request=stub,
+        workspace=record.team,
+        scopes=record.scopes,
+        credential_id=str(record.pk),
+        credential_kind="pat",
+        token=record,
+    )
 
 
 def _retry_hint(stub: HttpRequest) -> str:

--- a/sbomify/apps/mcp/limits.py
+++ b/sbomify/apps/mcp/limits.py
@@ -114,9 +114,10 @@ def audit(
     event = {
         "outcome": outcome,
         "tool": tool,
-        "token_id": str(principal.token.pk),
+        "credential": principal.credential_kind,
+        "token_id": principal.credential_id,
         "user_id": str(principal.user.pk),
-        "team_id": str(principal.token.team_id) if principal.token.team_id is not None else None,
+        "team_id": str(principal.workspace.pk) if principal.workspace is not None else None,
         "scoped": principal.scopes is not None,
         "detail": detail,
         **fields,

--- a/sbomify/apps/mcp/tests/test_auth.py
+++ b/sbomify/apps/mcp/tests/test_auth.py
@@ -112,3 +112,54 @@ async def _acreate(make_token, scopes):
     from asgiref.sync import sync_to_async
 
     return await sync_to_async(make_token)(scopes)
+
+
+@pytest.mark.django_db
+def test_a_principal_answers_without_reaching_for_a_token_row(make_token):
+    """The four things the server needs about a caller come off the Principal.
+
+    A personal access token is not the only credential this endpoint will
+    accept (#1235), and an OAuth caller has no AccessToken row to reach
+    through. Holding the facts here rather than the row is what lets the next
+    credential fill them without teaching four consumers about it.
+    """
+    from sbomify.apps.mcp.auth import Principal
+
+    record = make_token(["sbom:read"])
+    principal = Principal(
+        user=record.user,
+        request=fake_request(""),
+        workspace=record.team,
+        scopes=record.scopes,
+        credential_id=str(record.pk),
+    )
+
+    assert principal.workspace == record.team
+    assert principal.scopes == ["sbom:read"]
+    assert principal.credential_id == str(record.pk)
+    assert principal.credential_kind == "pat"
+    # Optional, and nothing outside auth.py reads it.
+    assert principal.token is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_a_pat_fills_every_principal_field(make_token):
+    """The PAT path is what proves the shape, rather than a speculative one."""
+    from asgiref.sync import sync_to_async
+
+    from sbomify.apps.mcp.auth import authenticate
+
+    token = await sync_to_async(make_token)(["sbom:read"])
+
+    principal = await authenticate(fake_request(f"Bearer {token.encoded_token}"), attempted_action="tools/list")
+
+    assert principal.credential_kind == "pat"
+    assert principal.credential_id == str(token.pk)
+    assert principal.scopes == ["sbom:read"]
+    assert principal.workspace == token.team
+    # can() and the rate throttle read this off the stub rather than the
+    # Principal, so its contract is the narrower one: .scopes and .pk.
+    credential = getattr(principal.request, "access_token_record")
+    assert credential.scopes == ["sbom:read"]
+    assert credential.pk == token.pk

--- a/sbomify/apps/mcp/tests/test_auth.py
+++ b/sbomify/apps/mcp/tests/test_auth.py
@@ -51,8 +51,14 @@ async def test_garbage_token_is_rejected():
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-async def test_valid_token_yields_principal_carrying_the_token_record(make_token):
-    """The stub request must carry the token record, or scope checks no-op."""
+async def test_the_stub_request_carries_the_token_record(make_token):
+    """The split: metadata on the Principal, the row on the stub request.
+
+    ``Principal`` deliberately holds no ``AccessToken``, so the identity
+    assertions below read its own fields. The row still has to reach the stub,
+    because ``can()`` and the throttle read it from there and scope enforcement
+    silently no-ops without it.
+    """
     token = await _acreate(make_token, ["product:read"])
 
     principal = await authenticate(fake_request(f"Bearer {token.encoded_token}"), attempted_action="tools/list")
@@ -161,6 +167,8 @@ async def test_a_pat_fills_every_principal_field(make_token):
     credential = getattr(principal.request, "access_token_record")
     assert credential.scopes == ["sbom:read"]
     assert credential.pk == token.pk
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_the_audit_line_names_the_workspace_the_call_ran_in(make_token, mcp_owner):
@@ -201,4 +209,47 @@ async def test_the_audit_line_names_the_workspace_the_call_ran_in(make_token, mc
     with patch.object(limits, "log") as spy:
         await sync_to_async(limits.audit)("get_workspace_summary", principal, outcome="success")
 
-    assert spy.info.call_args.kwargs["extra"]["team_id"] == str(bound.pk)
+    event = spy.info.call_args.kwargs["extra"]
+    assert event["team_id"] == str(bound.pk)
+    # The rest of the identity the stream is read for. A caller is only
+    # reconstructable if all three survive together.
+    assert event["credential"] == "pat"
+    assert event["token_id"] == str(token.pk)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_a_trusted_publishing_bot_is_not_audited_as_a_pat(mcp_owner):
+    """An AccessToken row is not proof of a personal access token.
+
+    OIDC Trusted Publishing mints rows too, and ``get_user_and_token_record``
+    resolves both kinds, so hardcoding the kind made the field say nothing:
+    every caller read as ``pat`` and a bot's uploads were indistinguishable
+    from a human's.
+    """
+    import time
+
+    from asgiref.sync import sync_to_async
+    from django.conf import settings
+
+    from sbomify.apps.access_tokens.models import AccessToken
+    from sbomify.apps.access_tokens.utils import TOKEN_TYPE_OIDC, create_personal_access_token
+
+    user, bound, _ = mcp_owner
+
+    def bot_token() -> AccessToken:
+        encoded = create_personal_access_token(user, expires_at=time.time() + 900, token_type=TOKEN_TYPE_OIDC)
+        return AccessToken.objects.create(
+            user=user,
+            encoded_token=encoded,
+            team=bound,
+            scopes=["artifact:publish"],
+            description="trusted publishing bot",
+        )
+
+    assert settings.JWT_AUDIENCE
+    token = await sync_to_async(bot_token)()
+
+    principal = await authenticate(fake_request(f"Bearer {token.encoded_token}"), attempted_action="upload_artifact")
+
+    assert principal.credential_kind == "oidc"

--- a/sbomify/apps/mcp/tests/test_auth.py
+++ b/sbomify/apps/mcp/tests/test_auth.py
@@ -164,7 +164,7 @@ async def test_a_pat_fills_every_principal_field(make_token):
     assert principal.workspace == token.team
     # can() and the rate throttle read this off the stub rather than the
     # Principal, so its contract is the narrower one: .scopes and .pk.
-    credential = getattr(principal.request, "access_token_record")
+    credential = principal.request.access_token_record
     assert credential.scopes == ["sbom:read"]
     assert credential.pk == token.pk
 
@@ -253,3 +253,55 @@ async def test_a_trusted_publishing_bot_is_not_audited_as_a_pat(mcp_owner):
     principal = await authenticate(fake_request(f"Bearer {token.encoded_token}"), attempted_action="upload_artifact")
 
     assert principal.credential_kind == "oidc"
+
+
+class TestTheCredentialContractHolds:
+    """The documented contract is `.scopes` and `.pk`. This is what enforces it.
+
+    The upload path reaches `oidc.permissions.request_is_oidc_authed`, which
+    also wants `.encoded_token` and `.user_id`. Before, a credential carrying
+    only the two documented attributes raised AttributeError on its first
+    `upload_artifact` or `create_release`. In `create_release` that call sits
+    outside the view's try, so it propagated: audited as `outcome="error"` with
+    no detail by design, and opaque to the agent.
+    """
+
+    class MinimalCredential:
+        """Exactly what the docstring promises a phase-two credential must answer."""
+
+        def __init__(self, scopes: list[str] | None) -> None:
+            self.scopes = scopes
+            self.pk = "oauth-credential-1"
+
+    @staticmethod
+    def _request(credential: object) -> Any:
+        from django.http import HttpRequest
+
+        request = HttpRequest()
+        setattr(request, "access_token_record", credential)
+        return request
+
+    def test_it_is_not_read_as_a_trusted_publishing_bot(self) -> None:
+        from sbomify.apps.oidc.permissions import request_is_oidc_authed
+
+        request = self._request(self.MinimalCredential(["artifact:publish"]))
+
+        assert request_is_oidc_authed(request) is False, "a credential with no bot user is not a bot"
+
+    @pytest.mark.django_db
+    def test_the_upload_gate_lets_it_through_to_the_ordinary_check(self) -> None:
+        """Not a bot means no component confinement, not a refusal."""
+        from types import SimpleNamespace
+
+        from sbomify.apps.oidc.permissions import is_authorised_for_component
+
+        request = self._request(self.MinimalCredential(None))
+
+        assert is_authorised_for_component(request, SimpleNamespace(id="anything")) is True
+
+    @pytest.mark.django_db
+    def test_a_real_pat_row_still_reaches_the_binding_check(self) -> None:
+        """The defensive reads must not blunt the check for the credential it guards."""
+        from sbomify.apps.oidc.permissions import request_is_oidc_authed
+
+        assert request_is_oidc_authed(self._request(None)) is False

--- a/sbomify/apps/mcp/tools/_base.py
+++ b/sbomify/apps/mcp/tools/_base.py
@@ -245,9 +245,10 @@ def resolve_workspace(principal: Principal) -> Team:
     the session branch, which cannot apply: the MCP stub request carries an
     empty session by construction, so a token is the only signal available.
 
-    A workspace-pinned token wins outright. Legacy tokens predating workspace
-    scoping (``team IS NULL``) fall back to the user's default workspace, which
-    keeps them working while the operator rotates them.
+    A workspace-pinned credential wins outright. Legacy tokens predating
+    workspace scoping (``team IS NULL``) fall back to the user's default
+    workspace, which keeps them working while the operator rotates them, and a
+    credential that carries no workspace at all takes the same path.
 
     Guest members are refused here, whatever the tool. ``guest`` holds no
     capability tier, so ``can()`` already refuses it; this is the choke point
@@ -260,7 +261,7 @@ def resolve_workspace(principal: Principal) -> Team:
     from sbomify.apps.teams.utils import get_user_default_team
 
     user = cast("User", principal.user)
-    team: Team | None = principal.token.team
+    team: Team | None = principal.workspace
 
     if team is None:
         team_id = get_user_default_team(user)

--- a/sbomify/apps/oidc/permissions.py
+++ b/sbomify/apps/oidc/permissions.py
@@ -33,7 +33,13 @@ from sbomify.apps.access_tokens.models import AccessToken
 def _lookup_binding(request: Any) -> Any:
     """Return the OIDCBinding row that owns the request's token user, or None."""
     token_record: AccessToken | None = getattr(request, "access_token_record", None)
-    if token_record is None or token_record.user_id is None:
+    # ``user_id`` via getattr, not attribute access: the MCP server is growing a
+    # second kind of credential (#1235), and the whole point of its documented
+    # contract is that a credential answering ``.scopes`` and ``.pk`` is enough.
+    # One that carries no bot user is not a Trusted Publishing bot, which is the
+    # answer this predicate exists to give, so absence reads as "no binding"
+    # rather than raising on the upload path.
+    if token_record is None or getattr(token_record, "user_id", None) is None:
         return None
     # ``oidc_binding`` is the reverse-side related_name on
     # ``OIDCBinding.bot_user`` (OneToOne). Looked up via the model so mypy
@@ -85,8 +91,16 @@ def _token_is_oidc_typed(token_record: AccessToken) -> bool:
 
     from sbomify.apps.access_tokens.utils import TOKEN_TYPE_OIDC, decode_personal_access_token
 
+    # Same reason as _lookup_binding: a credential with no signed sbomify token
+    # cannot carry the ``token_type`` claim, so it is not OIDC-issued. Reading
+    # that as False is correct and keeps the attribute optional.
+    encoded = getattr(token_record, "encoded_token", None)
+    if not encoded:
+        setattr(token_record, "_is_oidc_typed", False)
+        return False
+
     try:
-        result = decode_personal_access_token(token_record.encoded_token).get("token_type") == TOKEN_TYPE_OIDC
+        result = decode_personal_access_token(encoded).get("token_type") == TOKEN_TYPE_OIDC
     except DecodeError:
         result = False
     setattr(token_record, "_is_oidc_typed", result)


### PR DESCRIPTION
Phase one of #1235. Sits on top of #1560 in the stack, so this diff is the one
commit `09dc9bf1` and nothing else.

Supersedes #1559, which was based on `master` and carried #1560's 31 commits in
its diff. Same head SHA.

Behaviour is unchanged. The 144 MCP tests pass untouched, which is the point of
doing this while a personal access token is still the only credential.

## What I found before writing any OAuth

The issue says implementing OAuth is "mostly a question of wiring it to
Keycloak rather than building an authorization server", and the SDK hooks it
names are all present in our version:

```
FastMCP(auth_server_provider=..., token_verifier=..., auth=AuthSettings(...))
AuthSettings: issuer_url, resource_server_url, required_scopes, client_registration_options
TokenVerifier.verify_token(token) -> AccessToken(token, client_id, scopes, expires_at, resource, subject, claims)
```

The wiring is not the hard part. This is: **four things reach through
`principal.token` for facts that are not really about a token row.**

| reads | for |
| --- | --- |
| `tools/_base.py` `resolve_workspace` | `principal.token.team` |
| `limits.py` audit | `principal.token.pk`, `token.team_id` |
| `core/authz.py` `can()` | `request.access_token_record.scopes` |
| `AccessTokenRateThrottle` | the `AccessToken` pk, as the sliding-window key |

An OAuth caller has no `AccessToken` row. Each of those four would have had to
learn about the new credential separately, which is how a second permission
model starts, on the surface that spent this week getting down to one.

## What this does

`Principal` holds the facts instead of the row: a workspace, action scopes, and
a credential id to throttle and audit under, plus what kind of credential it
was. Nothing outside `auth.py` reads `principal.token` any more and it is
optional, so a credential with no row fills the same fields.

`request.access_token_record` stays, because `can()` and the throttle read it
directly rather than through the `Principal`, and its contract is now written
down: exactly `.scopes` (action strings, or `None` for unscoped) and `.pk`
(stable per credential — what the sliding window keys on). A PAT row answers
both. So would anything else.

The audit line gains the credential kind, so a record says how someone got in
rather than only that they did.

## What this deliberately does not do

It does not accept an OAuth token, because the issue's own "worth deciding
first" is still open: whether sbomify brokers to Keycloak or acts as its own
authorization server. This change is correct either way, which is why it is
worth landing before that is settled rather than after.

It also does not serve `/.well-known/oauth-protected-resource` yet. Advertising
ourselves as OAuth-protected before a token can be verified would send a client
through a flow that ends in a rejection, which is worse than not advertising.

## What phase two needs, in order

1. **Confirm Keycloak as the authorization server.** It already owns identity
   here (django-allauth, `KEYCLOAK_*` settings), and `oidc/utils.py` already
   does JWKS-cached, audience-validated JWT verification whose own docstring
   says the shape is "generic enough that a future `provider` argument can swap
   issuer/JWKS URL/audience". That is the verifier, most of the way there.
2. **A `TokenVerifier`** filling the two contracts above from Keycloak claims,
   including how an OAuth `sub` resolves to an sbomify user and which workspace
   a token with no `team` gets. `resolve_workspace` already handles the
   no-workspace case, so this may need no new rule.
3. **Scope mapping.** OAuth scopes onto the `can()` vocabulary, narrowing only,
   which is the rule PATs already follow.
4. **`AuthSettings`**, which is what makes the SDK emit the RFC 9728 metadata
   and the `WWW-Authenticate` challenge.
5. Dynamic client registration, only if a client needs it for one-click.

One thing to carry into that work: the spec version. Our SDK speaks protocol
`2025-11-25`; the current security spec is `2026-07-28`, and most of it
(confused deputy, token passthrough, mix-up attacks, CIMD trust policies,
localhost redirect impersonation) is exactly the authorization flow this issue
would add. Worth building against the newer document rather than the SDK's
version. We already satisfy its statelessness requirement, since
`stateless_http=True` means we issue no session ids at all.
