### PR TITLE
fix(vulns): a VEX statement we cannot apply says so

### DIFF
--- a/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_spdx3_embedded_vex.py
@@ -289,3 +289,73 @@ class TestOnlyTheDocumentsThatCanCarryItAreRead:
 
         assert _embedded_statements(sbom) == []
         fetch.assert_not_called()
+
+
+class TestADroppedStatementSaysSo:
+    """A statement we cannot apply is a fact about the document, not a non-event.
+
+    Dropping a statement whose target carries no purl is right: suppressing by
+    vulnerability id alone would apply it wider than its author wrote it. Doing
+    it silently is what hid the Yocto case, where the release SBOM's every
+    statement goes this way and the scan simply suppressed nothing.
+    """
+
+    @staticmethod
+    def _cpe_only_document(count: int) -> dict[str, Any]:
+        """The Yocto shape: packages identified by cpe23 and nothing else."""
+        graph: list[dict[str, Any]] = [
+            {
+                "type": "CreationInfo",
+                "@id": "_:ci",
+                "specVersion": "3.0.1",
+                "created": "2026-01-01T00:00:00Z",
+                "createdBy": ["urn:agent"],
+            }
+        ]
+        for i in range(count):
+            graph += [
+                {
+                    "type": "software_Package",
+                    "spdxId": f"urn:pkg{i}",
+                    "name": f"ldconfig{i}",
+                    "externalIdentifier": [
+                        {"externalIdentifierType": "cpe23", "identifier": f"cpe:2.3:a:gnu:glibc{i}:2.38:*:*:*:*:*:*:*"}
+                    ],
+                },
+                {"type": "security_Vulnerability", "spdxId": f"urn:vuln{i}", "name": f"CVE-2019-10100{i}"},
+                {
+                    "type": "security_VexNotAffectedVulnAssessmentRelationship",
+                    "spdxId": f"urn:vex{i}",
+                    "from": f"urn:vuln{i}",
+                    "to": [f"urn:pkg{i}"],
+                },
+            ]
+        return {"@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld", "@graph": graph}
+
+    def test_the_count_is_reported_once_for_the_document(self) -> None:
+        from unittest.mock import patch
+
+        from sbomify.apps.vulnerability_scanning import vex_formats
+
+        document = self._cpe_only_document(55)
+
+        with patch.object(vex_formats, "logger") as spy:
+            statements = derive_spdx3_vex_suppressions(document)
+
+        assert statements == [], "a target with no purl cannot be identified, so nothing may be suppressed"
+        assert spy.warning.call_count == 1, "one line per document, not 55"
+        assert spy.warning.call_args.args[1:] == ("SPDX 3", 55, 55)
+
+    def test_a_document_we_understand_says_nothing(self) -> None:
+        """The warning marks a real gap, so it must not fire on a clean document."""
+        from unittest.mock import patch
+
+        from sbomify.apps.vulnerability_scanning import vex_formats
+
+        with patch.object(vex_formats, "logger") as spy:
+            statements = derive_spdx3_vex_suppressions(
+                _document(_assessment("security_VexNotAffectedVulnAssessmentRelationship"))
+            )
+
+        assert len(statements) == 1
+        assert spy.warning.call_count == 0

--- a/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/tests/test_vex_formats.py
@@ -427,9 +427,7 @@ class TestExternalVexUpload:
     def test_upload_file_bare_context_stores_v001(self, sample_user, sample_team_with_owner_member, component) -> None:
         client = Client()
         setup_authenticated_client_session(client, sample_team_with_owner_member.team, sample_user)
-        doc = _openvex_doc(
-            {"vulnerability": "CVE-1", "status": "not_affected"}, context="https://openvex.dev/ns"
-        )
+        doc = _openvex_doc({"vulnerability": "CVE-1", "status": "not_affected"}, context="https://openvex.dev/ns")
         response = self._upload(client, component.id, doc)
         assert response.status_code == 201, response.content
         assert SBOM.objects.get(id=response.json()["id"]).format_version == "v0.0.1"
@@ -518,7 +516,9 @@ class TestVexArtifactEndpoint:
         assert sbom.format == "cyclonedx"
         assert sbom.bom_type == "vex"
 
-    def test_markerless_cyclonedx_delegates(self, authenticated_api_client, sample_team_with_owner_member, component) -> None:
+    def test_markerless_cyclonedx_delegates(
+        self, authenticated_api_client, sample_team_with_owner_member, component
+    ) -> None:
         """A CycloneDX VEX without the bomFormat marker is treated as CycloneDX
         (specVersion present), matching the session upload flow's leniency.
 
@@ -656,3 +656,50 @@ def test_csaf_relationship_id_inherits_component_purl() -> None:
     assert len(statements) == 1
     assert statements[0]["packages"] == {("rpm", "redhat/kernel", "5.14.0")}
     assert statements[0]["product_scoped"] is False
+
+
+def test_openvex_unidentified_products_are_reported_once() -> None:
+    """The same silence the SPDX 3 reader had: a scoped statement we cannot map.
+
+    Dropping it is right, because suppressing by vulnerability id alone would
+    apply it wider than its author scoped it. Saying nothing while dropping it
+    leaves an operator with a document that carries VEX and a scan that
+    suppressed nothing.
+    """
+    from unittest.mock import patch
+
+    from sbomify.apps.vulnerability_scanning import vex_formats
+
+    doc = _openvex_doc(
+        *[
+            {
+                "vulnerability": {"name": f"CVE-2026-100{i}"},
+                "products": [{"@id": f"https://example.com/thing{i}"}],
+                "status": "not_affected",
+            }
+            for i in range(3)
+        ]
+    )
+
+    with patch.object(vex_formats, "logger") as spy:
+        statements = derive_openvex_suppressions(doc)
+
+    assert statements == []
+    assert spy.warning.call_count == 1
+    assert spy.warning.call_args.args[1:] == ("OpenVEX", 3, 3)
+
+
+def test_openvex_a_document_level_claim_is_not_a_dropped_statement() -> None:
+    """No product declaration anywhere is a whole-document claim, not a failure."""
+    from unittest.mock import patch
+
+    from sbomify.apps.vulnerability_scanning import vex_formats
+
+    doc = _openvex_doc({"vulnerability": {"name": "CVE-2026-2000"}, "status": "not_affected"})
+
+    with patch.object(vex_formats, "logger") as spy:
+        statements = derive_openvex_suppressions(doc)
+
+    assert len(statements) == 1
+    assert statements[0]["product_scoped"] is True
+    assert spy.warning.call_count == 0

--- a/sbomify/apps/vulnerability_scanning/vex_formats.py
+++ b/sbomify/apps/vulnerability_scanning/vex_formats.py
@@ -157,6 +157,30 @@ def _packages_from_purls(purls: list[str]) -> set[tuple[str | None, str, str | N
     return packages
 
 
+def _report_unidentified_targets(dropped: int, total: int, format_word: str) -> None:
+    """Say that scoped statements were discarded for want of an identity.
+
+    Dropping them is right: suppressing by vulnerability id alone would apply a
+    statement wider than its author wrote it. Dropping them in silence is not.
+    An operator otherwise sees a document that plainly carries VEX and a scan
+    that suppressed nothing, with nothing in between to connect the two.
+
+    One line per document, not per statement: the case this exists for is the
+    Yocto release SBOM, where all 55 statements go the same way for the same
+    reason, and 55 identical lines would bury the count that matters.
+    """
+    if not dropped:
+        return
+    logger.warning(
+        "%s VEX: %d of %d suppressing statements name a target this document does not identify "
+        "with a purl, so none of them can suppress anything. Suppressing by vulnerability id "
+        "alone would apply them wider than their author scoped them.",
+        format_word,
+        dropped,
+        total,
+    )
+
+
 def _openvex_statement_ids(vulnerability: Any) -> set[str]:
     """Vulnerability ids from an OpenVEX statement. ``vulnerability`` is an
     object with ``name``/``aliases`` since v0.2.0 but was a plain string in
@@ -202,6 +226,7 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
     doc_products = raw_doc_products if isinstance(raw_doc_products, list) else []
     doc_products_malformed = raw_doc_products is not None and not isinstance(raw_doc_products, list)
     statements: list[dict[str, Any]] = []
+    unidentified = 0
     for statement in _as_list(document.get("statements")):
         if not isinstance(statement, dict) or statement.get("status") != "not_affected":
             continue
@@ -264,7 +289,9 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
             # maps to no purls fails closed: honouring it as id-only
             # suppression would apply the statement wider than its author
             # scoped it. Only a statement with no declaration anywhere is a
-            # whole-document claim.
+            # whole-document claim. Counted so the discard is reported once
+            # for the document rather than passing in silence.
+            unidentified += 1
             continue
         justification, detail = _mapped_justification(
             statement.get("justification"),
@@ -281,6 +308,7 @@ def derive_openvex_suppressions(document: dict[str, Any]) -> list[dict[str, Any]
                 "detail": detail,
             }
         )
+    _report_unidentified_targets(unidentified, len(statements) + unidentified, "OpenVEX")
     return statements
 
 
@@ -709,6 +737,7 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
                 purls[spdx_id] = purl
 
     statements: list[dict[str, Any]] = []
+    unidentified = 0
     for tail, element in assessments:
         subject = element.get("from")
         if isinstance(subject, str):
@@ -738,6 +767,10 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
             # Scoped to something we cannot identify. Suppressing by id alone
             # would apply it wider than its author wrote it, and an empty list
             # is a scope its author wrote rather than a scope they omitted.
+            # Counted so the discard is reported once for the document: a
+            # Yocto release SBOM loses every statement here, and used to do it
+            # without saying anything at all.
+            unidentified += 1
             continue
 
         justification, detail = _mapped_justification(
@@ -756,4 +789,5 @@ def derive_spdx3_vex_suppressions(document: dict[str, Any]) -> list[dict[str, An
                 "source": EMBEDDED_SOURCE,
             }
         )
+    _report_unidentified_targets(unidentified, len(statements) + unidentified, "SPDX 3")
     return statements


### PR DESCRIPTION
Closes #1556.

`derive_spdx3_vex_suppressions` drops a VEX statement whose target it cannot identify, and says nothing. On the Yocto 6.0.3 release SBOM that is 55 of 55 discarded in silence.

This is what hid #1555. The embedded-VEX reader shipped in #1499, was correct in its own terms, produced zero output on the document that motivated it, and nothing anywhere said so.

## What does not change

The drop. Suppressing by vulnerability id alone would apply a statement wider than its author wrote it, and over-suppression hides real findings, which is worse than showing cleared ones.

## What does

The document reports the count. One line per document, not one per statement, because 55 identical lines would bury the number that matters:

```
SPDX 3 VEX: 55 of 55 suppressing statements name a target this document does not
identify with a purl, so none of them can suppress anything. Suppressing by
vulnerability id alone would apply them wider than their author scoped them.
```

## Wider than the issue

The issue names the SPDX 3 reader. The OpenVEX reader drops the same way for the same reason and was equally silent, so it gets the same line. Both now route through one helper rather than growing two wordings that drift.

CSAF is deliberately untouched: it already keeps an unmappable statement as `product_scoped` with a scope note in the detail, rather than discarding it.

## Tests

Four, built from the real shapes:

- The Yocto shape, 55 CPE-only packages, asserts one warning carrying `55 of 55` rather than 55 lines.
- A document we do understand asserts silence, so the warning marks a real gap rather than becoming background noise.
- The same pair for OpenVEX, including that a statement with no product declaration anywhere is a whole-document claim and not a dropped one.

`caplog` does not see these: the audit loggers do not propagate, so the tests spy on the module logger instead.

## Verification

472 vulnerability_scanning tests pass. `ruff`, `mypy` clean.
